### PR TITLE
fix(render): flag abnormal labs in brief Recent Labs section

### DIFF
--- a/pemr/render.py
+++ b/pemr/render.py
@@ -85,6 +85,19 @@ def _is_abnormal(row: sqlite3.Row | dict) -> bool:
     return False
 
 
+def _ref_range(row: sqlite3.Row | dict) -> str:
+    """Trailing ``(ref ...)`` note for a lab's reference interval, or ``""`` when the
+    row carries no bounds. Leading double space so callers can append it directly."""
+    low, high = row["ref_low"], row["ref_high"]
+    if low is not None and high is not None:
+        return f"  (ref {_fmt(low)}-{_fmt(high)})"
+    if high is not None:
+        return f"  (ref <= {_fmt(high)})"
+    if low is not None:
+        return f"  (ref >= {_fmt(low)})"
+    return ""
+
+
 # --------------------------------------------------------------------------- #
 # Read helpers (pure SELECTs; person already resolved to an id)
 # --------------------------------------------------------------------------- #
@@ -238,18 +251,9 @@ def render_summary(
     lab_lines = []
     for r in _abnormal_labs(conn, person_id):
         flag = f" [{r['flag']}]" if r["flag"] else ""
-        low, high = r["ref_low"], r["ref_high"]
-        if low is not None and high is not None:
-            ref = f"  (ref {_fmt(low)}-{_fmt(high)})"
-        elif high is not None:
-            ref = f"  (ref <= {_fmt(high)})"
-        elif low is not None:
-            ref = f"  (ref >= {_fmt(low)})"
-        else:
-            ref = ""
         lab_lines.append(
             f"- {_date_part(r['collected_at'])}  {r['test_name']}  "
-            f"{_lab_value(r)}{flag}{ref}"
+            f"{_lab_value(r)}{flag}{_ref_range(r)}"
         )
 
     appt_lines = [
@@ -326,8 +330,12 @@ def render_brief(
     lab_lines = []
     for r in lab_rows:
         flag = f" [{r['flag']}]" if r["flag"] else ""
+        # The brief is the doc handed to a clinician: an abnormal value must not read as
+        # ordinary, so mark it and surface its reference interval (mirrors render summary).
+        abnormal = f"  [!]{_ref_range(r)}" if _is_abnormal(r) else ""
         lab_lines.append(
-            f"- {_date_part(r['collected_at'])}  {r['test_name']}  {_lab_value(r)}{flag}"
+            f"- {_date_part(r['collected_at'])}  {r['test_name']}  "
+            f"{_lab_value(r)}{flag}{abnormal}"
         )
 
     proc_rows = conn.execute(

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -177,6 +177,22 @@ def test_brief_scopes_to_appointment_and_person(seeded):
     assert "999" not in md           # john's lab must never leak in
 
 
+def test_brief_flags_abnormal_labs_with_marker_and_ref(seeded):
+    """Recent Labs in the brief must not hide an abnormal value: each abnormal lab gets
+    a marker + its reference interval, mirroring render summary; normal labs stay bare."""
+    md = render.render_brief(seeded, _upcoming_appt_id(seeded))
+    section = md.split("## Recent Labs")[1].split("##")[0]
+    lines = {ln.split("  ")[1]: ln for ln in section.splitlines() if ln.startswith("- ")}
+    # Glucose is abnormal by reference interval alone (no flag) -> marker + ref shown.
+    assert "[!]" in lines["Glucose, fasting"]
+    assert "(ref <= 100.0)" in lines["Glucose, fasting"]
+    # LDL is flag-abnormal; still marked even though it carries no reference bounds.
+    assert "[!]" in lines["LDL"]
+    # Normal labs carry neither marker nor ref note.
+    assert "[!]" not in lines["HbA1c"]
+    assert "[!]" not in lines["TSH"]
+
+
 def test_brief_has_interaction_placeholder(seeded):
     md = render.render_brief(seeded, _upcoming_appt_id(seeded))
     assert "## Medication Interaction Review" in md


### PR DESCRIPTION
## Summary
- `render brief` Recent Labs previously listed all values bare, hiding abnormal results (e.g. TSH 8.9, ref 0.4-4.5) from the clinician-facing brief doc.
- Reuses `_is_abnormal` and a new shared `_ref_range` helper (extracted from `render_summary`) to append a `[!]` marker + ref interval to abnormal lab lines in the brief; `render_summary` output is byte-identical (single source of truth for ref formatting).

## Test plan
- [x] Targeted: `tests/test_render.py`, `tests/test_cli_phase4.py`, `tests/test_mcp_server.py` (39 passed)
- [x] Full suite: 172 passed
- [x] New test `test_brief_flags_abnormal_labs_with_marker_and_ref`
- [x] Manual: seeded DB, TSH 8.9 -> `[!] (ref 0.4-4.5)`; in-range Sodium 140 stays unmarked

Closes #27

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>