### PR TITLE
feat(dedup): real-data hardening — corpus dictionary, qualifier/unit normalization (#11)

### DIFF
--- a/data/dictionary.example.toml
+++ b/data/dictionary.example.toml
@@ -6,9 +6,12 @@
 # to a single canonical token so `A1c`, `HbA1c`, `Hemoglobin A1c` all collapse to
 # one dedup identity. Agents propose additions; a human approves them.
 #
-# Keys are matched AFTER norm() lowercases, trims and collapses whitespace, so write
-# keys in that already-normalized form (lowercase, single spaces). Seeded from common
-# lab-panel headers; extend as real documents surface new spellings.
+# Keys are matched AFTER norm() lowercases, trims and collapses whitespace AND strips
+# parenthetical qualifiers, so write keys in that already-normalized form: lowercase,
+# single spaces, and NO parentheses — norm() removes `(HGB)`, `(SPEP)`, `(calculated)`
+# etc. before lookup, so `Hemoglobin (HGB)` matches the bare `hemoglobin` key. Seeded
+# from common lab-panel headers plus the real-corpus report vocabulary (CMP/CBC panel
+# codes, serum free light chains, SPEP); extend as new documents surface new spellings.
 
 [synonyms]
 # --- Glycemic ---
@@ -44,6 +47,7 @@
 # --- Renal / metabolic ---
 "creatinine" = "creatinine"
 "cr" = "creatinine"
+"crea" = "creatinine"
 "egfr" = "egfr"
 "estimated gfr" = "egfr"
 "bun" = "bun"
@@ -59,6 +63,17 @@
 "wbc" = "wbc"
 "platelet count" = "platelets"
 "platelets" = "platelets"
+"plt" = "platelets"
+
+# --- Basic metabolic panel (CMP abbreviations) ---
+# Report codes for non-fasting serum chemistries. (Fasting glucose is its own token
+# under Glycemic — a bare `Glucose`/`GLUC` reading is not a fasting result.)
+"glucose" = "glucose"
+"gluc" = "glucose"
+"sodium" = "sodium"
+"na" = "sodium"
+"potassium" = "potassium"
+"k" = "potassium"
 
 # --- Vitamins ---
 "vitamin d" = "vitamin_d_25oh"
@@ -66,6 +81,24 @@
 "25-hydroxyvitamin d" = "vitamin_d_25oh"
 "vitamin b12" = "vitamin_b12"
 "b12" = "vitamin_b12"
+"vit b12" = "vitamin_b12"
+
+# --- Myeloma / paraprotein panel (SPEP, serum free light chains) ---
+# Serum free light chains, their ratio, the monoclonal spike and the immunoglobulin
+# quant / beta-2 microglobulin that track plasma-cell disease. Parenthetical method
+# tags like `(SPEP)` are stripped by norm() before this lookup.
+"kappa" = "kappa_free_light_chain"
+"free kappa light chain" = "kappa_free_light_chain"
+"lambda" = "lambda_free_light_chain"
+"free lambda light chain" = "lambda_free_light_chain"
+"k/l ratio" = "kappa_lambda_ratio"
+"kappa/lambda ratio" = "kappa_lambda_ratio"
+"m-spike" = "m_spike"
+"immunoglobulin g" = "igg"
+"immunoglobulin g, qn, serum" = "igg"
+"b2 microglobulin" = "beta2_microglobulin"
+"beta2 microglobulin" = "beta2_microglobulin"
+"beta-2 microglobulin" = "beta2_microglobulin"
 
 # --- observation obs_type conventions (phase 4 render layer) ---
 # The render layer (master summary / appointment brief) reads three obs_type

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -338,8 +338,13 @@ it's the best possible dedup/extraction test corpus.
 
 ## Open questions
 
-- **Analyte dictionary seed**: start from your existing lab CSVs' column headers, or a
-  standard LOINC subset?
+- **Analyte dictionary seed**: ~~start from your existing lab CSVs' column headers, or a
+  standard LOINC subset?~~ **Resolved (phase 4.5):** seed from the real-corpus report
+  vocabulary (CSV `test_name` headers + observed report abbreviations), not LOINC. The
+  starter `data/dictionary.example.toml` now carries CMP/CBC panel codes, serum free
+  light chains and SPEP naming variants; `norm()` additionally strips parenthetical
+  qualifiers (`(HGB)`, `(SPEP)`, `(calculated)`) and compares units case-insensitively
+  so the dictionary only needs bare canonical spellings.
 - **FTS**: ~~SQLite FTS5 is plenty; confirm you don't need semantic/vector search over
   notes (could add a sidecar later).~~ **Resolved (phase 3):** plain SQLite FTS5, no
   vector sidecar. `migrations/003_fts.sql` adds a standalone `record_fts` index over

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -82,6 +82,7 @@ FIELD_SPECS: dict[str, dict[str, tuple[object, bool]]] = {
 KNOWN_TYPES = tuple(FIELD_SPECS)
 
 _WS = re.compile(r"\s+")
+_PAREN = re.compile(r"\([^)]*\)")
 
 
 class ValidationError(ValueError):
@@ -116,13 +117,23 @@ def _collapse(value: str) -> str:
     return _WS.sub(" ", value.strip().lower().replace("_", " "))
 
 
+def _strip_qualifiers(value: str) -> str:
+    """Drop parenthetical qualifiers (``(SPEP)``, ``(HGB)``, ``(calculated)``) that
+    label a value's method/source without changing *which analyte it is*, then
+    re-collapse whitespace. Applied inside :func:`norm` so real-report spellings like
+    ``Hemoglobin (HGB)`` or ``M-Spike (SPEP)`` reduce to their bare analyte name and
+    the dictionary only has to carry the minimal spelling, not every parenthesized
+    variant a lab happens to print."""
+    return _WS.sub(" ", _PAREN.sub(" ", value)).strip()
+
+
 def norm(value: object, dictionary: dict[str, str] | None = None) -> str:
     """Normalize a free-text field: lowercase, trim, collapse whitespace (underscores
-    count as whitespace), then map synonyms through the dictionary. ``None`` -> ``""``
-    (deterministic key part)."""
+    count as whitespace), strip parenthetical qualifiers, then map synonyms through
+    the dictionary. ``None`` -> ``""`` (deterministic key part)."""
     if value is None:
         return ""
-    collapsed = _collapse(str(value))
+    collapsed = _strip_qualifiers(_collapse(str(value)))
     if dictionary:
         return dictionary.get(collapsed, collapsed)
     return collapsed
@@ -254,6 +265,13 @@ def _stored_fields(record_type: str, row_map: dict) -> dict:
     return {name: row_map.get(name) for name in FIELD_SPECS[record_type]}
 
 
+def _norm_unit(value: object) -> str:
+    """Units compare case-insensitively: ``MG/DL`` and ``mg/dL`` are the same unit,
+    not a conflict (real reports vary the casing freely). Stored display casing is
+    left untouched — this only governs the duplicate-vs-conflict decision."""
+    return "" if value is None else str(value).strip().lower()
+
+
 def _rows_equal(record_type: str, existing: sqlite3.Row, incoming: dict) -> bool:
     """True when two rows with a matching dedup_key are the *same fact* (a duplicate)
     rather than a conflicting one — i.e. their payload fields all agree."""
@@ -262,6 +280,12 @@ def _rows_equal(record_type: str, existing: sqlite3.Row, incoming: dict) -> bool
         ev = existing_map.get(name)
         iv = incoming.get(name)
         if ev is None and iv is None:
+            continue
+        # Unit strings are compared case-insensitively so casing variants across
+        # documents don't stage a spurious conflict.
+        if name == "unit":
+            if _norm_unit(ev) != _norm_unit(iv):
+                return False
             continue
         # Numeric columns round-trip through SQLite as float; compare numerically.
         if isinstance(ev, _NUM) and isinstance(iv, _NUM):

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -68,6 +68,43 @@ def test_vitals_synonyms_map_to_canonical():
         assert dedup.norm(spelling, d) == "blood_pressure"
 
 
+def test_norm_strips_parenthetical_qualifiers():
+    d = dedup.load_dictionary(DICT_PATH)
+    # `(HGB)` / `(HCT)` / `(SPEP)` are method/label tags, not different analytes.
+    assert dedup.norm("Hemoglobin (HGB)", d) == "hemoglobin"
+    assert dedup.norm("Hematocrit (HCT)", d) == "hematocrit"
+    assert dedup.norm("M-Spike (SPEP)", d) == "m_spike"
+    # Stripping happens even without a dictionary (pure normalization step).
+    assert dedup.norm("Creatinine (calculated)") == "creatinine"
+
+
+# Real-corpus naming variants (issue #11): report-side spelling <-> CSV-side spelling
+# for the same clinical fact. Every pair must collapse to a single canonical token or
+# the same analyte splits into parallel rows/series downstream.
+_CORPUS_VARIANTS = [
+    ("GLUC", "Glucose"),
+    ("NA", "Sodium"),
+    ("K", "Potassium"),
+    ("CREA", "Creatinine"),
+    ("Hemoglobin (HGB)", "HGB"),
+    ("Hematocrit (HCT)", "HCT"),
+    ("Platelet count", "PLT"),
+    ("Free Kappa light chain", "Kappa"),
+    ("Free Lambda light chain", "Lambda"),
+    ("Kappa/Lambda ratio", "K/L Ratio"),
+    ("M-Spike (SPEP)", "M-Spike"),
+    ("Immunoglobulin G, Qn, Serum", "Immunoglobulin G"),
+    ("VIT B12", "Vitamin B12"),
+    ("B2 Microglobulin", "Beta-2 Microglobulin"),
+]
+
+
+def test_corpus_naming_variants_share_canonical_token():
+    d = dedup.load_dictionary(DICT_PATH)
+    for report, csv in _CORPUS_VARIANTS:
+        assert dedup.norm(report, d) == dedup.norm(csv, d), (report, csv)
+
+
 # --- dedup_key determinism ----------------------------------------------------
 
 def test_dedup_key_is_stable_across_formatting():
@@ -177,6 +214,65 @@ def test_differing_value_stages_conflict(conn):
     assert conn.execute("SELECT value_num FROM lab_result").fetchone()["value_num"] == 5.7
     assert conn.execute("SELECT COUNT(*) AS n FROM conflict WHERE status='open'"
                         ).fetchone()["n"] == 1
+
+
+def test_unit_casing_difference_is_duplicate_not_conflict(conn):
+    # `MG/DL` (report) vs `mg/dL` (CSV) is the same unit — must not stage a conflict.
+    d = dedup.load_dictionary(DICT_PATH)
+    doc1 = _make_document(conn)
+    doc2 = _make_document(conn)
+    r1 = {"test_name": "Glucose", "collected_at": "2026-02-01", "value_num": 95,
+          "unit": "MG/DL"}
+    r2 = {"test_name": "GLUC", "collected_at": "2026-02-01", "value_num": 95,
+          "unit": "mg/dL"}
+    dedup.commit_extraction(conn, doc1, {"lab_result": [r1]}, d)
+    summary = dedup.commit_extraction(conn, doc2, {"lab_result": [r2]}, d)
+    assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
+
+
+def test_real_corpus_overlap_dedups_not_splits(conn):
+    """Acceptance (issue #11): a report document and the historical CSV committed as a
+    second document must recognize every overlapping fact — none slip through as new,
+    unit casing doesn't fabricate conflicts, one stored row per analyte so `trends`
+    can't split a series and `render summary` can't double-count."""
+    d = dedup.load_dictionary(DICT_PATH)
+    doc_report = _make_document(conn)
+    doc_csv = _make_document(conn)
+    date = "2026-01-05"
+    # Same person, same date, same value per analyte — only the spelling and unit
+    # casing differ between the two documents.
+    report_rows = [
+        {"test_name": report, "collected_at": date, "value_num": float(i + 1),
+         "unit": "MG/DL"}
+        for i, (report, _csv) in enumerate(_CORPUS_VARIANTS)
+    ]
+    csv_rows = [
+        {"test_name": csv, "collected_at": date, "value_num": float(i + 1),
+         "unit": "mg/dL"}
+        for i, (_report, csv) in enumerate(_CORPUS_VARIANTS)
+    ]
+    s1 = dedup.commit_extraction(conn, doc_report, {"lab_result": report_rows}, d)
+    assert s1.counts == {"new": len(_CORPUS_VARIANTS), "duplicate": 0, "conflict": 0}
+    s2 = dedup.commit_extraction(conn, doc_csv, {"lab_result": csv_rows}, d)
+    assert s2.counts == {"new": 0, "duplicate": len(_CORPUS_VARIANTS), "conflict": 0}
+    # One row per analyte, not two — the split-series / double-count damage is gone.
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] \
+        == len(_CORPUS_VARIANTS)
+
+
+def test_corrected_value_still_conflicts_after_normalization(conn):
+    # Normalization must not swallow a genuine value change into a silent duplicate.
+    d = dedup.load_dictionary(DICT_PATH)
+    doc1 = _make_document(conn)
+    doc2 = _make_document(conn)
+    r1 = {"test_name": "HGB", "collected_at": "2026-03-01", "value_num": 13.1,
+          "unit": "g/dL"}
+    r2 = {"test_name": "Hemoglobin (HGB)", "collected_at": "2026-03-01",
+          "value_num": 13.4, "unit": "G/DL"}  # same round-bucket, corrected value
+    dedup.commit_extraction(conn, doc1, {"lab_result": [r1]}, d)
+    summary = dedup.commit_extraction(conn, doc2, {"lab_result": [r2]}, d)
+    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
 
 
 def test_commit_unknown_type_rolls_back(conn):


### PR DESCRIPTION
## Summary

Phase 4.5 real-data hardening. The first end-to-end run against the real corpus (scanned
multi-panel lab-report PDF + historical lab-results CSV, ~705 rows) showed 14 of 19
overlapping clinical facts slipping through dedup as "new" because the starter analyte
dictionary didn't cover real report naming, plus spurious conflicts from unit casing.

- Seed `data/dictionary.example.toml` from real-corpus vocabulary: CMP/CBC panel codes
  (GLUC/NA/K/CREA/PLT), serum free light chains, K/L ratio, M-Spike, IgG quant,
  beta-2 microglobulin, VIT B12.
- `norm()` strips parenthetical qualifiers (`(HGB)`, `(SPEP)`, `(calculated)`) before
  dictionary lookup so entries stay minimal.
- Duplicate-vs-conflict compares units case-insensitively (`MG/DL` == `mg/dL`); stored
  display casing untouched.
- Acceptance test: report doc + historical-CSV doc committed as a second document —
  every overlapping fact dedups or stages a genuine conflict (0 new, 0 spurious
  conflict, one row per analyte), so `trends` can't split a series and `render summary`
  can't double-count.
- `docs/Architecture.md`: resolves the "analyte dictionary seed" open question
  (corpus vocabulary, not LOINC).

Pipeline history: build → verify (independently reproduced, CONFIRMED) → audit
(no blocking findings; one non-blocking note on `_strip_qualifiers` scope for
medication names, out of scope for this issue).

Closes #11

## Test plan

- [x] Full suite green (116 tests, incl. new dedup coverage) — verified independently
  by the verify-lane worker on `feat/11`.
- [x] Acceptance scenario re-run: 19/19 overlapping facts dedup/stage correctly, zero
  split `trends` series, no double-counted `render summary` rows (data stays local,
  not committed to repo).
