### PR TITLE
Capture non-medication orders as obs_type='order'

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,17 +73,26 @@ report's verbatim label.
   (`docs/Architecture.md` §3).
 - MUST NOT invent abbreviations or "helpful" renames.
 
-### 2. Observation rows — conditions, allergies, vitals
+### 2. Observation rows — conditions, allergies, vitals, orders
 
-`render_summary` populates its **Conditions**, **Allergies**, and **Latest Vitals** sections purely
-from `observation` rows, keyed by `obs_type`. An extraction that omits them leaves those sections
-permanently `_none recorded_`, so a visit note carrying a diagnosis, allergy, or vital reading MUST
-commit the matching `observation` rows in `commit_extraction`:
+`render_summary` populates its **Conditions**, **Allergies**, **Orders & Referrals**, and **Latest
+Vitals** sections purely from `observation` rows, keyed by `obs_type`. An extraction that omits them
+leaves those sections permanently `_none recorded_`, so a visit note carrying a diagnosis, allergy,
+vital reading, or non-medication order MUST commit the matching `observation` rows in
+`commit_extraction`:
 
 - **Condition** → `obs_type='condition'`, `key=<condition name>`, optional `value_text=<detail>`.
 - **Allergy** → `obs_type='allergy'`, `key=<allergen>`, optional `value_text=<reaction>`.
 - **Vital** → `obs_type='vital'`, `key=<canonical vital token>` (below), the reading in `value_num`
   (+ `unit`) or `value_text`. "Latest vitals" is the most recent `vital` row per normalized `key`.
+- **Order** → `obs_type='order'`, `key=<item/order name>`, optional `value_text=<instructions
+  and/or prescriber/target specialty>`; set `observed_at` to the order/referral date when the source
+  gives one. This is the home for **non-medication orders** mined from the med-list section —
+  durable medical equipment (e.g. a cervical collar), outpatient PT, referrals, and pre-op consults.
+  A non-medication item surfacing in the med-list section MUST be committed as an `order`
+  observation — never dropped (surviving only in `ocr_text`), and never miscommitted as a
+  `medication` or `procedure` row. Unlike vitals, `key` is free-text: emit the verbatim item name,
+  there is no canonical `order` vocabulary.
 
 Canonical vital `key` tokens — emit these verbatim (same discipline as rule 1): `blood_pressure`,
 `bmi`, `weight`, `height`, `temperature`, `pulse`, `spo2`, `respiratory_rate`. `dedup.norm()`

--- a/data/dictionary.example.toml
+++ b/data/dictionary.example.toml
@@ -101,12 +101,16 @@
 "beta-2 microglobulin" = "beta2_microglobulin"
 
 # --- observation obs_type conventions (phase 4 render layer) ---
-# The render layer (master summary / appointment brief) reads three obs_type
+# The render layer (master summary / appointment brief) reads four obs_type
 # families out of the generic `observation` table. Extraction agents should emit:
 #   * obs_type='vital'     key=<canonical vital token below>  (blood_pressure ...)
 #   * obs_type='condition' key=<condition name>   value_text=<optional detail>
 #   * obs_type='allergy'   key=<allergen>         value_text=<optional reaction>
+#   * obs_type='order'     key=<item/order name>  value_text=<instructions/prescriber>
 # "Latest vitals" in the summary is the most recent `vital` row per normalized key.
+# The `order` family captures non-medication orders mined from the med-list section
+# (DME, outpatient PT, referrals, pre-op consults); `key` is free-text (verbatim item
+# name), NOT a canonical token vocabulary — no synonyms are added for it here.
 
 # --- Vitals (observation keys) ---
 # Canonical observation-key vocabulary — extraction agents should emit these

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -18,6 +18,10 @@ canonical *vital* vocabulary in ``data/dictionary.example.toml``):
   * **vitals**     -> ``observation`` rows with ``obs_type='vital'`` whose ``key`` is one
     of the dictionary's canonical vital tokens (``blood_pressure``, ``weight`` ...).
     "Latest vitals" is the most recent row per normalized ``key``.
+  * **orders**     -> ``observation`` rows with ``obs_type='order'`` for non-medication
+    orders mined from the med-list section (DME, outpatient PT, referrals, consults):
+    ``key`` = free-text item/order name (no canonical vocabulary), optional
+    ``value_text`` = instructions and/or prescriber/target specialty.
 
 Output is **ASCII-only** (the cp1252/cp437 Windows-console lesson from phases 2-3):
 plain hyphens, never em-dashes -- a non-ASCII byte crashes a non-UTF-8 console.
@@ -35,6 +39,7 @@ from .dedup import norm
 OBS_CONDITION = "condition"
 OBS_ALLERGY = "allergy"
 OBS_VITAL = "vital"
+OBS_ORDER = "order"
 
 # Default window for "recent labs" in an appointment brief (last N most recent).
 _BRIEF_RECENT_LABS = 10
@@ -240,6 +245,11 @@ def render_summary(
         + (f" - {a['value_text']}" if a["key"] and a["value_text"] else "")
         for a in _observations(conn, person_id, OBS_ALLERGY)
     ]
+    order_lines = [
+        f"- {o['key'] or o['value_text'] or '(unspecified)'}"
+        + (f" - {o['value_text']}" if o["key"] and o["value_text"] else "")
+        for o in _observations(conn, person_id, OBS_ORDER)
+    ]
 
     vital_lines = []
     for v in _latest_vitals(conn, person_id, dictionary):
@@ -265,6 +275,7 @@ def render_summary(
         _section("Active Medications", med_lines),
         _section("Conditions", cond_lines),
         _section("Allergies", allergy_lines),
+        _section("Orders & Referrals", order_lines),
         _section("Latest Vitals", vital_lines),
         _section("Recent Abnormal Labs", lab_lines, empty="_none flagged_"),
         _section("Upcoming / Open Appointments", appt_lines),

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -85,6 +85,9 @@ def seeded(tmp_path):
             {"obs_type": "condition", "key": "Type 2 Diabetes", "observed_at": "2024-01-01"},
             {"obs_type": "allergy", "key": "Penicillin", "value_text": "rash",
              "observed_at": "2010-01-01"},
+            {"obs_type": "order", "key": "cervical collar", "value_text": "Dr. Smith, ortho",
+             "observed_at": "2026-02-01"},                                        # DME order
+            {"obs_type": "order", "key": "outpatient physical therapy"},          # bare item, no detail
         ],
     }, d)
 
@@ -113,7 +116,7 @@ def test_summary_header_is_self_identifying(seeded):
     assert "DOB: 1980-01-01" in md
     assert "Generated:" in md
     # source row counts so a stale export identifies itself
-    assert "labs=4" in md and "medications=2" in md and "observations=5" in md
+    assert "labs=4" in md and "medications=2" in md and "observations=7" in md
 
 
 def test_summary_active_meds_only(seeded):
@@ -126,6 +129,18 @@ def test_summary_conditions_and_allergies(seeded):
     md = render.render_summary(seeded, "jane-doe")
     assert "## Conditions" in md and "Type 2 Diabetes" in md
     assert "## Allergies" in md and "Penicillin - rash" in md
+
+
+def test_summary_orders_and_referrals(seeded):
+    """Non-medication `order` observations render under a dedicated section: item name
+    with optional prescriber/instructions detail, placed after Allergies before Vitals."""
+    md = render.render_summary(seeded, "jane-doe")
+    section = md.split("## Orders & Referrals")[1].split("##")[0]
+    assert "cervical collar - Dr. Smith, ortho" in section   # key - value_text
+    assert "outpatient physical therapy" in section          # bare item, no trailing detail
+    assert "outpatient physical therapy - " not in section   # no dangling separator
+    # placement: after Allergies, before Latest Vitals (clinical-status block stays together)
+    assert md.index("## Allergies") < md.index("## Orders & Referrals") < md.index("## Latest Vitals")
 
 
 def test_summary_latest_vitals_pick(seeded):
@@ -160,6 +175,9 @@ def test_summary_empty_sections_are_explicit(seeded):
     md = render.render_summary(seeded, "john-doe")
     assert "## Active Medications" in md and "_none recorded_" in md
     assert "## Conditions" in md
+    assert "## Orders & Referrals" in md
+    order_section = md.split("## Orders & Referrals")[1].split("##")[0]
+    assert "_none recorded_" in order_section  # no orders -> explicit empty state
     assert "## Recent Abnormal Labs" in md  # john has an abnormal LDL, so it appears
     assert "999" in md
 


### PR DESCRIPTION
## Summary
- Extends the condition/allergy/vital observation convention (`obs_type`) to non-medication orders mined from the med-list section — DME, outpatient PT, referrals, pre-op consults — as a new `obs_type='order'` family instead of dropping them or mis-filing as medication/procedure.
- `pemr/render.py`: adds `OBS_ORDER = "order"` and an "Orders & Referrals" summary section (placed after Allergies, before Latest Vitals), reading `key`/`value_text` with the same fallback/separator logic as the existing condition/allergy builders.
- `AGENTS.md` §2: retitled and documents the new `order` family with a MUST rule (never dropped, never mis-filed) and free-text `key` semantics.
- `data/dictionary.example.toml`: obs_type block updated from three to four families, noting free-text `key` and no synonyms for orders.
- `tests/test_render.py`: covers key+value_text, bare item (no dangling separator), empty state, and section placement.

Design decided in-thread (Option 1 — `observation` rows over `procedure` rows or out-of-scope) after independent build/verify/audit passes; no schema/migration change, no new trust boundary (render-only, parameterized query, hardcoded `obs_type` constant).

**Merge note:** `dev` (`85ccc93`, adding `screening`/`immunization` observation families from #45/#46) was merged into this branch (`d2b62b1`) to keep it mergeable. Two doc/convention files had overlapping edits — `AGENTS.md` §2's heading now reads "conditions, allergies, vitals, orders, screenings, immunizations" (both this PR's `order` bullet and dev's `screening`/`immunization` bullets kept), and `data/dictionary.example.toml`'s `obs_type` comment block combines both families' notes. Resolution was independently re-verified and re-audited against both parents post-merge; no residual conflict markers, no functional overlap (the families are keyed independently).

## Test plan
- [x] `pytest tests/` — 252 passed post-merge (229 pre-merge + dev's screening/immunization coverage), independently reproduced
- [x] Verified `render_summary` places "Orders & Referrals" correctly and falls back to `_none recorded_` when empty
- [x] Verified `render_brief` lists order rows unconditionally under "Procedures & Observations" (no code change needed there)
- [x] Audit: no SQL injection surface, no new trust boundary, pattern matches sibling `OBS_CONDITION`/`OBS_ALLERGY`/`OBS_VITAL` builders

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)
