### PR TITLE
feat(person): edit/deactivate/reactivate/remove

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ Read-only tools (never mutate the DB; safe to call freely):
 Write tools (mutate the DB; the only tools that do):
 
 - `person_add` — add a person to the roster.
+- `person_edit` — update a person's fields (partial; `slug` is not editable, pass `""` to
+  clear a nullable field).
 - `ingest` — hash + blob-store + layer-1 dedup a document.
 - `commit_extraction` — validate + dedup + commit extracted rows for a document.
 - `review_conflicts` — lists conflicts read-only; **writes only when given a `resolve` id**, and

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -258,7 +258,7 @@ giving the agent text to work from instead of re-reading pixels every time.
 ### CLI (the tested engine)
 
 ```
-pemr person add|list|show
+pemr person add|list|show|edit|deactivate|reactivate|remove
 pemr ingest <file> --person <slug> [--ocr tesseract]
 pemr commit-extraction --document <id> --json <file>
 pemr review-conflicts [--resolve ...]
@@ -283,15 +283,15 @@ under a PEP 660 editable install); see issue #22.
 ### MCP tools (thin wrappers, same verbs) — implemented phase 5
 
 Read-only: `person_list`, `person_show`, `query` (`kind` = `labs`/`meds`/`timeline`), `find`,
-`trends`, `render_summary`, `render_brief`, `render_journal`. Write: `person_add`, `ingest`,
-`commit_extraction`, `review_conflicts` (resolution gated on human sign-off). Each returns the
+`trends`, `render_summary`, `render_brief`, `render_journal`. Write: `person_add`, `person_edit`,
+`ingest`, `commit_extraction`, `review_conflicts` (resolution gated on human sign-off). Each returns the
 same `--json`-shaped payload as the CLI; the MCP server (`pemr/mcp_server.py`) parses args and
 calls the same Python functions the CLI calls — one implementation, two front doors. `readOnlyHint`
 annotations expose the read/write split to the client.
 
 `AGENTS.md` documents this contract so any agent (Cowork, Claude Code, local) knows to
 **call tools, not reinvent** — and specifically: never write to the DB except through
-`commit_extraction`/`person_add`/`ingest`; always `ingest` (with `ocr_text` populated) before
+`commit_extraction`/`person_add`/`person_edit`/`ingest`; always `ingest` (with `ocr_text` populated) before
 extracting; dictionary additions go through human review, never agent-direct edits.
 
 ---

--- a/migrations/004_person_deactivate.sql
+++ b/migrations/004_person_deactivate.sql
@@ -1,0 +1,9 @@
+-- 004_person_deactivate: soft-deactivate support for person records (issue #26).
+-- Retiring a person record must be reversible and must never destroy ingested
+-- medical history, so `pemr person deactivate` sets this timestamp instead of
+-- deleting. NULL = active; a non-NULL ISO timestamp = deactivated (hidden from the
+-- default `person list`, still visible via `person list --all` and `person show`).
+-- `pemr person reactivate` clears it. Hard `person remove` stays available only for a
+-- childless record (a typo'd roster entry with nothing ingested yet).
+
+ALTER TABLE person ADD COLUMN deactivated_at TEXT;   -- ISO timestamp; NULL = active

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -120,7 +120,7 @@ def _cmd_person_add(args: argparse.Namespace) -> int:
 def _cmd_person_list(args: argparse.Namespace) -> int:
     conn = db.connect(_resolve_db_path(args))
     try:
-        people = persons.list_people(conn)
+        people = persons.list_people(conn, include_inactive=args.all_people)
     finally:
         conn.close()
     if not people:
@@ -128,8 +128,16 @@ def _cmd_person_list(args: argparse.Namespace) -> int:
         return 0
     for p in people:
         dob = f"  dob={p.dob}" if p.dob else ""
-        print(f"#{p.person_id}  {p.slug}  {p.full_name}{dob}")
+        status = "  [inactive]" if p.deactivated_at else ""
+        print(f"#{p.person_id}  {p.slug}  {p.full_name}{dob}{status}")
     return 0
+
+
+def _print_person(person) -> None:
+    """Print one person record as aligned key/value lines (the `person show` shape,
+    reused by `person edit`/`deactivate`/`reactivate` so they echo the updated record)."""
+    for key, value in asdict(person).items():
+        print(f"{key:14} {value if value is not None else ''}")
 
 
 def _cmd_person_show(args: argparse.Namespace) -> int:
@@ -141,8 +149,83 @@ def _cmd_person_show(args: argparse.Namespace) -> int:
     if person is None:
         print(f"error: no person with slug '{args.slug}'", file=sys.stderr)
         return 1
-    for key, value in asdict(person).items():
-        print(f"{key:12} {value if value is not None else ''}")
+    _print_person(person)
+    return 0
+
+
+def _cmd_person_edit(args: argparse.Namespace) -> int:
+    # A flag left unset is None -> not part of the update; an explicit empty string
+    # (e.g. --dob "") is passed through and clears that nullable column (persons.py).
+    fields: dict[str, str] = {}
+    if args.name is not None:
+        fields["full_name"] = args.name
+    if args.dob is not None:
+        fields["dob"] = args.dob
+    if args.sex is not None:
+        fields["sex"] = args.sex
+    if args.blood_type is not None:
+        fields["blood_type"] = args.blood_type
+    if args.notes is not None:
+        fields["notes"] = args.notes
+
+    conn = db.connect(_resolve_db_path(args))
+    try:
+        try:
+            person = persons.update_person(conn, args.slug, **fields)
+        except persons.PersonNotFoundError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+    finally:
+        conn.close()
+    _print_person(person)
+    return 0
+
+
+def _cmd_person_deactivate(args: argparse.Namespace) -> int:
+    conn = db.connect(_resolve_db_path(args))
+    try:
+        try:
+            person = persons.deactivate_person(conn, args.slug)
+        except persons.PersonNotFoundError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+    finally:
+        conn.close()
+    print(f"deactivated {person.slug} (as of {person.deactivated_at})")
+    return 0
+
+
+def _cmd_person_reactivate(args: argparse.Namespace) -> int:
+    conn = db.connect(_resolve_db_path(args))
+    try:
+        try:
+            person = persons.reactivate_person(conn, args.slug)
+        except persons.PersonNotFoundError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+    finally:
+        conn.close()
+    print(f"reactivated {person.slug}")
+    return 0
+
+
+def _cmd_person_remove(args: argparse.Namespace) -> int:
+    conn = db.connect(_resolve_db_path(args))
+    try:
+        try:
+            person = persons.remove_person(conn, args.slug)
+        except persons.PersonNotFoundError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+        except persons.PersonHasDependentsError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+    finally:
+        conn.close()
+    print(f"removed person #{person.person_id}: {person.slug}")
     return 0
 
 
@@ -519,11 +602,44 @@ def build_parser() -> argparse.ArgumentParser:
     p_add.set_defaults(func=_cmd_person_add)
 
     p_list = person_sub.add_parser("list", help="list people")
+    p_list.add_argument(
+        "--all", dest="all_people", action="store_true",
+        help="include deactivated people",
+    )
     p_list.set_defaults(func=_cmd_person_list)
 
     p_show = person_sub.add_parser("show", help="show one person")
     p_show.add_argument("slug")
     p_show.set_defaults(func=_cmd_person_show)
+
+    p_edit = person_sub.add_parser(
+        "edit", help="update a person's fields (partial; slug is not editable)"
+    )
+    p_edit.add_argument("slug")
+    p_edit.add_argument("--name", help="full name (non-empty)")
+    p_edit.add_argument("--dob", help='ISO date; pass "" to clear')
+    p_edit.add_argument("--sex", help='pass "" to clear')
+    p_edit.add_argument("--blood-type", dest="blood_type", help='pass "" to clear')
+    p_edit.add_argument("--notes", help='pass "" to clear')
+    p_edit.set_defaults(func=_cmd_person_edit)
+
+    p_deactivate = person_sub.add_parser(
+        "deactivate", help="soft-deactivate a person (reversible; hides from list)"
+    )
+    p_deactivate.add_argument("slug")
+    p_deactivate.set_defaults(func=_cmd_person_deactivate)
+
+    p_reactivate = person_sub.add_parser(
+        "reactivate", help="undo deactivate (restore to the default list)"
+    )
+    p_reactivate.add_argument("slug")
+    p_reactivate.set_defaults(func=_cmd_person_reactivate)
+
+    p_remove = person_sub.add_parser(
+        "remove", help="hard-delete a person (only if they have no records)"
+    )
+    p_remove.add_argument("slug")
+    p_remove.set_defaults(func=_cmd_person_remove)
 
     p_ingest = sub.add_parser(
         "ingest", help="ingest a document (hash, blob store, layer-1 dedup)"

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -102,6 +102,40 @@ def person_add(
     return asdict(person)
 
 
+def person_edit(
+    conn: sqlite3.Connection,
+    *,
+    slug: str,
+    full_name: str | None = None,
+    dob: str | None = None,
+    sex: str | None = None,
+    blood_type: str | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
+    """[write] Edit a person's fields (partial update). Mirrors ``pemr person edit``.
+
+    Only the fields you pass change; ``slug`` is not editable. Pass an empty string for
+    a nullable field (``dob``/``sex``/``blood_type``/``notes``) to clear it to ``NULL``.
+    """
+    # None means "not provided" (skip); an explicit "" clears — same as the CLI, where
+    # an unset flag is None and `--dob ""` clears the column.
+    fields = {
+        name: value
+        for name, value in (
+            ("full_name", full_name), ("dob", dob), ("sex", sex),
+            ("blood_type", blood_type), ("notes", notes),
+        )
+        if value is not None
+    }
+    try:
+        person = _persons.update_person(conn, slug, **fields)
+    except _persons.PersonNotFoundError as exc:
+        raise ToolError(str(exc)) from exc
+    except ValueError as exc:  # empty name / no fields / unknown field
+        raise _friendly(exc) from exc
+    return asdict(person)
+
+
 def person_list(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     """[read] List people. Mirrors ``pemr person list``."""
     return [asdict(p) for p in _persons.list_people(conn)]
@@ -301,7 +335,9 @@ READ_ONLY_TOOLS = (
     "person_list", "person_show", "query", "find", "trends",
     "render_summary", "render_brief", "render_journal",
 )
-WRITE_TOOLS = ("person_add", "ingest", "commit_extraction", "review_conflicts")
+WRITE_TOOLS = (
+    "person_add", "person_edit", "ingest", "commit_extraction", "review_conflicts",
+)
 TOOL_NAMES = READ_ONLY_TOOLS + WRITE_TOOLS
 
 
@@ -380,6 +416,14 @@ def build_server():  # pragma: no cover - exercised only with the mcp SDK instal
                         sex: str | None = None, blood_type: str | None = None,
                         notes: str | None = None) -> dict:
         return _run(person_add, slug=slug, full_name=full_name, dob=dob, sex=sex,
+                    blood_type=blood_type, notes=notes)
+
+    @server.tool(name="person_edit", annotations=rw)
+    def person_edit_tool(slug: str, full_name: str | None = None,
+                         dob: str | None = None, sex: str | None = None,
+                         blood_type: str | None = None,
+                         notes: str | None = None) -> dict:
+        return _run(person_edit, slug=slug, full_name=full_name, dob=dob, sex=sex,
                     blood_type=blood_type, notes=notes)
 
     @server.tool(name="ingest", annotations=rw)

--- a/pemr/models.py
+++ b/pemr/models.py
@@ -15,9 +15,13 @@ class Person:
     sex: str | None = None
     blood_type: str | None = None
     notes: str | None = None
+    deactivated_at: str | None = None   # ISO timestamp; NULL = active (migration 004)
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Person":
+        # `deactivated_at` arrives with migration 004; tolerate its absence so person
+        # reads still work against a DB migrated to an earlier schema version.
+        has_deactivated = "deactivated_at" in row.keys()
         return cls(
             person_id=row["person_id"],
             slug=row["slug"],
@@ -26,6 +30,7 @@ class Person:
             sex=row["sex"],
             blood_type=row["blood_type"],
             notes=row["notes"],
+            deactivated_at=row["deactivated_at"] if has_deactivated else None,
         )
 
 

--- a/pemr/persons.py
+++ b/pemr/persons.py
@@ -1,14 +1,38 @@
-"""Person CRUD — phase 1 (`pemr person add|list|show`)."""
+"""Person CRUD — `pemr person add|list|show|edit|deactivate|reactivate|remove`."""
 
 from __future__ import annotations
 
 import sqlite3
+from datetime import datetime, timezone
 
 from .models import Person
 
 
 class SlugExistsError(ValueError):
     """Raised when adding a person whose slug is already taken."""
+
+
+class PersonNotFoundError(ValueError):
+    """Raised when a slug does not resolve to a person (friendly rc=1 at the CLI)."""
+
+
+class PersonHasDependentsError(ValueError):
+    """Raised when a hard ``remove`` is refused because dependent records exist."""
+
+
+# Fields editable via `person edit`. `slug` is deliberately excluded — it is the stable
+# identity handle referenced by `--person` across ingest/query/render (see issue #26
+# design). `full_name` is non-nullable (parity with `add`); the rest are nullable and
+# can be cleared by passing an empty string.
+_EDITABLE_FIELDS = ("full_name", "dob", "sex", "blood_type", "notes")
+
+# Tables whose rows reference person(person_id) with ON DELETE NO ACTION (RESTRICT).
+# A hard `remove` is refused if any of these hold a dependent row — the DELETE would
+# otherwise fail with an IntegrityError, and destroying medical history is irreversible.
+_CHILD_TABLES = (
+    "document", "lab_result", "medication", "procedure",
+    "appointment", "observation", "conflict",
+)
 
 
 def add_person(
@@ -28,7 +52,7 @@ def add_person(
         raise ValueError("full_name must be non-empty")
     try:
         with conn:
-            cur = conn.execute(
+            conn.execute(
                 """
                 INSERT INTO person (slug, full_name, dob, sex, blood_type, notes)
                 VALUES (?, ?, ?, ?, ?, ?)
@@ -42,8 +66,135 @@ def add_person(
     return person
 
 
-def list_people(conn: sqlite3.Connection) -> list[Person]:
-    rows = conn.execute("SELECT * FROM person ORDER BY slug").fetchall()
+def update_person(conn: sqlite3.Connection, slug: str, **fields: str | None) -> Person:
+    """Partial field-level update of a person (``pemr person edit``).
+
+    Only the fields passed in ``fields`` change; at least one must be given. ``slug`` is
+    not editable. ``full_name`` must be non-empty when provided (parity with ``add``).
+    The nullable fields (``dob``/``sex``/``blood_type``/``notes``) accept an empty string
+    to clear the column to ``NULL`` — the way to undo a mistakenly-set value.
+
+    Raises :class:`PersonNotFoundError` for an unknown slug and ``ValueError`` for an
+    unknown field, an empty ``full_name``, or no fields to update.
+    """
+    slug = slug.strip().lower()
+    unknown = set(fields) - set(_EDITABLE_FIELDS)
+    if unknown:
+        raise ValueError(f"cannot edit field(s): {', '.join(sorted(unknown))}")
+    if not fields:
+        raise ValueError("nothing to update - pass at least one field to change")
+
+    updates: dict[str, str | None] = {}
+    for name, value in fields.items():
+        if name == "full_name":
+            cleaned = (value or "").strip()
+            if not cleaned:
+                raise ValueError("full_name must be non-empty")
+            updates[name] = cleaned
+        else:
+            # Nullable field: an explicit empty string clears the column to NULL.
+            updates[name] = value if value not in (None, "") else None
+
+    if get_person(conn, slug) is None:
+        raise PersonNotFoundError(f"no person with slug '{slug}'")
+
+    assignments = ", ".join(f"{name} = ?" for name in updates)
+    values = list(updates.values())
+    values.append(slug)
+    with conn:
+        conn.execute(f"UPDATE person SET {assignments} WHERE slug = ?", values)
+    person = get_person(conn, slug)
+    assert person is not None  # slug existence checked above, under the same connection
+    return person
+
+
+def deactivate_person(conn: sqlite3.Connection, slug: str) -> Person:
+    """Soft-deactivate a person (reversible; hides them from the default ``person list``).
+
+    Idempotent: an already-deactivated record keeps its original ``deactivated_at``.
+    Raises :class:`PersonNotFoundError` for an unknown slug.
+    """
+    slug = slug.strip().lower()
+    person = get_person(conn, slug)
+    if person is None:
+        raise PersonNotFoundError(f"no person with slug '{slug}'")
+    if person.deactivated_at is None:
+        ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        with conn:
+            conn.execute(
+                "UPDATE person SET deactivated_at = ? WHERE slug = ?", (ts, slug)
+            )
+        person = get_person(conn, slug)
+        assert person is not None
+    return person
+
+
+def reactivate_person(conn: sqlite3.Connection, slug: str) -> Person:
+    """Clear a person's deactivated flag (undo :func:`deactivate_person`).
+
+    Raises :class:`PersonNotFoundError` for an unknown slug.
+    """
+    slug = slug.strip().lower()
+    person = get_person(conn, slug)
+    if person is None:
+        raise PersonNotFoundError(f"no person with slug '{slug}'")
+    if person.deactivated_at is not None:
+        with conn:
+            conn.execute(
+                "UPDATE person SET deactivated_at = NULL WHERE slug = ?", (slug,)
+            )
+        person = get_person(conn, slug)
+        assert person is not None
+    return person
+
+
+def remove_person(conn: sqlite3.Connection, slug: str) -> Person:
+    """Hard-delete a person, permitted **only** when they have zero dependent rows.
+
+    This is the childless-typo case (a roster entry with nothing ingested). If any
+    child record references the person, refuse with :class:`PersonHasDependentsError`
+    pointing at ``deactivate`` — deleting real medical history is irreversible and is
+    not exposed behind a single flag. Returns the (now-deleted) person for reporting.
+
+    Raises :class:`PersonNotFoundError` for an unknown slug.
+    """
+    slug = slug.strip().lower()
+    person = get_person(conn, slug)
+    if person is None:
+        raise PersonNotFoundError(f"no person with slug '{slug}'")
+
+    for table in _CHILD_TABLES:
+        row = conn.execute(
+            f"SELECT 1 FROM {table} WHERE person_id = ? LIMIT 1", (person.person_id,)
+        ).fetchone()
+        if row is not None:
+            raise PersonHasDependentsError(
+                f"person '{slug}' has dependent {table} record(s); hard remove would "
+                "destroy medical history. Use `pemr person deactivate` instead."
+            )
+
+    try:
+        with conn:
+            conn.execute("DELETE FROM person WHERE slug = ?", (slug,))
+    except sqlite3.IntegrityError as exc:  # backstop: an unlisted FK still referencing
+        raise PersonHasDependentsError(
+            f"person '{slug}' still has dependent records; use "
+            "`pemr person deactivate` instead."
+        ) from exc
+    return person
+
+
+def list_people(
+    conn: sqlite3.Connection, include_inactive: bool = False
+) -> list[Person]:
+    """List people ordered by slug. Deactivated records are hidden unless
+    ``include_inactive`` is set (``pemr person list --all``)."""
+    if include_inactive:
+        rows = conn.execute("SELECT * FROM person ORDER BY slug").fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT * FROM person WHERE deactivated_at IS NULL ORDER BY slug"
+        ).fetchall()
     return [Person.from_row(row) for row in rows]
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -31,9 +31,17 @@ def test_connect_applies_pragmas(conn):
     assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
 
 
+ALL_MIGRATIONS = [
+    "001_init.sql",
+    "002_conflict.sql",
+    "003_fts.sql",
+    "004_person_deactivate.sql",
+]
+
+
 def test_migrate_creates_all_tables(conn):
     applied = db.migrate(conn)
-    assert applied == ["001_init.sql", "002_conflict.sql", "003_fts.sql"]
+    assert applied == ALL_MIGRATIONS
     tables = {
         row["name"]
         for row in conn.execute(
@@ -44,15 +52,19 @@ def test_migrate_creates_all_tables(conn):
 
 
 def test_migrate_is_idempotent(conn):
-    assert db.migrate(conn) == ["001_init.sql", "002_conflict.sql", "003_fts.sql"]
+    assert db.migrate(conn) == ALL_MIGRATIONS
     assert db.migrate(conn) == []  # second run: nothing pending
 
 
 def test_migrate_records_versions(conn):
     db.migrate(conn)
-    assert db.applied_versions(conn) == {
-        "001_init.sql", "002_conflict.sql", "003_fts.sql"
-    }
+    assert db.applied_versions(conn) == set(ALL_MIGRATIONS)
+
+
+def test_person_has_deactivated_at_column(conn):
+    db.migrate(conn)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(person)").fetchall()}
+    assert "deactivated_at" in cols
 
 
 def test_multi_statement_migration_rolls_back_partial_ddl(conn, tmp_path):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -138,6 +138,28 @@ def test_person_add_writes(seeded):
     assert {p["slug"] for p in mcp_server.person_list(seeded)} == {"jane-doe", "john-doe"}
 
 
+def test_person_edit_writes(seeded):
+    out = mcp_server.person_edit(seeded, slug="jane-doe", dob="1981-02-03")
+    assert out["dob"] == "1981-02-03"
+    assert out["full_name"] == "Jane Doe"  # untouched partial update
+
+
+def test_person_edit_clears_nullable_with_empty_string(seeded):
+    mcp_server.person_edit(seeded, slug="jane-doe", notes="typo")
+    out = mcp_server.person_edit(seeded, slug="jane-doe", notes="")
+    assert out["notes"] is None
+
+
+def test_person_edit_unknown_slug_raises(seeded):
+    with pytest.raises(mcp_server.ToolError, match="no person"):
+        mcp_server.person_edit(seeded, slug="nobody", dob="2000-01-01")
+
+
+def test_person_edit_no_fields_raises(seeded):
+    with pytest.raises(mcp_server.ToolError, match="nothing to update"):
+        mcp_server.person_edit(seeded, slug="jane-doe")
+
+
 def test_ingest_with_agent_ocr_text(seeded, tmp_path, monkeypatch):
     monkeypatch.setenv("PEMR_SOURCES", str(tmp_path / "sources"))
     scan = tmp_path / "scan.txt"

--- a/tests/test_persons.py
+++ b/tests/test_persons.py
@@ -50,6 +50,108 @@ def test_get_missing_person_returns_none(conn):
     assert persons.get_person(conn, "nobody") is None
 
 
+# --- edit (partial field-level update) ---
+
+
+def test_update_person_partial(conn):
+    persons.add_person(conn, "jane-doe", "Jane Doe", dob="1980-01-01", blood_type="O+")
+    updated = persons.update_person(conn, "jane-doe", dob="1981-02-03")
+    assert updated.dob == "1981-02-03"
+    assert updated.full_name == "Jane Doe"       # untouched
+    assert updated.blood_type == "O+"            # untouched
+
+
+def test_update_person_clears_nullable_with_empty_string(conn):
+    persons.add_person(conn, "jane-doe", "Jane Doe", dob="1980-01-01", notes="typo")
+    updated = persons.update_person(conn, "jane-doe", dob="", notes="")
+    assert updated.dob is None
+    assert updated.notes is None
+
+
+def test_update_person_rejects_empty_name(conn):
+    persons.add_person(conn, "jane-doe", "Jane Doe")
+    with pytest.raises(ValueError):
+        persons.update_person(conn, "jane-doe", full_name="  ")
+
+
+def test_update_person_requires_a_field(conn):
+    persons.add_person(conn, "jane-doe", "Jane Doe")
+    with pytest.raises(ValueError):
+        persons.update_person(conn, "jane-doe")
+
+
+def test_update_person_rejects_unknown_field(conn):
+    persons.add_person(conn, "jane-doe", "Jane Doe")
+    with pytest.raises(ValueError):
+        persons.update_person(conn, "jane-doe", nickname="Janey")
+
+
+def test_update_unknown_slug_raises(conn):
+    with pytest.raises(persons.PersonNotFoundError):
+        persons.update_person(conn, "nobody", dob="2000-01-01")
+
+
+# --- deactivate / reactivate (soft, reversible) ---
+
+
+def test_deactivate_hides_from_default_list_and_all_shows(conn):
+    persons.add_person(conn, "jane-doe", "Jane Doe")
+    persons.add_person(conn, "john-doe", "John Doe")
+    persons.deactivate_person(conn, "john-doe")
+    assert [p.slug for p in persons.list_people(conn)] == ["jane-doe"]
+    assert [p.slug for p in persons.list_people(conn, include_inactive=True)] == [
+        "jane-doe", "john-doe",
+    ]
+    assert persons.get_person(conn, "john-doe").deactivated_at is not None
+
+
+def test_deactivate_is_idempotent(conn):
+    persons.add_person(conn, "jane-doe", "Jane Doe")
+    first = persons.deactivate_person(conn, "jane-doe").deactivated_at
+    second = persons.deactivate_person(conn, "jane-doe").deactivated_at
+    assert first == second  # timestamp preserved
+
+
+def test_reactivate_restores(conn):
+    persons.add_person(conn, "jane-doe", "Jane Doe")
+    persons.deactivate_person(conn, "jane-doe")
+    restored = persons.reactivate_person(conn, "jane-doe")
+    assert restored.deactivated_at is None
+    assert [p.slug for p in persons.list_people(conn)] == ["jane-doe"]
+
+
+def test_deactivate_unknown_slug_raises(conn):
+    with pytest.raises(persons.PersonNotFoundError):
+        persons.deactivate_person(conn, "nobody")
+
+
+# --- remove (hard delete, childless-only) ---
+
+
+def test_remove_childless_person(conn):
+    persons.add_person(conn, "typo", "Typo Person")
+    persons.remove_person(conn, "typo")
+    assert persons.get_person(conn, "typo") is None
+
+
+def test_remove_with_dependents_refused(conn):
+    person = persons.add_person(conn, "jane-doe", "Jane Doe")
+    conn.execute(
+        "INSERT INTO document (sha256, person_id, source_path, ingested_at) "
+        "VALUES (?, ?, ?, ?)",
+        ("sha-1", person.person_id, "aa/x.pdf", "2026-01-01T00:00:00"),
+    )
+    conn.commit()
+    with pytest.raises(persons.PersonHasDependentsError):
+        persons.remove_person(conn, "jane-doe")
+    assert persons.get_person(conn, "jane-doe") is not None  # not deleted
+
+
+def test_remove_unknown_slug_raises(conn):
+    with pytest.raises(persons.PersonNotFoundError):
+        persons.remove_person(conn, "nobody")
+
+
 # --- CLI surface (argparse wiring end-to-end against a temp DB) ---
 
 
@@ -80,3 +182,63 @@ def test_cli_duplicate_add_fails_cleanly(tmp_path, capsys):
     _run(tmp_path, "person", "add", "--slug", "j", "--name", "J")
     assert _run(tmp_path, "person", "add", "--slug", "j", "--name", "J2") == 1
     assert "already exists" in capsys.readouterr().err
+
+
+def test_cli_person_edit_updates_field(tmp_path, capsys):
+    _run(tmp_path, "migrate")
+    _run(tmp_path, "person", "add", "--slug", "jane", "--name", "Jane",
+         "--dob", "1980-01-01")
+    assert _run(tmp_path, "person", "edit", "jane", "--dob", "1981-02-03") == 0
+    out = capsys.readouterr().out
+    assert "1981-02-03" in out
+
+
+def test_cli_person_edit_clears_nullable(tmp_path, capsys):
+    _run(tmp_path, "migrate")
+    _run(tmp_path, "person", "add", "--slug", "jane", "--name", "Jane",
+         "--dob", "1980-01-01")
+    assert _run(tmp_path, "person", "edit", "jane", "--dob", "") == 0
+    assert _run(tmp_path, "person", "show", "jane") == 0
+    out = capsys.readouterr().out
+    assert "1980-01-01" not in out
+
+
+def test_cli_person_edit_no_fields_fails(tmp_path, capsys):
+    _run(tmp_path, "migrate")
+    _run(tmp_path, "person", "add", "--slug", "jane", "--name", "Jane")
+    assert _run(tmp_path, "person", "edit", "jane") == 1
+    assert "nothing to update" in capsys.readouterr().err
+
+
+def test_cli_person_edit_unknown_slug_fails(tmp_path, capsys):
+    _run(tmp_path, "migrate")
+    assert _run(tmp_path, "person", "edit", "nobody", "--name", "X") == 1
+    assert "no person" in capsys.readouterr().err
+
+
+def test_cli_person_deactivate_reactivate_and_list_all(tmp_path, capsys):
+    _run(tmp_path, "migrate")
+    _run(tmp_path, "person", "add", "--slug", "jane", "--name", "Jane")
+    assert _run(tmp_path, "person", "deactivate", "jane") == 0
+    capsys.readouterr()  # drain output from the setup commands above
+    # default list hides the deactivated person
+    _run(tmp_path, "person", "list")
+    default_out = capsys.readouterr().out
+    assert "jane" not in default_out
+    # --all reveals them, marked inactive
+    _run(tmp_path, "person", "list", "--all")
+    all_out = capsys.readouterr().out
+    assert "jane" in all_out and "inactive" in all_out
+    # reactivate restores to the default list
+    assert _run(tmp_path, "person", "reactivate", "jane") == 0
+    capsys.readouterr()  # drain the reactivate confirmation
+    _run(tmp_path, "person", "list")
+    assert "jane" in capsys.readouterr().out
+
+
+def test_cli_person_remove_childless(tmp_path, capsys):
+    _run(tmp_path, "migrate")
+    _run(tmp_path, "person", "add", "--slug", "typo", "--name", "Typo")
+    assert _run(tmp_path, "person", "remove", "typo") == 0
+    assert "removed person" in capsys.readouterr().out
+    assert _run(tmp_path, "person", "show", "typo") == 1


### PR DESCRIPTION
## Summary
- `pemr person edit <slug>` — partial field-level update (name/dob/sex/blood-type/notes); empty string clears a nullable field; slug not editable.
- `pemr person deactivate|reactivate <slug>` — soft, reversible retirement (new `person.deactivated_at` column, migration 004); `person list --all` shows deactivated records.
- `pemr person remove <slug>` — hard delete, refused when the person has dependent rows in any child table (no `--force`).
- MCP `person_edit` `[write]` tool mirrors the CLI edit semantics; removal verbs stay CLI/human-only.
- `AGENTS.md` and `docs/Architecture.md` updated to keep the tool-surface contract and CLI/MCP lists in sync.

Closes #26

## Test plan
- [x] `python -m pytest` — 195 passed
- [x] MCP wire-surface contract test (`registered tool names == TOOL_NAMES`) passes
- [x] Manual CLI smoke: add -> edit (set + clear) -> deactivate (hidden/`--all`) -> reactivate -> remove (childless succeeds, refused with dependents)