### PR TITLE
fix(query): treat terminal med status as ended, not "(current)"

### DIFF
--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -355,7 +355,13 @@ def _cmd_query_meds(args: argparse.Namespace) -> int:
         for r in rows:
             dose = f"  {r['dose']}" if r["dose"] else ""
             freq = f"  {r['frequency']}" if r["frequency"] else ""
-            span = _fmt(r["started_on"]) + (f" -> {r['ended_on']}" if r["ended_on"] else " -> (current)")
+            if r["ended_on"]:
+                end = f" -> {r['ended_on']}"
+            elif query.med_is_current(r):
+                end = " -> (current)"
+            else:  # terminal status but no explicit end date (issue #21)
+                end = " -> (ended)"
+            span = _fmt(r["started_on"]) + end
             status = f"  [{r['status']}]" if r["status"] else ""
             print(f"{r['name']:24}{dose}{freq}  {span}{status}")
         return 0

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -25,6 +25,35 @@ from .dedup import norm
 # can never be mis-parsed as FTS syntax (each token is quoted as a phrase, AND-ed).
 _WORD = re.compile(r"\w+", re.UNICODE)
 
+# Medication ``status`` values that end the course even when no explicit ``ended_on``
+# date was extracted (issue #21). ``status`` is unconstrained at the DB layer
+# (migrations/001_init.sql documents active|discontinued|prn, but extraction agents emit
+# terminal values like completed/stopped as well), so matching is lowercased and trimmed.
+TERMINAL_MED_STATUSES = frozenset({"completed", "stopped", "discontinued"})
+
+
+def _row_get(row: sqlite3.Row | dict, key: str) -> object:
+    """Column access that tolerates a missing key on either a dict or ``sqlite3.Row``."""
+    try:
+        return row[key]
+    except (KeyError, IndexError):
+        return None
+
+
+def med_is_current(row: sqlite3.Row | dict) -> bool:
+    """True when a medication is still current: no end date *and* no terminal status.
+
+    An explicit ``status='active'`` always counts as current (even alongside an end
+    date). A terminal status (:data:`TERMINAL_MED_STATUSES`) ends the course even when
+    no ``ended_on`` was extracted — the contradiction behind issue #21, where a
+    ``completed`` med with a null ``ended_on`` rendered as ``(current)``."""
+    status = str(_row_get(row, "status") or "").strip().lower()
+    if status == "active":
+        return True
+    if _row_get(row, "ended_on"):
+        return False
+    return status not in TERMINAL_MED_STATUSES
+
 
 class PersonNotFoundError(ValueError):
     """Raised when a slug does not resolve to a person (friendly rc=1 at the CLI)."""
@@ -77,15 +106,17 @@ def query_labs(
 def query_meds(
     conn: sqlite3.Connection, slug: str, active: bool = False
 ) -> list[dict]:
-    """Medications for a person. ``active`` keeps only current ones — no end date, or
-    an explicit ``status='active'`` (Architecture.md §5)."""
+    """Medications for a person. ``active`` keeps only current ones — no end date and
+    no terminal status, or an explicit ``status='active'`` (Architecture.md §5). A
+    terminal status (completed/stopped/discontinued) ends the course even without an
+    ``ended_on``, so such rows are excluded from ``active`` (issue #21)."""
     person_id = resolve_person_id(conn, slug)
-    sql = "SELECT * FROM medication WHERE person_id = ?"
-    params: list[object] = [person_id]
+    sql = ("SELECT * FROM medication WHERE person_id = ? "
+           "ORDER BY (started_on IS NULL), started_on, name")
+    rows = [dict(r) for r in conn.execute(sql, (person_id,)).fetchall()]
     if active:
-        sql += " AND (ended_on IS NULL OR status = 'active')"
-    sql += " ORDER BY (started_on IS NULL), started_on, name"
-    return [dict(r) for r in conn.execute(sql, params).fetchall()]
+        rows = [r for r in rows if med_is_current(r)]
+    return rows
 
 
 def query_timeline(

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -67,6 +67,28 @@ def test_query_meds_active_json(ready, capsys):
     assert [m["name"] for m in payload] == ["Metformin"]
 
 
+def test_query_meds_terminal_status_renders_ended_not_current(ready, capsys):
+    """Issue #21: a completed med with no ended_on must not render '(current)'."""
+    conn = db.connect(ready / "cli.db")
+    d = dedup.load_dictionary(DICT_ARG[1])
+    doc = conn.execute("SELECT document_id FROM document LIMIT 1").fetchone()["document_id"]
+    dedup.commit_extraction(conn, doc, {
+        "medication": [{"name": "Amoxicillin", "dose": "250mg", "frequency": "BID",
+                        "started_on": "2026-05-20", "status": "completed"}],
+    }, d)
+    conn.close()
+
+    assert _run(ready, "query", "meds", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    amox = next(line for line in out.splitlines() if "Amoxicillin" in line)
+    assert "(current)" not in amox
+    assert "(ended)" in amox
+    assert "[completed]" in amox
+    # the still-current med is unaffected
+    metformin = next(line for line in out.splitlines() if "Metformin" in line)
+    assert "(current)" in metformin
+
+
 def test_query_timeline_json(ready, capsys):
     assert _run(ready, "query", "timeline", "--person", "jane-doe", "--json") == 0
     events = json.loads(capsys.readouterr().out)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -109,6 +109,36 @@ def test_query_meds_all_vs_active(seeded):
     assert [m["name"] for m in active] == ["Metformin"]  # Lisinopril is ended
 
 
+@pytest.mark.parametrize("row, expected", [
+    ({"status": None, "ended_on": None}, True),          # nothing set -> current
+    ({"status": "", "ended_on": None}, True),            # blank status -> current
+    ({"status": "active", "ended_on": None}, True),      # explicitly active
+    ({"status": "active", "ended_on": "2024-01-01"}, True),  # explicit active wins over end
+    ({"status": "prn", "ended_on": None}, True),         # prn is not terminal
+    ({"status": "completed", "ended_on": None}, False),  # issue #21: terminal, no end date
+    ({"status": "Stopped", "ended_on": None}, False),    # case-insensitive
+    ({"status": " discontinued ", "ended_on": None}, False),  # trimmed
+    ({"status": None, "ended_on": "2024-06-01"}, False), # explicit end date
+])
+def test_med_is_current(row, expected):
+    assert query.med_is_current(row) is expected
+
+
+def test_query_meds_active_excludes_terminal_status_without_end(seeded):
+    """A med with a terminal status but no ended_on is not 'active' (issue #21)."""
+    doc = _doc(seeded, "jane-doe")
+    dedup.commit_extraction(seeded, doc, {
+        "medication": [
+            {"name": "Amoxicillin", "dose": "250mg", "frequency": "BID",
+             "started_on": "2026-05-20", "status": "completed"},
+        ],
+    }, dedup.load_dictionary(DICT_PATH))
+    names_all = {m["name"] for m in query.query_meds(seeded, "jane-doe")}
+    assert "Amoxicillin" in names_all  # still listed by the unfiltered query
+    names_active = {m["name"] for m in query.query_meds(seeded, "jane-doe", active=True)}
+    assert "Amoxicillin" not in names_active
+
+
 # --- structured: timeline -----------------------------------------------------
 
 def test_timeline_merge_ordering_and_since(seeded):


### PR DESCRIPTION
## Summary
- A medication with a terminal `status` (`completed`/`stopped`/`discontinued`) but no explicit `ended_on` rendered as `-> (current)`, contradicting the status printed beside it (e.g. `Amoxicillin ... -> (current)  [completed]`).
- Added `query.TERMINAL_MED_STATUSES` and `query.med_is_current(row)` as the single source of truth: `active` status always wins as current even alongside an end date; explicit `ended_on` means not current; otherwise current iff status isn't terminal (status normalized lowercase/trimmed).
- CLI meds formatter now renders `-> (ended)` for a terminal-status/no-end-date med instead of `-> (current)`.
- `query_meds(active=True)` now filters through `med_is_current` (was `ended_on IS NULL OR status='active'` in SQL), so a completed-no-end med is no longer wrongly returned as "active" — this also fixes the appointment/summary brief "current meds" lists and the MCP server, which all reuse this query.

Closes #21

## Test plan
- [x] `pytest tests/test_query.py tests/test_cli_phase3.py` — 39 passed (new: `test_med_is_current` parametrized, `test_query_meds_active_excludes_terminal_status_without_end`, CLI render test asserting `(ended)`/not `(current)`/`[completed]`)
- [x] Full suite: 161 passed
- [x] Manual CLI repro against issue #21's Amoxicillin case, plus constructed edge cases (case/whitespace-variant status, `active`+explicit end date, `prn`/no-status non-terminal) — all verified independently in the pipeline's verify and audit stages
- [x] Reviewed by pipeline verify (adversarial CONFIRMED) and audit (security-executor, no blocking findings) stages; full trail on issue #21

🤖 Generated with the pemr SDLC pipeline (ship lane)