### PR TITLE
fix(dedup): validate date fields as strict ISO in validate_row (#19)

### DIFF
--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -81,12 +81,46 @@ FIELD_SPECS: dict[str, dict[str, tuple[object, bool]]] = {
 
 KNOWN_TYPES = tuple(FIELD_SPECS)
 
+# Date-typed fields per record type. These feed timeline sort / trends date math and
+# the dedup_key (via _date_only), all of which assume a lexically-sortable ISO date —
+# so validate_row enforces strict ISO on them, not just the base `str` type.
+DATE_FIELDS: dict[str, frozenset[str]] = {
+    "lab_result": frozenset({"collected_at"}),
+    "medication": frozenset({"started_on", "ended_on"}),
+    "procedure": frozenset({"performed_on"}),
+    "appointment": frozenset({"scheduled_for"}),
+    "observation": frozenset({"observed_at"}),
+}
+
 _WS = re.compile(r"\s+")
 _PAREN = re.compile(r"\([^)]*\)")
+
+# A date value must begin with a strict `YYYY-MM-DD` (the part _date_only slices for
+# the dedup_key and timeline sort); an optional time component may follow after `T` or
+# a space. Calendar validity (real month/day, valid time) is then confirmed by
+# datetime.fromisoformat below.
+_ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}(?:[T ].*)?")
 
 
 class ValidationError(ValueError):
     """Raised when the extraction JSON violates a record schema."""
+
+
+def _is_iso_date(value: str) -> bool:
+    """True when ``value`` is a strict ISO date (``YYYY-MM-DD``) or ISO timestamp
+    (``YYYY-MM-DD`` + ``T``/space + a valid time, optionally with offset/``Z``).
+
+    Non-ISO forms like ``06/15/2026`` or ``not-a-date`` are rejected — they would
+    otherwise sort lexically ahead of real ISO dates and corrupt the timeline."""
+    if not _ISO_DATE_RE.fullmatch(value):
+        return False
+    try:
+        # datetime.fromisoformat (3.11+) parses date-only and full timestamps and
+        # enforces calendar/time validity; `Z` is accepted only from 3.11 onward.
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
 
 
 # --------------------------------------------------------------------------- #
@@ -216,6 +250,11 @@ def validate_row(record_type: str, row: object) -> None:
             raise ValidationError(
                 f"{record_type}.{name}: expected {_type_names(types)}, "
                 f"got {type(value).__name__}"
+            )
+        if name in DATE_FIELDS.get(record_type, frozenset()) and not _is_iso_date(value):
+            raise ValidationError(
+                f"{record_type}.{name}: expected ISO date (YYYY-MM-DD) or ISO "
+                f"timestamp, got {value!r}"
             )
 
 

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -169,6 +169,56 @@ def test_validate_rejects_wrong_type():
         )
 
 
+@pytest.mark.parametrize("bad", ["06/15/2026", "not-a-date", "2026-13-01",
+                                  "2026-01-32", "20260102", "2026/01/02", "Jan 2 2026"])
+def test_validate_rejects_non_iso_date(bad):
+    # Non-ISO date strings must be rejected by name+value (issue #19): they sort
+    # lexically ahead of real ISO dates and corrupt the timeline.
+    with pytest.raises(dedup.ValidationError, match=r"collected_at.*ISO date"):
+        dedup.validate_row(
+            "lab_result",
+            {"test_name": "Sodium", "value_num": 140, "collected_at": bad},
+        )
+
+
+@pytest.mark.parametrize("good", ["2026-01-02", "2026-01-02T09:30",
+                                   "2026-01-02T09:30:00", "2026-01-02 09:30:00",
+                                   "2026-01-02T09:30:00+00:00", "2026-01-02T09:30:00Z"])
+def test_validate_accepts_iso_dates_and_timestamps(good):
+    # Full ISO timestamps are accepted alongside bare YYYY-MM-DD.
+    dedup.validate_row(
+        "lab_result",
+        {"test_name": "Sodium", "value_num": 140, "collected_at": good},
+    )
+
+
+def test_validate_rejects_non_iso_date_across_record_types():
+    # Every date-typed field, not just lab_result.collected_at, is guarded.
+    with pytest.raises(dedup.ValidationError, match=r"started_on.*ISO date"):
+        dedup.validate_row("medication", {"name": "Metformin", "started_on": "06/15/2026"})
+    with pytest.raises(dedup.ValidationError, match=r"ended_on.*ISO date"):
+        dedup.validate_row("medication", {"name": "Metformin", "ended_on": "bad"})
+    with pytest.raises(dedup.ValidationError, match=r"performed_on.*ISO date"):
+        dedup.validate_row("procedure", {"name": "MRI", "performed_on": "13/01/2026"})
+    with pytest.raises(dedup.ValidationError, match=r"scheduled_for.*ISO date"):
+        dedup.validate_row("appointment", {"scheduled_for": "next tuesday"})
+    with pytest.raises(dedup.ValidationError, match=r"observed_at.*ISO date"):
+        dedup.validate_row("observation", {"obs_type": "vital", "observed_at": "2026/01/02"})
+
+
+def test_commit_bad_date_rolls_back_whole_batch(conn):
+    # End-to-end: a non-ISO date in a committed batch rolls the whole thing back.
+    doc = _make_document(conn)
+    with pytest.raises(dedup.ValidationError, match="ISO date"):
+        dedup.commit_extraction(
+            conn, doc,
+            {"lab_result": [_lab(5.7),
+                            {"test_name": "Sodium", "value_num": 140,
+                             "collected_at": "06/15/2026"}]},
+        )
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 0
+
+
 # --- commit_extraction: new / duplicate / conflict ----------------------------
 
 def _lab(value):


### PR DESCRIPTION
## Summary
- `validate_row` only type-checked date fields (`collected_at`, `started_on`, `ended_on`, `performed_on`, `scheduled_for`, `observed_at`) as `str`, so non-ISO values like `06/15/2026` or `not-a-date` committed without error and then sorted lexically ahead of real ISO dates in `query timeline`, corrupting trends date math.
- Adds a `DATE_FIELDS` map + `_is_iso_date()` (strict `YYYY-MM-DD` prefix confirmed via `datetime.fromisoformat`) and enforces it in `validate_row`, raising `ValidationError` naming the offending field and value. Accepts bare dates and full ISO timestamps (`T`/space separator, offset/`Z`); rejects slash dates, prose, and invalid calendar dates (e.g. Feb 30).
- Validation runs in commit's up-front Pass-1, ahead of any insert, so a bad date can never half-commit.

Closes #19

## Test plan
- [x] `pytest tests/test_dedup.py` -> 41 passed
- [x] Full suite -> 146 passed
- [x] Real CLI repro: `collected_at: "06/15/2026"` -> `ValidationError`, exit 1 (previously committed silently)
- [x] Real CLI repro: `observed_at: "not-a-date"` -> `ValidationError`, exit 1
- [x] Good `collected_at: "2026-06-15"` -> commits normally, exit 0
- [x] Batch atomicity: good sibling row does not land when a bad date is in the same batch (rollback confirmed)
- [x] Verify + audit lanes both independently reproduced tests and CLI runs; audit found no security findings (ReDoS/injection/bypass probes all clear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)