### PR TITLE
test(sdlc): regression test for claim-verify formatted-EMIT ghost race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,4 @@ jobs:
           node-version: "22"
       - run: npm run sync:claude-config:check
       - run: npm run check:meta-drift
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "sync:claude-config": "node scripts/sync-claude-config.mjs",
     "sync:claude-config:check": "node scripts/sync-claude-config.mjs --check",
     "check:meta-drift": "node scripts/check-meta-drift.mjs",
-    "sdlc": "node scripts/sdlc.mjs"
+    "sdlc": "node scripts/sdlc.mjs",
+    "test": "node --test"
   }
 }

--- a/scripts/sdlc.test.mjs
+++ b/scripts/sdlc.test.mjs
@@ -1,0 +1,72 @@
+// Tests for the pure planning helpers in sdlc.mjs. Run with `npm test`
+// (node:test, built in — no dependencies). The main-guard in sdlc.mjs keeps
+// importing side-effect free.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { planClaimVerify, lastUnlabeledAt } from './sdlc.mjs';
+
+// Regression for issue #13: a formatted EMIT comment (e.g.
+// `**Intake triage: ADVANCE -> stage:queued**`) must NOT be mistaken for
+// anything that supersedes or blocks a later claim. Supersession is driven
+// solely by the `sdlc:wip` unlabeled timeline boundary, never by parsing
+// outcome keywords out of comment text — so no "ghost lost race".
+test('planClaimVerify: formatted EMIT comment does not cause a ghost lost race', () => {
+  const boundary = '2026-07-12T22:28:22Z'; // wip removed at intake's ADVANCE
+  const comments = [
+    { body: 'sdlc:claim dispatch-intake intake', createdAt: '2026-07-12T22:26:46Z' },
+    {
+      // The exact shape that broke the old `^(ADVANCE|BOUNCE|PARK|CONTINUE)`
+      // regex: outcome keyword buried behind Markdown emphasis and a label.
+      body: '**Intake triage: ADVANCE -> stage:queued**\n\nConfirmed at scripts/sdlc.mjs...',
+      createdAt: '2026-07-12T22:28:22Z',
+    },
+    { body: 'sdlc:claim dispatch-build build', createdAt: '2026-07-17T01:19:04Z' },
+  ];
+
+  const result = planClaimVerify(comments, 'dispatch-build', boundary);
+  assert.equal(result.won, true, 'post-boundary build claim must win');
+  assert.equal(result.winner, 'dispatch-build');
+});
+
+test('planClaimVerify: claims at/before the boundary are settled history', () => {
+  const boundary = '2026-07-12T22:28:22Z';
+  // Only the pre-boundary intake claim exists; my own (build) claim is absent.
+  const comments = [
+    { body: 'sdlc:claim dispatch-intake intake', createdAt: '2026-07-12T22:26:46Z' },
+  ];
+  const result = planClaimVerify(comments, 'dispatch-build', boundary);
+  assert.equal(result.won, false);
+  assert.equal(result.reason, 'own claim not found');
+});
+
+test('planClaimVerify: earliest live claim wins; ties break to lower run-id', () => {
+  // No boundary → all claims live. Two claims at the same instant: the
+  // lexicographically lower run-id wins.
+  const comments = [
+    { body: 'sdlc:claim run-b build', createdAt: '2026-07-17T01:00:00Z' },
+    { body: 'sdlc:claim run-a build', createdAt: '2026-07-17T01:00:00Z' },
+  ];
+  assert.equal(planClaimVerify(comments, 'run-a').won, true);
+  assert.equal(planClaimVerify(comments, 'run-b').won, false);
+
+  // Earlier claim beats a later one regardless of run-id ordering.
+  const staggered = [
+    { body: 'sdlc:claim zzz build', createdAt: '2026-07-17T01:00:00Z' },
+    { body: 'sdlc:claim aaa build', createdAt: '2026-07-17T01:05:00Z' },
+  ];
+  assert.equal(planClaimVerify(staggered, 'zzz').won, true);
+  assert.equal(planClaimVerify(staggered, 'aaa').won, false);
+});
+
+test('lastUnlabeledAt: returns the most recent removal of the label', () => {
+  const timeline = [
+    { event: 'unlabeled', label: { name: 'sdlc:wip' }, created_at: '2026-07-12T22:28:22Z' },
+    { event: 'labeled', label: { name: 'sdlc:wip' }, created_at: '2026-07-17T01:18:00Z' },
+    { event: 'unlabeled', label: { name: 'sdlc:wip' }, created_at: '2026-07-17T03:00:00Z' },
+    { event: 'unlabeled', label: { name: 'other' }, created_at: '2026-07-18T00:00:00Z' },
+  ];
+  assert.equal(lastUnlabeledAt(timeline, 'sdlc:wip'), '2026-07-17T03:00:00Z');
+  assert.equal(lastUnlabeledAt([], 'sdlc:wip'), null);
+  assert.equal(lastUnlabeledAt(timeline, 'never'), null);
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/sdlc.test.mjs` (node:test, no deps): covers `planClaimVerify`'s formatted-EMIT
  ghost-race scenario from #12 (a comment like `**Intake triage: ADVANCE ...` must not cause a
  ghost lost race), settled pre-boundary history, earliest-live/lower-run-id tiebreak, and
  `lastUnlabeledAt`'s boundary-source behavior.
- Wires it up: `npm test` (`node --test`) in `package.json`, run from the `meta` CI job
  (`.github/workflows/ci.yml`).
- The underlying fix (retiring the fragile `^(ADVANCE|BOUNCE|PARK|CONTINUE)` outcome-comment
  regex in `planClaimVerify` in favor of the `sdlc:wip` unlabeled-timeline boundary) already
  landed on `dev` in 9c7780d as part of the concurrent-dispatch port — this PR is test coverage
  and CI enforcement only.

Closes #13

## Test plan
- [x] `npm test` — 4/4 pass locally
- [x] Direct `planClaimVerify` probe against #13's real comment history (which contains the
      exact bug-triggering formatted EMIT comments) — wins cleanly, no ghost lost race
- [x] Branch already contains `origin/dev` tip; no merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)