### PR TITLE
feat(backup): pemr backup - VACUUM INTO snapshot + rotation

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -17,6 +17,15 @@ backup_dir = 'C:\Users\you\My Drive\pemr\backups'
 # Cloud-synced: retained original documents, content-addressed (sha256).
 sources_dir = 'C:\Users\you\My Drive\pemr\sources'
 
+# Backup snapshot rotation (`pemr backup`). Retention is layered flag > config >
+# default; these are the built-in defaults, so leave them commented unless you want
+# to change them. Rule: keep the newest snapshot for each of the last keep_daily
+# calendar days, plus the newest for each of the last keep_weekly ISO weeks; prune
+# the rest. --no-rotate on the command line disables pruning for a single run.
+# [backup]
+# keep_daily = 7
+# keep_weekly = 4
+
 # People roster — informational convenience; the DB `person` table is the source of
 # truth (`pemr person add`). Listed here so a fresh machine knows who to re-add.
 [[people]]

--- a/pemr/backup.py
+++ b/pemr/backup.py
@@ -8,8 +8,10 @@ snapshots by a calendar daily + weekly retention policy.
 Because rotation prunes *irreplaceable-data* snapshots, its safety invariants are
 part of the contract, not incidental:
 
-* The snapshot just written is always the newest entry overall, so it lands in the
-  newest daily bucket and a run can never prune its own output.
+* A run can never prune its own output. The just-written snapshot lands in the newest
+  daily bucket under any ``keep_daily >= 1``; ``rotate(..., protect=<snapshot>)`` makes
+  this hold *unconditionally* — even for degenerate ``keep_daily=0, keep_weekly=0`` the
+  protected snapshot is always retained.
 * Prune only ever deletes files whose names match the ``pemr-*.sqlite`` pattern this
   command creates — anything else in the directory is out of scope by construction.
 
@@ -107,6 +109,7 @@ def rotate(
     backup_dir: str | Path,
     keep_daily: int = DEFAULT_KEEP_DAILY,
     keep_weekly: int = DEFAULT_KEEP_WEEKLY,
+    protect: str | Path | None = None,
 ) -> RotationResult:
     """Prune snapshots in ``backup_dir`` down to the daily + weekly retention set.
 
@@ -123,9 +126,16 @@ def rotate(
     5. Everything retained by neither tier is deleted. This also collapses redundant
        same-day / same-week snapshots.
 
+    ``protect`` — a snapshot that must always be retained regardless of the daily and
+    weekly counts. The caller passes the path it just wrote so that the contract
+    invariant "a run can never prune its own output" holds *unconditionally*, even for
+    degenerate retention such as ``keep_daily=0, keep_weekly=0``. Matched by filename
+    (all snapshots live in ``backup_dir``).
+
     Returns the kept and pruned paths, each newest-first.
     """
     backup_dir = Path(backup_dir)
+    protect_name = Path(protect).name if protect is not None else None
     entries: list[tuple[datetime, Path]] = []
     for path in backup_dir.glob("pemr-*.sqlite"):
         ts = _parse_ts(path.name)
@@ -134,6 +144,13 @@ def rotate(
     entries.sort(key=lambda e: e[0], reverse=True)  # newest first
 
     kept: set[Path] = set()
+
+    # Always retain the just-written snapshot: makes the "never prune own output"
+    # invariant hold even when the daily/weekly buckets are empty (keep_* == 0).
+    if protect_name is not None:
+        for _, path in entries:
+            if path.name == protect_name:
+                kept.add(path)
 
     # Daily tier: newest snapshot for each of the most recent keep_daily distinct
     # calendar days. Same-day entries are contiguous (sorted by full timestamp), so

--- a/pemr/backup.py
+++ b/pemr/backup.py
@@ -1,0 +1,169 @@
+"""Phase 6: `pemr backup` — VACUUM INTO snapshot + calendar-bucketed rotation.
+
+Architecture.md §8: the live `pemr.db` is local-only (WAL `-wal`/`-shm` sidecars
+corrupt under cloud sync); `pemr backup` writes a consistent single-file
+``VACUUM INTO`` snapshot into the cloud-synced ``backup_dir``, then rotates older
+snapshots by a calendar daily + weekly retention policy.
+
+Because rotation prunes *irreplaceable-data* snapshots, its safety invariants are
+part of the contract, not incidental:
+
+* The snapshot just written is always the newest entry overall, so it lands in the
+  newest daily bucket and a run can never prune its own output.
+* Prune only ever deletes files whose names match the ``pemr-*.sqlite`` pattern this
+  command creates — anything else in the directory is out of scope by construction.
+
+Timestamps are **local time** (single-machine personal tool; Task Scheduler fires on
+wall-clock and "daily/weekly" should track the user's calendar) and are parsed from
+the *filename*, never from mtime (authoritative and cloud-sync-stable).
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+
+DEFAULT_KEEP_DAILY = 7
+DEFAULT_KEEP_WEEKLY = 4
+
+# pemr-YYYYMMDD-HHMM.sqlite, plus the -HHMMSS same-minute collision variant.
+# Anything not matching this exact shape is never parsed and never pruned.
+_SNAPSHOT_RE = re.compile(r"^pemr-(\d{8})-(\d{6}|\d{4})\.sqlite$")
+
+
+class BackupError(RuntimeError):
+    """A snapshot could not be taken (missing DB, sqlite/OS failure)."""
+
+
+@dataclass
+class RotationResult:
+    kept: list[Path]
+    pruned: list[Path]
+
+
+def _snapshot_name(now: datetime, *, seconds: bool) -> str:
+    fmt = "pemr-%Y%m%d-%H%M%S.sqlite" if seconds else "pemr-%Y%m%d-%H%M.sqlite"
+    return now.strftime(fmt)
+
+
+def _parse_ts(name: str) -> datetime | None:
+    """Timestamp encoded in a snapshot filename, or None if it isn't one of ours."""
+    m = _SNAPSHOT_RE.match(name)
+    if m is None:
+        return None
+    day, clock = m.group(1), m.group(2)
+    fmt = "%Y%m%d%H%M%S" if len(clock) == 6 else "%Y%m%d%H%M"
+    try:
+        return datetime.strptime(day + clock, fmt)
+    except ValueError:
+        return None
+
+
+def snapshot(
+    db_path: str | Path, backup_dir: str | Path, now: datetime | None = None
+) -> tuple[Path, int]:
+    """Write a ``VACUUM INTO`` snapshot of ``db_path`` into ``backup_dir``.
+
+    Returns ``(snapshot_path, size_bytes)``. Local-time, minute-precision filename;
+    on a same-minute collision falls back to seconds precision. ``VACUUM INTO``
+    refuses to overwrite an existing target — that safety is preserved, so if even
+    the seconds-precision name exists the underlying error propagates as
+    :class:`BackupError` rather than clobbering a file.
+
+    Raises :class:`BackupError` if the DB file is missing or the vacuum fails.
+    """
+    db_path = Path(db_path)
+    if not db_path.is_file():
+        raise BackupError(f"no database at {db_path}")
+
+    backup_dir = Path(backup_dir)
+    try:
+        backup_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise BackupError(f"cannot create backup dir {backup_dir}: {exc}") from exc
+
+    now = now or datetime.now()
+    target = backup_dir / _snapshot_name(now, seconds=False)
+    if target.exists():
+        target = backup_dir / _snapshot_name(now, seconds=True)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        # VACUUM INTO runs in autocommit (Python's sqlite3 only auto-BEGINs for
+        # INSERT/UPDATE/DELETE/REPLACE) and refuses to overwrite an existing target.
+        conn.execute("VACUUM INTO ?", (str(target),))
+    except sqlite3.Error as exc:
+        raise BackupError(f"snapshot failed: {exc}") from exc
+    finally:
+        conn.close()
+
+    return target, target.stat().st_size
+
+
+def rotate(
+    backup_dir: str | Path,
+    keep_daily: int = DEFAULT_KEEP_DAILY,
+    keep_weekly: int = DEFAULT_KEEP_WEEKLY,
+) -> RotationResult:
+    """Prune snapshots in ``backup_dir`` down to the daily + weekly retention set.
+
+    Deterministic, filename-driven (§8 "prune older"):
+
+    1. Glob ``pemr-*.sqlite`` and keep only names matching the exact snapshot
+       pattern; parse the local-time timestamp from the filename.
+    2. Sort newest → oldest.
+    3. **Daily tier** — for each of the most recent ``keep_daily`` distinct calendar
+       days, retain that day's newest snapshot.
+    4. **Weekly tier** — of the snapshots not already retained, for each of the most
+       recent ``keep_weekly`` distinct ISO weeks (``date.isocalendar()`` ``(year,
+       week)``), retain that week's newest snapshot.
+    5. Everything retained by neither tier is deleted. This also collapses redundant
+       same-day / same-week snapshots.
+
+    Returns the kept and pruned paths, each newest-first.
+    """
+    backup_dir = Path(backup_dir)
+    entries: list[tuple[datetime, Path]] = []
+    for path in backup_dir.glob("pemr-*.sqlite"):
+        ts = _parse_ts(path.name)
+        if ts is not None:
+            entries.append((ts, path))
+    entries.sort(key=lambda e: e[0], reverse=True)  # newest first
+
+    kept: set[Path] = set()
+
+    # Daily tier: newest snapshot for each of the most recent keep_daily distinct
+    # calendar days. Same-day entries are contiguous (sorted by full timestamp), so
+    # the first time a day is seen is its newest snapshot.
+    daily_days: list[date] = []
+    for ts, path in entries:
+        day = ts.date()
+        if day in daily_days:
+            continue
+        if len(daily_days) >= keep_daily:
+            break
+        daily_days.append(day)
+        kept.add(path)
+
+    # Weekly tier: of the snapshots not already daily-kept, newest per ISO week for
+    # the most recent keep_weekly distinct weeks.
+    weekly_weeks: list[tuple[int, int]] = []
+    for ts, path in entries:
+        if path in kept:
+            continue
+        week = ts.isocalendar()[:2]  # (iso_year, iso_week)
+        if week in weekly_weeks:
+            continue
+        if len(weekly_weeks) >= keep_weekly:
+            break
+        weekly_weeks.append(week)
+        kept.add(path)
+
+    kept_paths = [path for _, path in entries if path in kept]
+    pruned_paths = [path for _, path in entries if path not in kept]
+    for path in pruned_paths:
+        path.unlink()
+    return RotationResult(kept=kept_paths, pruned=pruned_paths)

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -15,7 +15,7 @@ import tomllib
 from dataclasses import asdict
 from pathlib import Path
 
-from . import __version__, db, dedup, ingest, persons, query, render
+from . import __version__, backup, db, dedup, ingest, persons, query, render
 
 # Shipped starter analyte/name dictionary (framework, not user data — see .gitignore).
 _DEFAULT_DICTIONARY = Path(__file__).resolve().parent.parent / "data" / "dictionary.example.toml"
@@ -66,6 +66,38 @@ def _resolve_sources_dir(args: argparse.Namespace) -> Path:
         "error: no sources dir — pass --sources, set PEMR_SOURCES, or set "
         "[paths].sources_dir in config.toml (see config.example.toml)"
     )
+
+
+def _resolve_backup_dir(args: argparse.Namespace) -> Path:
+    override = getattr(args, "backup_dir", None)
+    if override:
+        return Path(override)
+    env = os.environ.get("PEMR_BACKUP_DIR")
+    if env:
+        return Path(env)
+    backup_dir = _load_config(args).get("paths", {}).get("backup_dir")
+    if backup_dir:
+        return Path(backup_dir)
+    raise SystemExit(
+        "error: no backup dir — pass --backup-dir, set PEMR_BACKUP_DIR, or set "
+        "[paths].backup_dir in config.toml (see config.example.toml)"
+    )
+
+
+def _resolve_retention(args: argparse.Namespace) -> tuple[int, int]:
+    """Retention counts, layered flag > [backup] config > hardcoded default."""
+    cfg = _load_config(args).get("backup", {})
+    keep_daily = (
+        args.keep_daily
+        if args.keep_daily is not None
+        else cfg.get("keep_daily", backup.DEFAULT_KEEP_DAILY)
+    )
+    keep_weekly = (
+        args.keep_weekly
+        if args.keep_weekly is not None
+        else cfg.get("keep_weekly", backup.DEFAULT_KEEP_WEEKLY)
+    )
+    return int(keep_daily), int(keep_weekly)
 
 
 def _resolve_dictionary_path(args: argparse.Namespace) -> Path | None:
@@ -491,6 +523,48 @@ def _cmd_render_journal(args: argparse.Namespace) -> int:
     return _render_with_conn(args, work)
 
 
+# --------------------------------------------------------------------------- #
+# Phase 6: backup (VACUUM INTO snapshot + rotation)
+# --------------------------------------------------------------------------- #
+
+def _cmd_backup(args: argparse.Namespace) -> int:
+    db_path = _resolve_db_path(args)
+    backup_dir = _resolve_backup_dir(args)
+    try:
+        snap, size = backup.snapshot(db_path, backup_dir)
+    except backup.BackupError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    kept: list[Path] = []
+    pruned: list[Path] = []
+    rotated = not args.no_rotate
+    if rotated:
+        keep_daily, keep_weekly = _resolve_retention(args)
+        try:
+            result = backup.rotate(backup_dir, keep_daily, keep_weekly)
+        except OSError as exc:
+            print(f"error: rotation failed: {exc}", file=sys.stderr)
+            return 1
+        kept, pruned = result.kept, result.pruned
+
+    if args.json:
+        _print_json({
+            "snapshot": str(snap),
+            "bytes": size,
+            "kept": [str(p) for p in kept],
+            "pruned": [str(p) for p in pruned],
+        })
+        return 0
+
+    print(f"wrote {snap} ({size} bytes)")
+    if rotated:
+        print(f"rotated: kept {len(kept)}, pruned {len(pruned)}")
+    else:
+        print("rotation skipped (--no-rotate)")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="pemr", description="Personal EMR engine — SQLite is truth."
@@ -645,6 +719,31 @@ def build_parser() -> argparse.ArgumentParser:
     r_journal.add_argument("--since", help="ISO date; keep events on/after this date")
     r_journal.add_argument("--out", help="write to file instead of stdout")
     r_journal.set_defaults(func=_cmd_render_journal)
+
+    # --- phase 6: backup (VACUUM INTO snapshot + rotation) ----------------
+    p_backup = sub.add_parser(
+        "backup", help="VACUUM INTO timestamped snapshot + rotate old snapshots"
+    )
+    p_backup.add_argument(
+        "--backup-dir", dest="backup_dir",
+        help="output dir (overrides PEMR_BACKUP_DIR / [paths].backup_dir)",
+    )
+    p_backup.add_argument(
+        "--keep-daily", dest="keep_daily", type=int,
+        help="retain newest snapshot for this many recent days "
+             "(default [backup].keep_daily or 7)",
+    )
+    p_backup.add_argument(
+        "--keep-weekly", dest="keep_weekly", type=int,
+        help="retain newest snapshot for this many recent ISO weeks "
+             "(default [backup].keep_weekly or 4)",
+    )
+    p_backup.add_argument(
+        "--no-rotate", dest="no_rotate", action="store_true",
+        help="take the snapshot, skip pruning entirely",
+    )
+    p_backup.add_argument("--json", action="store_true", help="machine-readable output")
+    p_backup.set_defaults(func=_cmd_backup)
 
     return parser
 

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -97,7 +97,14 @@ def _resolve_retention(args: argparse.Namespace) -> tuple[int, int]:
         if args.keep_weekly is not None
         else cfg.get("keep_weekly", backup.DEFAULT_KEEP_WEEKLY)
     )
-    return int(keep_daily), int(keep_weekly)
+    keep_daily, keep_weekly = int(keep_daily), int(keep_weekly)
+    if keep_daily < 0 or keep_weekly < 0:
+        raise SystemExit(
+            "error: retention counts cannot be negative "
+            f"(keep_daily={keep_daily}, keep_weekly={keep_weekly}); "
+            "use --no-rotate to keep every snapshot"
+        )
+    return keep_daily, keep_weekly
 
 
 def _resolve_dictionary_path(args: argparse.Namespace) -> Path | None:
@@ -542,7 +549,7 @@ def _cmd_backup(args: argparse.Namespace) -> int:
     if rotated:
         keep_daily, keep_weekly = _resolve_retention(args)
         try:
-            result = backup.rotate(backup_dir, keep_daily, keep_weekly)
+            result = backup.rotate(backup_dir, keep_daily, keep_weekly, protect=snap)
         except OSError as exc:
             print(f"error: rotation failed: {exc}", file=sys.stderr)
             return 1

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,341 @@
+"""Phase 6: `pemr backup` — VACUUM INTO snapshot + calendar-bucketed rotation.
+
+Covers snapshot round-trip/validity, local-time filename + same-minute collision,
+the daily/weekly rotation algorithm (newest-per-day/week, same-day/same-week
+collapse, older-than-window pruning, ISO-week + year-rollover edges, non-matching
+filenames left untouched, fresh snapshot always survives), and the CLI wiring
+(--no-rotate, --json, missing-DB and unresolvable-backup-dir rc=1).
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from pemr import backup, cli, db
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+
+def _seed_db(path: Path) -> None:
+    """A migrated DB with one person, so snapshots have real content to read back."""
+    conn = db.connect(path)
+    try:
+        db.migrate(conn)
+        conn.execute(
+            "INSERT INTO person (slug, full_name, dob) VALUES (?, ?, ?)",
+            ("jane-doe", "Jane Doe", "1980-01-01"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _touch_snapshots(backup_dir: Path, names: list[str]) -> None:
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (backup_dir / name).write_bytes(b"stub")
+
+
+def _snap(day: str, clock: str = "1200") -> str:
+    return f"pemr-{day}-{clock}.sqlite"
+
+
+# --------------------------------------------------------------------------- #
+# snapshot
+# --------------------------------------------------------------------------- #
+
+def test_snapshot_is_valid_queryable_sqlite(tmp_path):
+    src = tmp_path / "pemr.db"
+    _seed_db(src)
+    out = tmp_path / "backups"
+    snap, size = backup.snapshot(src, out)
+
+    assert snap.parent == out
+    assert snap.name.startswith("pemr-") and snap.suffix == ".sqlite"
+    assert size == snap.stat().st_size > 0
+
+    # Round-trip: the snapshot opens and the seeded row reads back.
+    conn = db.connect(snap)
+    try:
+        assert db.is_migrated(conn)
+        row = conn.execute("SELECT full_name FROM person WHERE slug='jane-doe'").fetchone()
+        assert row["full_name"] == "Jane Doe"
+    finally:
+        conn.close()
+
+
+def test_snapshot_filename_is_local_time_minute_precision(tmp_path):
+    src = tmp_path / "pemr.db"
+    _seed_db(src)
+    now = datetime(2026, 3, 4, 9, 7)  # naive local time
+    snap, _ = backup.snapshot(src, tmp_path / "backups", now=now)
+    assert snap.name == "pemr-20260304-0907.sqlite"
+
+
+def test_snapshot_same_minute_collision_falls_back_to_seconds(tmp_path):
+    src = tmp_path / "pemr.db"
+    _seed_db(src)
+    out = tmp_path / "backups"
+    now = datetime(2026, 3, 4, 9, 7, 42)
+    first, _ = backup.snapshot(src, out, now=now)
+    second, _ = backup.snapshot(src, out, now=now)
+
+    assert first.name == "pemr-20260304-0907.sqlite"
+    assert second.name == "pemr-20260304-090742.sqlite"
+    assert first.exists() and second.exists()  # neither overwritten
+
+
+def test_snapshot_never_overwrites_even_seconds_target(tmp_path):
+    src = tmp_path / "pemr.db"
+    _seed_db(src)
+    out = tmp_path / "backups"
+    now = datetime(2026, 3, 4, 9, 7, 42)
+    backup.snapshot(src, out, now=now)  # minute
+    backup.snapshot(src, out, now=now)  # seconds fallback
+    # A third same-second run has no free name → VACUUM INTO refuses → BackupError.
+    with pytest.raises(backup.BackupError):
+        backup.snapshot(src, out, now=now)
+
+
+def test_snapshot_missing_db_raises(tmp_path):
+    with pytest.raises(backup.BackupError, match="no database at"):
+        backup.snapshot(tmp_path / "absent.db", tmp_path / "backups")
+
+
+def test_snapshot_creates_backup_dir(tmp_path):
+    src = tmp_path / "pemr.db"
+    _seed_db(src)
+    nested = tmp_path / "a" / "b" / "backups"
+    snap, _ = backup.snapshot(src, nested)
+    assert snap.parent == nested and nested.is_dir()
+
+
+# --------------------------------------------------------------------------- #
+# rotation
+# --------------------------------------------------------------------------- #
+
+def test_rotate_daily_keeps_newest_per_day(tmp_path):
+    out = tmp_path / "backups"
+    # Three consecutive days, two snapshots each; keep_daily=7 keeps newest per day.
+    names = [
+        _snap("20260701", "0800"), _snap("20260701", "2000"),
+        _snap("20260702", "0800"), _snap("20260702", "2000"),
+        _snap("20260703", "0800"), _snap("20260703", "2000"),
+    ]
+    _touch_snapshots(out, names)
+    # keep_weekly=0 isolates the daily tier (all three days share one ISO week, so a
+    # nonzero weekly tier would legitimately retain the newest leftover too).
+    result = backup.rotate(out, keep_daily=7, keep_weekly=0)
+
+    kept = {p.name for p in result.kept}
+    assert kept == {
+        _snap("20260701", "2000"),
+        _snap("20260702", "2000"),
+        _snap("20260703", "2000"),
+    }
+    # Same-day older snapshots pruned (collapse).
+    assert {p.name for p in result.pruned} == {
+        _snap("20260701", "0800"),
+        _snap("20260702", "0800"),
+        _snap("20260703", "0800"),
+    }
+    for p in result.pruned:
+        assert not p.exists()
+    for p in result.kept:
+        assert p.exists()
+
+
+def test_rotate_weekly_tier_and_older_pruned(tmp_path):
+    out = tmp_path / "backups"
+    # 10 distinct days spanning ~2 weeks. keep_daily=3 keeps the 3 newest days;
+    # keep_weekly=1 keeps the newest not-daily-kept snapshot in the most recent
+    # remaining ISO week; everything else prunes.
+    days = [
+        "20260706", "20260707", "20260708", "20260709", "20260710",  # ISO week 28
+        "20260713", "20260714", "20260715", "20260716", "20260717",  # ISO week 29
+    ]
+    _touch_snapshots(out, [_snap(d) for d in days])
+    result = backup.rotate(out, keep_daily=3, keep_weekly=1)
+    kept = {p.name for p in result.kept}
+
+    # Daily: 3 newest calendar days.
+    assert _snap("20260717") in kept
+    assert _snap("20260716") in kept
+    assert _snap("20260715") in kept
+    # Weekly: newest remaining is 20260714 (week 29, since 15-17 are daily-kept).
+    assert _snap("20260714") in kept
+    assert len(kept) == 4
+    # Everything older pruned.
+    assert _snap("20260713") not in kept
+    assert _snap("20260706") not in kept
+
+
+def test_rotate_weekly_collapses_same_week(tmp_path):
+    out = tmp_path / "backups"
+    # Two snapshots in one older ISO week; only the newest survives the weekly tier.
+    _touch_snapshots(out, [
+        _snap("20260717"),                 # daily-kept (most recent day)
+        _snap("20260707"), _snap("20260709"),  # same ISO week 28, weekly tier
+    ])
+    result = backup.rotate(out, keep_daily=1, keep_weekly=1)
+    kept = {p.name for p in result.kept}
+    assert kept == {_snap("20260717"), _snap("20260709")}
+    assert {p.name for p in result.pruned} == {_snap("20260707")}
+
+
+def test_rotate_year_rollover_distinct_iso_weeks(tmp_path):
+    out = tmp_path / "backups"
+    # 2025-12-29 is ISO week 1 of 2026; 2025-12-22 is ISO week 52 of 2025 — distinct
+    # week keys across the year boundary, so with keep_weekly=2 both weeklies survive.
+    _touch_snapshots(out, [
+        _snap("20260105"),   # daily-kept anchor (most recent)
+        _snap("20251229"),   # ISO (2026, 1)
+        _snap("20251222"),   # ISO (2025, 52)
+    ])
+    result = backup.rotate(out, keep_daily=1, keep_weekly=2)
+    kept = {p.name for p in result.kept}
+    assert kept == {_snap("20260105"), _snap("20251229"), _snap("20251222")}
+    assert result.pruned == []
+
+
+def test_rotate_ignores_non_matching_filenames(tmp_path):
+    out = tmp_path / "backups"
+    _touch_snapshots(out, [_snap("20260701"), _snap("20260601")])
+    # Foreign / hand-named files that must never be touched.
+    foreign = [
+        "notes.txt",
+        "pemr-backup.sqlite",         # no timestamp
+        "pemr-2026070.sqlite",        # too few digits
+        "pemr-20260701.sqlite",       # missing -HHMM
+        "pemr-20260701-12.sqlite",    # wrong clock width
+        "backup-20260701-1200.sqlite",  # wrong prefix
+    ]
+    for f in foreign:
+        (out / f).write_bytes(b"keepme")
+
+    backup.rotate(out, keep_daily=1, keep_weekly=0)
+    for f in foreign:
+        assert (out / f).exists(), f"rotation must not touch {f}"
+
+
+def test_rotate_seconds_variant_is_recognized(tmp_path):
+    out = tmp_path / "backups"
+    _touch_snapshots(out, [
+        _snap("20260701", "120045"),  # seconds-precision same-minute variant (12:00:45)
+        _snap("20260701", "1200"),    # minute-precision (12:00:00)
+    ])
+    result = backup.rotate(out, keep_daily=1, keep_weekly=0)
+    # Both parse as day 2026-07-01; the seconds variant is genuinely newer → kept,
+    # the minute one collapsed. Proves the -HHMMSS filename form is recognized.
+    assert {p.name for p in result.kept} == {_snap("20260701", "120045")}
+    assert {p.name for p in result.pruned} == {_snap("20260701", "1200")}
+
+
+def test_rotate_empty_dir_is_noop(tmp_path):
+    out = tmp_path / "backups"
+    out.mkdir()
+    result = backup.rotate(out)
+    assert result.kept == [] and result.pruned == []
+
+
+# --------------------------------------------------------------------------- #
+# CLI wiring
+# --------------------------------------------------------------------------- #
+
+def _run(tmp_path, *argv):
+    return cli.main(["--db", str(tmp_path / "pemr.db"), *argv])
+
+
+def test_cli_backup_writes_snapshot_and_rotates(tmp_path, capsys):
+    _seed_db(tmp_path / "pemr.db")
+    out = tmp_path / "backups"
+    rc = _run(tmp_path, "backup", "--backup-dir", str(out))
+    assert rc == 0
+    printed = capsys.readouterr().out
+    assert "wrote " in printed and "rotated: kept 1, pruned 0" in printed
+    snaps = list(out.glob("pemr-*.sqlite"))
+    assert len(snaps) == 1
+
+
+def test_cli_backup_json(tmp_path, capsys):
+    import json as _json
+    _seed_db(tmp_path / "pemr.db")
+    out = tmp_path / "backups"
+    rc = _run(tmp_path, "backup", "--backup-dir", str(out), "--json")
+    assert rc == 0
+    payload = _json.loads(capsys.readouterr().out)
+    assert Path(payload["snapshot"]).exists()
+    assert payload["bytes"] > 0
+    assert len(payload["kept"]) == 1 and payload["pruned"] == []
+
+
+def test_cli_backup_fresh_snapshot_survives_rotation(tmp_path, capsys):
+    _seed_db(tmp_path / "pemr.db")
+    out = tmp_path / "backups"
+    # Pre-populate with an old snapshot that would otherwise be outside the window.
+    _touch_snapshots(out, [_snap("20200101")])
+    rc = _run(tmp_path, "backup", "--backup-dir", str(out),
+              "--keep-daily", "1", "--keep-weekly", "0")
+    assert rc == 0
+    remaining = {p.name for p in out.glob("pemr-*.sqlite")}
+    # Today's fresh snapshot is the newest day → kept; the 2020 one pruned.
+    assert _snap("20200101") not in remaining
+    assert len(remaining) == 1  # only the just-written snapshot
+
+
+def test_cli_backup_no_rotate_prunes_nothing(tmp_path, capsys):
+    _seed_db(tmp_path / "pemr.db")
+    out = tmp_path / "backups"
+    _touch_snapshots(out, [_snap("20200101")])
+    rc = _run(tmp_path, "backup", "--backup-dir", str(out), "--no-rotate")
+    assert rc == 0
+    assert "rotation skipped (--no-rotate)" in capsys.readouterr().out
+    # Old snapshot untouched; new one added.
+    assert (out / _snap("20200101")).exists()
+    assert len(list(out.glob("pemr-*.sqlite"))) == 2
+
+
+def test_cli_backup_missing_db_rc1(tmp_path, capsys):
+    # No DB created.
+    rc = _run(tmp_path, "backup", "--backup-dir", str(tmp_path / "backups"))
+    assert rc == 1
+    assert "no database at" in capsys.readouterr().err
+
+
+def test_cli_backup_unresolvable_backup_dir_exits(tmp_path, monkeypatch):
+    _seed_db(tmp_path / "pemr.db")
+    monkeypatch.delenv("PEMR_BACKUP_DIR", raising=False)
+    # No --backup-dir, no env, no config → resolver raises SystemExit (rc=1 shape).
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["--db", str(tmp_path / "pemr.db"), "--config",
+                  str(tmp_path / "absent.toml"), "backup"])
+    assert "no backup dir" in str(exc.value)
+
+
+def test_cli_backup_dir_env_resolution(tmp_path, capsys, monkeypatch):
+    _seed_db(tmp_path / "pemr.db")
+    out = tmp_path / "env-backups"
+    monkeypatch.setenv("PEMR_BACKUP_DIR", str(out))
+    rc = _run(tmp_path, "backup")
+    assert rc == 0
+    assert len(list(out.glob("pemr-*.sqlite"))) == 1
+
+
+def test_cli_backup_retention_from_config(tmp_path, capsys, monkeypatch):
+    _seed_db(tmp_path / "pemr.db")
+    out = tmp_path / "backups"
+    _touch_snapshots(out, [_snap("20200101")])
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        f"[paths]\nbackup_dir = {out.as_posix()!r}\n"
+        "[backup]\nkeep_daily = 1\nkeep_weekly = 0\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("PEMR_BACKUP_DIR", raising=False)
+    rc = cli.main(["--db", str(tmp_path / "pemr.db"), "--config", str(cfg), "backup"])
+    assert rc == 0
+    # config keep_daily=1/keep_weekly=0 prunes the old 2020 snapshot.
+    assert not (out / _snap("20200101")).exists()

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -3,8 +3,10 @@
 Covers snapshot round-trip/validity, local-time filename + same-minute collision,
 the daily/weekly rotation algorithm (newest-per-day/week, same-day/same-week
 collapse, older-than-window pruning, ISO-week + year-rollover edges, non-matching
-filenames left untouched, fresh snapshot always survives), and the CLI wiring
-(--no-rotate, --json, missing-DB and unresolvable-backup-dir rc=1).
+filenames left untouched, fresh snapshot always survives — including the
+``protect=`` guard that keeps the just-written snapshot under degenerate keep 0/0),
+and the CLI wiring (--no-rotate, --json, missing-DB and unresolvable-backup-dir rc=1,
+negative retention rejected).
 """
 
 from datetime import datetime
@@ -241,6 +243,28 @@ def test_rotate_empty_dir_is_noop(tmp_path):
     assert result.kept == [] and result.pruned == []
 
 
+def test_rotate_protect_survives_zero_retention(tmp_path):
+    # Contract invariant made unconditional: with keep_daily=0 and keep_weekly=0
+    # (empty buckets), the protected just-written snapshot is still retained.
+    out = tmp_path / "backups"
+    fresh = _snap("20260701", "1200")
+    _touch_snapshots(out, [fresh, _snap("20260630"), _snap("20260620")])
+    result = backup.rotate(out, keep_daily=0, keep_weekly=0, protect=out / fresh)
+    assert {p.name for p in result.kept} == {fresh}
+    assert fresh not in {p.name for p in result.pruned}
+    assert (out / fresh).exists()
+
+
+def test_rotate_without_protect_zero_retention_prunes_everything(tmp_path):
+    # Documents the boundary: absent `protect`, keep 0/0 is a full purge — which is
+    # exactly why the CLI always passes protect and rejects negative counts.
+    out = tmp_path / "backups"
+    _touch_snapshots(out, [_snap("20260701"), _snap("20260630")])
+    result = backup.rotate(out, keep_daily=0, keep_weekly=0)
+    assert result.kept == []
+    assert len(result.pruned) == 2
+
+
 # --------------------------------------------------------------------------- #
 # CLI wiring
 # --------------------------------------------------------------------------- #
@@ -339,3 +363,31 @@ def test_cli_backup_retention_from_config(tmp_path, capsys, monkeypatch):
     assert rc == 0
     # config keep_daily=1/keep_weekly=0 prunes the old 2020 snapshot.
     assert not (out / _snap("20200101")).exists()
+
+
+def test_cli_backup_zero_retention_keeps_fresh_snapshot(tmp_path, capsys):
+    # keep_daily=0 keep_weekly=0 must still leave the just-written snapshot on disk
+    # (the audit finding: a run must never prune its own output). rc=0, kept >= 1.
+    _seed_db(tmp_path / "pemr.db")
+    out = tmp_path / "backups"
+    rc = _run(tmp_path, "backup", "--backup-dir", str(out), "--json",
+              "--keep-daily", "0", "--keep-weekly", "0")
+    import json as _json
+    assert rc == 0
+    payload = _json.loads(capsys.readouterr().out)
+    assert Path(payload["snapshot"]).exists()
+    assert len(payload["kept"]) == 1
+    assert payload["pruned"] == []
+    assert len(list(out.glob("pemr-*.sqlite"))) == 1
+
+
+def test_cli_backup_negative_retention_rejected(tmp_path, capsys):
+    # Negative retention has no policy meaning and previously mapped to "delete all";
+    # it is now rejected before any pruning (rc=1), and the snapshot still survives.
+    _seed_db(tmp_path / "pemr.db")
+    out = tmp_path / "backups"
+    with pytest.raises(SystemExit) as exc:
+        _run(tmp_path, "backup", "--backup-dir", str(out), "--keep-daily", "-3")
+    assert "cannot be negative" in str(exc.value)
+    # The snapshot was written before rotation; the failure leaves it intact.
+    assert len(list(out.glob("pemr-*.sqlite"))) == 1


### PR DESCRIPTION
## Summary
- Adds `pemr/backup.py`: `VACUUM INTO` a timestamped snapshot of `pemr.db` into `backup_dir`, plus calendar-bucketed daily/weekly rotation (Architecture.md §8).
- Adds `pemr backup` CLI verb (`--backup-dir`, `--keep-daily`, `--keep-weekly`, `--no-rotate`, `--json`).
- `config.example.toml` documents `[paths].backup_dir` and `[backup]` retention keys.
- Retention floor fix: a run can never prune the snapshot it just wrote.
- Tests in `tests/test_backup.py`.
- `dev` merged in cleanly (auto-resolved by git `ort`; the only overlap was the ASCII-only description string in `cli.py` from #23, already reflected on both sides).

Closes #24

## Test plan
- [x] `python -m pytest` — 196 passed
- [x] Verified `pemr/backup.py` non-ASCII chars are confined to docstrings/comments, not console output (test_cli_ascii.py coverage)
- [x] Architecture.md §8 already documents `pemr backup`; no doc updates needed