### PR TITLE
Extraction convention for health-screening / immunization-due tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ report's verbatim label.
   (`docs/Architecture.md` §3).
 - MUST NOT invent abbreviations or "helpful" renames.
 
-### 2. Observation rows — conditions, allergies, vitals
+### 2. Observation rows — conditions, allergies, vitals, screenings, immunizations
 
 `render_summary` populates its **Conditions**, **Allergies**, and **Latest Vitals** sections purely
 from `observation` rows, keyed by `obs_type`. An extraction that omits them leaves those sections
@@ -91,6 +91,25 @@ treats underscores as spaces, so `blood_pressure` matches "blood pressure"; the 
 also maps common synonyms (`bp` → `blood_pressure`), but agents SHOULD emit the canonical token
 directly. Set `observed_at` (ISO date) whenever the source gives one — it drives timeline order and
 the "latest" selection.
+
+Two more observation families capture care-gap inputs. They have **no dedicated summary section** —
+their structured consumer is the future `pemr due` (care-gap) command, so they surface only via the
+generic `observation` loop in the appointment brief and timeline. Commit them anyway; the last-done
+date is what phase 7 needs and re-extraction to recover it later is expensive:
+
+- **Screening** → `obs_type='screening'`, `key=<snake_case screening name>` (e.g. `mammogram`,
+  `colonoscopy`, `diabetes_screening`), `observed_at=<last-done ISO date>` (the load-bearing
+  field), optional `value_text=<the source table's stated frequency / next-due, verbatim>`. The
+  frequency/next-due is context only — `pemr due` recomputes "due" from its own cadence rules.
+- **Immunization** → `obs_type='immunization'`, `key=<snake_case vaccine name>` (e.g. `influenza`,
+  `tdap`, `mmr`, `pneumococcal`), `observed_at=<date administered>`, optional `value_text=<detail:
+  dose #, lot, site>`. One row per administration; multiple rows over time = vaccination history.
+
+Vaccine overlap (influenza appears in both worlds): an **administered** vaccine → an `immunization`
+row; a health-screening-table *"due / last-done"* line → a `screening` row **only when the table is
+the sole evidence of last-done** (no administration record to capture). Don't double-count the same
+event as both. Canonical screening/vaccine vocabulary is owned by the care-gap phase — for now emit
+sensible `snake_case` tokens (same discipline as vitals) and let `dedup.norm()` handle case/spacing.
 
 ### 3. OCR text at ingest
 

--- a/data/dictionary.example.toml
+++ b/data/dictionary.example.toml
@@ -100,13 +100,20 @@
 "beta2 microglobulin" = "beta2_microglobulin"
 "beta-2 microglobulin" = "beta2_microglobulin"
 
-# --- observation obs_type conventions (phase 4 render layer) ---
-# The render layer (master summary / appointment brief) reads three obs_type
-# families out of the generic `observation` table. Extraction agents should emit:
-#   * obs_type='vital'     key=<canonical vital token below>  (blood_pressure ...)
-#   * obs_type='condition' key=<condition name>   value_text=<optional detail>
-#   * obs_type='allergy'   key=<allergen>         value_text=<optional reaction>
-# "Latest vitals" in the summary is the most recent `vital` row per normalized key.
+# --- observation obs_type conventions ---
+# Five obs_type families out of the generic `observation` table. Extraction
+# agents should emit:
+#   * obs_type='vital'        key=<canonical vital token below>  (blood_pressure ...)
+#   * obs_type='condition'    key=<condition name>     value_text=<optional detail>
+#   * obs_type='allergy'      key=<allergen>           value_text=<optional reaction>
+#   * obs_type='screening'    key=<snake_case screen>  observed_at=<last-done date>  value_text=<freq/next-due>
+#   * obs_type='immunization' key=<snake_case vaccine> observed_at=<date given>      value_text=<optional detail>
+# The first three drive the phase-4 render layer (master summary / appointment
+# brief); "Latest vitals" is the most recent `vital` row per normalized key.
+# Screening/immunization have no render section — they feed the future care-gap
+# `pemr due` command (phase 7), which owns the canonical screening/vaccine
+# vocabulary. Until then there is no dictionary here for them: agents emit
+# sensible snake_case tokens and norm() is the interim case/spacing backstop.
 
 # --- Vitals (observation keys) ---
 # Canonical observation-key vocabulary — extraction agents should emit these

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -88,7 +88,7 @@ CREATE TABLE observation (
   observation_id INTEGER PRIMARY KEY,
   person_id      INTEGER NOT NULL REFERENCES person(person_id),
   document_id    INTEGER REFERENCES document(document_id),
-  obs_type       TEXT NOT NULL,          -- 'blood_pressure','weight','allergy','immunization'...
+  obs_type       TEXT NOT NULL,          -- 'blood_pressure','weight','allergy','screening','immunization'...
   observed_at    TEXT,
   key            TEXT,
   value_num      REAL,


### PR DESCRIPTION
## Summary
- Adopts extraction conventions for two previously-undocumented `observation` families:
  `obs_type='screening'` (recommendation/last-done from a visit summary's Health Screening
  table) and `obs_type='immunization'` (administered vaccines) — the latter was already
  name-checked in the schema comment but had no documented convention.
- `AGENTS.md` §2 — adds screening/immunization bullets with exact field mappings (screening:
  `key`=snake_case name, `observed_at`=last-done load-bearing date, `value_text`=verbatim
  frequency/next-due; immunization: `key`=vaccine, `observed_at`=date administered, one row
  per administration), plus vaccine-overlap guidance (an administered dose is always
  `immunization`; a screening table's due/last-done line is `screening` only when it's the
  sole evidence, no double-count) and a note that these feed the future `pemr due` command
  rather than a render section.
- `migrations/001_init.sql` — adds `'screening'` to the `obs_type` column comment's example
  list alongside the pre-existing `'immunization'`.
- `data/dictionary.example.toml` — extends the obs_type-conventions comment block from three
  families to five; states the canonical screening/vaccine vocabulary is deferred to the
  future care-gap phase, with `dedup.norm()` as the interim key backstop.

Pure documentation change — no `pemr/` or `tests/` code touched. Render intentionally gets no
dedicated section (rows already surface via the generic `observation` loop in appointment
briefs); a dedicated "Latest Screenings/Immunizations" section is explicitly out of scope,
reserved for the future care-gap phase.

Closes #43

## Test plan
- [x] `pytest tests/test_db.py tests/test_dedup.py tests/test_render.py` (73 passed, build/verify)
- [x] Full suite `pytest` — 228 passed (verify, audit, and reproduced again pre-push here)
- [x] `data/dictionary.example.toml` reparsed clean with `tomllib` after the comment-block edit
- [x] Verify drove the convention end-to-end: seeded `screening`/`immunization` rows and
      confirmed they surface via the generic observation loop in the appointment brief with no
      dedicated summary section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
