### PR TITLE
feat(find): make --person optional for household-wide search

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -266,6 +266,7 @@ pemr query labs --person jane --test hba1c --since 2023-01-01
 pemr query meds --person jane --active
 pemr query timeline --person jane --since 2024-01-01     # merged event stream
 pemr find --person jane "cholesterol"                    # full-text over ocr_text + records
+pemr find "mmr booster"                                  # omit --person: whole-household, slug-prefixed hits
 pemr trends --person jane --test hba1c                   # min/max/latest/slope
 pemr due --person jane                                   # screening/vaccine gaps (rules)
 pemr render summary --person jane        > exports/jane-summary.md

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -397,7 +397,8 @@ def _cmd_find(args: argparse.Namespace) -> int:
             return 0
         for h in hits:
             prov = f"  (doc #{h['document_id']})" if h["document_id"] is not None else ""
-            print(f"{h['source_table']}#{h['source_id']}{prov}: {h['snippet']}")
+            who = "" if args.person is not None else f"{h['person']}  "
+            print(f"{who}{h['source_table']}#{h['source_id']}{prov}: {h['snippet']}")
         return 0
 
     return _with_conn_person(args, work)
@@ -600,7 +601,7 @@ def build_parser() -> argparse.ArgumentParser:
     q_timeline.set_defaults(func=_cmd_query_timeline)
 
     p_find = sub.add_parser("find", help="full-text search over OCR text + record fields")
-    p_find.add_argument("--person", required=True, help="owner slug")
+    p_find.add_argument("--person", help="owner slug; omit to search all people")
     p_find.add_argument("query", help="search text")
     p_find.add_argument("--json", action="store_true", help="machine-readable output")
     p_find.set_defaults(func=_cmd_find)

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -243,8 +243,14 @@ def query(
     return [{k: v for k, v in r.items() if k != "dedup_key"} for r in rows]
 
 
-def find(conn: sqlite3.Connection, *, person: str, query_text: str) -> list[dict[str, Any]]:
-    """[read] Full-text search over OCR text + record fields. Mirrors ``pemr find``."""
+def find(
+    conn: sqlite3.Connection, *, query_text: str, person: str | None = None
+) -> list[dict[str, Any]]:
+    """[read] Full-text search over OCR text + record fields. Mirrors ``pemr find``.
+
+    Omit ``person`` to search the whole household; each hit carries its owning
+    person slug.
+    """
     try:
         return _query.find(conn, person, query_text)
     except (db.NotMigratedError, _query.PersonNotFoundError) as exc:
@@ -355,7 +361,7 @@ def build_server():  # pragma: no cover - exercised only with the mcp SDK instal
         return _run(query, kind=kind, person=person, test=test, since=since, active=active)
 
     @server.tool(name="find", annotations=ro)
-    def find_tool(person: str, query_text: str) -> list[dict]:
+    def find_tool(query_text: str, person: str | None = None) -> list[dict]:
         return _run(find, person=person, query_text=query_text)
 
     @server.tool(name="trends", annotations=ro)

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -206,23 +206,32 @@ def _fts_query(raw: str) -> str | None:
     return " ".join(f'"{t}"' for t in tokens)
 
 
-def find(conn: sqlite3.Connection, slug: str, query: str) -> list[dict]:
-    """Full-text search across OCR text + record text fields for one person.
+def find(conn: sqlite3.Connection, slug: str | None, query: str) -> list[dict]:
+    """Full-text search across OCR text + record text fields.
 
-    Returns hits ranked best-first, each with its source (table + id), a highlighted
-    ``snippet`` and ``document_id`` provenance.
+    With ``slug`` set, restricts to that person; with ``slug=None`` searches the
+    whole household. Returns hits ranked best-first, each carrying its owning
+    ``person`` slug, source (table + id), a highlighted ``snippet`` and
+    ``document_id`` provenance.
     """
-    person_id = resolve_person_id(conn, slug)
     match = _fts_query(query)
     if match is None:
         return []
-    rows = conn.execute(
-        "SELECT source_table, source_id, document_id, "
-        "snippet(record_fts, 4, '[', ']', '...', 12) AS snippet, rank "
-        "FROM record_fts WHERE record_fts MATCH ? AND person_id = ? "
-        "ORDER BY rank",
-        (match, person_id),
-    ).fetchall()
+    sql = (
+        "SELECT person.slug AS person, record_fts.source_table, "
+        "record_fts.source_id, record_fts.document_id, "
+        "snippet(record_fts, 4, '[', ']', '...', 12) AS snippet, record_fts.rank "
+        "FROM record_fts JOIN person ON person.person_id = record_fts.person_id "
+        "WHERE record_fts MATCH ?"
+    )
+    params: list = [match]
+    if slug is None:
+        db.require_migrated(conn)
+    else:
+        sql += " AND record_fts.person_id = ?"
+        params.append(resolve_person_id(conn, slug))
+    sql += " ORDER BY record_fts.rank"
+    rows = conn.execute(sql, params).fetchall()
     return [dict(r) for r in rows]
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -104,9 +104,17 @@ def test_query_unknown_kind_raises(seeded):
 def test_find_and_trends(seeded):
     hits = mcp_server.find(seeded, person="jane-doe", query_text="glucose")
     assert hits  # ocr_text was populated, so FTS sees it
+    assert all(h["person"] == "jane-doe" for h in hits)
     tr = mcp_server.trends(seeded, person="jane-doe", test="a1c")  # dictionary-normalized
     assert tr["count"] == 2
     assert tr["latest"] == 6.5
+
+
+def test_find_household_wide_omits_person(seeded):
+    # person omitted -> whole-household search; each hit attributes its owner
+    hits = mcp_server.find(seeded, query_text="glucose")
+    assert hits and all(h["person"] == "jane-doe" for h in hits)
+    assert mcp_server.find(seeded, query_text="nonesuch-xyz") == []
 
 
 def test_renderers_return_markdown(seeded):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -194,6 +194,20 @@ def test_find_is_person_scoped(seeded):
     assert query.find(seeded, "john-doe", "unrelated")
 
 
+def test_find_carries_person_slug(seeded):
+    # every hit names its owning person, scoped or household-wide
+    for h in query.find(seeded, "jane-doe", "cholesterol"):
+        assert h["person"] == "jane-doe"
+
+
+def test_find_household_wide_when_slug_none(seeded):
+    # slug=None searches all people; jane can't see john's 'unrelated', the
+    # household can, and the hit is attributed to john
+    assert query.find(seeded, "jane-doe", "unrelated") == []
+    hits = query.find(seeded, None, "unrelated")
+    assert hits and all(h["person"] == "john-doe" for h in hits)
+
+
 def test_find_ignores_fts_operators_safely(seeded):
     # punctuation / bare operators must not raise or change meaning
     assert isinstance(query.find(seeded, "jane-doe", 'cholesterol AND ("'), list)


### PR DESCRIPTION
## Summary
- `pemr find` no longer requires `--person`: omitting it searches the whole household, with each
  hit prefixed by the owning person's slug. Scoped output (`--person` given) is byte-for-byte
  unchanged.
- `pemr/query.py`: `find(conn, slug, query)` accepts `slug=None` for a household-wide FTS search
  (`record_fts JOIN person`); every hit carries a `person` slug key. `db.require_migrated` is
  invoked explicitly on the household path (the scoped path already gets it via
  `resolve_person_id`).
- `pemr/mcp_server.py`: `find` tool's `person` param is now optional, mirroring the CLI.
- `docs/Architecture.md`: added a household-wide example line.
- `dev` is an ancestor of this branch — nothing to merge in.

Closes #28

## Test plan
- [x] `python -m pytest` — 174 passed (build + verify both reproduced this)
- [x] Verify's real CLI E2E: household search spans people with slug prefixes, `--json` carries
      `person`, scoped search format unchanged, unknown-slug and un-migrated-DB error paths intact
- [x] Audit (security-executor): SQL injection closed (tokenized + parameterized FTS query),
      no cross-tenant access-control concern (single-operator tool), migration gate intact on both
      paths — CLEAN, one non-blocking edge-behavior note only (empty/punctuation-only query with
      unknown `--person` now short-circuits to rc=0 "no matches" instead of rc=1; no data
      disclosure)