### PR TITLE
feat(query): Phase 3 query layer - query/find/trends + FTS5 (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ backup → care-gap rules) per the Architecture doc. **Phase 1 (skeleton) is don
 layout, `migrations/001_init.sql`, `pemr migrate`, `pemr person add|list|show`, config, CI.
 **Phase 2 (ingest + two-layer dedup) is done**: content-hash blob store + commit-extraction
 (`pemr ingest`), semantic dedup keys with conflict staging (`migrations/002_conflict.sql`,
-`pemr review-conflicts`), starter analyte/name dictionary.
+`pemr review-conflicts`), starter analyte/name dictionary. **Phase 3 (query layer) is done**:
+structured reads (`pemr query labs|meds|timeline`), full-text search over OCR text + record
+fields (`migrations/003_fts.sql`, `pemr find`), and lab `pemr trends` — all with `--json`.
 
 ## Data / privacy posture
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -338,8 +338,12 @@ it's the best possible dedup/extraction test corpus.
 
 - **Analyte dictionary seed**: start from your existing lab CSVs' column headers, or a
   standard LOINC subset?
-- **FTS**: SQLite FTS5 is plenty; confirm you don't need semantic/vector search over
-  notes (could add a sidecar later).
+- **FTS**: ~~SQLite FTS5 is plenty; confirm you don't need semantic/vector search over
+  notes (could add a sidecar later).~~ **Resolved (phase 3):** plain SQLite FTS5, no
+  vector sidecar. `migrations/003_fts.sql` adds a standalone `record_fts` index over
+  `document.ocr_text` + record text fields, kept current by triggers on the base tables
+  (ingest/commit paths unchanged) and backfilled on migrate. A semantic/vector sidecar
+  can bolt on later without schema changes if keyword search proves insufficient.
 - **Med interactions in briefs**: rules-based flags only, or call an external drug DB?
   (Recommend rules + "verify with pharmacist" framing — no clinical guarantees.)
 ```

--- a/migrations/003_fts.sql
+++ b/migrations/003_fts.sql
@@ -1,0 +1,120 @@
+-- 003_fts: full-text search over document OCR text + high-value record text fields
+-- (docs/Architecture.md §5 `pemr find`). A single standalone FTS5 index, kept in sync
+-- by AFTER INSERT/UPDATE/DELETE triggers on the base tables so ingest/commit paths need
+-- no code changes. Metadata columns are UNINDEXED (stored, not tokenized) so a match can
+-- report its source table/row + document provenance and be filtered by person.
+--
+-- Design decision (Architecture.md §Open questions): plain FTS5, no vector sidecar. A
+-- semantic sidecar can bolt on later without touching this schema.
+
+CREATE VIRTUAL TABLE record_fts USING fts5(
+  source_table UNINDEXED,   -- 'document'|'lab_result'|'medication'|'procedure'|'appointment'|'observation'
+  source_id    UNINDEXED,   -- primary key of the row in source_table
+  person_id    UNINDEXED,   -- owner, for the `pemr find --person` filter
+  document_id  UNINDEXED,   -- provenance (self for 'document' rows)
+  text                      -- the indexed content
+);
+
+-- --- document.ocr_text ------------------------------------------------------
+CREATE TRIGGER record_fts_document_ai AFTER INSERT ON document BEGIN
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('document', NEW.document_id, NEW.person_id, NEW.document_id, COALESCE(NEW.ocr_text, ''));
+END;
+CREATE TRIGGER record_fts_document_ad AFTER DELETE ON document BEGIN
+  DELETE FROM record_fts WHERE source_table='document' AND source_id=OLD.document_id;
+END;
+CREATE TRIGGER record_fts_document_au AFTER UPDATE ON document BEGIN
+  DELETE FROM record_fts WHERE source_table='document' AND source_id=OLD.document_id;
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('document', NEW.document_id, NEW.person_id, NEW.document_id, COALESCE(NEW.ocr_text, ''));
+END;
+
+-- --- lab_result.test_name ---------------------------------------------------
+CREATE TRIGGER record_fts_lab_ai AFTER INSERT ON lab_result BEGIN
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('lab_result', NEW.lab_result_id, NEW.person_id, NEW.document_id, COALESCE(NEW.test_name, ''));
+END;
+CREATE TRIGGER record_fts_lab_ad AFTER DELETE ON lab_result BEGIN
+  DELETE FROM record_fts WHERE source_table='lab_result' AND source_id=OLD.lab_result_id;
+END;
+CREATE TRIGGER record_fts_lab_au AFTER UPDATE ON lab_result BEGIN
+  DELETE FROM record_fts WHERE source_table='lab_result' AND source_id=OLD.lab_result_id;
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('lab_result', NEW.lab_result_id, NEW.person_id, NEW.document_id, COALESCE(NEW.test_name, ''));
+END;
+
+-- --- medication.name --------------------------------------------------------
+CREATE TRIGGER record_fts_med_ai AFTER INSERT ON medication BEGIN
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('medication', NEW.medication_id, NEW.person_id, NEW.document_id, COALESCE(NEW.name, ''));
+END;
+CREATE TRIGGER record_fts_med_ad AFTER DELETE ON medication BEGIN
+  DELETE FROM record_fts WHERE source_table='medication' AND source_id=OLD.medication_id;
+END;
+CREATE TRIGGER record_fts_med_au AFTER UPDATE ON medication BEGIN
+  DELETE FROM record_fts WHERE source_table='medication' AND source_id=OLD.medication_id;
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('medication', NEW.medication_id, NEW.person_id, NEW.document_id, COALESCE(NEW.name, ''));
+END;
+
+-- --- procedure.name ---------------------------------------------------------
+CREATE TRIGGER record_fts_proc_ai AFTER INSERT ON procedure BEGIN
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('procedure', NEW.procedure_id, NEW.person_id, NEW.document_id, COALESCE(NEW.name, ''));
+END;
+CREATE TRIGGER record_fts_proc_ad AFTER DELETE ON procedure BEGIN
+  DELETE FROM record_fts WHERE source_table='procedure' AND source_id=OLD.procedure_id;
+END;
+CREATE TRIGGER record_fts_proc_au AFTER UPDATE ON procedure BEGIN
+  DELETE FROM record_fts WHERE source_table='procedure' AND source_id=OLD.procedure_id;
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('procedure', NEW.procedure_id, NEW.person_id, NEW.document_id, COALESCE(NEW.name, ''));
+END;
+
+-- --- appointment.reason + summary -------------------------------------------
+CREATE TRIGGER record_fts_appt_ai AFTER INSERT ON appointment BEGIN
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('appointment', NEW.appointment_id, NEW.person_id, NEW.document_id,
+          TRIM(COALESCE(NEW.reason, '') || ' ' || COALESCE(NEW.summary, '')));
+END;
+CREATE TRIGGER record_fts_appt_ad AFTER DELETE ON appointment BEGIN
+  DELETE FROM record_fts WHERE source_table='appointment' AND source_id=OLD.appointment_id;
+END;
+CREATE TRIGGER record_fts_appt_au AFTER UPDATE ON appointment BEGIN
+  DELETE FROM record_fts WHERE source_table='appointment' AND source_id=OLD.appointment_id;
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('appointment', NEW.appointment_id, NEW.person_id, NEW.document_id,
+          TRIM(COALESCE(NEW.reason, '') || ' ' || COALESCE(NEW.summary, '')));
+END;
+
+-- --- observation.key + value_text -------------------------------------------
+CREATE TRIGGER record_fts_obs_ai AFTER INSERT ON observation BEGIN
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('observation', NEW.observation_id, NEW.person_id, NEW.document_id,
+          TRIM(COALESCE(NEW.key, '') || ' ' || COALESCE(NEW.value_text, '')));
+END;
+CREATE TRIGGER record_fts_obs_ad AFTER DELETE ON observation BEGIN
+  DELETE FROM record_fts WHERE source_table='observation' AND source_id=OLD.observation_id;
+END;
+CREATE TRIGGER record_fts_obs_au AFTER UPDATE ON observation BEGIN
+  DELETE FROM record_fts WHERE source_table='observation' AND source_id=OLD.observation_id;
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('observation', NEW.observation_id, NEW.person_id, NEW.document_id,
+          TRIM(COALESCE(NEW.key, '') || ' ' || COALESCE(NEW.value_text, '')));
+END;
+
+-- --- backfill: index rows that predate this migration (no re-ingest needed) --
+INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  SELECT 'document', document_id, person_id, document_id, COALESCE(ocr_text, '') FROM document;
+INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  SELECT 'lab_result', lab_result_id, person_id, document_id, COALESCE(test_name, '') FROM lab_result;
+INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  SELECT 'medication', medication_id, person_id, document_id, COALESCE(name, '') FROM medication;
+INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  SELECT 'procedure', procedure_id, person_id, document_id, COALESCE(name, '') FROM procedure;
+INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  SELECT 'appointment', appointment_id, person_id, document_id,
+         TRIM(COALESCE(reason, '') || ' ' || COALESCE(summary, '')) FROM appointment;
+INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  SELECT 'observation', observation_id, person_id, document_id,
+         TRIM(COALESCE(key, '') || ' ' || COALESCE(value_text, '')) FROM observation;

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -15,7 +15,7 @@ import tomllib
 from dataclasses import asdict
 from pathlib import Path
 
-from . import __version__, db, dedup, ingest, persons
+from . import __version__, db, dedup, ingest, persons, query
 
 # Shipped starter analyte/name dictionary (framework, not user data — see .gitignore).
 _DEFAULT_DICTIONARY = Path(__file__).resolve().parent.parent / "data" / "dictionary.example.toml"
@@ -263,6 +263,148 @@ def _cmd_review_conflicts(args: argparse.Namespace) -> int:
     return 0
 
 
+# --------------------------------------------------------------------------- #
+# Phase 3: query / find / trends
+# --------------------------------------------------------------------------- #
+
+# Internal columns never emitted in --json (unstable / not part of the contract).
+_HIDDEN_FIELDS = ("dedup_key",)
+
+
+def _clean(row: dict) -> dict:
+    return {k: v for k, v in row.items() if k not in _HIDDEN_FIELDS}
+
+
+def _print_json(payload: object) -> None:
+    # ensure_ascii keeps output cp1252-console-safe (phase 2 lesson).
+    print(json.dumps(payload, indent=2, ensure_ascii=True, default=str))
+
+
+def _fmt(value: object) -> str:
+    return "" if value is None else str(value)
+
+
+def _with_conn_person(args: argparse.Namespace, work):
+    """Open the DB, run ``work(conn)``, translating the two friendly failure modes
+    (un-migrated DB, unknown person slug) into an rc=1 stderr message."""
+    conn = db.connect(_resolve_db_path(args))
+    try:
+        try:
+            return work(conn)
+        except db.NotMigratedError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+        except query.PersonNotFoundError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+    finally:
+        conn.close()
+
+
+def _cmd_query_labs(args: argparse.Namespace) -> int:
+    def work(conn):
+        dictionary = dedup.load_dictionary(_resolve_dictionary_path(args))
+        rows = query.query_labs(
+            conn, args.person, test=args.test, since=args.since, dictionary=dictionary
+        )
+        if args.json:
+            _print_json([_clean(r) for r in rows])
+            return 0
+        if not rows:
+            print("no lab results")
+            return 0
+        for r in rows:
+            value = r["value_num"] if r["value_num"] is not None else r["value_text"]
+            unit = f" {r['unit']}" if r["unit"] else ""
+            flag = f"  [{r['flag']}]" if r["flag"] else ""
+            ref = ""
+            if r["ref_low"] is not None or r["ref_high"] is not None:
+                ref = f"  (ref {_fmt(r['ref_low'])}-{_fmt(r['ref_high'])})"
+            print(f"{_fmt(r['collected_at']):19}  {r['test_name']:20}  "
+                  f"{_fmt(value)}{unit}{flag}{ref}")
+        return 0
+
+    return _with_conn_person(args, work)
+
+
+def _cmd_query_meds(args: argparse.Namespace) -> int:
+    def work(conn):
+        rows = query.query_meds(conn, args.person, active=args.active)
+        if args.json:
+            _print_json([_clean(r) for r in rows])
+            return 0
+        if not rows:
+            print("no active medications" if args.active else "no medications")
+            return 0
+        for r in rows:
+            dose = f"  {r['dose']}" if r["dose"] else ""
+            freq = f"  {r['frequency']}" if r["frequency"] else ""
+            span = _fmt(r["started_on"]) + (f" -> {r['ended_on']}" if r["ended_on"] else " -> (current)")
+            status = f"  [{r['status']}]" if r["status"] else ""
+            print(f"{r['name']:24}{dose}{freq}  {span}{status}")
+        return 0
+
+    return _with_conn_person(args, work)
+
+
+def _cmd_query_timeline(args: argparse.Namespace) -> int:
+    def work(conn):
+        events = query.query_timeline(conn, args.person, since=args.since)
+        if args.json:
+            _print_json(events)
+            return 0
+        if not events:
+            print("no events")
+            return 0
+        for e in events:
+            prov = f"  (doc #{e['document_id']})" if e["document_id"] is not None else ""
+            print(f"{e['date']:10}  {e['type']:12}  {e['summary']}{prov}")
+        return 0
+
+    return _with_conn_person(args, work)
+
+
+def _cmd_find(args: argparse.Namespace) -> int:
+    def work(conn):
+        hits = query.find(conn, args.person, args.query)
+        if args.json:
+            _print_json(hits)
+            return 0
+        if not hits:
+            print("no matches")
+            return 0
+        for h in hits:
+            prov = f"  (doc #{h['document_id']})" if h["document_id"] is not None else ""
+            print(f"{h['source_table']}#{h['source_id']}{prov}: {h['snippet']}")
+        return 0
+
+    return _with_conn_person(args, work)
+
+
+def _cmd_trends(args: argparse.Namespace) -> int:
+    def work(conn):
+        dictionary = dedup.load_dictionary(_resolve_dictionary_path(args))
+        result = query.trends(conn, args.person, args.test, dictionary=dictionary)
+        if args.json:
+            _print_json(result)
+            return 0
+        if result["count"] == 0:
+            print(f"no numeric results for '{result['test']}'")
+            return 0
+        unit = f" {result['unit']}" if result["unit"] else ""
+        print(f"{result['test']}  ({result['count']} point(s))")
+        print(f"  min    {_fmt(result['min'])}{unit}")
+        print(f"  max    {_fmt(result['max'])}{unit}")
+        print(f"  latest {_fmt(result['latest'])}{unit}  @ {_fmt(result['latest_at'])}")
+        if result["slope_per_day"] is None:
+            print("  slope  n/a (need >=2 dated points)")
+        else:
+            print(f"  slope  {result['slope_per_day']:+.4g}{unit}/day")
+        return 0
+
+    return _with_conn_person(args, work)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="pemr", description="Personal EMR engine — SQLite is truth."
@@ -339,6 +481,47 @@ def build_parser() -> argparse.ArgumentParser:
         "--all", action="store_true", help="list resolved conflicts too"
     )
     p_review.set_defaults(func=_cmd_review_conflicts)
+
+    # --- phase 3: query / find / trends -----------------------------------
+    p_query = sub.add_parser("query", help="structured reads over the record tables")
+    query_sub = p_query.add_subparsers(dest="query_command", required=True)
+
+    q_labs = query_sub.add_parser("labs", help="lab results for a person")
+    q_labs.add_argument("--person", required=True, help="owner slug")
+    q_labs.add_argument("--test", help="analyte name (dictionary-normalized)")
+    q_labs.add_argument("--since", help="ISO date; keep rows on/after this date")
+    q_labs.add_argument("--dictionary", help="synonym dictionary TOML (overrides default)")
+    q_labs.add_argument("--json", action="store_true", help="machine-readable output")
+    q_labs.set_defaults(func=_cmd_query_labs)
+
+    q_meds = query_sub.add_parser("meds", help="medications for a person")
+    q_meds.add_argument("--person", required=True, help="owner slug")
+    q_meds.add_argument("--active", action="store_true", help="current meds only")
+    q_meds.add_argument("--json", action="store_true", help="machine-readable output")
+    q_meds.set_defaults(func=_cmd_query_meds)
+
+    q_timeline = query_sub.add_parser(
+        "timeline", help="merged chronological event stream"
+    )
+    q_timeline.add_argument("--person", required=True, help="owner slug")
+    q_timeline.add_argument("--since", help="ISO date; keep events on/after this date")
+    q_timeline.add_argument("--json", action="store_true", help="machine-readable output")
+    q_timeline.set_defaults(func=_cmd_query_timeline)
+
+    p_find = sub.add_parser("find", help="full-text search over OCR text + record fields")
+    p_find.add_argument("--person", required=True, help="owner slug")
+    p_find.add_argument("query", help="search text")
+    p_find.add_argument("--json", action="store_true", help="machine-readable output")
+    p_find.set_defaults(func=_cmd_find)
+
+    p_trends = sub.add_parser(
+        "trends", help="min/max/latest/slope for one analyte over time"
+    )
+    p_trends.add_argument("--person", required=True, help="owner slug")
+    p_trends.add_argument("--test", required=True, help="analyte name (dictionary-normalized)")
+    p_trends.add_argument("--dictionary", help="synonym dictionary TOML (overrides default)")
+    p_trends.add_argument("--json", action="store_true", help="machine-readable output")
+    p_trends.set_defaults(func=_cmd_trends)
 
     return parser
 

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -153,30 +153,39 @@ def ingest_document(
     ext = src.suffix.lower()
     dest = blob_dest(sources_dir, sha, ext)
     dest.parent.mkdir(parents=True, exist_ok=True)
-    if not dest.exists():  # content-addressed => identical bytes, never overwrite
+    # content-addressed => identical bytes, never overwrite. Track whether *this*
+    # call created the blob so a failed `document` insert doesn't orphan it
+    # (carry-forward advisory from #4): clean up only what we wrote.
+    blob_created = not dest.exists()
+    if blob_created:
         shutil.copy2(src, dest)
 
     ocr_text = run_ocr(dest) if ocr else None
 
-    with conn:
-        cur = conn.execute(
-            """
-            INSERT INTO document
-              (sha256, person_id, doc_date, category, provider, source_path,
-               ocr_text, ingested_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                sha,
-                person_id,
-                doc_date,
-                category,
-                provider,
-                _relative_source_path(sha, ext),
-                ocr_text,
-                datetime.now(timezone.utc).isoformat(timespec="seconds"),
-            ),
-        )
+    try:
+        with conn:
+            cur = conn.execute(
+                """
+                INSERT INTO document
+                  (sha256, person_id, doc_date, category, provider, source_path,
+                   ocr_text, ingested_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    sha,
+                    person_id,
+                    doc_date,
+                    category,
+                    provider,
+                    _relative_source_path(sha, ext),
+                    ocr_text,
+                    datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                ),
+            )
+    except Exception:
+        if blob_created:
+            dest.unlink(missing_ok=True)
+        raise
     document = get_document_by_id(conn, cur.lastrowid)
     assert document is not None  # just inserted
     return IngestResult(status="new", document=document)

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -1,0 +1,273 @@
+"""Phase 3 read layer: structured queries, full-text `find`, and lab `trends`.
+
+All functions are pure reads over the tables phases 1–2 populate (Architecture.md §5).
+They return plain Python data (dicts / lists of dicts) with stable field names; the CLI
+owns human-readable vs ``--json`` formatting, and phase 5's MCP wrapper reuses the same
+shapes as its payload. Person is always addressed by slug and resolved to ``person_id``
+here — an unknown slug raises :class:`PersonNotFoundError` (a friendly rc=1 at the CLI).
+
+Analyte matching (``--test`` on labs/trends) runs through the same ``norm()`` +
+dictionary as dedup, so ``A1c`` finds rows stored as ``HbA1c``. Because the typed tables
+store the *original* spelling (only ``dedup_key`` is normalized), that match is done in
+Python over the candidate rows rather than in SQL.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from datetime import date
+
+from . import db
+from .dedup import norm
+
+# Word tokens for a safe FTS5 query: strips punctuation/operators so raw user input
+# can never be mis-parsed as FTS syntax (each token is quoted as a phrase, AND-ed).
+_WORD = re.compile(r"\w+", re.UNICODE)
+
+
+class PersonNotFoundError(ValueError):
+    """Raised when a slug does not resolve to a person (friendly rc=1 at the CLI)."""
+
+
+def resolve_person_id(conn: sqlite3.Connection, slug: str) -> int:
+    db.require_migrated(conn)
+    row = conn.execute(
+        "SELECT person_id FROM person WHERE slug = ?", (slug.strip().lower(),)
+    ).fetchone()
+    if row is None:
+        raise PersonNotFoundError(f"no person with slug '{slug}'")
+    return row["person_id"]
+
+
+def _date_part(value: object) -> str:
+    """Date portion of an ISO date/datetime string ('2026-01-02T09:00' -> '2026-01-02')."""
+    if value is None:
+        return ""
+    return str(value).strip().replace("T", " ").split(" ")[0]
+
+
+# --------------------------------------------------------------------------- #
+# Structured queries
+# --------------------------------------------------------------------------- #
+
+def query_labs(
+    conn: sqlite3.Connection,
+    slug: str,
+    test: str | None = None,
+    since: str | None = None,
+    dictionary: dict[str, str] | None = None,
+) -> list[dict]:
+    """Lab rows for a person, oldest first. ``test`` is dictionary-normalized and matched
+    against each row's normalized ``test_name``; ``since`` keeps rows on/after that date."""
+    person_id = resolve_person_id(conn, slug)
+    sql = "SELECT * FROM lab_result WHERE person_id = ?"
+    params: list[object] = [person_id]
+    if since:
+        sql += " AND date(collected_at) >= date(?)"
+        params.append(since)
+    sql += " ORDER BY collected_at, test_name"
+    rows = [dict(r) for r in conn.execute(sql, params).fetchall()]
+    if test:
+        target = norm(test, dictionary)
+        rows = [r for r in rows if norm(r["test_name"], dictionary) == target]
+    return rows
+
+
+def query_meds(
+    conn: sqlite3.Connection, slug: str, active: bool = False
+) -> list[dict]:
+    """Medications for a person. ``active`` keeps only current ones — no end date, or
+    an explicit ``status='active'`` (Architecture.md §5)."""
+    person_id = resolve_person_id(conn, slug)
+    sql = "SELECT * FROM medication WHERE person_id = ?"
+    params: list[object] = [person_id]
+    if active:
+        sql += " AND (ended_on IS NULL OR status = 'active')"
+    sql += " ORDER BY (started_on IS NULL), started_on, name"
+    return [dict(r) for r in conn.execute(sql, params).fetchall()]
+
+
+def query_timeline(
+    conn: sqlite3.Connection, slug: str, since: str | None = None
+) -> list[dict]:
+    """Merged chronological event stream across the typed tables + observations.
+
+    Each event carries ``date``, ``type``, a one-line ``summary`` and ``document_id``
+    provenance. Medications contribute up to two events (start and, if ended, stop).
+    Events without a usable date are omitted (they cannot be placed on a timeline).
+    ``since`` (a date) drops events strictly before it. Ordered oldest first.
+    """
+    person_id = resolve_person_id(conn, slug)
+    events: list[dict] = []
+
+    def add(when: object, etype: str, summary: str, document_id: object) -> None:
+        d = _date_part(when)
+        if not d:
+            return
+        events.append(
+            {"date": d, "type": etype, "summary": summary, "document_id": document_id}
+        )
+
+    for r in conn.execute(
+        "SELECT * FROM lab_result WHERE person_id = ?", (person_id,)
+    ).fetchall():
+        value = r["value_num"] if r["value_num"] is not None else r["value_text"]
+        unit = f" {r['unit']}" if r["unit"] else ""
+        flag = f" [{r['flag']}]" if r["flag"] else ""
+        val = "" if value is None else f" {value}{unit}"
+        add(r["collected_at"], "lab", f"{r['test_name']}{val}{flag}".strip(), r["document_id"])
+
+    for r in conn.execute(
+        "SELECT * FROM medication WHERE person_id = ?", (person_id,)
+    ).fetchall():
+        dose = f" {r['dose']}" if r["dose"] else ""
+        add(r["started_on"], "med-start", f"started {r['name']}{dose}", r["document_id"])
+        add(r["ended_on"], "med-stop", f"stopped {r['name']}", r["document_id"])
+
+    for r in conn.execute(
+        "SELECT * FROM procedure WHERE person_id = ?", (person_id,)
+    ).fetchall():
+        outcome = f" — {r['outcome']}" if r["outcome"] else ""
+        add(r["performed_on"], "procedure", f"{r['name']}{outcome}", r["document_id"])
+
+    for r in conn.execute(
+        "SELECT * FROM appointment WHERE person_id = ?", (person_id,)
+    ).fetchall():
+        who = " ".join(p for p in (r["provider"], r["specialty"]) if p)
+        why = r["reason"] or r["summary"] or ""
+        summary = " — ".join(p for p in (who, why) if p) or "appointment"
+        add(r["scheduled_for"], "appointment", summary, r["document_id"])
+
+    for r in conn.execute(
+        "SELECT * FROM observation WHERE person_id = ?", (person_id,)
+    ).fetchall():
+        value = r["value_num"] if r["value_num"] is not None else r["value_text"]
+        unit = f" {r['unit']}" if r["unit"] else ""
+        parts = [r["obs_type"]]
+        if r["key"]:
+            parts.append(str(r["key"]))
+        detail = " ".join(parts)
+        val = "" if value is None else f" = {value}{unit}"
+        add(r["observed_at"], "observation", f"{detail}{val}".strip(), r["document_id"])
+
+    if since:
+        cutoff = _date_part(since)
+        events = [e for e in events if e["date"] >= cutoff]
+    events.sort(key=lambda e: (e["date"], e["type"]))
+    return events
+
+
+# --------------------------------------------------------------------------- #
+# Full-text search
+# --------------------------------------------------------------------------- #
+
+def _fts_query(raw: str) -> str | None:
+    """Build a safe FTS5 MATCH expression from free user text.
+
+    Each word token is quoted as a phrase and the tokens are AND-ed (implicit), so
+    punctuation or FTS operators in the input can't blow up or change the query's
+    meaning. Returns ``None`` when the input has no searchable tokens.
+    """
+    tokens = _WORD.findall(raw or "")
+    if not tokens:
+        return None
+    return " ".join(f'"{t}"' for t in tokens)
+
+
+def find(conn: sqlite3.Connection, slug: str, query: str) -> list[dict]:
+    """Full-text search across OCR text + record text fields for one person.
+
+    Returns hits ranked best-first, each with its source (table + id), a highlighted
+    ``snippet`` and ``document_id`` provenance.
+    """
+    person_id = resolve_person_id(conn, slug)
+    match = _fts_query(query)
+    if match is None:
+        return []
+    rows = conn.execute(
+        "SELECT source_table, source_id, document_id, "
+        "snippet(record_fts, 4, '[', ']', '...', 12) AS snippet, rank "
+        "FROM record_fts WHERE record_fts MATCH ? AND person_id = ? "
+        "ORDER BY rank",
+        (match, person_id),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+# --------------------------------------------------------------------------- #
+# Trends
+# --------------------------------------------------------------------------- #
+
+def _ordinal(value: object) -> int | None:
+    try:
+        return date.fromisoformat(_date_part(value)).toordinal()
+    except (ValueError, TypeError):
+        return None
+
+
+def _slope_per_day(points: list[tuple[int, float]]) -> float | None:
+    """Least-squares slope (value units per day) of y vs x=ordinal-day. ``None`` when
+    fewer than two points or all points share one date (zero x-variance)."""
+    n = len(points)
+    if n < 2:
+        return None
+    mx = sum(x for x, _ in points) / n
+    my = sum(y for _, y in points) / n
+    denom = sum((x - mx) ** 2 for x, _ in points)
+    if denom == 0:
+        return None
+    num = sum((x - mx) * (y - my) for x, y in points)
+    return num / denom
+
+
+def trends(
+    conn: sqlite3.Connection,
+    slug: str,
+    test: str,
+    dictionary: dict[str, str] | None = None,
+) -> dict:
+    """Summary stats for one dictionary-normalized analyte over time.
+
+    Returns ``{test, count, unit, min, max, latest, latest_at, slope_per_day}``.
+    ``count`` is the number of numeric points; ``slope_per_day`` degrades to ``None``
+    with fewer than two numeric points (or a single collection date).
+    """
+    person_id = resolve_person_id(conn, slug)
+    target = norm(test, dictionary)
+    rows = conn.execute(
+        "SELECT value_num, unit, collected_at, test_name FROM lab_result "
+        "WHERE person_id = ? AND value_num IS NOT NULL ORDER BY collected_at",
+        (person_id,),
+    ).fetchall()
+    matched = [r for r in rows if norm(r["test_name"], dictionary) == target]
+
+    result: dict = {
+        "test": target,
+        "count": len(matched),
+        "unit": None,
+        "min": None,
+        "max": None,
+        "latest": None,
+        "latest_at": None,
+        "slope_per_day": None,
+    }
+    if not matched:
+        return result
+
+    values = [float(r["value_num"]) for r in matched]
+    units = {r["unit"] for r in matched if r["unit"]}
+    result["unit"] = next(iter(units)) if len(units) == 1 else None
+    result["min"] = min(values)
+    result["max"] = max(values)
+    latest = matched[-1]  # rows came back ORDER BY collected_at
+    result["latest"] = float(latest["value_num"])
+    result["latest_at"] = latest["collected_at"]
+
+    points = [
+        (o, float(r["value_num"]))
+        for r in matched
+        if (o := _ordinal(r["collected_at"])) is not None
+    ]
+    result["slope_per_day"] = _slope_per_day(points)
+    return result

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -128,7 +128,7 @@ def query_timeline(
     for r in conn.execute(
         "SELECT * FROM procedure WHERE person_id = ?", (person_id,)
     ).fetchall():
-        outcome = f" — {r['outcome']}" if r["outcome"] else ""
+        outcome = f" - {r['outcome']}" if r["outcome"] else ""
         add(r["performed_on"], "procedure", f"{r['name']}{outcome}", r["document_id"])
 
     for r in conn.execute(
@@ -136,7 +136,7 @@ def query_timeline(
     ).fetchall():
         who = " ".join(p for p in (r["provider"], r["specialty"]) if p)
         why = r["reason"] or r["summary"] or ""
-        summary = " — ".join(p for p in (who, why) if p) or "appointment"
+        summary = " - ".join(p for p in (who, why) if p) or "appointment"
         add(r["scheduled_for"], "appointment", summary, r["document_id"])
 
     for r in conn.execute(

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -1,0 +1,112 @@
+"""End-to-end CLI wiring for phase 3: query labs|meds|timeline, find, trends —
+human + --json output, empty-result rc=0 messages, unknown-slug rc=1."""
+
+import json
+
+import pytest
+
+from pemr import cli, db, dedup, persons
+
+DICT_ARG = ["--dictionary", str(
+    __import__("pathlib").Path(__file__).resolve().parent.parent
+    / "data" / "dictionary.example.toml"
+)]
+
+
+def _run(tmp_path, *argv):
+    return cli.main(["--db", str(tmp_path / "cli.db"), *argv])
+
+
+def _doc(conn, slug, ocr=None, doc_date="2026-01-01"):
+    pid = conn.execute(
+        "SELECT person_id FROM person WHERE slug=?", (slug,)
+    ).fetchone()["person_id"]
+    cur = conn.execute(
+        "INSERT INTO document (sha256, person_id, doc_date, source_path, ocr_text, "
+        "ingested_at) VALUES (?, ?, ?, ?, ?, ?)",
+        (f"sha-{conn.total_changes}", pid, doc_date, "aa/x.pdf", ocr, "2026-01-01T00:00:00"),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+@pytest.fixture()
+def ready(tmp_path):
+    """Migrated DB + jane with a few labs, a med, and an OCR'd document."""
+    assert _run(tmp_path, "migrate") == 0
+    assert _run(tmp_path, "person", "add", "--slug", "jane-doe", "--name", "Jane Doe") == 0
+    conn = db.connect(tmp_path / "cli.db")
+    d = dedup.load_dictionary(DICT_ARG[1])
+    doc = _doc(conn, "jane-doe", ocr="total cholesterol elevated")
+    dedup.commit_extraction(conn, doc, {
+        "lab_result": [
+            {"test_name": "HbA1c", "collected_at": "2024-01-01", "value_num": 5.5, "unit": "%"},
+            {"test_name": "A1c", "collected_at": "2026-01-01", "value_num": 6.5, "unit": "%"},
+        ],
+        "medication": [{"name": "Metformin", "dose": "500mg", "started_on": "2024-02-01"}],
+    }, d)
+    conn.close()
+    return tmp_path
+
+
+def test_query_labs_human_and_json(ready, capsys):
+    assert _run(ready, "query", "labs", "--person", "jane-doe") == 0
+    assert "HbA1c" in capsys.readouterr().out
+
+    assert _run(ready, "query", "labs", "--person", "jane-doe", "--test", "a1c",
+                *DICT_ARG, "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload) == 2
+    assert "dedup_key" not in payload[0]  # internal field hidden from the contract
+    assert {"test_name", "value_num", "collected_at"} <= set(payload[0])
+
+
+def test_query_meds_active_json(ready, capsys):
+    assert _run(ready, "query", "meds", "--person", "jane-doe", "--active", "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [m["name"] for m in payload] == ["Metformin"]
+
+
+def test_query_timeline_json(ready, capsys):
+    assert _run(ready, "query", "timeline", "--person", "jane-doe", "--json") == 0
+    events = json.loads(capsys.readouterr().out)
+    assert [e["date"] for e in events] == sorted(e["date"] for e in events)
+    assert {"date", "type", "summary", "document_id"} <= set(events[0])
+
+
+def test_find_human_and_json(ready, capsys):
+    assert _run(ready, "find", "--person", "jane-doe", "cholesterol") == 0
+    assert "cholesterol" in capsys.readouterr().out.lower()
+
+    assert _run(ready, "find", "--person", "jane-doe", "cholesterol", "--json") == 0
+    hits = json.loads(capsys.readouterr().out)
+    assert hits and {"source_table", "source_id", "snippet", "document_id"} <= set(hits[0])
+
+
+def test_trends_json_shape(ready, capsys):
+    assert _run(ready, "trends", "--person", "jane-doe", "--test", "hba1c",
+                *DICT_ARG, "--json") == 0
+    t = json.loads(capsys.readouterr().out)
+    assert t["count"] == 2
+    assert {"test", "min", "max", "latest", "slope_per_day", "unit"} <= set(t)
+
+
+def test_empty_results_are_clean_rc0(ready, capsys):
+    assert _run(ready, "query", "labs", "--person", "jane-doe", "--test", "tsh",
+                *DICT_ARG) == 0
+    assert "no lab results" in capsys.readouterr().out
+    assert _run(ready, "find", "--person", "jane-doe", "zzznotfound") == 0
+    assert "no matches" in capsys.readouterr().out
+
+
+def test_unknown_person_is_friendly_rc1(ready, capsys):
+    assert _run(ready, "query", "labs", "--person", "ghost") == 1
+    assert "ghost" in capsys.readouterr().err
+    assert _run(ready, "trends", "--person", "ghost", "--test", "hba1c") == 1
+    assert "ghost" in capsys.readouterr().err
+
+
+def test_query_on_unmigrated_db_is_friendly(tmp_path, capsys):
+    rc = _run(tmp_path, "query", "labs", "--person", "jane-doe")
+    assert rc == 1
+    assert "migrate" in capsys.readouterr().err

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -33,7 +33,7 @@ def test_connect_applies_pragmas(conn):
 
 def test_migrate_creates_all_tables(conn):
     applied = db.migrate(conn)
-    assert applied == ["001_init.sql", "002_conflict.sql"]
+    assert applied == ["001_init.sql", "002_conflict.sql", "003_fts.sql"]
     tables = {
         row["name"]
         for row in conn.execute(
@@ -44,13 +44,15 @@ def test_migrate_creates_all_tables(conn):
 
 
 def test_migrate_is_idempotent(conn):
-    assert db.migrate(conn) == ["001_init.sql", "002_conflict.sql"]
+    assert db.migrate(conn) == ["001_init.sql", "002_conflict.sql", "003_fts.sql"]
     assert db.migrate(conn) == []  # second run: nothing pending
 
 
 def test_migrate_records_versions(conn):
     db.migrate(conn)
-    assert db.applied_versions(conn) == {"001_init.sql", "002_conflict.sql"}
+    assert db.applied_versions(conn) == {
+        "001_init.sql", "002_conflict.sql", "003_fts.sql"
+    }
 
 
 def test_multi_statement_migration_rolls_back_partial_ddl(conn, tmp_path):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,5 +1,7 @@
 """Document ingest: hashing, content-addressed blob store, layer-1 dedup."""
 
+import sqlite3
+
 import pytest
 
 from pemr import db, ingest, persons
@@ -83,6 +85,23 @@ def test_ingest_on_unmigrated_db_raises(tmp_path, sources):
             ingest.ingest_document(fresh, _make_file(tmp_path), "jane-doe", sources)
     finally:
         fresh.close()
+
+
+def test_failed_insert_does_not_orphan_blob(conn, tmp_path, sources):
+    # carry-forward advisory from #4: if the `document` INSERT fails, the blob this
+    # call copied into sources/ must be cleaned up, not left orphaned. A BEFORE INSERT
+    # trigger forces the insert to abort *after* the blob has been staged.
+    src = _make_file(tmp_path, "scan.txt", b"orphan check bytes")
+    sha = ingest.hash_file(src)
+    conn.execute(
+        "CREATE TRIGGER boom BEFORE INSERT ON document "
+        "BEGIN SELECT RAISE(ABORT, 'insert exploded'); END"
+    )
+    conn.commit()
+
+    with pytest.raises(sqlite3.Error, match="insert exploded"):
+        ingest.ingest_document(conn, src, "jane-doe", sources)
+    assert not (sources / sha[:2] / f"{sha}.txt").exists()  # blob cleaned up
 
 
 def test_ocr_degrades_when_tesseract_absent(conn, tmp_path, sources, monkeypatch, capsys):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -130,6 +130,20 @@ def test_timeline_carries_provenance(seeded):
     assert any(e["document_id"] is not None for e in events)
 
 
+def test_timeline_summaries_are_ascii_safe(seeded):
+    """§4 cp1252/cp437 console lesson: human-table summaries must be ASCII-only, or
+    they crash on a non-UTF-8 Windows console (regression for the em-dash bounce —
+    procedure ' - outcome' and 'provider - reason' joins used a U+2014 em-dash)."""
+    events = query.query_timeline(seeded, "jane-doe")
+    proc = next(e for e in events if e["type"] == "procedure")
+    appt = next(e for e in events if e["type"] == "appointment")
+    assert " - normal" in proc["summary"]          # ascii hyphen, not em-dash
+    assert "Dr. Smith Endocrinology - diabetes follow-up" == appt["summary"]
+    for e in events:
+        assert e["summary"].isascii(), f"non-ASCII summary would crash cp437: {e['summary']!r}"
+        e["summary"].encode("cp437")  # raises UnicodeEncodeError if not console-safe
+
+
 # --- full-text search ---------------------------------------------------------
 
 def test_find_matches_ocr_and_records(seeded):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,240 @@
+"""Phase 3 query layer: structured queries, timeline merge, FTS find + trigger sync,
+FTS backfill on migrate, trends math, dictionary normalization, and person isolation."""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from pemr import db, dedup, persons, query
+
+DICT_PATH = Path(__file__).resolve().parent.parent / "data" / "dictionary.example.toml"
+
+
+def _doc(conn, slug, ocr=None, doc_date="2026-01-01"):
+    pid = conn.execute(
+        "SELECT person_id FROM person WHERE slug=?", (slug,)
+    ).fetchone()["person_id"]
+    cur = conn.execute(
+        "INSERT INTO document (sha256, person_id, doc_date, source_path, ocr_text, "
+        "ingested_at) VALUES (?, ?, ?, ?, ?, ?)",
+        (f"sha-{slug}-{conn.total_changes}", pid, doc_date, "aa/x.pdf", ocr,
+         "2026-01-01T00:00:00"),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+@pytest.fixture()
+def seeded(tmp_path):
+    """Migrated DB with two people and a spread of records for jane, plus one
+    same-analyte lab for john to prove person isolation."""
+    conn = db.connect(tmp_path / "q.db")
+    db.migrate(conn)
+    persons.add_person(conn, "jane-doe", "Jane Doe")
+    persons.add_person(conn, "john-doe", "John Doe")
+    d = dedup.load_dictionary(DICT_PATH)
+
+    doc1 = _doc(conn, "jane-doe", ocr="Fasting glucose and total cholesterol panel")
+    dedup.commit_extraction(conn, doc1, {
+        "lab_result": [
+            {"test_name": "HbA1c", "collected_at": "2024-01-01", "value_num": 5.5, "unit": "%"},
+            {"test_name": "Hemoglobin A1c", "collected_at": "2025-01-01", "value_num": 6.0, "unit": "%"},
+            {"test_name": "A1c", "collected_at": "2026-01-01", "value_num": 6.5, "unit": "%"},
+            {"test_name": "LDL", "collected_at": "2025-01-01", "value_num": 130, "unit": "mg/dL", "flag": "H"},
+        ],
+        "medication": [
+            {"name": "Metformin", "dose": "500mg", "started_on": "2024-02-01"},
+            {"name": "Lisinopril", "dose": "10mg", "started_on": "2023-01-01",
+             "ended_on": "2024-06-01", "status": "discontinued"},
+        ],
+        "procedure": [
+            {"name": "Colonoscopy", "performed_on": "2025-03-15", "outcome": "normal"},
+        ],
+        "appointment": [
+            {"scheduled_for": "2026-02-01", "provider": "Dr. Smith",
+             "specialty": "Endocrinology", "reason": "diabetes follow-up"},
+        ],
+        "observation": [
+            {"obs_type": "blood_pressure", "observed_at": "2025-07-01",
+             "key": "systolic", "value_num": 128, "unit": "mmHg"},
+        ],
+    }, d)
+
+    doc2 = _doc(conn, "john-doe", ocr="unrelated note")
+    dedup.commit_extraction(conn, doc2, {
+        "lab_result": [
+            {"test_name": "HbA1c", "collected_at": "2026-01-01", "value_num": 9.0, "unit": "%"},
+        ],
+    }, d)
+    yield conn
+    conn.close()
+
+
+# --- structured: labs ---------------------------------------------------------
+
+def test_query_labs_all(seeded):
+    rows = query.query_labs(seeded, "jane-doe")
+    assert len(rows) == 4
+    # oldest first
+    assert [r["collected_at"] for r in rows] == sorted(r["collected_at"] for r in rows)
+
+
+def test_query_labs_test_filter_is_dictionary_normalized(seeded):
+    d = dedup.load_dictionary(DICT_PATH)
+    rows = query.query_labs(seeded, "jane-doe", test="A1c", dictionary=d)
+    # three hba1c spellings collapse under the dictionary; LDL excluded
+    assert len(rows) == 3
+    assert {r["test_name"] for r in rows} == {"HbA1c", "Hemoglobin A1c", "A1c"}
+
+
+def test_query_labs_since_edge_is_inclusive(seeded):
+    rows = query.query_labs(seeded, "jane-doe", since="2025-01-01")
+    assert all(r["collected_at"] >= "2025-01-01" for r in rows)
+    assert any(r["collected_at"] == "2025-01-01" for r in rows)  # boundary kept
+    assert not any(r["collected_at"] == "2024-01-01" for r in rows)
+
+
+def test_query_labs_isolated_per_person(seeded):
+    assert all(r["value_num"] != 9.0 for r in query.query_labs(seeded, "jane-doe"))
+    john = query.query_labs(seeded, "john-doe")
+    assert len(john) == 1 and john[0]["value_num"] == 9.0
+
+
+# --- structured: meds ---------------------------------------------------------
+
+def test_query_meds_all_vs_active(seeded):
+    assert len(query.query_meds(seeded, "jane-doe")) == 2
+    active = query.query_meds(seeded, "jane-doe", active=True)
+    assert [m["name"] for m in active] == ["Metformin"]  # Lisinopril is ended
+
+
+# --- structured: timeline -----------------------------------------------------
+
+def test_timeline_merge_ordering_and_since(seeded):
+    events = query.query_timeline(seeded, "jane-doe")
+    dates = [e["date"] for e in events]
+    assert dates == sorted(dates)
+    types = {e["type"] for e in events}
+    assert {"lab", "med-start", "med-stop", "procedure", "appointment", "observation"} <= types
+    # med start + stop both present for the ended med
+    assert sum(1 for e in events if e["type"] == "med-stop") == 1
+    since = query.query_timeline(seeded, "jane-doe", since="2026-01-01")
+    assert all(e["date"] >= "2026-01-01" for e in since)
+    assert len(since) < len(events)
+
+
+def test_timeline_carries_provenance(seeded):
+    events = query.query_timeline(seeded, "jane-doe")
+    assert all("document_id" in e for e in events)
+    assert any(e["document_id"] is not None for e in events)
+
+
+# --- full-text search ---------------------------------------------------------
+
+def test_find_matches_ocr_and_records(seeded):
+    hits = query.find(seeded, "jane-doe", "cholesterol")
+    tables = {h["source_table"] for h in hits}
+    assert "document" in tables  # ocr_text hit
+    assert all("snippet" in h and "document_id" in h for h in hits)
+
+
+def test_find_matches_record_field(seeded):
+    hits = query.find(seeded, "jane-doe", "metformin")
+    assert any(h["source_table"] == "medication" for h in hits)
+
+
+def test_find_is_person_scoped(seeded):
+    # john's HbA1c/ocr must never surface under jane
+    assert query.find(seeded, "jane-doe", "unrelated") == []
+    assert query.find(seeded, "john-doe", "unrelated")
+
+
+def test_find_ignores_fts_operators_safely(seeded):
+    # punctuation / bare operators must not raise or change meaning
+    assert isinstance(query.find(seeded, "jane-doe", 'cholesterol AND ("'), list)
+    assert query.find(seeded, "jane-doe", "!!!") == []
+
+
+def test_find_trigger_syncs_on_insert(seeded):
+    # a brand-new record (committed after migrate) is searchable via the trigger
+    hits = query.find(seeded, "jane-doe", "colonoscopy")
+    assert any(h["source_table"] == "procedure" for h in hits)
+
+
+def test_find_trigger_syncs_on_update(seeded):
+    assert query.find(seeded, "jane-doe", "cholesterol")
+    doc_id = seeded.execute(
+        "SELECT document_id FROM document WHERE ocr_text LIKE '%cholesterol%'"
+    ).fetchone()["document_id"]
+    with seeded:
+        seeded.execute(
+            "UPDATE document SET ocr_text='thyroid panel' WHERE document_id=?", (doc_id,)
+        )
+    assert not any(
+        h["source_table"] == "document" for h in query.find(seeded, "jane-doe", "cholesterol")
+    )
+    assert any(
+        h["source_table"] == "document" for h in query.find(seeded, "jane-doe", "thyroid")
+    )
+
+
+def test_fts_backfill_on_migrate(tmp_path):
+    """A DB migrated before 003 gets its existing rows indexed by 003's backfill —
+    no re-ingest required."""
+    mdir = tmp_path / "migrations"
+    mdir.mkdir()
+    real = db.DEFAULT_MIGRATIONS_DIR
+    for name in ("001_init.sql", "002_conflict.sql"):
+        shutil.copy(real / name, mdir / name)
+    conn = db.connect(tmp_path / "b.db")
+    db.migrate(conn, mdir)
+    persons.add_person(conn, "jane-doe", "Jane Doe")
+    _doc(conn, "jane-doe", ocr="pre-existing cholesterol note")  # inserted pre-003
+
+    shutil.copy(real / "003_fts.sql", mdir / "003_fts.sql")
+    assert db.migrate(conn, mdir) == ["003_fts.sql"]
+    hits = query.find(conn, "jane-doe", "cholesterol")
+    assert any(h["source_table"] == "document" for h in hits)
+    conn.close()
+
+
+# --- trends -------------------------------------------------------------------
+
+def test_trends_math_and_slope(seeded):
+    d = dedup.load_dictionary(DICT_PATH)
+    t = query.trends(seeded, "jane-doe", "hba1c", dictionary=d)
+    assert t["count"] == 3
+    assert t["min"] == 5.5 and t["max"] == 6.5
+    assert t["latest"] == 6.5 and t["latest_at"] == "2026-01-01"
+    assert t["unit"] == "%"
+    assert t["slope_per_day"] is not None and t["slope_per_day"] > 0  # rising
+
+
+def test_trends_dictionary_normalization(seeded):
+    d = dedup.load_dictionary(DICT_PATH)
+    # querying with a synonym still finds the canonical analyte's points
+    assert query.trends(seeded, "jane-doe", "Hemoglobin A1c", dictionary=d)["count"] == 3
+
+
+def test_trends_single_point_degrades_slope(seeded):
+    d = dedup.load_dictionary(DICT_PATH)
+    t = query.trends(seeded, "jane-doe", "ldl", dictionary=d)
+    assert t["count"] == 1
+    assert t["slope_per_day"] is None  # <2 points -> graceful degrade
+
+
+def test_trends_unknown_analyte_is_empty(seeded):
+    t = query.trends(seeded, "jane-doe", "nonesuch")
+    assert t["count"] == 0 and t["slope_per_day"] is None
+
+
+# --- error surfaces -----------------------------------------------------------
+
+def test_unknown_person_raises(seeded):
+    with pytest.raises(query.PersonNotFoundError):
+        query.query_labs(seeded, "nobody")
+    with pytest.raises(query.PersonNotFoundError):
+        query.trends(seeded, "nobody", "hba1c")
+    with pytest.raises(query.PersonNotFoundError):
+        query.find(seeded, "nobody", "cholesterol")


### PR DESCRIPTION
## Summary

Phase 3 query layer: structured reads, full-text search, and trends over the phase 1/2 tables,
per Architecture.md §5/§9.

- `pemr query labs --person <slug> [--test <name>] [--since <date>]`
- `pemr query meds --person <slug> [--active]`
- `pemr query timeline --person <slug> [--since <date>]` — merged chronological stream across
  lab_result, medication, procedure, appointment, observation
- `pemr find --person <slug> "<query>"` — FTS5 (`migrations/003_fts.sql`) over OCR text + record
  fields, with sync triggers so ingest/commit paths need no code changes, and a migration-time
  backfill for pre-003 DBs
- `pemr trends --person <slug> --test <test>` — min/max/latest/count/slope, graceful single-point
  degrade
- `--json` on every command (stable field names for the phase-5 MCP payload), ASCII-safe output
  (fixes the cp1252/cp437 console defect a verify bounce caught — U+2014 -> `-` in
  `query.py build_timeline()`)
- Carry-forward from #4: ingest blob-orphan cleanup on failed `document` INSERT
- Design decision resolved: plain SQLite FTS5, no vector sidecar (Architecture.md §Open questions)

## Pipeline trail

- build -> verify: BOUNCE (ASCII-safe output defect, §4) -> build fix -> verify: CONFIRMED ->
  audit: CONFIRMED, no blocking findings (trust-boundary per-person isolation, SQL/FTS injection,
  `--json` field exposure all reviewed clean; two non-blocking advisories noted, out of scope)
- 84/84 tests green on `feat/6`; `git diff --name-only HEAD...origin/dev` empty (no path overlap
  with `dev` since branch cut) — no merge needed, already up to date

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
