### PR TITLE
fix(cli): force UTF-8 stdout/stderr so find prints stored non-ASCII verbatim

### DIFF
--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -878,6 +878,16 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # Force UTF-8 stdout/stderr so stored document content (accents, em-dashes,
+    # smart quotes) prints verbatim instead of `?` on a legacy Windows console
+    # codepage (cp1252/cp437). Guarded: streams without ``reconfigure`` (already
+    # wrapped, or pytest capture) are left untouched. Orthogonal to issue #23's
+    # ASCII-literal convention — that governs static messages, this governs the
+    # dynamic data echoed by ``find`` (issue #46).
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8", errors="replace")
     args = build_parser().parse_args(argv)
     return args.func(args)
 

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -21,6 +21,12 @@ canonical *vital* vocabulary in ``data/dictionary.example.toml``):
 
 Output is **ASCII-only** (the cp1252/cp437 Windows-console lesson from phases 2-3):
 plain hyphens, never em-dashes -- a non-ASCII byte crashes a non-UTF-8 console.
+
+This ASCII rule governs *static, CLI-authored literals* only. *Dynamic stored
+document content* (e.g. the ``find`` snippet -- OCR'd text that can legitimately
+carry accents/em-dashes/smart quotes) is echoed verbatim, never ASCII-normalized;
+``cli.main`` reconfigures stdout/stderr to UTF-8 so a legacy Windows console
+prints it correctly instead of ``?`` (issue #46). Literal vs. data are orthogonal.
 """
 
 from __future__ import annotations

--- a/tests/test_cli_find_utf8.py
+++ b/tests/test_cli_find_utf8.py
@@ -1,0 +1,89 @@
+"""Regression for issue #46: `pemr find` echoes *dynamic* document content, which
+can legitimately contain non-ASCII codepoints (em-dashes, smart quotes, accents)
+from the source medical document. Unlike the static CLI-facing literals governed
+by issue #23 (``test_cli_ascii.py``), this data must pass through **verbatim** —
+never ASCII-normalized or replaced. ``main`` reconfigures stdout/stderr to UTF-8
+so a legacy Windows console (cp1252/cp437) prints it correctly instead of ``?``.
+
+The cp437 console path itself is Windows-runtime and can't be exercised
+cross-platform; these tests guard the two things that *are* portable: that the
+code does not strip/normalize the data, and that ``main`` reconfigures a
+reconfigurable stream.
+"""
+
+import io
+
+from pemr import cli, db, persons
+
+
+# A snippet drawn straight from stored OCR text: an em-dash (U+2014) and an
+# accented character, both of which cp437/cp1252 would garble.
+_NON_ASCII_OCR = "diagnosis — severe migraña with aura"
+
+
+def _seed(tmp_path):
+    conn = db.connect(tmp_path / "find.db")
+    db.migrate(conn)
+    persons.add_person(conn, "jane-doe", "Jane Doe")
+    pid = conn.execute(
+        "SELECT person_id FROM person WHERE slug=?", ("jane-doe",)
+    ).fetchone()["person_id"]
+    conn.execute(
+        "INSERT INTO document (sha256, person_id, doc_date, source_path, ocr_text, "
+        "ingested_at) VALUES (?, ?, ?, ?, ?, ?)",
+        ("sha-jane-1", pid, "2026-01-01", "aa/x.pdf", _NON_ASCII_OCR,
+         "2026-01-01T00:00:00"),
+    )
+    conn.commit()
+    conn.close()
+    return tmp_path
+
+
+def test_find_snippet_preserves_non_ascii_data(tmp_path, capsys):
+    """The stored non-ASCII content survives the human-readable ``find`` path
+    unmodified — no ``?`` substitution, no ASCII-normalization."""
+    _seed(tmp_path)
+    capsys.readouterr()
+    rc = cli.main(["--db", str(tmp_path / "find.db"), "find", "diagnosis",
+                   "--person", "jane-doe"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "—" in out, f"em-dash was dropped/replaced: {out!r}"
+    assert "migraña" in out, f"accented data was normalized: {out!r}"
+    assert "?" not in out
+
+
+def test_main_reconfigures_streams_to_utf8(tmp_path, monkeypatch):
+    """On a reconfigurable stream, ``main`` forces UTF-8 with ``errors='replace'``
+    so a legacy console codepage can't garble or crash on stored data."""
+    _seed(tmp_path)
+    calls: list[dict] = []
+
+    class _Reconfigurable(io.StringIO):
+        def reconfigure(self, **kwargs):
+            calls.append(kwargs)
+
+    monkeypatch.setattr("sys.stdout", _Reconfigurable())
+    monkeypatch.setattr("sys.stderr", _Reconfigurable())
+    rc = cli.main(["--db", str(tmp_path / "find.db"), "find", "diagnosis",
+                   "--person", "jane-doe"])
+    assert rc == 0
+    assert calls == [
+        {"encoding": "utf-8", "errors": "replace"},
+        {"encoding": "utf-8", "errors": "replace"},
+    ]
+
+
+def test_main_tolerates_streams_without_reconfigure(tmp_path, monkeypatch):
+    """A stream lacking ``reconfigure`` (already-wrapped, or a capture buffer) is
+    left untouched — the guard degrades to a no-op instead of raising."""
+    _seed(tmp_path)
+
+    class _Plain(io.StringIO):
+        reconfigure = None  # attribute present but not callable -> skipped
+
+    monkeypatch.setattr("sys.stdout", _Plain())
+    monkeypatch.setattr("sys.stderr", _Plain())
+    rc = cli.main(["--db", str(tmp_path / "find.db"), "find", "diagnosis",
+                   "--person", "jane-doe"])
+    assert rc == 0


### PR DESCRIPTION
## Summary
- Reconfigures `sys.stdout`/`sys.stderr` to UTF-8 (`errors="replace"`) at the single CLI entry point (`pemr/cli.py::main`), guarded to no-op when the stream lacks `reconfigure` (pytest capture, already-wrapped streams). Covers both `python -m pemr` and the installed console script.
- Fixes `pemr find` printing stored non-ASCII document content (em-dashes, accents, smart quotes from OCR'd/extracted text) as `?` on Windows, which uses the legacy console codepage by default. DB storage was already correct UTF-8 — this was a display-only bug.
- Orthogonal to #23/PR #34's ASCII-literal convention: that fix covers *static* CLI-authored string literals (kept ASCII); this fix covers *dynamic* stored document content echoed verbatim by `find`, which can legitimately contain non-ASCII characters from the source medical document. `pemr/render.py` docstring now documents this data-vs-literal distinction.
- `--json` output path is unchanged (`_print_json` keeps `ensure_ascii=True`).
- New test `tests/test_cli_find_utf8.py`: `find` preserves non-ASCII snippet content verbatim, `main` reconfigures both streams when possible, and degrades to a no-op when a stream isn't reconfigurable.

## Test plan
- [x] `pytest tests/test_cli_find_utf8.py tests/test_cli_ascii.py tests/test_query.py` — 44 passed
- [x] Full suite `pytest` — 231 passed
- [x] Verified on real Windows console (win32): stored `— severe migraña —` prints as correct UTF-8 bytes via `python -m pemr find`, no `?` substitution; confirmed the pre-fix cp437 symptom reproduces without the fix and the fix overrides even a forced legacy codepage (`PYTHONIOENCODING=cp1252`)
- [x] `test_cli_ascii.py` and `test_timeline_summaries_are_ascii_safe` remain green — the #23 static-literal ASCII convention is untouched

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)