### PR TITLE
Dictionary: add ESR / sed rate synonyms

### DIFF
--- a/data/dictionary.example.toml
+++ b/data/dictionary.example.toml
@@ -65,6 +65,15 @@
 "platelets" = "platelets"
 "plt" = "platelets"
 
+# --- Inflammatory markers ---
+# ESR (erythrocyte sedimentation rate). Report labels vary by method; the
+# `(modified westergren)` method tag reduces to the bare "sed rate by modified
+# westergren" form once norm() strips parentheses. All spellings collapse to `esr`.
+"esr" = "esr"
+"sed rate" = "esr"
+"sed rate by modified westergren" = "esr"
+"erythrocyte sedimentation rate" = "esr"
+
 # --- Basic metabolic panel (CMP abbreviations) ---
 # Report codes for non-fasting serum chemistries. (Fasting glucose is its own token
 # under Glycemic — a bare `Glucose`/`GLUC` reading is not a fasting result.)

--- a/data/dictionary.example.toml
+++ b/data/dictionary.example.toml
@@ -66,9 +66,11 @@
 "plt" = "platelets"
 
 # --- Inflammatory markers ---
-# ESR (erythrocyte sedimentation rate). Report labels vary by method; the
-# `(modified westergren)` method tag reduces to the bare "sed rate by modified
-# westergren" form once norm() strips parentheses. All spellings collapse to `esr`.
+# ESR (erythrocyte sedimentation rate). Report labels vary by method. The
+# unparenthesized Quest label "sed rate by modified westergren" matches its own
+# key below; a parenthetical variant like "Sed Rate (Modified Westergren)" has
+# the method tag stripped by norm() and reduces to the bare "sed rate" key
+# instead. All spellings collapse to `esr`.
 "esr" = "esr"
 "sed rate" = "esr"
 "sed rate by modified westergren" = "esr"

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -53,6 +53,15 @@ def test_load_missing_dictionary_is_empty(tmp_path):
     assert dedup.load_dictionary(None) == {}
 
 
+def test_esr_synonyms_map_to_canonical():
+    # Issue #41: an ESR result labeled "SED RATE BY MODIFIED WESTERGREN" on a Quest
+    # report must share the `esr` identity with every other ESR spelling.
+    d = dedup.load_dictionary(DICT_PATH)
+    for spelling in ("ESR", "Sed Rate", "SED RATE BY MODIFIED WESTERGREN",
+                     "Erythrocyte Sedimentation Rate"):
+        assert dedup.norm(spelling, d) == "esr", spelling
+
+
 def test_norm_treats_underscores_as_spaces():
     assert dedup.norm("blood_pressure") == "blood pressure"
     d = dedup.load_dictionary(DICT_PATH)


### PR DESCRIPTION
## Summary
- Adds an `[synonyms]` -> `esr` mapping to `data/dictionary.example.toml` for `esr`, `sed rate`, `sed rate by modified westergren`, and `erythrocyte sedimentation rate`, so differently-labeled ESR results (e.g. a Quest report's "SED RATE BY MODIFIED WESTERGREN") join the same identity under `trends --test esr`.
- Adds `test_esr_synonyms_map_to_canonical` covering all four spellings, following the existing vitals-synonym test convention.
- Clarifies the new comment's wording on how `norm()` handles the `(modified westergren)` parenthetical tag (audit nit: it strips the tag entirely down to bare `sed rate`, rather than reducing to `sed rate by modified westergren`).

## Test plan
- [x] `pytest tests/test_dedup.py` (46 passed)
- [x] Full suite `pytest` (230 passed)
- [x] Verified `dedup.norm()` maps all four spellings, case/whitespace/underscore variants, and parenthetical method-tag variants to `esr`
- [x] Verified `dedup_key('lab_result', …)` produces an identical key for `SED RATE BY MODIFIED WESTERGREN` and `ESR` on the same person/date

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)