### PR TITLE
fix(cli): render one-sided lab reference ranges correctly

### DIFF
--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -455,9 +455,9 @@ def _cmd_query_labs(args: argparse.Namespace) -> int:
             value = r["value_num"] if r["value_num"] is not None else r["value_text"]
             unit = f" {r['unit']}" if r["unit"] else ""
             flag = f"  [{r['flag']}]" if r["flag"] else ""
-            ref = ""
-            if r["ref_low"] is not None or r["ref_high"] is not None:
-                ref = f"  (ref {_fmt(r['ref_low'])}-{_fmt(r['ref_high'])})"
+            # Reuse render's shared helper so one-sided ranges (issue #45) render
+            # as "(ref <= 20)" / "(ref >= 8)" instead of a bogus "(ref -20.0)".
+            ref = render._ref_range(r)
             print(f"{_fmt(r['collected_at']):19}  {r['test_name']:20}  "
                   f"{_fmt(value)}{unit}{flag}{ref}")
         return 0

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -62,6 +62,30 @@ def test_query_labs_human_and_json(ready, capsys):
     assert {"test_name", "value_num", "collected_at"} <= set(payload[0])
 
 
+def test_query_labs_one_sided_ref_range(ready, capsys):
+    """Issue #45: a lab with only ref_high must render '(ref <= N)', never '(ref -N)'."""
+    conn = db.connect(ready / "cli.db")
+    d = dedup.load_dictionary(DICT_ARG[1])
+    doc = conn.execute("SELECT document_id FROM document LIMIT 1").fetchone()["document_id"]
+    dedup.commit_extraction(conn, doc, {
+        "lab_result": [
+            {"test_name": "Ferritin", "collected_at": "2026-02-01", "value_num": 15.0,
+             "unit": "ng/mL", "ref_high": 20.0},                       # one-sided upper
+            {"test_name": "TSH", "collected_at": "2026-02-01", "value_num": 3.0,
+             "unit": "mIU/L", "ref_low": 8.0},                         # one-sided lower
+        ],
+    }, d)
+    conn.close()
+
+    assert _run(ready, "query", "labs", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    ferritin = next(line for line in out.splitlines() if "Ferritin" in line)
+    assert "(ref <= 20.0)" in ferritin
+    assert "(ref -" not in ferritin       # the old bug rendered "(ref -20.0)"
+    tsh = next(line for line in out.splitlines() if "TSH" in line)
+    assert "(ref >= 8.0)" in tsh
+
+
 def test_query_meds_active_json(ready, capsys):
     assert _run(ready, "query", "meds", "--person", "jane-doe", "--active", "--json") == 0
     payload = json.loads(capsys.readouterr().out)


### PR DESCRIPTION
## Summary
- `pemr query labs` (`_cmd_query_labs` in `pemr/cli.py`) formatted the reference-range note as
  `f"(ref {_fmt(ref_low)}-{_fmt(ref_high)})"` unconditionally, so a one-sided range (only
  `ref_high` set, e.g. Ferritin `<= 20.0`) rendered the nonsensical `(ref -20.0)`.
- Fixed by reusing the existing `render._ref_range` helper (already handles all four cases:
  two-sided `(ref low-high)`, upper-only `(ref <= high)`, lower-only `(ref >= low)`, and
  no-bounds `""`) instead of duplicating ad hoc formatting logic at the CLI site.
- No schema/interface change: `query.query_labs` rows already carry `ref_low`/`ref_high`, which
  `_ref_range` indexes directly; `--json` output path is unaffected.

## Test plan
- [x] `pytest tests/` — 229 passed (verify pass, independently reproduced)
- [x] New `test_query_labs_one_sided_ref_range` asserts both `(ref <= 20.0)` and `(ref >= 8.0)`,
      and absence of the old `(ref -` defect
- [x] Real CLI drive (subprocess, not test harness) against a seeded DB: confirmed upper-only,
      lower-only, two-sided, and no-bounds labs all render correctly
- [x] Audit: no SQL/shell sink, no new trust boundary, straight reuse of a tested sibling helper

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)