### PR TITLE
fix(cli): add pemr/__main__.py so `python -m pemr` works

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -275,6 +275,11 @@ pemr backup                                              # VACUUM INTO snapshot
 pemr migrate                                             # apply pending migrations
 ```
 
+Invoke as `pemr <cmd>` (console script) or `python -m pemr <cmd>` (`pemr/__main__.py`,
+delegating to `cli.main`) — the latter is the portable fallback when the console-script
+launcher isn't generated (e.g. a system Python whose `Scripts`/launcher dir isn't writable
+under a PEP 660 editable install); see issue #22.
+
 ### MCP tools (thin wrappers, same verbs) — implemented phase 5
 
 Read-only: `person_list`, `person_show`, `query` (`kind` = `labs`/`meds`/`timeline`), `find`,

--- a/pemr/__main__.py
+++ b/pemr/__main__.py
@@ -1,0 +1,12 @@
+"""Enable `python -m pemr`, delegating to the console-script entry point.
+
+Mirrors the `[project.scripts] pemr = "pemr.cli:main"` wiring so the CLI is
+reachable without a generated `pemr.exe` (see issue #22).
+"""
+
+from __future__ import annotations
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_main_module.py
+++ b/tests/test_main_module.py
@@ -1,0 +1,31 @@
+"""`python -m pemr` entry point (issue #22).
+
+The console-script `pemr.exe` isn't reliably generated on every install (e.g. a
+system Python whose Scripts dir isn't writable), so `python -m pemr` — backed by
+`pemr/__main__.py` — is the portable way to invoke the CLI. This guards the
+delegation to `cli.main`.
+"""
+
+import subprocess
+import sys
+
+import pemr
+
+
+def test_main_module_runs_as_subprocess():
+    """`python -m pemr --version` exits 0 and prints the package version."""
+    result = subprocess.run(
+        [sys.executable, "-m", "pemr", "--version"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert pemr.__version__ in result.stdout
+
+
+def test_main_module_delegates_to_cli_main():
+    """`pemr.__main__` re-exports `cli.main` so `-m pemr` runs the same entry point."""
+    import pemr.__main__ as entry
+    from pemr.cli import main
+
+    assert entry.main is main


### PR DESCRIPTION
## Summary
- Adds `pemr/__main__.py` delegating to `cli.main()` so `python -m pemr` works as a portable, install-independent entry point.
- Investigated (not fixed in code — environment issue, not a project defect): the missing `pemr.exe` console script traces to the system Python's `Scripts` dir not being writable under a PEP 660 editable install, causing pip to roll back the launcher while still registering the entry-point metadata.
- Adds `tests/test_main_module.py` (subprocess `--version` check + delegation identity).
- Docs: `docs/Architecture.md` §5 now notes `python -m pemr` as the portable fallback invocation and the Scripts-dir writability caveat.

## Test plan
- [x] `pytest tests/test_main_module.py -v` — 2 passed
- [x] Full suite — all passing after merging `dev` (163 passed)
- [x] `python -m pemr --version` / `--help` / no-args — exit 0 / 0 / 2 (clean usage error)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)