### PR TITLE
Phase 5: MCP wrapper + AGENTS.md contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+# AGENTS.md — the pemr agent contract
+
+`pemr` is a **local-first personal EMR engine**: the SQLite database is the single source of
+truth, and every clinically meaningful transformation is a deterministic, pure-Python function of
+DB state. An LLM agent drives the workflow (reads scans, proposes extractions, writes summaries),
+but the agent is a *client* of the engine — it never edits the database directly and never
+substitutes its judgment for the engine's deterministic rails.
+
+This file is the binding contract for that agent layer. It governs how agents call the MCP wrapper
+(`pemr/mcp_server.py`, run as `python -m pemr.mcp_server`). The MCP tools are a thin mirror of the
+CLI verbs (`docs/Architecture.md` §5/§9): each parses args, calls the same engine function the CLI
+calls, and returns the `--json`-shaped payload as-is.
+
+## Client configuration
+
+The server speaks stdio. Install the optional SDK (`pip install pemr[mcp]`) and point your MCP
+client at it, resolving the DB the same way the CLI does — via env or `config.toml`:
+
+```json
+{
+  "mcpServers": {
+    "pemr": {
+      "command": "python",
+      "args": ["-m", "pemr.mcp_server"],
+      "env": { "PEMR_DB": "/path/to/pemr.db" }
+    }
+  }
+}
+```
+
+DB/config resolution is identical to the flagless CLI: `PEMR_DB` > `[paths].data_dir/pemr.db` in
+`PEMR_CONFIG`/`./config.toml`. No path logic lives in the wrapper.
+
+## Tool surface
+
+Read-only tools (never mutate the DB; safe to call freely):
+
+- `person_list` — roster.
+- `person_show` — one person by slug.
+- `query` — structured reads; `kind` = `labs` | `meds` | `timeline`.
+- `find` — full-text search over `ocr_text` + record fields.
+- `trends` — min/max/latest/slope for one analyte.
+- `render_summary` — master summary Markdown for a person.
+- `render_brief` — walk-in brief Markdown for one appointment.
+- `render_journal` — narrative chronology Markdown for a person.
+
+Write tools (mutate the DB; the only tools that do):
+
+- `person_add` — add a person to the roster.
+- `ingest` — hash + blob-store + layer-1 dedup a document.
+- `commit_extraction` — validate + dedup + commit extracted rows for a document.
+- `review_conflicts` — lists conflicts read-only; **writes only when given a `resolve` id**, and
+  then only with human sign-off (see below).
+
+Read/write separation is also declared to the client via MCP `readOnlyHint` annotations.
+
+## MUST rules
+
+### 1. Extraction naming
+
+Agents MUST use **canonical analyte-dictionary names** in `commit_extraction` payloads, not the
+report's verbatim label.
+
+- For any analyte present in `data/dictionary.toml`, use the canonical token (e.g. `hba1c`, not
+  "Hemoglobin A1c" or "A1c"). The deterministic dictionary + `dedup.py` normalization remain the
+  backstop, not the only defense — getting the name right at the source keeps trends, `query`, and
+  dedup coherent.
+- **Unknown analyte** (no canonical match after normalization): commit the verbatim report name
+  (parentheticals stripped) and **propose the synonym to the human** in your response. Agents
+  never edit `data/dictionary.toml` directly — dictionary additions are human-approved
+  (`docs/Architecture.md` §3).
+- MUST NOT invent abbreviations or "helpful" renames.
+
+### 2. OCR text at ingest
+
+Every `ingest` MUST end with `document.ocr_text` populated. This is what makes a document visible
+to `find` (FTS5); an ingest without it is silently unsearchable.
+
+- **Default path: agent-supplied transcription.** You already read the document to extract from it;
+  pass that text as the `ocr_text` tool param (CLI: `--ocr-text-file <path>`). A vision transcript
+  beats tesseract on messy scans.
+- **Fallback:** `ocr=true` (tesseract) only when you cannot read the file type yourself.
+- Self-check: the `ingest` response includes `ocr_text_populated: bool`. If it is `false`, treat
+  the ingest as incomplete and supply text before moving on. (The engine only *warns* here rather
+  than hard-failing, because a human at the CLI may legitimately defer — but the agent MUST not.)
+
+### 3. Conflict discipline
+
+Agents never resolve staged conflicts silently.
+
+- `review_conflicts` with no `resolve` id **lists** conflicts — call it freely.
+- **Resolution requires explicit human sign-off.** The human must have named the specific conflict
+  and the chosen resolution (`keep existing` / `keep incoming`) in the current session. "Clean this
+  up", silence, or a standing general instruction is **not** sign-off.
+- Mechanically: `review_conflicts(resolve=…)` requires a non-empty `signoff` param quoting the
+  human's instruction verbatim; the wrapper refuses the write otherwise and stores the sign-off
+  text with the resolution.
+
+### 4. Medication-interaction section
+
+`render_brief` emits a placeholder **"Medication Interaction Review"** section for the agent layer
+to fill. The engine deliberately does not compute this: an external drug-interaction API would send
+the med list off-machine (violating the local-first posture), and a rules DB inside the engine was
+rejected in phase 4 as not a pure function of DB state.
+
+The agent fills it **from its own general knowledge**, under fixed framing it MUST include verbatim:
+
+- A header stating the section is AI-generated from general knowledge, **not** a
+  drug-interaction database, and must be verified with a pharmacist or prescriber.
+- The exact current-med snapshot considered (so a human can spot staleness).
+- Any "no flags raised" statement accompanied by "this is not a clearance."
+
+The agent MUST NEVER: claim safety or the absence of interactions, give dosing advice, or recommend
+starting, stopping, or changing a medication.
+
+## Privacy posture
+
+This repository is **public**. It is framework + documentation only.
+
+- **No PHI anywhere in the repo** — no real names, DOBs, values, encounter dates, or personal-name
+  filenames in issues, commits, logs, PRs, or test fixtures. Fixtures are synthetic only.
+- MCP responses stay on the local machine. Agents MUST NOT relay record contents into any remote
+  channel (issue comments, PRs, external APIs) beyond what the human explicitly asks for.
+- The live database and blobs stay out of git: `pemr.db` (and `*-wal`/`*-shm`), `sources/`,
+  `exports/`, `inbox/`, `backups/`, and `config.toml` are all `.gitignore`d.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -262,17 +262,19 @@ pemr backup                                              # VACUUM INTO snapshot
 pemr migrate                                             # apply pending migrations
 ```
 
-### MCP tools (thin wrappers, same verbs)
+### MCP tools (thin wrappers, same verbs) — implemented phase 5
 
-`add_record`, `ingest_document`, `commit_extraction`, `find_records`, `query_labs`,
-`get_timeline`, `lab_trends`, `care_gaps`, `appointment_brief`, `master_summary`,
-`review_conflicts`. Each returns structured JSON. The MCP server shells the CLI or calls
-the Python functions directly — one implementation, two front doors.
+Read-only: `person_list`, `person_show`, `query` (`kind` = `labs`/`meds`/`timeline`), `find`,
+`trends`, `render_summary`, `render_brief`, `render_journal`. Write: `person_add`, `ingest`,
+`commit_extraction`, `review_conflicts` (resolution gated on human sign-off). Each returns the
+same `--json`-shaped payload as the CLI; the MCP server (`pemr/mcp_server.py`) parses args and
+calls the same Python functions the CLI calls — one implementation, two front doors. `readOnlyHint`
+annotations expose the read/write split to the client.
 
 `AGENTS.md` documents this contract so any agent (Cowork, Claude Code, local) knows to
 **call tools, not reinvent** — and specifically: never write to the DB except through
-`commit_extraction`/`add_record`; always `ingest` before extracting; dictionary additions
-go through review.
+`commit_extraction`/`person_add`/`ingest`; always `ingest` (with `ocr_text` populated) before
+extracting; dictionary additions go through human review, never agent-direct edits.
 
 ---
 
@@ -326,7 +328,7 @@ Because they regenerate from truth, they never drift. Old exports are disposable
    both dedup layers, conflict table. (The determinism payload.)
 3. **Query layer** — `query`, `find` (FTS5 over `ocr_text` + records), `trends`.
 4. **Render** — master summary + appointment brief + journal.
-5. **MCP wrapper** + `AGENTS.md` contract.
+5. **MCP wrapper** + `AGENTS.md` contract. **Done.**
 6. **Backup** command + scheduled task.
 7. **Care-gap rules** (`due`) — vaccines/screenings by age/sex; lowest priority, highest
    ongoing value.
@@ -351,9 +353,10 @@ it's the best possible dedup/extraction test corpus.
   `document.ocr_text` + record text fields, kept current by triggers on the base tables
   (ingest/commit paths unchanged) and backfilled on migrate. A semantic/vector sidecar
   can bolt on later without schema changes if keyword search proves insufficient.
-- **Med interactions in briefs**: rules-based flags only, or call an external drug DB?
-  (Recommend rules + "verify with pharmacist" framing — no clinical guarantees.) **Partially
-  resolved (phase 4):** deferred out of the deterministic engine — external drug knowledge
-  isn't pure-function-of-DB-state work. `render brief` emits a placeholder section for
-  phase 5's agent layer to fill; the rules-vs-external-DB choice itself is still open.
+- **Med interactions in briefs**: ~~rules-based flags only, or call an external drug DB?~~
+  **Resolved (phase 5):** neither — an external API would send meds off-machine, and an
+  in-engine rules DB isn't a pure function of DB state. `render brief`'s placeholder section is
+  filled by the **agent's own general knowledge**, under fixed framing `AGENTS.md` mandates
+  verbatim (AI-generated, not a drug-interaction DB, verify with pharmacist; never claims safety
+  or gives dosing/start-stop advice).
 ```

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -147,6 +147,15 @@ def _cmd_person_show(args: argparse.Namespace) -> int:
 
 
 def _cmd_ingest(args: argparse.Namespace) -> int:
+    ocr_text = None
+    if getattr(args, "ocr_text_file", None):
+        try:
+            with open(args.ocr_text_file, encoding="utf-8") as fh:
+                ocr_text = fh.read()
+        except OSError as exc:
+            print(f"error: cannot read {args.ocr_text_file}: {exc}", file=sys.stderr)
+            return 1
+
     conn = db.connect(_resolve_db_path(args))
     try:
         try:
@@ -159,6 +168,7 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
                 category=args.category,
                 provider=args.provider,
                 ocr=(args.ocr == "tesseract"),
+                ocr_text=ocr_text,
             )
         except db.NotMigratedError as exc:
             print(f"error: {exc}", file=sys.stderr)
@@ -180,6 +190,12 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
         f"ingested document #{doc.document_id} (sha256 {doc.sha256[:12]}...) "
         f"-> sources/{doc.source_path}"
     )
+    if not result.ocr_text_populated:
+        print(
+            "note: no ocr_text stored — `find` (full-text search) will not see this "
+            "document. Supply --ocr-text-file <path> or --ocr tesseract.",
+            file=sys.stderr,
+        )
     print(f"next: extract, then `pemr commit-extraction --document {doc.document_id} --json <file>`")
     return 0
 
@@ -514,6 +530,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_ingest.add_argument("--provider")
     p_ingest.add_argument(
         "--ocr", choices=["tesseract"], help="pre-fill ocr_text (soft dependency)"
+    )
+    p_ingest.add_argument(
+        "--ocr-text-file",
+        dest="ocr_text_file",
+        help="file of agent-supplied document text to store as ocr_text (wins over --ocr)",
     )
     p_ingest.set_defaults(func=_cmd_ingest)
 

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -39,6 +39,15 @@ class IngestResult:
     def is_duplicate(self) -> bool:
         return self.status == "duplicate"
 
+    @property
+    def ocr_text_populated(self) -> bool:
+        """Whether the stored document ended up with any OCR/transcription text.
+
+        The `AGENTS.md` contract asks agents to populate `ocr_text` on every ingest
+        (empty FTS otherwise); this lets a caller self-check without a follow-up read.
+        """
+        return bool(self.document.ocr_text)
+
 
 _READ_CHUNK = 1 << 20  # 1 MiB
 
@@ -130,12 +139,20 @@ def ingest_document(
     category: str | None = None,
     provider: str | None = None,
     ocr: bool = False,
+    ocr_text: str | None = None,
 ) -> IngestResult:
     """Ingest one document: hash, layer-1 dedup, blob store, insert `document`.
 
     On a content-hash hit (layer 1), the existing document is returned with
     status "duplicate" and nothing is written. Otherwise the blob is copied into
     the immutable content-addressed store and a new `document` row is inserted.
+
+    ``ocr_text`` is caller-supplied document text (the agent's own transcription —
+    the `AGENTS.md` default path, which beats tesseract on messy scans). When
+    provided it wins; otherwise ``ocr=True`` falls back to a best-effort tesseract
+    pass. An empty/whitespace-only string is treated as absent. Populating text here
+    is what makes a document findable via FTS (`find`), so it is a warning-not-error
+    when it ends up empty — see :attr:`IngestResult.ocr_text_populated`.
     """
     db.require_migrated(conn)
 
@@ -160,7 +177,8 @@ def ingest_document(
     if blob_created:
         shutil.copy2(src, dest)
 
-    ocr_text = run_ocr(dest) if ocr else None
+    supplied = ocr_text.strip() if ocr_text else None
+    ocr_text = supplied or (run_ocr(dest) if ocr else None)
 
     try:
         with conn:

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -334,60 +334,66 @@ def build_server():  # pragma: no cover - exercised only with the mcp SDK instal
     ro = {"readOnlyHint": True}
     rw = {"readOnlyHint": False}
 
+    # Tools are registered with explicit `name=` so the wire surface equals TOOL_NAMES —
+    # FastMCP otherwise registers under the function name (`*_tool`), and an agent
+    # following AGENTS.md (which documents the CLI-mirroring names) would call a
+    # nonexistent tool. The `*_tool` function names stay distinct from the plain
+    # connection-injected tool functions above they delegate to.
+
     # -- read-only --
-    @server.tool(annotations=ro)
+    @server.tool(name="person_list", annotations=ro)
     def person_list_tool() -> list[dict]:
         return _run(person_list)
 
-    @server.tool(annotations=ro)
+    @server.tool(name="person_show", annotations=ro)
     def person_show_tool(slug: str) -> dict:
         return _run(person_show, slug=slug)
 
-    @server.tool(annotations=ro)
+    @server.tool(name="query", annotations=ro)
     def query_tool(kind: str, person: str, test: str | None = None,
                    since: str | None = None, active: bool = False) -> list[dict]:
         return _run(query, kind=kind, person=person, test=test, since=since, active=active)
 
-    @server.tool(annotations=ro)
+    @server.tool(name="find", annotations=ro)
     def find_tool(person: str, query_text: str) -> list[dict]:
         return _run(find, person=person, query_text=query_text)
 
-    @server.tool(annotations=ro)
+    @server.tool(name="trends", annotations=ro)
     def trends_tool(person: str, test: str) -> dict:
         return _run(trends, person=person, test=test)
 
-    @server.tool(annotations=ro)
+    @server.tool(name="render_summary", annotations=ro)
     def render_summary_tool(person: str) -> dict:
         return _run(render_summary, person=person)
 
-    @server.tool(annotations=ro)
+    @server.tool(name="render_brief", annotations=ro)
     def render_brief_tool(appointment: int) -> dict:
         return _run(render_brief, appointment=appointment)
 
-    @server.tool(annotations=ro)
+    @server.tool(name="render_journal", annotations=ro)
     def render_journal_tool(person: str, since: str | None = None) -> dict:
         return _run(render_journal, person=person, since=since)
 
     # -- write --
-    @server.tool(annotations=rw)
+    @server.tool(name="person_add", annotations=rw)
     def person_add_tool(slug: str, full_name: str, dob: str | None = None,
                         sex: str | None = None, blood_type: str | None = None,
                         notes: str | None = None) -> dict:
         return _run(person_add, slug=slug, full_name=full_name, dob=dob, sex=sex,
                     blood_type=blood_type, notes=notes)
 
-    @server.tool(annotations=rw)
+    @server.tool(name="ingest", annotations=rw)
     def ingest_tool(file: str, person: str, ocr_text: str | None = None,
                     doc_date: str | None = None, category: str | None = None,
                     provider: str | None = None, ocr: bool = False) -> dict:
         return _run(ingest_document, file=file, person=person, ocr_text=ocr_text,
                     doc_date=doc_date, category=category, provider=provider, ocr=ocr)
 
-    @server.tool(annotations=rw)
+    @server.tool(name="commit_extraction", annotations=rw)
     def commit_extraction_tool(document_id: int, records: dict) -> dict:
         return _run(commit_extraction, document_id=document_id, records=records)
 
-    @server.tool(annotations=rw)
+    @server.tool(name="review_conflicts", annotations=rw)
     def review_conflicts_tool(resolve: int | None = None, keep: str = "existing",
                               signoff: str | None = None, note: str | None = None,
                               all: bool = False) -> object:

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -1,0 +1,405 @@
+"""Phase 5 MCP wrapper — a thin server over the deterministic engine (Architecture.md §9).
+
+Design (issue #12, settled in its design comment):
+
+* **No business logic here.** Every tool resolves config/db exactly as the CLI does
+  (``_resolve_*`` reused from :mod:`pemr.cli`), calls the *same* ``pemr.*`` function the
+  CLI dispatches to, and returns the engine's structured (``--json``-shaped) result as-is.
+* **In-process, never a subprocess.** The renderers/query layer are plain callables with
+  structured args for exactly this reuse (#9); the wrapper imports and calls them.
+* **The ``mcp`` SDK is an optional dependency** (``pip install pemr[mcp]``). The tool
+  functions below import nothing from ``mcp`` and take a caller-managed ``sqlite3``
+  connection, so the wrapper test-suite runs without the SDK installed. Only
+  :func:`build_server` / :func:`main` (the stdio entry point) require it, imported lazily.
+* **Read/write separation** is declared via MCP ``readOnlyHint`` annotations in
+  :func:`build_server`. The read-only tools here never write; the write tools
+  (``person_add``, ``ingest``, ``commit_extraction``, and ``review_conflicts`` *with* a
+  resolution) are the only ones that mutate.
+
+Run it: ``python -m pemr.mcp_server`` (stdio transport). Config/db resolution is env +
+``config.toml`` (``PEMR_DB`` / ``PEMR_CONFIG`` / ``[paths]``) — identical to the CLI with
+no flags; see ``AGENTS.md`` for the client-config snippet.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import asdict
+from types import SimpleNamespace
+from typing import Any
+
+# Engine modules are underscore-aliased so the public tool named `query` (and any future
+# tool sharing a module name) can't shadow the module it delegates to.
+from . import cli, db
+from . import dedup as _dedup
+from . import ingest as _ingest
+from . import persons as _persons
+from . import query as _query
+from . import render as _render
+
+
+class ToolError(RuntimeError):
+    """A friendly, expected tool failure (bad slug, un-migrated DB, validation, …).
+
+    The stdio server maps this to an MCP tool error; tests assert it directly. It is
+    deliberately distinct from an unexpected crash so the wrapper never leaks a raw
+    traceback for the ordinary "you asked for something that isn't there" cases.
+    """
+
+
+# --------------------------------------------------------------------------- #
+# Resolution — reuse the CLI's exact logic (no new path logic, issue §1)
+# --------------------------------------------------------------------------- #
+
+# A flagless args stand-in: the CLI resolvers read `.db`/`.config`/`.sources`/
+# `.dictionary`; MCP has no per-call flags, so all are None and resolution falls
+# through to env vars + config.toml — byte-identical to `pemr <cmd>` with no flags.
+_ARGS = SimpleNamespace(db=None, config=None, sources=None, dictionary=None)
+
+
+def _db_path():
+    return cli._resolve_db_path(_ARGS)
+
+
+def _dictionary() -> dict[str, str]:
+    return _dedup.load_dictionary(cli._resolve_dictionary_path(_ARGS))
+
+
+def _connect() -> sqlite3.Connection:
+    return db.connect(_db_path())
+
+
+def _friendly(exc: Exception) -> ToolError:
+    return ToolError(str(exc))
+
+
+# --------------------------------------------------------------------------- #
+# Tools — each mirrors one CLI verb; returns the engine payload as-is.
+# Every tool takes an explicit connection so tests seed a scratch DB directly and
+# the stdio wrappers (build_server) own connection lifecycle.
+# --------------------------------------------------------------------------- #
+
+# --- people (read: person_list/show; write: person_add) --------------------
+
+def person_add(
+    conn: sqlite3.Connection,
+    *,
+    slug: str,
+    full_name: str,
+    dob: str | None = None,
+    sex: str | None = None,
+    blood_type: str | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
+    """[write] Add a person to the roster. Mirrors ``pemr person add``."""
+    try:
+        person = _persons.add_person(
+            conn, slug=slug, full_name=full_name, dob=dob, sex=sex,
+            blood_type=blood_type, notes=notes,
+        )
+    except ValueError as exc:  # SlugExistsError / empty-field
+        raise _friendly(exc) from exc
+    return asdict(person)
+
+
+def person_list(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    """[read] List people. Mirrors ``pemr person list``."""
+    return [asdict(p) for p in _persons.list_people(conn)]
+
+
+def person_show(conn: sqlite3.Connection, *, slug: str) -> dict[str, Any]:
+    """[read] One person by slug. Mirrors ``pemr person show``."""
+    person = _persons.get_person(conn, slug)
+    if person is None:
+        raise ToolError(f"no person with slug '{slug}'")
+    return asdict(person)
+
+
+# --- ingest / extraction (write) -------------------------------------------
+
+def ingest_document(
+    conn: sqlite3.Connection,
+    *,
+    file: str,
+    person: str,
+    ocr_text: str | None = None,
+    doc_date: str | None = None,
+    category: str | None = None,
+    provider: str | None = None,
+    ocr: bool = False,
+) -> dict[str, Any]:
+    """[write] Ingest a document (hash, blob-store, layer-1 dedup). Mirrors ``pemr ingest``.
+
+    ``ocr_text`` is the agent's own transcription — the ``AGENTS.md`` default path.
+    The response's ``ocr_text_populated`` lets the agent self-check the FTS-visibility
+    contract without a follow-up read.
+    """
+    try:
+        sources_dir = cli._resolve_sources_dir(_ARGS)
+    except SystemExit as exc:  # CLI resolvers exit the process; a server must not
+        raise ToolError(str(exc)) from exc
+    try:
+        result = _ingest.ingest_document(
+            conn, file, person_slug=person, sources_dir=sources_dir,
+            doc_date=doc_date, category=category, provider=provider,
+            ocr=ocr, ocr_text=ocr_text,
+        )
+    except (db.NotMigratedError, _ingest.IngestError) as exc:
+        raise _friendly(exc) from exc
+    return {
+        "status": result.status,
+        "is_duplicate": result.is_duplicate,
+        "ocr_text_populated": result.ocr_text_populated,
+        "document": asdict(result.document),
+    }
+
+
+def commit_extraction(
+    conn: sqlite3.Connection,
+    *,
+    document_id: int,
+    records: dict[str, Any],
+) -> dict[str, Any]:
+    """[write] Validate + dedup + commit extracted rows for a document. Mirrors
+    ``pemr commit-extraction``. ``records`` maps record-type -> list of row dicts;
+    per the ``AGENTS.md`` naming rule, analyte names must be canonical dictionary tokens.
+    """
+    try:
+        summary = _dedup.commit_extraction(conn, document_id, records, _dictionary())
+    except (db.NotMigratedError, _dedup.ValidationError) as exc:
+        raise _friendly(exc) from exc
+    return {
+        "counts": summary.counts,
+        "new": summary.new,
+        "duplicate": summary.duplicate,
+        "conflict": summary.conflict,
+    }
+
+
+# --- conflicts (read to list; write only with a signed-off resolution) ------
+
+def review_conflicts(
+    conn: sqlite3.Connection,
+    *,
+    resolve: int | None = None,
+    keep: str = "existing",
+    signoff: str | None = None,
+    note: str | None = None,
+    all: bool = False,
+) -> Any:
+    """[read to list / write to resolve] List or resolve staged dedup conflicts.
+
+    Listing is free. **Resolution requires explicit human sign-off** (``AGENTS.md``
+    conflict discipline): ``signoff`` must quote the human's instruction verbatim, or the
+    write is refused. The sign-off text is threaded into the stored resolution note so the
+    record shows who authorized it.
+    """
+    if resolve is not None:
+        if not (signoff and signoff.strip()):
+            raise ToolError(
+                "conflict resolution requires human sign-off: pass `signoff` quoting the "
+                "human's explicit instruction. A standing/general instruction is not "
+                "sign-off (AGENTS.md conflict discipline)."
+            )
+        merged_note = f"signoff: {signoff.strip()}" + (f" — {note}" if note else "")
+        try:
+            _dedup.resolve_conflict(conn, resolve, keep=keep, note=merged_note)
+        except (db.NotMigratedError, ValueError) as exc:
+            raise _friendly(exc) from exc
+        return {"resolved": resolve, "keep": keep, "signoff": signoff.strip()}
+
+    try:
+        rows = _dedup.list_conflicts(conn, status=None if all else "open")
+    except db.NotMigratedError as exc:
+        raise _friendly(exc) from exc
+    return [dict(r) for r in rows]
+
+
+# --- structured reads -------------------------------------------------------
+
+def query(
+    conn: sqlite3.Connection,
+    *,
+    kind: str,
+    person: str,
+    test: str | None = None,
+    since: str | None = None,
+    active: bool = False,
+) -> list[dict[str, Any]]:
+    """[read] Structured reads over the record tables. ``kind`` is ``labs`` | ``meds`` |
+    ``timeline`` (mirrors ``pemr query <kind>`` rather than fanning out to three tools).
+    """
+    try:
+        if kind == "labs":
+            rows = _query.query_labs(conn, person, test=test, since=since, dictionary=_dictionary())
+        elif kind == "meds":
+            rows = _query.query_meds(conn, person, active=active)
+        elif kind == "timeline":
+            rows = _query.query_timeline(conn, person, since=since)
+        else:
+            raise ToolError(f"unknown query kind '{kind}' (known: labs, meds, timeline)")
+    except (db.NotMigratedError, _query.PersonNotFoundError) as exc:
+        raise _friendly(exc) from exc
+    return [{k: v for k, v in r.items() if k != "dedup_key"} for r in rows]
+
+
+def find(conn: sqlite3.Connection, *, person: str, query_text: str) -> list[dict[str, Any]]:
+    """[read] Full-text search over OCR text + record fields. Mirrors ``pemr find``."""
+    try:
+        return _query.find(conn, person, query_text)
+    except (db.NotMigratedError, _query.PersonNotFoundError) as exc:
+        raise _friendly(exc) from exc
+
+
+def trends(conn: sqlite3.Connection, *, person: str, test: str) -> dict[str, Any]:
+    """[read] min/max/latest/slope for one analyte over time. Mirrors ``pemr trends``."""
+    try:
+        return _query.trends(conn, person, test, dictionary=_dictionary())
+    except (db.NotMigratedError, _query.PersonNotFoundError) as exc:
+        raise _friendly(exc) from exc
+
+
+# --- renderers (read-only Markdown) ----------------------------------------
+
+def render_summary(conn: sqlite3.Connection, *, person: str) -> dict[str, str]:
+    """[read] Master summary for a person -> Markdown. Mirrors ``pemr render summary``."""
+    try:
+        markdown = _render.render_summary(conn, person, dictionary=_dictionary())
+    except (db.NotMigratedError, _query.PersonNotFoundError) as exc:
+        raise _friendly(exc) from exc
+    return {"markdown": markdown}
+
+
+def render_brief(conn: sqlite3.Connection, *, appointment: int) -> dict[str, str]:
+    """[read] Walk-in brief for one appointment -> Markdown. Mirrors ``pemr render brief``.
+
+    The Markdown carries a placeholder "Medication Interaction Review" section; per
+    ``AGENTS.md`` the agent fills it from general knowledge under the mandated
+    verify-with-a-pharmacist framing, and must never claim safety or give dosing advice.
+    """
+    try:
+        markdown = _render.render_brief(conn, appointment, dictionary=_dictionary())
+    except (db.NotMigratedError, _render.AppointmentNotFoundError) as exc:
+        raise _friendly(exc) from exc
+    return {"markdown": markdown}
+
+
+def render_journal(
+    conn: sqlite3.Connection, *, person: str, since: str | None = None
+) -> dict[str, str]:
+    """[read] Narrative chronology for a person -> Markdown. Mirrors ``pemr render journal``."""
+    try:
+        markdown = _render.render_journal(conn, person, since=since)
+    except (db.NotMigratedError, _query.PersonNotFoundError) as exc:
+        raise _friendly(exc) from exc
+    return {"markdown": markdown}
+
+
+# The exposed tool surface, in one place. AGENTS.md's contract-lint asserts it
+# references every name here; build_server registers exactly these.
+READ_ONLY_TOOLS = (
+    "person_list", "person_show", "query", "find", "trends",
+    "render_summary", "render_brief", "render_journal",
+)
+WRITE_TOOLS = ("person_add", "ingest", "commit_extraction", "review_conflicts")
+TOOL_NAMES = READ_ONLY_TOOLS + WRITE_TOOLS
+
+
+# --------------------------------------------------------------------------- #
+# stdio server — the only part that needs the `mcp` SDK (imported lazily).
+# --------------------------------------------------------------------------- #
+
+def build_server():  # pragma: no cover - exercised only with the mcp SDK installed
+    """Construct the FastMCP server, registering every tool with the right read/write
+    annotation. Each registered handler opens a connection, delegates to the plain tool
+    function above, and closes it — the tool functions stay connection-injected for tests.
+    """
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ModuleNotFoundError as exc:  # friendly nudge, not a traceback
+        raise SystemExit(
+            "error: the MCP server needs the optional `mcp` SDK — install with "
+            "`pip install pemr[mcp]` (or `pip install mcp`)."
+        ) from exc
+
+    server = FastMCP("pemr")
+
+    def _run(fn, /, **kwargs):
+        conn = _connect()
+        try:
+            return fn(conn, **kwargs)
+        finally:
+            conn.close()
+
+    ro = {"readOnlyHint": True}
+    rw = {"readOnlyHint": False}
+
+    # -- read-only --
+    @server.tool(annotations=ro)
+    def person_list_tool() -> list[dict]:
+        return _run(person_list)
+
+    @server.tool(annotations=ro)
+    def person_show_tool(slug: str) -> dict:
+        return _run(person_show, slug=slug)
+
+    @server.tool(annotations=ro)
+    def query_tool(kind: str, person: str, test: str | None = None,
+                   since: str | None = None, active: bool = False) -> list[dict]:
+        return _run(query, kind=kind, person=person, test=test, since=since, active=active)
+
+    @server.tool(annotations=ro)
+    def find_tool(person: str, query_text: str) -> list[dict]:
+        return _run(find, person=person, query_text=query_text)
+
+    @server.tool(annotations=ro)
+    def trends_tool(person: str, test: str) -> dict:
+        return _run(trends, person=person, test=test)
+
+    @server.tool(annotations=ro)
+    def render_summary_tool(person: str) -> dict:
+        return _run(render_summary, person=person)
+
+    @server.tool(annotations=ro)
+    def render_brief_tool(appointment: int) -> dict:
+        return _run(render_brief, appointment=appointment)
+
+    @server.tool(annotations=ro)
+    def render_journal_tool(person: str, since: str | None = None) -> dict:
+        return _run(render_journal, person=person, since=since)
+
+    # -- write --
+    @server.tool(annotations=rw)
+    def person_add_tool(slug: str, full_name: str, dob: str | None = None,
+                        sex: str | None = None, blood_type: str | None = None,
+                        notes: str | None = None) -> dict:
+        return _run(person_add, slug=slug, full_name=full_name, dob=dob, sex=sex,
+                    blood_type=blood_type, notes=notes)
+
+    @server.tool(annotations=rw)
+    def ingest_tool(file: str, person: str, ocr_text: str | None = None,
+                    doc_date: str | None = None, category: str | None = None,
+                    provider: str | None = None, ocr: bool = False) -> dict:
+        return _run(ingest_document, file=file, person=person, ocr_text=ocr_text,
+                    doc_date=doc_date, category=category, provider=provider, ocr=ocr)
+
+    @server.tool(annotations=rw)
+    def commit_extraction_tool(document_id: int, records: dict) -> dict:
+        return _run(commit_extraction, document_id=document_id, records=records)
+
+    @server.tool(annotations=rw)
+    def review_conflicts_tool(resolve: int | None = None, keep: str = "existing",
+                              signoff: str | None = None, note: str | None = None,
+                              all: bool = False) -> object:
+        return _run(review_conflicts, resolve=resolve, keep=keep, signoff=signoff,
+                    note=note, all=all)
+
+    return server
+
+
+def main() -> None:  # pragma: no cover - stdio entry point
+    build_server().run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,12 @@ version = "0.1.0"
 description = "Local-first personal EMR engine — SQLite is the source of truth"
 requires-python = ">=3.11"
 
+[project.optional-dependencies]
+# The phase-5 MCP wrapper (pemr/mcp_server.py). Optional: the engine, CLI, and the
+# wrapper's own tool functions/tests need none of it — only `python -m pemr.mcp_server`
+# does. Installed with `pip install pemr[mcp]`.
+mcp = ["mcp>=1.0"]
+
 [project.scripts]
 pemr = "pemr.cli:main"
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -227,3 +227,17 @@ def test_agents_md_has_the_four_must_sections():
         "Medication-interaction section",
     ):
         assert heading in text, f"AGENTS.md missing MUST section: {heading}"
+
+
+# --------------------------------------------------------------------------- #
+# Wire surface — the *registered* tool names must equal TOOL_NAMES (the contract
+# lint above only sees the documented strings; this asserts the real MCP surface,
+# so a rename can't silently ship names AGENTS.md never mentions). Requires the
+# optional `mcp` SDK; skipped when it isn't installed.
+# --------------------------------------------------------------------------- #
+
+def test_registered_tool_names_equal_contract():
+    pytest.importorskip("mcp")
+    server = mcp_server.build_server()
+    registered = {t.name for t in server._tool_manager.list_tools()}
+    assert registered == set(mcp_server.TOOL_NAMES)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,229 @@
+"""Phase 5 MCP wrapper (pemr/mcp_server.py).
+
+Two concerns, per issue #12 §3:
+
+* **Tool round-trips** — each tool, called against a seeded scratch DB, returns the same
+  structured payload the CLI's engine functions produce; write tools are refused on an
+  un-migrated DB with a friendly `ToolError`; read-only tools leave the DB byte-stable.
+* **Contract lint** — `AGENTS.md` exists, references every exposed tool, and carries the
+  four MUST-rule sections (B1–B4).
+
+The tests import the plain tool functions directly (connection-injected), so the suite
+needs neither the `mcp` SDK nor a running stdio server.
+"""
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from pemr import db, dedup, mcp_server, persons
+
+REPO = Path(__file__).resolve().parent.parent
+DICT_PATH = REPO / "data" / "dictionary.example.toml"
+AGENTS = REPO / "AGENTS.md"
+
+
+def _doc(conn, slug, ocr=None, doc_date="2026-01-01"):
+    pid = conn.execute(
+        "SELECT person_id FROM person WHERE slug=?", (slug,)
+    ).fetchone()["person_id"]
+    cur = conn.execute(
+        "INSERT INTO document (sha256, person_id, doc_date, source_path, ocr_text, "
+        "ingested_at) VALUES (?, ?, ?, ?, ?, ?)",
+        (f"sha-{slug}-{conn.total_changes}", pid, doc_date, "aa/x.pdf", ocr,
+         "2026-01-01T00:00:00"),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+@pytest.fixture()
+def db_path(tmp_path):
+    return tmp_path / "m.db"
+
+
+@pytest.fixture()
+def seeded(db_path):
+    """Migrated DB: one person with labs (incl. a synonym-collapsed HbA1c series),
+    a med, and an appointment — enough to exercise every read tool."""
+    conn = db.connect(db_path)
+    db.migrate(conn)
+    persons.add_person(conn, "jane-doe", "Jane Doe")
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _doc(conn, "jane-doe", ocr="fasting glucose panel and cholesterol")
+    dedup.commit_extraction(conn, doc, {
+        "lab_result": [
+            {"test_name": "HbA1c", "collected_at": "2024-01-01", "value_num": 5.5, "unit": "%"},
+            {"test_name": "A1c", "collected_at": "2026-01-01", "value_num": 6.5, "unit": "%"},
+        ],
+        "medication": [{"name": "Metformin", "dose": "500mg", "started_on": "2024-02-01"}],
+        "appointment": [{"scheduled_for": "2026-02-01", "provider": "Dr. Smith",
+                         "specialty": "Endocrinology", "reason": "diabetes follow-up"}],
+    }, d)
+    yield conn
+    conn.close()
+
+
+def _appt_id(conn):
+    return conn.execute("SELECT appointment_id FROM appointment").fetchone()[0]
+
+
+def _sha(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+# --------------------------------------------------------------------------- #
+# Read-tool round-trips
+# --------------------------------------------------------------------------- #
+
+def test_person_list_and_show(seeded):
+    people = mcp_server.person_list(seeded)
+    assert [p["slug"] for p in people] == ["jane-doe"]
+    assert mcp_server.person_show(seeded, slug="jane-doe")["full_name"] == "Jane Doe"
+
+
+def test_person_show_unknown_raises(seeded):
+    with pytest.raises(mcp_server.ToolError, match="no person"):
+        mcp_server.person_show(seeded, slug="nobody")
+
+
+def test_query_kinds(seeded):
+    labs = mcp_server.query(seeded, kind="labs", person="jane-doe")
+    assert len(labs) == 2
+    assert "dedup_key" not in labs[0]  # hidden field stripped, like the CLI
+    assert mcp_server.query(seeded, kind="meds", person="jane-doe")[0]["name"] == "Metformin"
+    assert mcp_server.query(seeded, kind="timeline", person="jane-doe")
+
+
+def test_query_unknown_kind_raises(seeded):
+    with pytest.raises(mcp_server.ToolError, match="unknown query kind"):
+        mcp_server.query(seeded, kind="bogus", person="jane-doe")
+
+
+def test_find_and_trends(seeded):
+    hits = mcp_server.find(seeded, person="jane-doe", query_text="glucose")
+    assert hits  # ocr_text was populated, so FTS sees it
+    tr = mcp_server.trends(seeded, person="jane-doe", test="a1c")  # dictionary-normalized
+    assert tr["count"] == 2
+    assert tr["latest"] == 6.5
+
+
+def test_renderers_return_markdown(seeded):
+    assert mcp_server.render_summary(seeded, person="jane-doe")["markdown"].startswith("#")
+    brief = mcp_server.render_brief(seeded, appointment=_appt_id(seeded))["markdown"]
+    assert "Medication Interaction Review" in brief  # the placeholder AGENTS.md fills
+    assert mcp_server.render_journal(seeded, person="jane-doe")["markdown"].startswith("#")
+
+
+def test_read_tools_leave_db_byte_stable(seeded, db_path):
+    seeded.commit()
+    before = _sha(db_path)
+    mcp_server.person_list(seeded)
+    mcp_server.query(seeded, kind="labs", person="jane-doe")
+    mcp_server.find(seeded, person="jane-doe", query_text="glucose")
+    mcp_server.trends(seeded, person="jane-doe", test="a1c")
+    mcp_server.render_summary(seeded, person="jane-doe")
+    mcp_server.render_journal(seeded, person="jane-doe")
+    assert _sha(db_path) == before
+
+
+# --------------------------------------------------------------------------- #
+# Write-tool round-trips + conflict sign-off
+# --------------------------------------------------------------------------- #
+
+def test_person_add_writes(seeded):
+    out = mcp_server.person_add(seeded, slug="john-doe", full_name="John Doe")
+    assert out["slug"] == "john-doe"
+    assert {p["slug"] for p in mcp_server.person_list(seeded)} == {"jane-doe", "john-doe"}
+
+
+def test_ingest_with_agent_ocr_text(seeded, tmp_path, monkeypatch):
+    monkeypatch.setenv("PEMR_SOURCES", str(tmp_path / "sources"))
+    scan = tmp_path / "scan.txt"
+    scan.write_bytes(b"a fresh lab report")
+    out = mcp_server.ingest_document(
+        seeded, file=str(scan), person="jane-doe",
+        ocr_text="Sodium 140 mmol/L; potassium 4.1",
+    )
+    assert out["status"] == "new"
+    assert out["ocr_text_populated"] is True
+    assert out["document"]["ocr_text"].startswith("Sodium")
+
+
+def test_commit_extraction_via_wrapper(seeded, tmp_path, monkeypatch):
+    monkeypatch.setenv("PEMR_SOURCES", str(tmp_path / "sources"))
+    scan = tmp_path / "s2.txt"
+    scan.write_bytes(b"another report")
+    doc = mcp_server.ingest_document(seeded, file=str(scan), person="jane-doe",
+                                     ocr_text="ldl panel")["document"]["document_id"]
+    out = mcp_server.commit_extraction(seeded, document_id=doc, records={
+        "lab_result": [{"test_name": "LDL", "collected_at": "2026-03-01",
+                        "value_num": 120, "unit": "mg/dL"}],
+    })
+    assert out["counts"]["new"] == 1
+
+
+def test_review_conflicts_lists_and_requires_signoff(seeded, tmp_path, monkeypatch):
+    monkeypatch.setenv("PEMR_SOURCES", str(tmp_path / "sources"))
+    # Stage a conflict: same lab key (person+test+date+rounded value) with a differing unit.
+    scan = tmp_path / "c.txt"
+    scan.write_bytes(b"conflicting report")
+    doc = mcp_server.ingest_document(seeded, file=str(scan), person="jane-doe",
+                                     ocr_text="a1c recheck")["document"]["document_id"]
+    mcp_server.commit_extraction(seeded, document_id=doc, records={
+        "lab_result": [{"test_name": "A1c", "collected_at": "2026-01-01",
+                        "value_num": 6.5, "unit": "mmol/mol"}],  # unit differs -> conflict
+    })
+    conflicts = mcp_server.review_conflicts(seeded)
+    assert len(conflicts) == 1
+    cid = conflicts[0]["conflict_id"]
+
+    # Resolution without sign-off is refused.
+    with pytest.raises(mcp_server.ToolError, match="sign-off"):
+        mcp_server.review_conflicts(seeded, resolve=cid)
+
+    # With verbatim sign-off it resolves, and the sign-off is persisted.
+    res = mcp_server.review_conflicts(
+        seeded, resolve=cid, keep="incoming",
+        signoff="Jane said keep the mmol/mol value",
+    )
+    assert res["resolved"] == cid
+    row = seeded.execute(
+        "SELECT status, resolution FROM conflict WHERE conflict_id=?", (cid,)
+    ).fetchone()
+    assert row["status"] == "resolved"
+    assert "Jane said keep" in row["resolution"]
+
+
+def test_write_tools_refused_on_unmigrated_db(tmp_path):
+    fresh = db.connect(tmp_path / "empty.db")
+    try:
+        with pytest.raises(mcp_server.ToolError):
+            mcp_server.commit_extraction(fresh, document_id=1, records={})
+        with pytest.raises(mcp_server.ToolError):
+            mcp_server.ingest_document(fresh, file=str(tmp_path / "x"), person="jane-doe")
+    finally:
+        fresh.close()
+
+
+# --------------------------------------------------------------------------- #
+# Contract lint
+# --------------------------------------------------------------------------- #
+
+def test_agents_md_exists_and_covers_every_tool():
+    assert AGENTS.is_file(), "AGENTS.md must exist"
+    text = AGENTS.read_text(encoding="utf-8")
+    missing = [name for name in mcp_server.TOOL_NAMES if name not in text]
+    assert not missing, f"AGENTS.md does not reference: {missing}"
+
+
+def test_agents_md_has_the_four_must_sections():
+    text = AGENTS.read_text(encoding="utf-8")
+    for heading in (
+        "Extraction naming",
+        "OCR text at ingest",
+        "Conflict discipline",
+        "Medication-interaction section",
+    ):
+        assert heading in text, f"AGENTS.md missing MUST section: {heading}"


### PR DESCRIPTION
## Summary
- Thin MCP server (`pemr/mcp_server.py`) wrapping the existing CLI/engine functions: 8 read-only
  tools (`person_list`, `person_show`, `query`, `find`, `trends`, `render_summary`, `render_brief`,
  `render_journal`) + 4 write tools (`person_add`, `ingest`, `commit_extraction`,
  `review_conflicts`), all registered under their contract names with `readOnlyHint` split.
- `AGENTS.md` — the binding agent contract: canonical-name extraction, mandatory `ocr_text` at
  ingest, human-sign-off-gated conflict resolution, and the fixed AI-general-knowledge framing for
  the medication-interaction brief section.
- `ingest.py`/`cli.py`: agent-supplied `ocr_text` (`--ocr-text-file`) takes priority over
  tesseract; `ocr_text_populated` self-check surfaced in the ingest response.
- Reconciled `docs/Architecture.md` §5 tool list (was still the design-phase placeholder names)
  and the med-interaction/phase-5 open questions against what actually shipped.

## Pipeline history
- verify: CONFIRMED, 126/126 tests reproduced independently, prior wire-name bounce re-verified fixed.
- audit: ADVANCE, no blocking correctness/security findings (one non-blocking note: `signoff` is a
  process guardrail the trusted agent-caller could bypass — inherent to the client/engine trust
  model, not a ship blocker).
- ship: merged `dev` in (no path overlap with upstream dedup/sdlc-prompt changes, clean merge),
  126/126 tests still pass, docs reconciliation added on top.

## Test plan
- [x] `python -m pytest -q` — 126/126 pass in the merged worktree.
- [x] Live tool-surface check: registered MCP tool names == `TOOL_NAMES` contract, no leftover
      `*_tool` names (verify's regression check).

Closes #12