### PR TITLE
fix(dedup): drop value from lab/observation keys; temporal identity carries the draw

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -195,11 +195,11 @@ Each typed/observation row computes a deterministic `dedup_key` from normalized 
 so the *same clinical fact* extracted from two different documents collapses to one row.
 
 ```
-lab_result.dedup_key   = hash(person_id | norm(test_name) | collected_at_date | round(value))
+lab_result.dedup_key   = hash(person_id | norm(test_name) | collected_at)
 medication.dedup_key    = hash(person_id | norm(name) | dose | started_on)
 procedure.dedup_key     = hash(person_id | norm(name) | performed_on)
 appointment.dedup_key   = hash(person_id | provider | scheduled_for)
-observation.dedup_key   = hash(person_id | obs_type | observed_at | key | value)
+observation.dedup_key   = hash(person_id | obs_type | observed_at | key)
 ```
 
 `norm()` = lowercase, trim, collapse whitespace, map synonyms via an **analyte/name
@@ -207,10 +207,23 @@ dictionary** (`data/dictionary.toml`) — e.g. `A1c`, `HbA1c`, `Hemoglobin A1c` 
 canonical `hba1c`. The dictionary is the one place fuzzy naming gets pinned down
 deterministically; agents propose additions, you approve.
 
+The **measured value is deliberately *not* in the key** — temporal identity carries the
+draw instead. `collected_at`/`observed_at` are used at full precision (timestamp when the
+document gives one, date when it only gives a date), not truncated to the date. Two draws
+of the same analyte on the same day at different times (serial glucose, peri-op, inpatient
+q6h) get distinct timestamps → distinct keys → two rows preserved; a correction or OCR
+re-read of the *same* draw carries the same timestamp → collides → surfaces as a conflict
+(below). When only a date is available, same-day differing values collide → conflict; that
+safety bias is intentional (a spurious conflict on a genuine repeat is human-recoverable, a
+silent duplicate of a correction poisons `trends`/brief/`query` irrecoverably).
+
 **Conflict handling.** On dedup-key collision with *differing* non-key fields (e.g. a
 corrected value), don't silently drop — write to a `conflict` staging table and surface
 it: `pemr review-conflicts`. Human/agent resolves. This is the safety valve that keeps
-"no duplicates" from quietly meaning "lost the corrected result."
+"no duplicates" from quietly meaning "lost the corrected result." Because the value is out
+of the key, this fires for *any* magnitude of value change on a matching draw — the
+headline `Glucose 92 → 95` (or `92 → 130`) case that previously slipped through as a silent
+new row now stages a conflict.
 
 ---
 

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -147,10 +147,20 @@ def _date_only(value: object) -> str:
     return text.replace("T", " ").split(" ")[0]
 
 
-def _round_value(value: object) -> str:
-    if value is None or value == "":
+def _norm_ts(value: object) -> str:
+    """Normalize an ISO date/datetime for use as a dedup-key identity part, keeping
+    *full precision* (unlike :func:`_date_only`, which truncates to the date).
+
+    A timestamped draw (``2026-01-02T09:00``) and a bare-date draw (``2026-01-02``)
+    stay distinct, and two draws on the same day at different times keep distinct keys
+    — so serial same-day repeats (GTT, peri-op, inpatient q6h) survive as separate
+    rows. A re-read/correction of the *same* draw carries the same timestamp, collides,
+    and surfaces as a CONFLICT via :data:`_COMPARE_FIELDS`. Only the ``T``/space
+    separator and surrounding/collapsed whitespace are normalized, so trivial
+    formatting differences don't fork the key."""
+    if value is None:
         return ""
-    return str(round(float(value)))
+    return _WS.sub(" ", str(value).strip().replace("T", " "))
 
 
 def _hash_parts(parts: list[object]) -> str:
@@ -167,8 +177,7 @@ def dedup_key(
         return norm(row.get(field_name), dictionary)
 
     if record_type == "lab_result":
-        parts = [person_id, n("test_name"), _date_only(row.get("collected_at")),
-                 _round_value(row.get("value_num"))]
+        parts = [person_id, n("test_name"), _norm_ts(row.get("collected_at"))]
     elif record_type == "medication":
         parts = [person_id, n("name"), _collapse(str(row.get("dose") or "")),
                  _date_only(row.get("started_on"))]
@@ -177,11 +186,8 @@ def dedup_key(
     elif record_type == "appointment":
         parts = [person_id, n("provider"), _date_only(row.get("scheduled_for"))]
     elif record_type == "observation":
-        value = row.get("value_num")
-        if value is None:
-            value = _collapse(str(row.get("value_text") or ""))
-        parts = [person_id, n("obs_type"), _date_only(row.get("observed_at")),
-                 n("key"), value]
+        parts = [person_id, n("obs_type"), _norm_ts(row.get("observed_at")),
+                 n("key")]
     else:  # pragma: no cover - guarded by validate()
         raise ValidationError(f"unknown record type: {record_type}")
     return _hash_parts(parts)
@@ -247,10 +253,11 @@ class CommitSummary:
 # Payload fields compared to decide duplicate-vs-conflict once dedup_keys match.
 # Identity fields (those feeding the dedup_key) are equal by construction — a
 # difference there yields a *different* key and hence a new row, never a collision —
-# so they are deliberately excluded here. The lone exception is the measured value:
-# value_num feeds the lab/observation key via a lossy round(), so a corrected value
-# in the same round-bucket still collides and must surface as a CONFLICT, not a
-# silent duplicate — hence value_num appears below.
+# so they are deliberately excluded here. The measured value is deliberately NOT an
+# identity field: the lab/observation keys carry temporal identity (collected_at /
+# observed_at at full precision) but not the value, so a corrected or re-read value on
+# an otherwise-matching key collides and surfaces here as a CONFLICT instead of a
+# silent duplicate — hence value_num/value_text appear below.
 _COMPARE_FIELDS: dict[str, list[str]] = {
     "lab_result": ["value_num", "value_text", "unit", "ref_low", "ref_high", "flag", "loinc"],
     "medication": ["route", "frequency", "ended_on", "prescriber", "status"],

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -110,12 +110,14 @@ def test_corpus_naming_variants_share_canonical_token():
 def test_dedup_key_is_stable_across_formatting():
     d = dedup.load_dictionary(DICT_PATH)
     a = dedup.dedup_key("lab_result",
-                        {"test_name": "HbA1c", "collected_at": "2026-01-02", "value_num": 5.7},
+                        {"test_name": "HbA1c", "collected_at": "2026-01-02T09:30", "value_num": 5.7},
                         person_id=1, dictionary=d)
     b = dedup.dedup_key("lab_result",
-                        {"test_name": "  a1c ", "collected_at": "2026-01-02T09:30", "value_num": 5.7},
+                        {"test_name": "  a1c ", "collected_at": "2026-01-02 09:30", "value_num": 6.2},
                         person_id=1, dictionary=d)
-    assert a == b  # same fact, different spelling/whitespace/time-of-day -> one key
+    # same draw (person/analyte/timestamp), different spelling/whitespace, T-vs-space
+    # separator, AND a differing value -> one key (value is no longer an identity field)
+    assert a == b
 
 
 def test_dedup_key_differs_by_person():
@@ -206,7 +208,8 @@ def test_differing_value_stages_conflict(conn):
     doc1 = _make_document(conn)
     doc2 = _make_document(conn)
     dedup.commit_extraction(conn, doc1, {"lab_result": [_lab(5.7)]}, d)
-    # same key bucket (round(5.7)==round(6.2)==6) but a corrected value -> conflict
+    # same person/analyte/date (the dedup key) but a corrected value -> conflict.
+    # The value is no longer in the key, so this fires regardless of magnitude.
     summary = dedup.commit_extraction(conn, doc2, {"lab_result": [_lab(6.2)]}, d)
     assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
     # original row untouched, no second lab row inserted
@@ -269,10 +272,74 @@ def test_corrected_value_still_conflicts_after_normalization(conn):
     r1 = {"test_name": "HGB", "collected_at": "2026-03-01", "value_num": 13.1,
           "unit": "g/dL"}
     r2 = {"test_name": "Hemoglobin (HGB)", "collected_at": "2026-03-01",
-          "value_num": 13.4, "unit": "G/DL"}  # same round-bucket, corrected value
+          "value_num": 13.4, "unit": "G/DL"}  # same draw, corrected value
     dedup.commit_extraction(conn, doc1, {"lab_result": [r1]}, d)
     summary = dedup.commit_extraction(conn, doc2, {"lab_result": [r2]}, d)
     assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+
+
+def test_far_apart_correction_conflicts_not_duplicates(conn):
+    # Issue #20 headline: a large-magnitude correction (92 -> 130, same draw) used to
+    # slip through as a silent new row because value fed the key via round(). With the
+    # value out of the key it now collides on person/analyte/timestamp -> conflict.
+    d = dedup.load_dictionary(DICT_PATH)
+    doc1 = _make_document(conn)
+    doc2 = _make_document(conn)
+    r1 = {"test_name": "Glucose", "collected_at": "2026-04-01T08:00", "value_num": 92,
+          "unit": "mg/dL"}
+    r2 = {"test_name": "GLUC", "collected_at": "2026-04-01T08:00", "value_num": 130,
+          "unit": "mg/dL"}  # OCR re-read of the *same* draw, wildly different value
+    dedup.commit_extraction(conn, doc1, {"lab_result": [r1]}, d)
+    summary = dedup.commit_extraction(conn, doc2, {"lab_result": [r2]}, d)
+    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
+
+
+def test_serial_same_day_draws_are_distinct_rows(conn):
+    # Two genuine draws on the same day at different times (GTT / peri-op / inpatient
+    # q6h) carry distinct timestamps -> distinct keys -> two rows, no data loss.
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _make_document(conn)
+    rows = [
+        {"test_name": "Glucose", "collected_at": "2026-04-01T08:00", "value_num": 92,
+         "unit": "mg/dL"},
+        {"test_name": "Glucose", "collected_at": "2026-04-01T14:00", "value_num": 130,
+         "unit": "mg/dL"},
+    ]
+    summary = dedup.commit_extraction(conn, doc, {"lab_result": rows}, d)
+    assert summary.counts == {"new": 2, "duplicate": 0, "conflict": 0}
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
+
+
+def test_observation_correction_conflicts_not_duplicates(conn):
+    # Same latent defect for observation: value used to be *in* the key, so a corrected
+    # reading silently duplicated. With value out of the key it now conflicts.
+    d = dedup.load_dictionary(DICT_PATH)
+    doc1 = _make_document(conn)
+    doc2 = _make_document(conn)
+    o1 = {"obs_type": "vital", "key": "systolic", "observed_at": "2026-05-01T09:00",
+          "value_num": 120}
+    o2 = {"obs_type": "vital", "key": "systolic", "observed_at": "2026-05-01T09:00",
+          "value_num": 155}  # re-read of the same measurement, corrected value
+    dedup.commit_extraction(conn, doc1, {"observation": [o1]}, d)
+    summary = dedup.commit_extraction(conn, doc2, {"observation": [o2]}, d)
+    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 1
+
+
+def test_serial_same_day_observations_are_distinct_rows(conn):
+    # Two same-day vitals at different times stay as two rows.
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _make_document(conn)
+    rows = [
+        {"obs_type": "vital", "key": "systolic", "observed_at": "2026-05-01T09:00",
+         "value_num": 120},
+        {"obs_type": "vital", "key": "systolic", "observed_at": "2026-05-01T17:00",
+         "value_num": 138},
+    ]
+    summary = dedup.commit_extraction(conn, doc, {"observation": rows}, d)
+    assert summary.counts == {"new": 2, "duplicate": 0, "conflict": 0}
+    assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 2
 
 
 def test_commit_unknown_type_rolls_back(conn):


### PR DESCRIPTION
## Summary
- `dedup_key` for `lab_result`/`observation` previously baked the measured value (round-bucketed for labs, raw for observations) into the key. A corrected value (OCR re-read or amended result) landing in a different bucket silently created a new row instead of surfacing the documented conflict path.
- Drops value from both keys; temporal identity now uses full-precision `collected_at`/`observed_at` (via new `_norm_ts` helper) instead of date-truncation, so serial same-day draws (distinct timestamps) stay distinct rows while a correction of the *same* draw (same timestamp) now collides into a CONFLICT for review.
- `docs/Architecture.md` key formulas and conflict-path explanation updated to match.

## Test plan
- [x] `python -m pytest` — 135 passed
- [x] Live CLI repro of the issue's exact scenario (Glucose 92 → 95, date-only) — now stages 1 conflict instead of a silent duplicate; `query labs`/`trends` return one row
- [x] New regression tests: far-apart correction conflicts (lab + observation), serial same-day distinct-time draws stay two rows (lab + observation)
- [x] Verify + audit passes completed with no blocking findings (see issue #20 comment history)

Closes #20

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>