### PR TITLE
fix(cli): ASCII-only console output; drop U+2014 em-dash

### DIFF
--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -47,7 +47,7 @@ def _resolve_db_path(args: argparse.Namespace) -> Path:
         if data_dir:
             return Path(data_dir) / "pemr.db"
     raise SystemExit(
-        "error: no database path — pass --db, set PEMR_DB, or set "
+        "error: no database path - pass --db, set PEMR_DB, or set "
         f"[paths].data_dir in {config_path} (see config.example.toml)"
     )
 
@@ -63,7 +63,7 @@ def _resolve_sources_dir(args: argparse.Namespace) -> Path:
     if sources_dir:
         return Path(sources_dir)
     raise SystemExit(
-        "error: no sources dir — pass --sources, set PEMR_SOURCES, or set "
+        "error: no sources dir - pass --sources, set PEMR_SOURCES, or set "
         "[paths].sources_dir in config.toml (see config.example.toml)"
     )
 
@@ -124,7 +124,7 @@ def _cmd_person_list(args: argparse.Namespace) -> int:
     finally:
         conn.close()
     if not people:
-        print("no people yet — `pemr person add --slug <slug> --name <name>`")
+        print("no people yet - `pemr person add --slug <slug> --name <name>`")
         return 0
     for p in people:
         dob = f"  dob={p.dob}" if p.dob else ""
@@ -183,7 +183,7 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
     if result.is_duplicate:
         print(
             f"duplicate: already filed as document #{doc.document_id} "
-            f"(sha256 {doc.sha256[:12]}...) — nothing ingested"
+            f"(sha256 {doc.sha256[:12]}...) - nothing ingested"
         )
         return 0
     print(
@@ -192,7 +192,7 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
     )
     if not result.ocr_text_populated:
         print(
-            "note: no ocr_text stored — `find` (full-text search) will not see this "
+            "note: no ocr_text stored - `find` (full-text search) will not see this "
             "document. Supply --ocr-text-file <path> or --ocr tesseract.",
             file=sys.stderr,
         )
@@ -234,7 +234,7 @@ def _cmd_commit_extraction(args: argparse.Namespace) -> int:
     )
     if summary.conflict:
         print(
-            f"note: {c['conflict']} conflict(s) staged — resolve with "
+            f"note: {c['conflict']} conflict(s) staged - resolve with "
             "`pemr review-conflicts`"
         )
     return 0
@@ -493,7 +493,7 @@ def _cmd_render_journal(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="pemr", description="Personal EMR engine — SQLite is truth."
+        prog="pemr", description="Personal EMR engine - SQLite is truth."
     )
     parser.add_argument("--version", action="version", version=f"pemr {__version__}")
     parser.add_argument("--db", help="path to pemr.db (overrides PEMR_DB/config)")

--- a/pemr/db.py
+++ b/pemr/db.py
@@ -21,7 +21,7 @@ _SENTINEL_TABLE = "document"
 class NotMigratedError(RuntimeError):
     """Raised when an operation runs against a database with no schema applied."""
 
-    def __init__(self, message: str = "database not migrated — run `pemr migrate` first"):
+    def __init__(self, message: str = "database not migrated - run `pemr migrate` first"):
         super().__init__(message)
 
 

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -361,7 +361,7 @@ def commit_extraction(
         "SELECT * FROM document WHERE document_id = ?", (document_id,)
     ).fetchone()
     if doc is None:
-        raise ValidationError(f"no document with id {document_id} — ingest it first")
+        raise ValidationError(f"no document with id {document_id} - ingest it first")
     person_id = doc["person_id"]
     if person_id is None:
         raise ValidationError(

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -124,7 +124,7 @@ def _person_id_for_slug(conn: sqlite3.Connection, slug: str) -> int:
     ).fetchone()
     if row is None:
         raise IngestError(
-            f"no person with slug '{slug}' — add them first: `pemr person add`"
+            f"no person with slug '{slug}' - add them first: `pemr person add`"
         )
     return row["person_id"]
 

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -318,7 +318,7 @@ def build_server():  # pragma: no cover - exercised only with the mcp SDK instal
         from mcp.server.fastmcp import FastMCP
     except ModuleNotFoundError as exc:  # friendly nudge, not a traceback
         raise SystemExit(
-            "error: the MCP server needs the optional `mcp` SDK — install with "
+            "error: the MCP server needs the optional `mcp` SDK - install with "
             "`pip install pemr[mcp]` (or `pip install mcp`)."
         ) from exc
 

--- a/tests/test_cli_ascii.py
+++ b/tests/test_cli_ascii.py
@@ -1,0 +1,128 @@
+"""Regression for issue #23: CLI-facing output must be ASCII so it survives a
+non-UTF-8 Windows console (cp1252/cp437), where a U+2014 em-dash renders as `?`
+or crashes with UnicodeEncodeError. Mirrors the phase-4 lesson guarded by
+``test_query.py::test_timeline_summaries_are_ascii_safe`` for query output.
+"""
+
+import json
+
+import pytest
+
+from pemr import cli
+
+
+def _run(tmp_path, *argv):
+    return cli.main(["--db", str(tmp_path / "cli.db"), *argv])
+
+
+def _assert_console_safe(text: str) -> None:
+    assert text.isascii(), f"non-ASCII CLI output would garble on cp437/cp1252: {text!r}"
+    text.encode("cp437")  # raises UnicodeEncodeError if not console-safe
+
+
+@pytest.fixture()
+def ready(tmp_path):
+    """Migrated DB + a person, ready for ingest."""
+    assert _run(tmp_path, "migrate") == 0
+    assert _run(tmp_path, "person", "add", "--slug", "jane-doe", "--name", "Jane Doe") == 0
+    return tmp_path
+
+
+def test_empty_person_list_is_console_safe(tmp_path, capsys):
+    assert _run(tmp_path, "migrate") == 0
+    capsys.readouterr()
+    assert _run(tmp_path, "person", "list") == 0
+    out = capsys.readouterr().out
+    assert "no people yet" in out
+    _assert_console_safe(out)
+
+
+def test_ingest_no_ocr_note_is_console_safe(ready, capsys):
+    scan = ready / "scan.txt"
+    scan.write_bytes(b"hba1c 5.7 percent")
+    capsys.readouterr()
+    assert _run(ready, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(ready / "sources")) == 0
+    captured = capsys.readouterr()
+    assert "no ocr_text stored" in captured.err
+    _assert_console_safe(captured.out)
+    _assert_console_safe(captured.err)
+
+
+def test_duplicate_output_is_console_safe(ready, capsys):
+    """The exact reproduction from the issue: '... - nothing ingested'."""
+    scan = ready / "s.txt"
+    scan.write_bytes(b"same")
+    sources = ready / "sources"
+    assert _run(ready, "ingest", str(scan), "--person", "jane-doe", "--sources", str(sources)) == 0
+    capsys.readouterr()
+    assert _run(ready, "ingest", str(scan), "--person", "jane-doe", "--sources", str(sources)) == 0
+    out = capsys.readouterr().out
+    assert "duplicate" in out and "nothing ingested" in out
+    _assert_console_safe(out)
+
+
+def test_conflict_note_is_console_safe(ready, capsys):
+    sources = ready / "sources"
+
+    def _extract(name, obj):
+        p = ready / name
+        p.write_text(json.dumps(obj), encoding="utf-8")
+        return str(p)
+
+    scan1 = ready / "scan1.txt"
+    scan1.write_bytes(b"hba1c 5.7 percent")
+    assert _run(ready, "ingest", str(scan1), "--person", "jane-doe", "--sources", str(sources)) == 0
+    labs1 = _extract("e1.json", {"lab_result": [{"test_name": "HbA1c", "collected_at": "2026-01-02",
+                                                 "value_num": 5.7, "unit": "%"}]})
+    assert _run(ready, "commit-extraction", "--document", "1", "--json", labs1) == 0
+
+    scan2 = ready / "scan2.txt"
+    scan2.write_bytes(b"hba1c 6.2 percent")
+    assert _run(ready, "ingest", str(scan2), "--person", "jane-doe", "--sources", str(sources)) == 0
+    labs2 = _extract("e2.json", {"lab_result": [{"test_name": "A1c", "collected_at": "2026-01-02",
+                                                 "value_num": 6.2, "unit": "%"}]})
+    capsys.readouterr()
+    assert _run(ready, "commit-extraction", "--document", "2", "--json", labs2) == 0
+    out = capsys.readouterr().out
+    assert "conflict(s) staged" in out
+    _assert_console_safe(out)
+
+
+def test_unmigrated_error_is_console_safe(tmp_path, capsys):
+    scan = tmp_path / "s.txt"
+    scan.write_bytes(b"x")
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources")) == 1
+    err = capsys.readouterr().err
+    assert "not migrated" in err
+    _assert_console_safe(err)
+
+
+def test_unknown_slug_error_is_console_safe(ready, capsys):
+    scan = ready / "s.txt"
+    scan.write_bytes(b"x")
+    capsys.readouterr()
+    assert _run(ready, "ingest", str(scan), "--person", "ghost",
+                "--sources", str(ready / "sources")) == 1
+    err = capsys.readouterr().err
+    assert "no person with slug" in err
+    _assert_console_safe(err)
+
+
+def test_bad_document_id_error_is_console_safe(ready, capsys):
+    labs = ready / "e.json"
+    labs.write_text(json.dumps({"lab_result": []}), encoding="utf-8")
+    capsys.readouterr()
+    assert _run(ready, "commit-extraction", "--document", "999", "--json", str(labs)) == 1
+    err = capsys.readouterr().err
+    assert "no document with id" in err
+    _assert_console_safe(err)
+
+
+def test_help_description_is_console_safe(capsys):
+    with pytest.raises(SystemExit):
+        cli.main(["--help"])
+    out = capsys.readouterr().out
+    assert "Personal EMR engine" in out
+    _assert_console_safe(out)


### PR DESCRIPTION
## Summary
- CLI-facing strings (`cli.py` print/argparse/SystemExit paths, plus exception messages surfaced through the CLI's `error:` handlers in `db.py`, `dedup.py`, `ingest.py`, and the MCP entry-point `SystemExit` in `mcp_server.py`) no longer use the U+2014 em-dash, which renders as `?` (or crashes) on a non-UTF-8 Windows console (cp1252/cp437).
- Replaces em-dashes with ASCII ` - `, matching the existing query-output convention already guarded by `test_query.py::test_timeline_summaries_are_ascii_safe`.
- Docstrings, comments, and MCP-JSON data (transmitted as UTF-8, never console-printed) are left untouched — this is scoped to console-visible output only.
- Adds `tests/test_cli_ascii.py` exercising the fixed paths and asserting every stream is ASCII + cp437-encodable.

## Test plan
- [x] `pytest tests/test_cli_ascii.py -v`
- [x] Full suite passing after merging `dev`

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)