### PR TITLE
fix(trends): clarify slope message and handle same-date duplicate points

### DIFF
--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -417,9 +417,14 @@ def _cmd_trends(args: argparse.Namespace) -> int:
         print(f"{result['test']}  ({result['count']} point(s))")
         print(f"  min    {_fmt(result['min'])}{unit}")
         print(f"  max    {_fmt(result['max'])}{unit}")
-        print(f"  latest {_fmt(result['latest'])}{unit}  @ {_fmt(result['latest_at'])}")
+        tie = result.get("latest_tie", 0)
+        tie_note = f"  (1 of {tie} at this timestamp)" if tie > 1 else ""
+        print(
+            f"  latest {_fmt(result['latest'])}{unit}"
+            f"  @ {_fmt(result['latest_at'])}{tie_note}"
+        )
         if result["slope_per_day"] is None:
-            print("  slope  n/a (need >=2 dated points)")
+            print("  slope  n/a (need >=2 distinct dates)")
         else:
             print(f"  slope  {result['slope_per_day']:+.4g}{unit}/day")
         return 0

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -260,15 +260,19 @@ def trends(
 ) -> dict:
     """Summary stats for one dictionary-normalized analyte over time.
 
-    Returns ``{test, count, unit, min, max, latest, latest_at, slope_per_day}``.
-    ``count`` is the number of numeric points; ``slope_per_day`` degrades to ``None``
-    with fewer than two numeric points (or a single collection date).
+    Returns ``{test, count, unit, min, max, latest, latest_at, latest_tie,
+    slope_per_day}``. ``count`` is the number of numeric points; ``slope_per_day``
+    degrades to ``None`` with fewer than two distinct collection dates. ``latest`` is
+    the row with the greatest ``collected_at``, ties broken by the greatest
+    ``lab_result_id`` (most-recently-ingested wins); ``latest_tie`` counts how many
+    matched rows share that exact ``collected_at`` timestamp.
     """
     person_id = resolve_person_id(conn, slug)
     target = norm(test, dictionary)
     rows = conn.execute(
-        "SELECT value_num, unit, collected_at, test_name FROM lab_result "
-        "WHERE person_id = ? AND value_num IS NOT NULL ORDER BY collected_at",
+        "SELECT lab_result_id, value_num, unit, collected_at, test_name FROM lab_result "
+        "WHERE person_id = ? AND value_num IS NOT NULL "
+        "ORDER BY collected_at, lab_result_id",
         (person_id,),
     ).fetchall()
     matched = [r for r in rows if norm(r["test_name"], dictionary) == target]
@@ -281,6 +285,7 @@ def trends(
         "max": None,
         "latest": None,
         "latest_at": None,
+        "latest_tie": 0,
         "slope_per_day": None,
     }
     if not matched:
@@ -291,9 +296,12 @@ def trends(
     result["unit"] = next(iter(units)) if len(units) == 1 else None
     result["min"] = min(values)
     result["max"] = max(values)
-    latest = matched[-1]  # rows came back ORDER BY collected_at
+    latest = matched[-1]  # rows came back ORDER BY collected_at, lab_result_id
     result["latest"] = float(latest["value_num"])
     result["latest_at"] = latest["collected_at"]
+    result["latest_tie"] = sum(
+        1 for r in matched if r["collected_at"] == latest["collected_at"]
+    )
 
     points = [
         (o, float(r["value_num"]))

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -2,6 +2,7 @@
 human + --json output, empty-result rc=0 messages, unknown-slug rc=1."""
 
 import json
+import uuid
 
 import pytest
 
@@ -110,7 +111,58 @@ def test_trends_json_shape(ready, capsys):
                 *DICT_ARG, "--json") == 0
     t = json.loads(capsys.readouterr().out)
     assert t["count"] == 2
-    assert {"test", "min", "max", "latest", "slope_per_day", "unit"} <= set(t)
+    assert {"test", "min", "max", "latest", "slope_per_day", "unit",
+            "latest_tie"} <= set(t)
+
+
+def _seed_lab(tmp_path, slug, **cols):
+    """Insert a lab_result row directly (bypassing dedup) to reach the #20
+    same-timestamp duplicate state, then return."""
+    conn = db.connect(tmp_path / "cli.db")
+    pid = conn.execute(
+        "SELECT person_id FROM person WHERE slug=?", (slug,)
+    ).fetchone()["person_id"]
+    cols.setdefault("dedup_key", f"k-{uuid.uuid4()}")
+    keys = ["person_id", *cols]
+    vals = [pid, *cols.values()]
+    placeholders = ", ".join("?" for _ in keys)
+    conn.execute(
+        f"INSERT INTO lab_result ({', '.join(keys)}) VALUES ({placeholders})", vals
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_trends_slope_na_message_reworded(ready, capsys):
+    """Issue #29 part A: the n/a message names distinct dates, not 'dated points'."""
+    # Single point -> slope n/a.
+    _seed_lab(ready, "jane-doe", test_name="LDL", value_num=100, unit="mg/dL",
+              collected_at="2026-01-01T08:00:00")
+    assert _run(ready, "trends", "--person", "jane-doe", "--test", "ldl", *DICT_ARG) == 0
+    out = capsys.readouterr().out
+    assert "n/a (need >=2 distinct dates)" in out
+    assert "dated points" not in out
+
+    # Two points that share one calendar date -> still n/a, same reworded message.
+    _seed_lab(ready, "jane-doe", test_name="Glucose", value_num=5.0, unit="mmol/L",
+              collected_at="2026-03-01T08:00:00")
+    _seed_lab(ready, "jane-doe", test_name="Glucose", value_num=5.5, unit="mmol/L",
+              collected_at="2026-03-01T20:00:00")
+    assert _run(ready, "trends", "--person", "jane-doe", "--test", "glucose", *DICT_ARG) == 0
+    assert "n/a (need >=2 distinct dates)" in capsys.readouterr().out
+
+
+def test_trends_same_timestamp_tie_disclosed(ready, capsys):
+    """Issue #29 part B: same exact timestamp with differing values is disclosed."""
+    _seed_lab(ready, "jane-doe", test_name="Glucose", value_num=5.0, unit="mmol/L",
+              collected_at="2026-07-17T09:00:00")
+    _seed_lab(ready, "jane-doe", test_name="Glucose", value_num=5.2, unit="mmol/L",
+              collected_at="2026-07-17T09:00:00")
+    assert _run(ready, "trends", "--person", "jane-doe", "--test", "glucose", *DICT_ARG) == 0
+    out = capsys.readouterr().out
+    latest = next(line for line in out.splitlines() if "latest" in line)
+    assert "5.2" in latest  # deterministic higher-id pick
+    assert "(1 of 2 at this timestamp)" in latest
 
 
 def test_empty_results_are_clean_rc0(ready, capsys):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2,6 +2,7 @@
 FTS backfill on migrate, trends math, dictionary normalization, and person isolation."""
 
 import shutil
+import uuid
 from pathlib import Path
 
 import pytest
@@ -271,6 +272,54 @@ def test_trends_single_point_degrades_slope(seeded):
 def test_trends_unknown_analyte_is_empty(seeded):
     t = query.trends(seeded, "jane-doe", "nonesuch")
     assert t["count"] == 0 and t["slope_per_day"] is None
+
+
+def _insert_lab(conn, slug, **cols):
+    """Insert a lab_result row directly (bypassing dedup) to simulate the #20
+    same-timestamp duplicate-row state. Returns the new lab_result_id."""
+    pid = conn.execute(
+        "SELECT person_id FROM person WHERE slug=?", (slug,)
+    ).fetchone()["person_id"]
+    cols.setdefault("dedup_key", f"k-{uuid.uuid4()}")
+    keys = ["person_id", *cols]
+    vals = [pid, *cols.values()]
+    placeholders = ", ".join("?" for _ in keys)
+    cur = conn.execute(
+        f"INSERT INTO lab_result ({', '.join(keys)}) VALUES ({placeholders})",
+        vals,
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def test_trends_same_timestamp_tie_is_deterministic(seeded):
+    d = dedup.load_dictionary(DICT_PATH)
+    # Two rows with the *same* collected_at but different values (the #20 symptom).
+    # Latest must be the greater lab_result_id (most-recently-ingested), and the
+    # tie must be disclosed via latest_tie.
+    _insert_lab(seeded, "jane-doe", test_name="Glucose",
+                value_num=5.0, unit="mmol/L", collected_at="2026-07-17T09:00:00")
+    later_id = _insert_lab(seeded, "jane-doe", test_name="Glucose",
+                           value_num=5.2, unit="mmol/L",
+                           collected_at="2026-07-17T09:00:00")
+    t = query.trends(seeded, "jane-doe", "glucose", dictionary=d)
+    assert t["count"] == 2
+    assert t["latest"] == 5.2  # higher lab_result_id wins the tie
+    assert t["latest_at"] == "2026-07-17T09:00:00"
+    assert t["latest_tie"] == 2
+    assert later_id  # sanity: the later insert got a greater PK
+    assert t["slope_per_day"] is None  # one distinct date
+
+
+def test_trends_distinct_intraday_times_are_not_a_tie(seeded):
+    d = dedup.load_dictionary(DICT_PATH)
+    # Genuinely ordered intraday times must NOT trip the tie note.
+    _insert_lab(seeded, "jane-doe", test_name="Glucose",
+                value_num=5.0, unit="mmol/L", collected_at="2026-07-17T09:00:00")
+    _insert_lab(seeded, "jane-doe", test_name="Glucose",
+                value_num=5.4, unit="mmol/L", collected_at="2026-07-17T14:00:00")
+    t = query.trends(seeded, "jane-doe", "glucose", dictionary=d)
+    assert t["latest"] == 5.4 and t["latest_tie"] == 1
 
 
 # --- error surfaces -----------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reworded the trends slope n/a message from "need >=2 dated points" to "need >=2 distinct
  dates" — accurate on every path `_slope_per_day` returns `None` (too few points, or all points
  share one calendar day).
- `trends`' "latest" pick over same-`collected_at` rows is now deterministic: `ORDER BY
  collected_at, lab_result_id` so ties resolve to the greatest PK (most-recently-ingested).
- Added `latest_tie` (always present in the result dict / `--json`) = count of matched rows whose
  `collected_at` byte-equals the latest row's timestamp. CLI discloses it on the latest line,
  e.g. `latest 5.2 mmol/L  @ 2026-07-17T09:00:00  (1 of 2 at this timestamp)`, so an equally-timed
  differing sibling value is never silently dropped.
- Out of scope (per design, respected): removing the duplicate rows themselves (#20), other query
  orderings, merging tied rows.
- `dev` is an ancestor of this branch — nothing to merge in.

Closes #29

## Test plan
- [x] `python -m pytest` — 175 passed (build + verify both reproduced)
- [x] Verify's real E2E: same-timestamp duplicate reproduces the shakedown case, tiebreak flips
      correctly when insertion order is reversed (confirms it's PK-driven, not accidental), tie
      count scoped to the latest timestamp only, distinct intraday times not flagged
- [x] Audit (security-executor): no new SQL surface (static ORDER BY column, existing
      parameterization untouched), correctness of tiebreak/tie-detection logic re-derived and
      confirmed, additive `latest_tie` key is consumer-safe (`.get` with default, no fixed-key
      consumer) — CLEAN, no blocking findings