### PR TITLE
feat(sdlc): retire dispatcher singleton; port concurrent-dispatch model from agentic-sdlc

### DIFF
--- a/prompts/sdlc/PROFILE.md
+++ b/prompts/sdlc/PROFILE.md
@@ -5,16 +5,20 @@ fork; some prompt placeholders are still unfilled — flagged below.
 
 - **Spine:** `intake → [design] → queued → build → verify → audit → ship`, collapsed tail (human
   PR merge is the `ready` gate).
-- **VP1 tracker:** GitHub issues, standard label taxonomy; labels + pinned `sdlc:dispatch-lock`
-  issue (#2) created 2026-07-11.
+- **VP1 tracker:** GitHub issues, standard label taxonomy; labels created 2026-07-11. The pinned
+  `sdlc:dispatch-lock` issue (#2) is **retired/obsolete** as of 2026-07-16 (dispatcher singleton
+  removed) — can be closed.
 - **VP2 topology:** single repo.
 - **VP3 modules:** design lane — [design.md](design.md) present but still the template stub;
   decide on/off when first UI-facing work appears (engine is CLI/SQLite today). PSI lane **off**.
-- **VP4 dispatcher:** Claude Code scheduled task → [dispatch.md](dispatch.md), per-issue
-  concurrency with worktrees (`C:\Claude\pemr-wt-<issue>`).
+- **VP4 dispatcher:** Claude Code scheduled task → [dispatch.md](dispatch.md); **no dispatcher
+  singleton** — concurrent dispatch runs deconflict via per-issue claims + a per-machine
+  maintenance lock (`.git/sdlc-maint.lock`) + idempotent GitHub writes. Per-issue concurrency
+  with worktrees (`C:\Claude\pemr-wt-<issue>`).
 - **VP5 quality bars:** Python engine — `pytest` over `tests/` (full suite); lint/type gate and
   smoke command **not yet declared** — fill before enabling the scheduled dispatcher.
 - **Deterministic core:** `scripts/sdlc.mjs` (`npm run sdlc`), with integration-branch detection
-  (f6124bb). Flow `feature → dev → main`; `dev` is default.
+  (f6124bb); provides `maint-lock`/`maint-release` (replacing the old `lock`/`unlock` singleton
+  mutex). Flow `feature → dev → main`; `dev` is default.
 - **Known deviations:** prompts retain generic template phrasing ("your integration branch") —
   placeholder fill incomplete.

--- a/prompts/sdlc/README.md
+++ b/prompts/sdlc/README.md
@@ -28,10 +28,12 @@ plumbing wrapper that posts a body the agent already authored.
 
 ## How to run
 
-- **Scheduled**: a dispatcher (see [`dispatch.md`](dispatch.md)) runs periodically: a dispatcher
-  singleton gate, a per-issue wip gate (stale-lock reaping only — a fresh lock just makes that
-  one issue ineligible), git + worktree maintenance, then one worker subagent per non-empty
-  lane. Locking is per-issue (claim comments, below), so lane workers may run concurrently.
+- **Scheduled**: a dispatcher (see [`dispatch.md`](dispatch.md)) runs periodically: a per-issue
+  wip gate (stale-lock reaping, verify-before-write — a fresh lock just makes that one issue
+  ineligible), machine-locked git + worktree maintenance, then one worker subagent per non-empty
+  lane. There is no dispatcher singleton: overlapping dispatch runs — same machine or different
+  machines — deconflict via per-issue claims (claim comments, below), a per-machine maintenance
+  lock, and idempotent GitHub writes.
 - **Manual**: paste this README plus a lane file's body into an agent session. Identical
   behavior — the prompt doesn't know what fired it. Mint your own run-id for the claim comment;
   manual and scheduled runs coexist safely because claims deconflict per-issue.
@@ -46,7 +48,11 @@ plumbing wrapper that posts a body the agent already authored.
       you mint for a manual run), then runs the claim-verify race check. The label is the
       visibility signal; the claim comment is the ownership record and tiebreaker (earliest
       claim newer than the last outcome EMIT wins; ties break to the lexicographically lower
-      run-id).
+      run-id). "Newer than the last outcome EMIT" has a machine-visible boundary: the issue's
+      most recent `sdlc:wip` *unlabeled* timeline event — every outcome EMIT removes `sdlc:wip`,
+      and a reaper strip also (correctly) invalidates earlier claims. The lock is machine-owned
+      and volatile; the dispatcher's reaper may strip it, and it re-checks the claim comment's
+      run-id + timestamp immediately before doing so.
    2. **Lost the race** (the command exits non-zero and says so) → leave the label and the
       winner's claim untouched, delete nothing, and go pick the next eligible item.
 2. **WORK** — per the lane file, with these constraints:
@@ -55,7 +61,19 @@ plumbing wrapper that posts a body the agent already authored.
      Where a lane names a role (`verifier`, `security-executor`, …) it names the **stance and
      checklist you apply inline**, not a subagent to dispatch. Cost-tiering happens one level
      up: the dispatcher sets each worker's `model` per lane (see `dispatch.md`).
-   - **Idempotent** — if the stage's artifact already exists, treat as done; don't redo it.
+   - **Idempotent — reconcile, don't re-execute.** If the stage's artifact already exists, treat
+     as done; don't redo it. Schedulers fire on a clock, not on need — a re-run must be a safe
+     no-op. The same applies to items a human rewound to an earlier stage or reopened after
+     close: investigate what already exists before doing any work. Evidence hierarchy: merged
+     code / branch state / PR status › recorded reports for the current HEAD › issue comments ›
+     labels — cite what you relied on when you no-op. Presume an existing valid artifact good
+     unless the human's rewind comment gives a reason to distrust it or your own check finds
+     something significant; then redo exactly the invalidated part. Keep the check cheap — dig
+     deeper only when evidence conflicts, and PARK if it stays ambiguous rather than burn the
+     pass. For partial work, post a short reconciliation note (what's already done + evidence,
+     what remains) before continuing, then do only the gap. If the item is conclusively shipped
+     already, PARK with the evidence (PR#, commit, observed behavior) for a human to close —
+     don't march it through the remaining lanes.
    - **Worktree isolation** — never work in the main checkout; it may hold human WIP or another
      worker. For any lane that touches a branch, use the issue-scoped worktree
      `../<repo>-wt-<issue#>`: `npm run sdlc worktree <issue> [<branch>]` creates it (or reuses
@@ -79,7 +97,23 @@ plumbing wrapper that posts a body the agent already authored.
 3. **EMIT exactly one outcome** — ADVANCE, BOUNCE, or PARK — never silent. Every outcome removes
    `sdlc:wip` on the way out. **Leave the worktree in place** — dispatcher maintenance prunes
    worktrees for merged/dead branches, and a reaped issue's next worker reuses it.
-4. **STOP** — reply the lane's one-line result. One item per pass; never pick up a second.
+4. **STOP** — reply the lane's one-line result, then end the reply with a fenced **JSON result
+   block** — the machine-parseable contract the dispatcher consumes (prose stays for humans):
+
+   ```json
+   {"issue": 60, "outcome": "ADVANCE", "next_stage": "verify", "notes": "one-line summary"}
+   ```
+
+   - `outcome`: `ADVANCE` | `BOUNCE` | `PARK` | `CONTINUE` | `IDLE`.
+   - `next_stage`: the stage label the item sits in after the outcome (e.g. `"verify"` after a
+     build ADVANCE, `"build"` after a build CONTINUE or a bounce to build, unchanged lane for
+     PARK); `null` for IDLE.
+   - Idle pass: `{"issue": null, "outcome": "IDLE", "next_stage": null, "notes": ""}`.
+   - The block is always the **last** element of the reply, exactly one per reply. A lane a project
+     configures to process multiple items in one pass returns an **array** of result objects, one
+     per item.
+
+   One item per pass; never pick up a second.
 
 ## Files
 

--- a/prompts/sdlc/audit.md
+++ b/prompts/sdlc/audit.md
@@ -29,3 +29,9 @@ find reasons this should NOT ship, not to rubber-stamp verify's pass.
 
 ### 4. STOP
 One-line result: `AUDIT: <#issue> → ADVANCE|BOUNCE — <reason>`
+
+## Notes
+- **Idempotent.** A clean report for the current branch HEAD = done; any new commit invalidates
+  it. An item rewound here by a human with a still-valid clean report → re-confirm cheaply and
+  ADVANCE, unless their rewind comment names a reason to distrust it — then re-audit that part.
+  Evidence that the work already shipped (merged PR) → PARK with the evidence for a human to close.

--- a/prompts/sdlc/build.md
+++ b/prompts/sdlc/build.md
@@ -27,3 +27,10 @@ Per the [README](README.md) universal loop — lane `stage:build`, idle reply `B
 
 ### 4. STOP
 One-line result: `BUILD: <#issue> → ADVANCE|CONTINUE|BOUNCE — <reason>`
+
+## Notes
+- **Idempotent.** An existing pushed branch with green targeted tests = done → ADVANCE; re-runs
+  continue an incomplete branch, they never restart it. An item **rewound here by a human** is
+  reconciled per the [README](README.md) universal loop: read their rewind comment, post a
+  reconciliation note (what's already implemented + evidence, what remains), and build only the
+  gap — existing work is presumed good unless the comment or your own check says otherwise.

--- a/prompts/sdlc/design.md
+++ b/prompts/sdlc/design.md
@@ -26,3 +26,9 @@ needs a storyboard/mockup; a pure-engineering design-exempt item shouldn't have 
 
 ### 4. STOP
 One-line result: `DESIGN: <#issue> → ADVANCE|PARK|BOUNCE — <reason>`
+
+## Notes
+- **Idempotent.** An existing settled design (in-thread or in a linked design artifact) is
+  presumed good — re-confirm it still matches the current issue body and codebase, don't
+  redesign. An item rewound here by a human: read their rewind comment; only the part it (or your
+  own check) invalidates gets reworked.

--- a/prompts/sdlc/dispatch.md
+++ b/prompts/sdlc/dispatch.md
@@ -1,10 +1,13 @@
 # Dispatcher (template)
 
 **Not a lane worker.** This is the pipeline dispatcher — meant to run on a schedule (cron /
-scheduled task): a dispatcher singleton gate, a per-issue wip gate (reap stale locks only), git +
-worktree maintenance, then one worker subagent per non-empty lane. It never works an issue
-itself. Locking is per-issue (claim comments, see [`README.md`](README.md)), so lane workers may
-run concurrently; a fresh lock only removes that one issue from eligibility, never aborts the run.
+scheduled task): a per-issue wip gate (reap stale locks only), machine-locked git + worktree
+maintenance, then one worker subagent per non-empty lane. It never works an issue itself. There
+is **no dispatcher singleton**: any number of dispatch runs — different machines, or overlapping
+scheduled/manual runs on one machine — may execute concurrently. Locking is per-issue (claim
+comments, see [`README.md`](README.md)) plus a per-machine maintenance lock; every GitHub-side
+write here is idempotent. A fresh per-issue lock only removes that one issue from eligibility,
+never aborts the run.
 
 This file is the canonical, reviewable copy; wire your scheduler to a thin pointer that reads it
 and executes one pass.
@@ -15,7 +18,7 @@ You are the SDLC pipeline dispatcher for `<project name>`.
 
 Repository (local working directory): `<absolute path>`
 
-Run ONE dispatch cycle: dispatcher singleton gate, per-issue wip gate (reap stale locks), git +
+Run ONE dispatch cycle: machine maintenance lock, per-issue wip gate (reap stale locks), git +
 worktree maintenance, then each stage worker at most once — intake, design, build, verify, audit,
 ship (`stage:queued` has no worker; it is the human throttle). Each worker runs as an ISOLATED
 subagent that cannot delegate further: workers share no context with you or with each other; the
@@ -29,17 +32,34 @@ The mechanical steps below each have a deterministic CLI one-shot (`npm run sdlc
 them instead of re-deriving the gh/git ritual. You supply judgment (what to spawn, how to route),
 the CLI supplies the state math.
 
-### Step -1 — Dispatcher singleton gate
+### Step -1 — Concurrency model + machine maintenance lock
 
-Two dispatchers must not run maintenance concurrently. The pinned issue titled
-`sdlc:dispatch-lock` (labeled `sdlc:hold` so no worker touches it) is the mutex:
+There is **no dispatcher singleton and no global lock.** Concurrent dispatch runs are expected
+and safe under three rules:
 
-- `npm run sdlc lock <your run-id>` — takes the lock. Exits non-zero if another dispatcher holds
-  a fresh lock (<2h, no unlock): output one line
-  `sdlc-dispatch: aborted — dispatcher lock held by <run-id> (<age>)` and do nothing else. A
-  stale lock (≥2h, no unlock) is dead — the command supersedes it and says so; note it in the
-  digest.
-- At the very end of the cycle: `npm run sdlc unlock <your run-id>`.
+1. **Per-issue state is optimistically locked** by worker claims (README universal loop, CLAIM
+   step) — this works identically across machines because the issue tracker is the shared store.
+2. **Every GitHub-side write in this prompt is idempotent and verify-before-write.** Label changes
+   converge (labels are sets — applying the same change twice yields the same state); comments are
+   run-id-tagged (a duplicate is attributable noise, never damage); and any write whose
+   precondition came from the Step 0 snapshot re-checks that precondition against live data
+   immediately before writing. Losing a race is never an error — record it and move on.
+3. **Machine-local maintenance (Step 0a) is serialized per machine** by a filesystem lock. Two
+   runs on one machine must not concurrently prune branches/worktrees; runs on different machines
+   share no local state and never contend.
+
+**Machine lock protocol.** pemr carries the CLI, so the protocol is one command each way:
+
+- **Acquire:** `npm run sdlc maint-lock <your run-id>`. Exit 1 = the lock is held: skip Step 0a
+  this cycle and record `maintenance: skipped (lock held by <run-id>, <age>)`. **Never abort the
+  cycle** — proceed to Step 0 and per-lane dispatch; only Step 0a is conditional on holding it.
+- **Release:** `npm run sdlc maint-release <your run-id>` at the **end of Step 0a** — not the end
+  of the cycle; lane dispatch never needs it.
+
+The lock is the directory `.git/sdlc-maint.lock` (inside `.git`: never tracked, never swept by
+git). Staleness is **30 minutes** (not the 2 h worker threshold: maintenance takes minutes, so a
+longer freeze only delays recovery); a stale lock is reaped atomically by the CLI on the next
+`maint-lock`. Runs on different machines share no local state and never contend.
 
 ### Step 0 — Snapshot + per-issue wip gate
 
@@ -49,16 +69,31 @@ Two dispatchers must not run maintenance concurrently. The pinned issue titled
 - `npm run sdlc -- gate --reap` — per-issue wip-lock ages (measured from the `sdlc:wip` labeled
   event, never `updatedAt`): a **LIVE** lock (<2h) means a running worker — that issue is simply
   ineligible this cycle, never an abort; a **stale** lock (≥2h) is reaped (label stripped +
-  comment posted; every other label untouched, so the item re-enters its lane). Reaped issues
-  keep their worktrees — the next worker reuses them.
+  comment posted; every other label untouched, so the item re-enters its lane). A **bare label
+  with no claim comment** ages from the same `labeled` timeline event; if that event can't be
+  found, the item is left and recorded — never reaped on unprovable age. The reap is
+  **verify-before-write**: under concurrent dispatchers the CLI re-fetches the newest `sdlc:claim`
+  comment immediately before stripping, so a fresh claim that appeared since the snapshot is left
+  in place and recorded as `reap skipped — fresh claim by <run-id>`. Reaped issues keep their
+  worktrees — the next worker reuses them.
 - Never touch `sdlc:needs-human`, `sdlc:hold`, or any human-set state.
 - Record live locks and reaps for the digest.
 
 ### Step 0a — Git + worktree maintenance
 
+Run this step **only while holding the machine lock from Step -1** (skipped it → go straight to
+per-lane dispatch). Release the lock (`npm run sdlc maint-release <your run-id>`) when this step
+ends, success or not.
+
 Keep the local repo fresh WITHOUT ever touching any working tree. The main tree may be dirty
 (human WIP in another session) — that is a signal, not an obstacle. **Never stash, never
 force-checkout, never discard or overwrite uncommitted files — in the main tree or any worktree.**
+
+Another dispatch run's *workers* may be running git commands on this machine concurrently — the
+machine lock serializes maintenance runs, not workers. Git's own ref locks make that safe: treat
+any `cannot lock ref` / `.lock exists` failure as transient contention — retry once, then skip
+that operation and record it. Git also refuses to delete a branch checked out in any worktree;
+treat that refusal as "in use — leave it", never force.
 
 1. **`npm run sdlc git-maint`** — fetch + prune, ff-update your integration branch without
    touching the tree, ancestry-merged branch prune (worktree-checked-out branches are skipped by
@@ -75,7 +110,10 @@ force-checkout, never discard or overwrite uncommitted files — in the main tre
    comment on the issue `sdlc-dispatch: branch <name> conflicts with the integration branch —
    needs a merge`, and if the issue sits in `stage:verify`/`stage:audit`/`stage:ship`, swap it
    back to `stage:build` (`npm run sdlc advance <issue> build` — conflict resolution is build's
-   lane). Never merge, update, or close any PR here. Record for the digest.
+   lane). Verify-before-write: re-read the issue's labels immediately before the swap (already
+   `stage:build` or now `sdlc:wip` → skip), and skip the comment if the issue's newest
+   `sdlc-dispatch:` conflict comment already names the same branch — another dispatch run got
+   there first. Never merge, update, or close any PR here. Record for the digest.
 
 ### Per-lane dispatch
 
@@ -85,7 +123,8 @@ For each lane (intake, design, build, verify, audit, ship):
    worker in this cycle ADVANCEd an item into it. Zero eligible → skip the lane (no subagent);
    record `<LANE>: skipped (empty)`.
 2. Otherwise spawn ONE subagent with the lane's worker prompt (read `prompts/sdlc/README.md`
-   first, then execute `prompts/sdlc/<lane>.md`), passing the run-id, **with the lane's `model`
+   first, then execute `prompts/sdlc/<lane>.md`, and end the reply with the fenced JSON result
+   block per the README STOP contract), passing the run-id, **with the lane's `model`
    set explicitly — never let a lane inherit the dispatcher's model** (the dispatcher itself may
    be downsized). Right-size: route volume work to the cheapest model that reliably does it;
    escalate a lane one tier only after its worker BOUNCEs the same issue twice for
@@ -105,27 +144,36 @@ For each lane (intake, design, build, verify, audit, ship):
    exceptions: run **intake before the batch** whenever its merge sweep has pending merges to
    process (this is load-bearing — an "empty" intake lane would otherwise skip the sweep
    entirely), and run a lane **serially after the batch** if it only became non-empty via an
-   ADVANCE this cycle. Never spawn two workers for the same lane in one cycle.
-4. **Self-heal (after each worker finishes):** parse the claimed issue # from the worker's
-   result, then `npm run sdlc heal <lane> <issue>` — it reports STALLED (still locked) or OK. If
-   STALLED and the issue's latest `sdlc:claim` comment belongs to this cycle
-   (`<run-id>-<lane>`): resume that worker ONCE to complete its EMIT; if it's still locked after
-   that, remove `sdlc:wip`, add `sdlc:needs-human`, and comment that it stalled twice. A claim
-   owned by a different run-id is another live worker — leave it alone.
+   ADVANCE this cycle. Never spawn two workers for the same lane in one cycle. Other dispatch
+   runs may have live workers in the same lanes right now — that's expected: workers deconflict
+   per issue (CLAIM step), and a worker that loses a claim race just moves to the next eligible
+   item. A lost race is never an error.
+4. **Self-heal (after each worker finishes):** read the worker's fenced JSON result block (README
+   STOP contract: `{issue, outcome, next_stage, notes}`, or an array of those for a multi-item
+   pass) — it is the authoritative record of what was claimed and how it ended. Block missing or
+   malformed → fall back to parsing the prose one-liner and record the contract violation for the
+   digest. For each non-IDLE result, take the claimed issue # and run `npm run sdlc heal <lane>
+   <issue>` — it reports STALLED (still locked) or OK. If STALLED and the issue's latest
+   `sdlc:claim` comment belongs to this cycle (`<run-id>-<lane>`): resume that worker ONCE to
+   complete its EMIT; if it's still locked after that, remove `sdlc:wip`, add `sdlc:needs-human`,
+   and comment that it stalled twice. A claim owned by a different run-id is another live worker —
+   leave it alone.
 
 ### Digest
 
 Report:
-- Dispatcher-lock result (acquired / superseded a stale lock).
-- Wip gate: live locks left alone (issue + age), reaped (issue numbers), or `wip gate: clear`.
+- Machine-lock result: acquired / skipped (held by `<run-id>`, `<age>`) / stale-reaped.
+- Wip gate: live locks left alone (issue + age), reaped (issue numbers), reaps skipped on fresh
+  claims, or `wip gate: clear`.
 - Git + worktree maintenance: integration branch updated (old..new SHA or `already current`),
   worktrees removed/left (with reasons), branches pruned/left (with reasons), conflicted PRs
   flagged (and any stage swaps), any skipped ops, and open-PR state.
-- One line per lane: the worker's one-line result, or `skipped (empty)`. Note any self-heal
-  resumes/parks.
+- One line per lane, derived from each worker's JSON result block (issue, outcome, next_stage), or
+  `skipped (empty)`; note any worker whose block was missing/malformed and required prose
+  fallback. Note any self-heal resumes/parks.
 - `npm run sdlc digest` — queue depths, parked/hold lists, and the arrivals/departures diff vs
   the last cycle, from one fresh snapshot.
 - Token cost per lane plus the cycle total, if available — the trend line for spotting cost
   regressions across cycles.
 
-Then `npm run sdlc unlock <your run-id>`.
+The machine lock was already released at the end of Step 0a — nothing is held after the digest.

--- a/prompts/sdlc/intake.md
+++ b/prompts/sdlc/intake.md
@@ -21,6 +21,26 @@ so this sweep is the only thing that notices it.
 ### 2. WORK
 - **Duplicate search**: `gh issue list --search "<feature keywords>" --state all --limit 30
   --json number,title,state`. An existing issue covering the same thing is a close-as-dup.
+- **In-progress collision sweep** — does work on this already exist somewhere, even without a
+  matching issue title? Three probes, cheap to expensive; stop as soon as one is conclusive:
+  1. **Remote branches**: `git fetch origin && git branch -r`. Branch names follow
+     `<type>/<issue#>-<slug>` (e.g. `feat/…`) — scan for a slug that matches this issue's subject
+     or an issue# whose issue covers the same ground. On a candidate,
+     `git log origin/dev..origin/<branch> --oneline` and
+     `git diff --name-only origin/dev...origin/<branch>` to see what it actually changes.
+  2. **Open PRs by touched paths**:
+     `gh pr list --state open --json number,title,headRefName,files` — a PR touching the files
+     this issue would touch is a collision even if the titles don't match.
+  3. **In-flight issues in later lanes**: `gh issue list --label stage:build --json number,title`
+     (likewise `stage:verify` / `stage:audit` / `stage:ship`) — an item already past queued may
+     subsume or conflict with this one; read its plan comment, not just its title.
+
+  Verdicts: same work in flight → close as dup linking the live item (or its issue). Partial
+  overlap where this issue can't proceed until the in-flight work lands → comment "blocked by #n",
+  apply the `blocked` label (the merge sweep flips it to `ready` when the blocker merges), and
+  still EMIT normally on the rest of the triage. Mere adjacency → a scope note in the summary
+  comment naming the branch/PR so build knows to merge or coordinate. Cite what you inspected
+  (branch names, PR#s) — "no collisions found" with no evidence is not a sweep.
 - **Assessment**: read the issue body/comments, check relevant docs for conflicts with settled
   design/architecture decisions. Judge: **coherent**, **scoped** (one unit of work), **non-dup**,
   and whether **design work still remains**.
@@ -41,6 +61,10 @@ so this sweep is the only thing that notices it.
 One-line result: `INTAKE: <#issue> → ADVANCE(design|queued)|PARK|CLOSE — <reason>`
 
 ## Notes
-- No code changes, no branches — intake only reads and relabels.
+- No code changes, no branches — intake only reads and relabels. The collision sweep's git
+  commands (`fetch`, `branch -r`, `log`, `diff`) are read-only too — they inspect remote branches
+  without checking anything out.
 - Idempotent: if the issue already has an intake comment from a prior run, re-confirm cheaply
-  rather than re-researching from scratch.
+  rather than re-researching from scratch. A **reopened** issue is reconciled, not re-triaged from
+  scratch: if the evidence (merged PR, code on `dev`) shows it already shipped, PARK with that
+  evidence for a human to close rather than advancing it back into the pipeline.

--- a/prompts/sdlc/ship.md
+++ b/prompts/sdlc/ship.md
@@ -13,6 +13,9 @@ You are the **ship worker**. Process **exactly one** issue, then stop.
 Per the [README](README.md) universal loop — lane `stage:ship`, idle reply `SHIP: idle`.
 
 ### 2. WORK
+Idempotency first: a PR for this branch already open with the docs fan-out done → skip to
+**ADVANCE**; a PR for this branch already **merged** with the issue still open → PARK with the
+merge evidence for a human to close (intake's merge sweep normally handles these). Otherwise:
 - **Merge the integration branch (`dev`) into the feature branch unconditionally** — the PR must
   be mergeable, and ship is the lane that always merges (per the README staleness rule).
   Docs-only conflicts you may resolve yourself; **code conflicts BOUNCE → `stage:build`** naming
@@ -20,7 +23,9 @@ Per the [README](README.md) universal loop — lane `stage:ship`, idle reply `SH
 - Push the branch, open a PR against `dev` (or your integration branch) with a summary and a
   link to the issue (`Closes #<n>`).
 - Update any L3 docs the change invalidated or that document new behavior (see
-  `docs/Documentation.md`).
+  `docs/Documentation.md`; when applying the tiered-docs discipline, the `pemr-doc-tiers` skill at
+  `.github/skills/pemr-doc-tiers/SKILL.md` carries the naming/sizing/placement rules — apply them
+  inline).
 - No-branch fallback: if the feature was already merged outside the pipeline, skip PR creation
   and instead comment confirming it's live, then close.
 

--- a/prompts/sdlc/verify.md
+++ b/prompts/sdlc/verify.md
@@ -32,3 +32,9 @@ not a checklist to tick. Assume the build is broken until your own evidence says
 
 ### 4. STOP
 One-line result: `VERIFY: <#issue> → ADVANCE|BOUNCE — <reason>`
+
+## Notes
+- **Idempotent.** A green report for the current branch HEAD = done; any new commit invalidates
+  it. An item rewound here by a human with a still-valid green report → re-confirm cheaply and
+  ADVANCE, unless their rewind comment names a reason to distrust it — then re-verify that part.
+  Evidence that the work already shipped (merged PR) → PARK with the evidence for a human to close.

--- a/scripts/check-meta-drift.mjs
+++ b/scripts/check-meta-drift.mjs
@@ -42,6 +42,10 @@ export const SKILL_LINE_CAP = 400;
 // slashes for possessive `pemr-x/y`) is excluded by the char class.
 const REF_RE = /pemr-[a-z0-9]+(?:-[a-z0-9]+)*/g;
 
+// Tokens that match REF_RE but are not skill/agent references: `pemr-wt` is
+// the issue-worktree path prefix (`C:\Claude\pemr-wt-<issue>`).
+const IGNORED_REFS = new Set(['pemr-wt']);
+
 /** Count body lines of an agent file (everything after the closing frontmatter `---`). */
 export function agentBodyLineCount(raw) {
   const match = raw.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n([\s\S]*)$/);
@@ -56,7 +60,10 @@ export function agentBodyLineCount(raw) {
 
 /** Extract the unique set of pemr-* reference tokens from text. */
 export function extractRefs(text) {
-  return new Set(text.match(REF_RE) ?? []);
+  const refs = (text.match(REF_RE) ?? []).filter(
+    (ref) => !IGNORED_REFS.has(ref) && ![...IGNORED_REFS].some((ig) => ref.startsWith(`${ig}-`)),
+  );
+  return new Set(refs);
 }
 
 async function readDirEntries(dir) {

--- a/scripts/sdlc.mjs
+++ b/scripts/sdlc.mjs
@@ -16,10 +16,10 @@
  *   sdlc worktree <issue> [<branch>]  add a sibling git worktree for the issue's branch
  *   sdlc comment <issue> <file>       post a body-file comment (plumbing only)
  *
- * Commands (dispatcher-side — issue #615; each a pure function of gh/git state):
+ * Commands (dispatcher-side — issue #615; each a pure function of gh/git/fs state):
  *   sdlc gate     [--reap]            per-issue wip-lock ages from timeline events → LIVE/REAP/CLEAR (#613)
- *   sdlc lock     <run-id>            take the dispatcher singleton lock (pinned dispatch-lock issue)
- *   sdlc unlock   <run-id>            release the dispatcher singleton lock
+ *   sdlc maint-lock    <run-id>       acquire the per-machine maintenance lock (.git/sdlc-maint.lock)
+ *   sdlc maint-release <run-id>       release the maintenance lock (idempotent)
  *   sdlc lanes                        per-lane depth + eligibility + the ≠1 stage-label check (#614)
  *   sdlc heal     [<lane>] <issue>    post-worker self-heal: did the worker clear its lock?
  *   sdlc git-maint                    fetch, ff dev, prune ancestry/squash-merged branches, PR state
@@ -170,42 +170,41 @@ export function planGate(wipItems, thresholdMs = WIP_STALE_MS) {
 }
 
 /**
- * Dispatcher singleton-lock decision from the dispatch-lock issue's comments
- * (`[{ body, createdAt }]`, chronological). The most recent `lock <run-id> <ts>`
- * comment holds the mutex unless a matching `unlock <run-id>` follows it or it
- * is older than the threshold (dead dispatcher). Pure.
+ * The machine maintenance-lock reap threshold (dispatch.md Step -1): 30 min,
+ * not the 2h worker threshold — maintenance takes minutes, so a longer freeze
+ * only delays recovery.
  */
-export function planLock(comments, nowMs, thresholdMs = WIP_STALE_MS) {
-  let holder = null;
-  for (const c of comments ?? []) {
-    const lock = c.body?.match(/^lock\s+(\S+)/);
-    const unlock = c.body?.match(/^unlock\s+(\S+)/);
-    if (lock) holder = { runId: lock[1], createdAt: c.createdAt };
-    else if (unlock && holder && unlock[1] === holder.runId) holder = null;
-  }
-  if (!holder) return { held: false, holder: null, stale: false };
-  const ageMs = nowMs - new Date(holder.createdAt).getTime();
-  const stale = ageMs >= thresholdMs;
-  return { held: !stale, holder: holder.runId, stale, ageMs };
+export const MAINT_STALE_MS = 30 * 60 * 1000;
+
+/**
+ * Machine maintenance-lock decision (dispatch.md Step -1). There is no
+ * dispatcher singleton: this lock only serializes Step 0a (git/worktree/
+ * artifact maintenance) on ONE machine, never aborts a cycle, and runs on
+ * different machines never contend. `state` is `{ exists, ageMs }` — age
+ * measured from the lock's owner.txt timestamp. Pure.
+ */
+export function planMaintLock(state, thresholdMs = MAINT_STALE_MS) {
+  if (!state?.exists) return { action: 'acquire' };
+  if (state.ageMs < thresholdMs) return { action: 'skip' }; // live run — skip Step 0a, never abort
+  return { action: 'reap' }; // holder presumed dead — reap by atomic rename
 }
 
 /**
  * Claim-verify race decision from an issue's comments (`[{ body, createdAt }]`,
- * chronological). Considers `sdlc:claim <run-id> <lane>` comments newer than the
- * last outcome EMIT (a comment starting with ADVANCE/BOUNCE/PARK/CONTINUE or a
- * reap). Winner = earliest claim; ties break to the lexicographically lower
- * run-id. Pure.
+ * chronological) plus the claim boundary: the newest `sdlc:wip` *unlabeled*
+ * timeline event (see `lastUnlabeledAt`), or null if the label was never
+ * removed. Every outcome EMIT removes `sdlc:wip`, so claims at/before that
+ * event are settled history — and a reaper strip also (correctly) invalidates
+ * earlier claims, which an outcome-comment heuristic would miss. Winner =
+ * earliest live claim; ties break to the lexicographically lower run-id. Pure.
  */
-export function planClaimVerify(comments, myRunId) {
-  const OUTCOME = /^(ADVANCE|BOUNCE|PARK|CONTINUE|sdlc-dispatch: reaped)/;
-  let claims = [];
+export function planClaimVerify(comments, myRunId, boundaryIso = null) {
+  const claims = [];
   for (const c of comments ?? []) {
-    if (OUTCOME.test(c.body ?? '')) {
-      claims = []; // claims before an outcome are settled history
-      continue;
-    }
     const m = c.body?.match(/^sdlc:claim\s+(\S+)/);
-    if (m) claims.push({ runId: m[1], createdAt: c.createdAt });
+    if (!m) continue;
+    if (boundaryIso && c.createdAt <= boundaryIso) continue; // settled history
+    claims.push({ runId: m[1], createdAt: c.createdAt });
   }
   if (!claims.some((c) => c.runId === myRunId)) {
     return { won: false, winner: null, reason: 'own claim not found' };
@@ -225,6 +224,21 @@ export function lastLabeledAt(timelineEvents, label) {
   let latest = null;
   for (const ev of timelineEvents ?? []) {
     if (ev.event === 'labeled' && ev.label?.name === label && ev.created_at) {
+      if (latest === null || ev.created_at > latest) latest = ev.created_at;
+    }
+  }
+  return latest;
+}
+
+/**
+ * The most recent time `label` was removed, from GitHub issue timeline events.
+ * Returns an ISO string or null. Pure over the parsed `/timeline` payload.
+ * For `sdlc:wip` this is the claim-verify boundary (see `planClaimVerify`).
+ */
+export function lastUnlabeledAt(timelineEvents, label) {
+  let latest = null;
+  for (const ev of timelineEvents ?? []) {
+    if (ev.event === 'unlabeled' && ev.label?.name === label && ev.created_at) {
       if (latest === null || ev.created_at > latest) latest = ev.created_at;
     }
   }
@@ -258,8 +272,8 @@ export function computeLanes(issues) {
     const stages = stagesOf(issue.labels);
     // Multiple stage labels are always corrupt. Zero is only corrupt when the
     // issue still carries a machine flag (wip/needs-human) — a stage-less open
-    // issue is otherwise a legitimate state: post-ship awaiting PR merge, the
-    // dispatch-lock issue, or simply not (yet) in the pipeline.
+    // issue is otherwise a legitimate state: post-ship awaiting PR merge, or
+    // simply not (yet) in the pipeline.
     const zeroButFlagged =
       stages.length === 0 &&
       (issue.labels.includes(WIP_LABEL) || issue.labels.includes('sdlc:needs-human'));
@@ -448,14 +462,34 @@ function cmdClaim(args, { gh, git, log }) {
     throw new SdlcError('--verify requires a run-id + lane: sdlc claim <issue> <run-id> <lane> --verify');
   }
   gh(['issue', 'edit', issue, '--add-label', WIP_LABEL]);
+  let myCommentUrl = null;
   if (runId) {
     // The label is the visibility signal; this comment is the ownership record
     // and race tiebreaker (see prompts/sdlc/README.md CLAIM).
-    gh(['issue', 'comment', issue, '--body', `sdlc:claim ${runId} ${lane}`]);
+    myCommentUrl = String(gh(['issue', 'comment', issue, '--body', `sdlc:claim ${runId} ${lane}`]) ?? '').trim();
   }
   if (verify) {
-    const result = planClaimVerify(fetchLockComments(gh, issue), runId);
+    // Boundary = newest sdlc:wip unlabel event; unavailable → null, which
+    // treats every claim as live (safe: strictly more competitors, never fewer).
+    let boundary = null;
+    try {
+      const timeline = JSON.parse(gh(['api', `repos/{owner}/{repo}/issues/${issue}/timeline`, '--paginate']));
+      boundary = lastUnlabeledAt(timeline, WIP_LABEL);
+    } catch {
+      boundary = null;
+    }
+    const result = planClaimVerify(fetchIssueComments(gh, issue), runId, boundary);
     if (!result.won) {
+      // README CLAIM iii: the winner's claim and the label stay untouched; only
+      // our own claim comment may be marked superseded.
+      const own = myCommentUrl?.match(/issuecomment-(\d+)/);
+      if (own) {
+        try {
+          gh(['api', '-X', 'PATCH', `repos/{owner}/{repo}/issues/comments/${own[1]}`, '-f', `body=sdlc:claim ${runId} ${lane} (superseded)`]);
+        } catch {
+          // cosmetic — losing cleanly matters more than the note
+        }
+      }
       log(`claim: LOST race on #${issue} to ${result.winner ?? '(unknown)'} — leave the label, pick the next item.`);
       process.exitCode = 1;
       return;
@@ -566,6 +600,21 @@ function cmdGate(args, { gh, log }) {
   for (const it of plan.reap) {
     log(`gate: REAP #${it.number} (stale ${fmtAge(it.ageMs)})`);
     if (reap) {
+      // Verify-before-write: the snapshot may be stale under concurrent
+      // dispatchers — another run may have reaped and a new worker claimed
+      // since. Re-fetch the newest claim and recompute the age before writing.
+      let freshAgeMs = null;
+      try {
+        const claims = fetchIssueComments(gh, it.number).filter((c) => /^sdlc:claim\s/.test(c.body ?? ''));
+        const newest = claims[claims.length - 1];
+        if (newest) freshAgeMs = Date.now() - new Date(newest.createdAt).getTime();
+      } catch {
+        freshAgeMs = null;
+      }
+      if (freshAgeMs !== null && freshAgeMs < WIP_STALE_MS) {
+        log(`  reap skipped — fresh claim (${fmtAge(freshAgeMs)}); another run got here first.`);
+        continue;
+      }
       gh(['issue', 'edit', String(it.number), '--remove-label', WIP_LABEL]);
       gh([
         'issue',
@@ -581,43 +630,94 @@ function cmdGate(args, { gh, log }) {
   if (plan.decision === 'clear') log('gate: CLEAR — no wip locks.');
 }
 
-/** Find the pinned dispatcher-mutex issue by its exact title. */
-function findDispatchLockIssue(gh) {
-  const list = JSON.parse(
-    gh(['issue', 'list', '--state', 'open', '--search', 'sdlc:dispatch-lock in:title', '--json', 'number,title']),
-  );
-  const hit = list.find((i) => i.title === 'sdlc:dispatch-lock');
-  if (!hit) throw new SdlcError('no open issue titled "sdlc:dispatch-lock" — create + pin it first');
-  return hit.number;
-}
-
-function fetchLockComments(gh, issue) {
+function fetchIssueComments(gh, issue) {
   return JSON.parse(
     gh(['issue', 'view', String(issue), '--json', 'comments', '--jq', '[.comments[] | {body: .body, createdAt: .createdAt}]']),
   );
 }
 
-function cmdLock(args, { gh, log }) {
+/** The machine maintenance-lock directory (inside .git: never tracked or swept). */
+function maintLockDir(root) {
+  return path.join(root, '.git', 'sdlc-maint.lock');
+}
+
+/** Best-effort owner + age of a held maintenance lock. */
+function readMaintOwner(dir) {
+  const ageFromMtime = () => {
+    try {
+      return Date.now() - fs.statSync(dir).mtimeMs;
+    } catch {
+      return 0; // dir vanished mid-read — treat as freshly held; next cycle acquires
+    }
+  };
+  try {
+    const txt = fs.readFileSync(path.join(dir, 'owner.txt'), 'utf8').trim();
+    const [runId, ...stamp] = txt.split(/\s+/);
+    const ts = new Date(stamp.join(' ')).getTime();
+    if (runId && !Number.isNaN(ts)) return { runId, ageMs: Date.now() - ts };
+    return { runId: runId || 'unknown', ageMs: ageFromMtime() };
+  } catch {
+    return { runId: 'unknown', ageMs: ageFromMtime() };
+  }
+}
+
+function cmdMaintLock(args, { log }, root) {
   const runId = args[0];
-  if (!runId) throw new SdlcError('lock requires a run-id: sdlc lock <run-id>');
-  const issue = findDispatchLockIssue(gh);
-  const plan = planLock(fetchLockComments(gh, issue), Date.now());
-  if (plan.held) {
-    log(`lock: HELD by ${plan.holder} (${fmtAge(plan.ageMs)}) — abort the cycle.`);
+  if (!runId) throw new SdlcError('maint-lock requires a run-id: sdlc maint-lock <run-id>');
+  const dir = maintLockDir(root);
+  const acquire = () => {
+    fs.mkdirSync(dir); // atomic, fail-if-exists: exactly one contender succeeds
+    fs.writeFileSync(path.join(dir, 'owner.txt'), `${runId} ${new Date().toISOString()}\n`);
+  };
+  try {
+    acquire();
+    log(`maint-lock: ACQUIRED ${runId}`);
+    return;
+  } catch (err) {
+    if (err?.code !== 'EEXIST') throw err;
+  }
+  const owner = readMaintOwner(dir);
+  const plan = planMaintLock({ exists: true, ageMs: owner.ageMs });
+  if (plan.action === 'skip') {
+    log(`maint-lock: HELD by ${owner.runId} (${fmtAge(owner.ageMs)}) — skip maintenance this cycle; never abort over this lock.`);
     process.exitCode = 1;
     return;
   }
-  if (plan.stale) log(`lock: superseding stale lock from ${plan.holder} (${fmtAge(plan.ageMs)}, no unlock).`);
-  gh(['issue', 'comment', String(issue), '--body', `lock ${runId} ${new Date().toISOString()}`]);
-  log(`lock: ACQUIRED ${runId} (issue #${issue}).`);
+  // Stale (holder presumed dead) → reap by rename: atomic, exactly one contender wins.
+  const stale = `${dir}.stale-${runId}`;
+  try {
+    fs.renameSync(dir, stale);
+  } catch {
+    log('maint-lock: HELD — another run just reaped or holds it; skip maintenance this cycle.');
+    process.exitCode = 1;
+    return;
+  }
+  fs.rmSync(stale, { recursive: true, force: true });
+  try {
+    acquire();
+  } catch {
+    log('maint-lock: HELD — lost the post-reap acquire race; skip maintenance this cycle.');
+    process.exitCode = 1;
+    return;
+  }
+  log(`maint-lock: REAPED stale lock from ${owner.runId} (${fmtAge(owner.ageMs)}); ACQUIRED ${runId}`);
 }
 
-function cmdUnlock(args, { gh, log }) {
+function cmdMaintRelease(args, { log }, root) {
   const runId = args[0];
-  if (!runId) throw new SdlcError('unlock requires a run-id: sdlc unlock <run-id>');
-  const issue = findDispatchLockIssue(gh);
-  gh(['issue', 'comment', String(issue), '--body', `unlock ${runId}`]);
-  log(`unlock: RELEASED ${runId} (issue #${issue}).`);
+  const dir = maintLockDir(root);
+  if (!fs.existsSync(dir)) {
+    log('maint-release: RELEASED (already clear)'); // idempotent — a missing lock is a successful no-op
+    return;
+  }
+  const owner = readMaintOwner(dir);
+  if (runId && owner.runId !== 'unknown' && owner.runId !== runId) {
+    log(`maint-release: NOT OWNER — held by ${owner.runId}; left in place.`);
+    process.exitCode = 1;
+    return;
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+  log(`maint-release: RELEASED${runId ? ` ${runId}` : ''}`);
 }
 
 function cmdLanes(args, { gh, log }) {
@@ -785,8 +885,8 @@ const USAGE = `sdlc — deterministic SDLC pipeline one-shots
 
   Dispatcher-side:
   sdlc gate     [--reap]            per-issue wip-lock ages (timeline-based) → LIVE/REAP/CLEAR
-  sdlc lock     <run-id>            take the dispatcher singleton lock (exits 1 if held)
-  sdlc unlock   <run-id>            release the dispatcher singleton lock
+  sdlc maint-lock    <run-id>       acquire the per-machine maintenance lock (exit 1 = held: skip Step 0a, never abort)
+  sdlc maint-release <run-id>       release the maintenance lock (idempotent)
   sdlc lanes                        per-lane depth + eligibility + ≠1 stage integrity
   sdlc heal     [<lane>] <issue>    post-worker self-heal check (still locked?)
   sdlc git-maint                    fetch, ff dev, prune merged branches, PR state
@@ -801,8 +901,8 @@ const COMMANDS = {
   worktree: cmdWorktree,
   comment: cmdComment,
   gate: cmdGate,
-  lock: cmdLock,
-  unlock: cmdUnlock,
+  'maint-lock': cmdMaintLock,
+  'maint-release': cmdMaintRelease,
   lanes: cmdLanes,
   heal: cmdHeal,
   'git-maint': cmdGitMaint,


### PR DESCRIPTION
## Summary
Ports upstream [agentic-sdlc](https://github.com/meridun/agentic-sdlc) `master..dev` (PRs #4–#8) into pemr's SDLC implementation.

- **CLI** (`scripts/sdlc.mjs`): `lock`/`unlock` (pinned dispatch-lock issue mutex) → `maint-lock`/`maint-release` (per-machine `.git/sdlc-maint.lock`, 30-min staleness, atomic mkdir/rename reap). `planClaimVerify` boundary = newest `sdlc:wip` *unlabeled* timeline event (new `lastUnlabeledAt`); losing claims self-mark `(superseded)`; `gate --reap` re-verifies claim freshness before stripping.
- **Prompts** (`prompts/sdlc/`): no dispatcher singleton — concurrent dispatch runs deconflict via per-issue claims + machine lock + idempotent verify-before-write writes. Workers end replies with a fenced JSON STOP block, consumed by self-heal. Idempotency strengthened to "reconcile, don't re-execute" (human rewinds, reopened issues). Intake gains the in-progress collision sweep.
- **PROFILE.md**: pinned `sdlc:dispatch-lock` issue #2 marked retired (close it after merge).

pemr adaptations preserved: `npm run sdlc` one-shots, branch auto-detection, model-routing table, design lane. Upstream's versioned-artifact maintenance step skipped (no built artifact here). Supersedes an uncommitted local stage-label-boundary claim-verify draft with upstream's final wip-unlabel-boundary version.

## Verification
Fresh-context verifier pass: `node --check` clean; maint-lock lifecycle exercised live (acquire, double-acquire → exit 1, wrong-owner release → exit 1, idempotent release, stale reap); 21/21 pure-function assertions (`planClaimVerify` boundary/tie-break, `lastUnlabeledAt`, `planMaintLock` thresholds); hunk-by-hunk cross-read against the upstream diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)