### PR TITLE
dedup: accept partial (month/year) dates on date fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,22 @@ The agent fills it **from its own general knowledge**, under fixed framing it MU
 The agent MUST NEVER: claim safety or the absence of interactions, give dosing advice, or recommend
 starting, stopping, or changing a medication.
 
+### 6. Date precision
+
+Every date field (`collected_at`, `started_on`, `ended_on`, `performed_on`, `scheduled_for`,
+`observed_at`) accepts an ISO prefix at **three precisions**: full `YYYY-MM-DD` (optionally + a
+`T`/space time), month `YYYY-MM`, or year `YYYY`. Emit the **most precise prefix the source
+supports** — a full date when the document gives one, else `YYYY-MM`, else `YYYY` — never invent a
+day or month the source didn't state, and never fall back to stashing an imprecise date elsewhere.
+
+- e.g. a prior surgery cited only as "03/2019" commits as `procedure.performed_on = "2019-03"`,
+  not stashed in a condition observation's `value_text`.
+- A time component is only valid with a full date (`2026-03T09:00` is rejected).
+- Non-ISO forms (`06/15/2026`, `2026-13`, `2026-3`, `Jan 2026`) are still rejected — reformat to an
+  ISO prefix first.
+- A partial and a later full date of the same event stay **distinct rows** (the dedup layer never
+  guesses that one refines the other); reconciling them is a human conflict-review action.
+
 ## Privacy posture
 
 This repository is **public**. It is framework + documentation only.

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -24,7 +24,7 @@ import re
 import sqlite3
 import tomllib
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 from . import db
@@ -83,7 +83,8 @@ KNOWN_TYPES = tuple(FIELD_SPECS)
 
 # Date-typed fields per record type. These feed timeline sort / trends date math and
 # the dedup_key (via _date_only), all of which assume a lexically-sortable ISO date —
-# so validate_row enforces strict ISO on them, not just the base `str` type.
+# so validate_row enforces ISO on them, not just the base `str` type. A partial
+# prefix (YYYY / YYYY-MM) is accepted alongside a full date; see _is_iso_date.
 DATE_FIELDS: dict[str, frozenset[str]] = {
     "lab_result": frozenset({"collected_at"}),
     "medication": frozenset({"started_on", "ended_on"}),
@@ -95,11 +96,17 @@ DATE_FIELDS: dict[str, frozenset[str]] = {
 _WS = re.compile(r"\s+")
 _PAREN = re.compile(r"\([^)]*\)")
 
-# A date value must begin with a strict `YYYY-MM-DD` (the part _date_only slices for
-# the dedup_key and timeline sort); an optional time component may follow after `T` or
-# a space. Calendar validity (real month/day, valid time) is then confirmed by
-# datetime.fromisoformat below.
+# A date value is accepted at one of three precisions, each a lexically-sortable ISO
+# prefix (so `_date_only` slicing, timeline sort and every `ORDER BY <datecol>` keep
+# working — a coarse date sorts at the start of its period):
+#   * YYYY-MM-DD (full date), optionally followed by `T`/space + a time component;
+#   * YYYY-MM    (month precision) — no time component permitted;
+#   * YYYY       (year precision)  — no time component permitted.
+# Calendar validity (real month/day, valid time, plausible year) is confirmed by the
+# datetime/date constructors in _is_iso_date below.
 _ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}(?:[T ].*)?")
+_ISO_MONTH_RE = re.compile(r"\d{4}-\d{2}")
+_ISO_YEAR_RE = re.compile(r"\d{4}")
 
 
 class ValidationError(ValueError):
@@ -107,20 +114,42 @@ class ValidationError(ValueError):
 
 
 def _is_iso_date(value: str) -> bool:
-    """True when ``value`` is a strict ISO date (``YYYY-MM-DD``) or ISO timestamp
-    (``YYYY-MM-DD`` + ``T``/space + a valid time, optionally with offset/``Z``).
+    """True when ``value`` is an ISO date/timestamp at one of three precisions:
 
-    Non-ISO forms like ``06/15/2026`` or ``not-a-date`` are rejected — they would
-    otherwise sort lexically ahead of real ISO dates and corrupt the timeline."""
-    if not _ISO_DATE_RE.fullmatch(value):
-        return False
-    try:
-        # datetime.fromisoformat (3.11+) parses date-only and full timestamps and
-        # enforces calendar/time validity; `Z` is accepted only from 3.11 onward.
-        datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return False
-    return True
+        * full date ``YYYY-MM-DD``, optionally + ``T``/space + a valid time
+          (optionally with offset/``Z``) — e.g. ``2026-03-15``, ``2026-03-15T09:30Z``;
+        * month precision ``YYYY-MM`` — e.g. ``2026-03``;
+        * year precision ``YYYY`` — e.g. ``2026``.
+
+    A time component is permitted **only** at full-date precision (``2026-03T09:00``
+    is rejected). Non-ISO forms like ``06/15/2026``, ``2026-13``, ``2026-3`` or
+    ``not-a-date`` are rejected — they would otherwise sort lexically ahead of real
+    ISO dates and corrupt the timeline. Each accepted form is a prefix of the next, so
+    all three sort correctly against each other and against full dates."""
+    if _ISO_DATE_RE.fullmatch(value):
+        try:
+            # datetime.fromisoformat (3.11+) parses date-only and full timestamps and
+            # enforces calendar/time validity; `Z` is accepted only from 3.11 onward.
+            datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return False
+        return True
+    if _ISO_MONTH_RE.fullmatch(value):
+        year, month = value.split("-")
+        try:
+            # date() enforces month 01-12 and a plausible (1-9999) year in one check.
+            date(int(year), int(month), 1)
+        except ValueError:
+            return False
+        return True
+    if _ISO_YEAR_RE.fullmatch(value):
+        try:
+            # Rejects the one implausible 4-digit year, 0000 (date min year is 1).
+            date(int(value), 1, 1)
+        except ValueError:
+            return False
+        return True
+    return False
 
 
 # --------------------------------------------------------------------------- #
@@ -259,7 +288,8 @@ def validate_row(record_type: str, row: object) -> None:
             )
         if name in DATE_FIELDS.get(record_type, frozenset()) and not _is_iso_date(value):
             raise ValidationError(
-                f"{record_type}.{name}: expected ISO date (YYYY-MM-DD) or ISO "
+                f"{record_type}.{name}: expected ISO date at year (YYYY), month "
+                f"(YYYY-MM) or full (YYYY-MM-DD) precision, or a full-date ISO "
                 f"timestamp, got {value!r}"
             )
 

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -143,6 +143,18 @@ def test_dedup_key_differs_by_date():
     assert a != b
 
 
+def test_partial_and_full_date_of_same_event_are_distinct_keys():
+    # Issue #42 Q2: the dedup layer never guesses a full date refines a partial one —
+    # a YYYY-MM procedure and a later fully-dated copy get distinct keys (two rows).
+    partial = dedup.dedup_key("procedure",
+                              {"name": "Appendectomy", "performed_on": "2019-03"}, 1)
+    full = dedup.dedup_key("procedure",
+                           {"name": "Appendectomy", "performed_on": "2019-03-15"}, 1)
+    year = dedup.dedup_key("procedure",
+                           {"name": "Appendectomy", "performed_on": "2019"}, 1)
+    assert partial != full != year and partial != year
+
+
 # --- validation ---------------------------------------------------------------
 
 def test_validate_rejects_unknown_type():
@@ -192,6 +204,22 @@ def test_validate_accepts_iso_dates_and_timestamps(good):
         "lab_result",
         {"test_name": "Sodium", "value_num": 140, "collected_at": good},
     )
+
+
+@pytest.mark.parametrize("good", ["2026", "2026-01", "2026-12", "1999", "2019-03"])
+def test_validate_accepts_partial_dates(good):
+    # Issue #42: month (YYYY-MM) and year (YYYY) precision prefixes are first-class.
+    dedup.validate_row("procedure", {"name": "Appendectomy", "performed_on": good})
+
+
+@pytest.mark.parametrize("bad", ["2026-13", "2026-00", "2026-3", "2026-1", "0000",
+                                  "202X", "2026-", "2026-03-", "2026-03T09:00",
+                                  "2026T09:00", "20260", "999"])
+def test_validate_rejects_partial_date_junk(bad):
+    # Near-miss partial forms are still rejected: bad month, single-digit or missing
+    # month, implausible year, and any time component on a non-full-date precision.
+    with pytest.raises(dedup.ValidationError, match=r"performed_on.*ISO date"):
+        dedup.validate_row("procedure", {"name": "MRI", "performed_on": bad})
 
 
 def test_validate_rejects_non_iso_date_across_record_types():


### PR DESCRIPTION
## Summary
- Widens `_is_iso_date` in `pemr/dedup.py` to accept three ISO date precisions on all
  `DATE_FIELDS`: full `YYYY-MM-DD` (optionally followed by `T`/space + time), month `YYYY-MM`, and
  year `YYYY`. Month/year values are calendar-validated (rejects `2026-13`, `2026-00`, etc.); a
  time component is only permitted alongside full-date precision.
- `_date_only` / `_norm_ts` are unchanged, so lexical sortability is preserved
  (`2019` < `2019-03` < `2019-03-15`) and `dedup_key` naturally gives partial vs. full-precision
  dates of the same event **distinct** keys — no cross-precision merge (design decision, see
  issue #42 discussion: dedup never guesses that a full date "refines" a partial one; that's
  reconciliation, left to human conflict-review).
- `AGENTS.md` — new rule 6: extraction should emit the most precise date prefix the source
  supports (full date, else `YYYY-MM`, else `YYYY`). Cites the smoke-test case that motivated
  this: a prior surgery cited only as "MM/YYYY" previously couldn't be committed as a `procedure`
  row and had to be stashed in a condition's `value_text`.
- `tests/test_dedup.py` — accept `YYYY`/`YYYY-MM`; reject partial junk (`2026-13`, `2026-3`,
  `2026-03T09:00`, `0000`, ...); assert partial/full/year dates of the same event produce distinct
  dedup_keys.

Graceful-degradation edges are preserved, not "fixed" (per design spec): `query._ordinal`/`trends`
drops a partial-date point from the least-squares slope (still counted in count/min/max);
`query_labs(since=…)`'s SQLite `date()` returns NULL for a partial value, excluding it from a
bounded `since` window (documented as a known limitation).

Closes #42

## Test plan
- [x] `pytest tests/test_dedup.py` (63 passed)
- [x] Full suite `pytest` (246 passed)
- [x] Verified end-to-end via `commit_extraction`: an `MM/YYYY`-cited surgery now commits as a
      `procedure` row with `performed_on = "YYYY-MM"`; a later full-dated copy of the same event
      produces a distinct row (no cross-precision merge); junk dates still reject the whole batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
