### PR TITLE
fix(dedup): vitals dictionary gap + keep-incoming identity overwrite

### DIFF
--- a/data/dictionary.example.toml
+++ b/data/dictionary.example.toml
@@ -66,3 +66,28 @@
 "25-hydroxyvitamin d" = "vitamin_d_25oh"
 "vitamin b12" = "vitamin_b12"
 "b12" = "vitamin_b12"
+
+# --- Vitals (observation keys) ---
+# Canonical observation-key vocabulary — extraction agents should emit these
+# tokens as `observation.key`: blood_pressure, bmi, weight, height,
+# temperature, pulse, spo2, respiratory_rate. Underscores in input are
+# treated as spaces by norm(), so "blood_pressure" matches "blood pressure".
+"blood pressure" = "blood_pressure"
+"bp" = "blood_pressure"
+"bmi" = "bmi"
+"body mass index" = "bmi"
+"weight" = "weight"
+"body weight" = "weight"
+"height" = "height"
+"body height" = "height"
+"temperature" = "temperature"
+"temp" = "temperature"
+"body temperature" = "temperature"
+"pulse" = "pulse"
+"pulse rate" = "pulse"
+"heart rate" = "pulse"
+"spo2" = "spo2"
+"o2 sat" = "spo2"
+"oxygen saturation" = "spo2"
+"respiratory rate" = "respiratory_rate"
+"resp rate" = "respiratory_rate"

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -111,12 +111,15 @@ def load_dictionary(path: str | Path | None) -> dict[str, str]:
 
 
 def _collapse(value: str) -> str:
-    return _WS.sub(" ", value.strip().lower())
+    # Underscores count as separators: machine-generated keys like
+    # "blood_pressure" must collapse to the same token as "Blood Pressure".
+    return _WS.sub(" ", value.strip().lower().replace("_", " "))
 
 
 def norm(value: object, dictionary: dict[str, str] | None = None) -> str:
-    """Normalize a free-text field: lowercase, trim, collapse whitespace, then map
-    synonyms through the dictionary. ``None`` -> ``""`` (deterministic key part)."""
+    """Normalize a free-text field: lowercase, trim, collapse whitespace (underscores
+    count as whitespace), then map synonyms through the dictionary. ``None`` -> ``""``
+    (deterministic key part)."""
     if value is None:
         return ""
     collapsed = _collapse(str(value))
@@ -408,10 +411,12 @@ def resolve_conflict(
     note: str | None = None,
 ) -> None:
     """Resolve a staged conflict. ``keep`` is 'existing' (drop the incoming row) or
-    'incoming' (overwrite the stored record's non-key fields with the incoming row).
+    'incoming' (overwrite the stored record's payload fields with the incoming row).
 
-    Key fields are identical by construction (a differing key would not have
-    collided), so overwriting only touches non-key columns; the dedup_key stays put.
+    Overwriting touches only the payload columns (``_COMPARE_FIELDS``) whose
+    disagreement defined the conflict, plus provenance ``document_id``. Identity
+    fields keep their stored display form (they are equal after norm() by
+    construction, but may differ in casing/spacing); the dedup_key stays put.
     """
     db.require_migrated(conn)
     if keep not in ("existing", "incoming"):
@@ -451,7 +456,7 @@ def _overwrite_record(
 ) -> None:
     assignments = ["document_id = ?"]
     values: list[object] = [document_id]
-    for name in FIELD_SPECS[record_type]:
+    for name in _COMPARE_FIELDS[record_type]:
         assignments.append(f"{name} = ?")
         values.append(incoming.get(name))
     values.append(key)

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -62,6 +62,25 @@ def test_resolve_keep_incoming_overwrites_row(conn, staged):
     assert "keep-incoming" in row["resolution"] and "correction" in row["resolution"]
 
 
+def test_resolve_keep_incoming_preserves_identity_fields(conn):
+    # Same fact, but the second scan's OCR differs in identity-field casing AND
+    # a payload value. keep-incoming must update the payload + provenance while
+    # leaving the stored identity display form ("hba1c") alone.
+    doc_a = _doc(conn, "doc-c")
+    doc_b = _doc(conn, "doc-d")
+    dedup.commit_extraction(conn, doc_a, {"lab_result": [
+        {"test_name": "hba1c", "collected_at": "2026-01-02", "value_num": 5.7}]})
+    summary = dedup.commit_extraction(conn, doc_b, {"lab_result": [
+        {"test_name": "HBA1C", "collected_at": "2026-01-02", "value_num": 6.2}]})
+    assert summary.counts["conflict"] == 1
+    conflict_id = dedup.list_conflicts(conn)[-1]["conflict_id"]
+    dedup.resolve_conflict(conn, conflict_id, keep="incoming")
+    row = conn.execute("SELECT * FROM lab_result").fetchone()
+    assert row["test_name"] == "hba1c"      # identity display form preserved
+    assert row["value_num"] == 6.2          # payload overwritten
+    assert row["document_id"] == doc_b      # provenance points at the winner
+
+
 def test_resolve_unknown_id_raises(conn):
     with pytest.raises(ValueError, match="no conflict"):
         dedup.resolve_conflict(conn, 999, keep="existing")

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -53,6 +53,21 @@ def test_load_missing_dictionary_is_empty(tmp_path):
     assert dedup.load_dictionary(None) == {}
 
 
+def test_norm_treats_underscores_as_spaces():
+    assert dedup.norm("blood_pressure") == "blood pressure"
+    d = dedup.load_dictionary(DICT_PATH)
+    assert dedup.norm("blood_pressure", d) == dedup.norm("Blood Pressure", d) \
+        == "blood_pressure"
+
+
+def test_vitals_synonyms_map_to_canonical():
+    d = dedup.load_dictionary(DICT_PATH)
+    for spelling in ("Pulse", "pulse rate", "Heart Rate"):
+        assert dedup.norm(spelling, d) == "pulse"
+    for spelling in ("BP", "Blood Pressure", "blood_pressure"):
+        assert dedup.norm(spelling, d) == "blood_pressure"
+
+
 # --- dedup_key determinism ----------------------------------------------------
 
 def test_dedup_key_is_stable_across_formatting():
@@ -69,6 +84,16 @@ def test_dedup_key_is_stable_across_formatting():
 def test_dedup_key_differs_by_person():
     row = {"test_name": "hba1c", "collected_at": "2026-01-02", "value_num": 5.7}
     assert dedup.dedup_key("lab_result", row, 1) != dedup.dedup_key("lab_result", row, 2)
+
+
+def test_observation_key_variants_share_dedup_key():
+    # Two scans of the same vital: one extraction pass says "blood_pressure",
+    # the other "Blood Pressure" — must collapse even without a dictionary.
+    row_a = {"obs_type": "vital", "key": "blood_pressure", "value_text": "155/90",
+             "observed_at": "2024-06-20"}
+    row_b = {"obs_type": "vital", "key": "Blood Pressure", "value_text": "155/90",
+             "observed_at": "2024-06-20"}
+    assert dedup.dedup_key("observation", row_a, 1) == dedup.dedup_key("observation", row_b, 1)
 
 
 def test_dedup_key_differs_by_date():


### PR DESCRIPTION
Fixes two layer-2 dedup defects surfaced by real-scan testing (two independent scans of the same 2024-06-20 after-visit summary, sandbox DB).

## 1. Observation-key naming variance escaped semantic dedup

One extraction pass emitted obs key `blood_pressure`, the other `Blood Pressure`. `norm()` didn't treat `_` as a separator and the starter dictionary had no vitals entries, so the same BP reading landed as two `observation` rows (both visible in `query timeline`).

- `dedup._collapse()` now maps underscores to spaces before whitespace collapse — the two forms collapse even with no dictionary
- Starter dictionary gains a `Vitals (observation keys)` section (blood_pressure, bmi, weight, height, temperature, pulse, spo2, respiratory_rate + synonyms) and documents the canonical vocabulary extraction agents should emit

**Key-stability note:** this changes dedup keys for values containing `_`. No live DB exists yet; if one existed, a re-key migration would be required.

## 2. `keep-incoming` overwrote identity display fields

`_overwrite_record()` wrote all `FIELD_SPECS` columns, so resolving a medication `frequency` conflict also rewrote `name` (`piroxicam` → `Piroxicam`) and `dose` — contradicting the `resolve_conflict` docstring. It now writes only the `_COMPARE_FIELDS` payload columns plus provenance `document_id`; docstring aligned.

## Verification

- 88/88 tests (4 new: underscore norm, vitals synonyms, obs-key dedup_key equality, keep-incoming identity preservation)
- End-to-end replay of the two real scans: second-scan commit went from `1 new / 13 dup / 1 conflict` (bug) to `0 new / 14 dup / 1 conflict` (correct); keep-incoming now preserves `piroxicam / 20 mg capsule` while updating the sig text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
