### PR TITLE
Fix brief lab truncation, extend dictionary, add `pemr rekey`

### DIFF
--- a/data/dictionary.example.toml
+++ b/data/dictionary.example.toml
@@ -64,6 +64,18 @@
 "platelet count" = "platelets"
 "platelets" = "platelets"
 "plt" = "platelets"
+"rbc" = "rbc"
+"red blood cell count" = "rbc"
+"mcv" = "mcv"
+"mean corpuscular volume" = "mcv"
+"mch" = "mch"
+"mean corpuscular hemoglobin" = "mch"
+"mchc" = "mchc"
+"mean corpuscular hemoglobin concentration" = "mchc"
+"rdw" = "rdw"
+"red cell distribution width" = "rdw"
+"mpv" = "mpv"
+"mean platelet volume" = "mpv"
 
 # --- Inflammatory markers ---
 # ESR (erythrocyte sedimentation rate). Report labels vary by method. The
@@ -85,6 +97,36 @@
 "na" = "sodium"
 "potassium" = "potassium"
 "k" = "potassium"
+"chloride" = "chloride"
+"cl" = "chloride"
+# Total CO2 on a CMP. `bicarbonate`/`HCO3` is deliberately NOT mapped here: it is a
+# different assay label and collapsing the two would fuse two rows from one draw.
+"co2" = "co2"
+"carbon dioxide" = "co2"
+"calcium" = "calcium"
+"ca" = "calcium"
+
+# --- Liver enzymes / bilirubin ---
+"alt" = "alt"
+"sgpt" = "alt"
+"ast" = "ast"
+"sgot" = "ast"
+"alk phos" = "alkaline_phosphatase"
+"alp" = "alkaline_phosphatase"
+"alkaline phosphatase" = "alkaline_phosphatase"
+"bili t" = "bilirubin_total"
+"total bilirubin" = "bilirubin_total"
+"bilirubin, total" = "bilirubin_total"
+"ldh" = "ldh"
+"lactate dehydrogenase" = "ldh"
+
+# --- Serum protein: NOT mapped, on purpose ---
+# A CMP and an SPEP run off the SAME draw both report total protein (`TPro` /
+# `Protein, Total`) and albumin (`ALB` / `Albumin`) — different methods, slightly
+# different numbers, same person + same collected_at. Mapping `alb`->`albumin` or
+# `tpro`->`protein_total` would give those two rows one dedup key, so the second
+# would land as a staged CONFLICT (or silently collapse when the numbers happen to
+# agree). Leave the report labels distinct; revisit only with a method-aware key.
 
 # --- Vitamins ---
 "vitamin d" = "vitamin_d_25oh"
@@ -107,6 +149,12 @@
 "m-spike" = "m_spike"
 "immunoglobulin g" = "igg"
 "immunoglobulin g, qn, serum" = "igg"
+"iga" = "iga"
+"immunoglobulin a" = "iga"
+"immunoglobulin a, qn, serum" = "iga"
+"igm" = "igm"
+"immunoglobulin m" = "igm"
+"immunoglobulin m, qn, serum" = "igm"
 "b2 microglobulin" = "beta2_microglobulin"
 "beta2 microglobulin" = "beta2_microglobulin"
 "beta-2 microglobulin" = "beta2_microglobulin"

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -207,6 +207,14 @@ dictionary** (`data/dictionary.toml`) — e.g. `A1c`, `HbA1c`, `Hemoglobin A1c` 
 canonical `hba1c`. The dictionary is the one place fuzzy naming gets pinned down
 deterministically; agents propose additions, you approve.
 
+**A dictionary edit is retroactive only if you make it so.** Stored keys are frozen at
+commit time, so a new synonym changes the key a *future* commit derives for a fact already
+in the DB: layer-2 dedup misses it and the same fact lands twice. `pemr rekey` re-derives
+every stored key under the current dictionary (dry-run by default, `--apply` to write,
+values and provenance untouched). It aborts whole if two rows would recompute to one key —
+that means the new synonym fuses two distinct facts, e.g. a CMP `ALB` and an SPEP `Albumin`
+off the same draw, and the fix belongs in the dictionary rather than the data.
+
 The **measured value is deliberately *not* in the key** — temporal identity carries the
 draw instead. `collected_at`/`observed_at` are used at full precision (timestamp when the
 document gives one, date when it only gives a date), not truncated to the date. Two draws
@@ -274,6 +282,7 @@ pemr render brief --appointment <id>     > exports/brief.md
 pemr render journal --person jane        > exports/jane-journal.md
 pemr backup                                              # VACUUM INTO snapshot
 pemr migrate                                             # apply pending migrations
+pemr rekey [--apply]                                     # re-derive dedup keys after a dictionary edit
 ```
 
 Invoke as `pemr <cmd>` (console script) or `python -m pemr <cmd>` (`pemr/__main__.py`,

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -362,6 +362,56 @@ def _cmd_commit_extraction(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_rekey(args: argparse.Namespace) -> int:
+    conn = db.connect(_resolve_db_path(args))
+    try:
+        dictionary = dedup.load_dictionary(_resolve_dictionary_path(args))
+        try:
+            report = dedup.rekey(conn, dictionary, apply=args.apply)
+        except db.NotMigratedError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+        except dedup.RekeyCollisionError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+    finally:
+        conn.close()
+
+    if args.json:
+        _print_json({
+            "applied": report.applied,
+            "scanned": report.scanned,
+            "changed": [
+                {
+                    "record_type": c.record_type,
+                    "row_id": c.row_id,
+                    "label": c.label,
+                    "old_key": c.old_key,
+                    "new_key": c.new_key,
+                }
+                for c in report.changes
+            ],
+        })
+        return 0
+
+    for record_type, count in report.scanned.items():
+        changed = sum(1 for c in report.changes if c.record_type == record_type)
+        print(f"{record_type}: {changed}/{count} key(s) change")
+    for c in report.changes:
+        print(f"  {c.record_type} #{c.row_id}  {c.label}")
+    if not report.changes:
+        print("all dedup keys already match the current dictionary")
+        return 0
+    if report.applied:
+        print(f"rekeyed {len(report.changes)} row(s)")
+    else:
+        print(
+            f"dry run: {len(report.changes)} row(s) would change - "
+            "re-run with --apply (back up first: `pemr backup`)"
+        )
+    return 0
+
+
 def _cmd_review_conflicts(args: argparse.Namespace) -> int:
     conn = db.connect(_resolve_db_path(args))
     try:
@@ -759,6 +809,18 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_commit.add_argument("--dictionary", help="synonym dictionary TOML (overrides default)")
     p_commit.set_defaults(func=_cmd_commit_extraction)
+
+    p_rekey = sub.add_parser(
+        "rekey",
+        help="recompute stored dedup keys after a dictionary edit (dry run by default)",
+    )
+    p_rekey.add_argument(
+        "--apply", action="store_true",
+        help="write the recomputed keys (default: report only)",
+    )
+    p_rekey.add_argument("--dictionary", help="synonym dictionary TOML (overrides default)")
+    p_rekey.add_argument("--json", action="store_true", help="machine-readable output")
+    p_rekey.set_defaults(func=_cmd_rekey)
 
     p_review = sub.add_parser(
         "review-conflicts", help="list or resolve staged dedup conflicts"

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -547,6 +547,106 @@ def resolve_conflict(
         )
 
 
+def _rekey_label(record_type: str, row: sqlite3.Row) -> str:
+    """Short human identifier for a row in `pemr rekey` output ("CL", "Metformin")."""
+    if record_type == "lab_result":
+        return row["test_name"] or ""
+    if record_type in ("medication", "procedure"):
+        return row["name"] or ""
+    if record_type == "appointment":
+        return " ".join(p for p in (row["provider"], row["scheduled_for"]) if p)
+    return " ".join(p for p in (row["obs_type"], row["key"]) if p)  # observation
+
+
+@dataclass
+class RekeyChange:
+    record_type: str
+    row_id: int
+    label: str
+    old_key: str
+    new_key: str
+
+
+@dataclass
+class RekeyReport:
+    scanned: dict[str, int] = field(default_factory=dict)      # type -> rows examined
+    changes: list[RekeyChange] = field(default_factory=list)
+    applied: bool = False
+
+
+class RekeyCollisionError(Exception):
+    """Two rows recompute to one dedup_key — the dictionary would fuse distinct facts."""
+
+
+def rekey(
+    conn: sqlite3.Connection,
+    dictionary: dict[str, str] | None = None,
+    *,
+    apply: bool = False,
+) -> RekeyReport:
+    """Recompute every stored ``dedup_key`` under the *current* dictionary.
+
+    A ``dedup_key`` is frozen at commit time, so adding a synonym (``cl`` ->
+    ``chloride``) changes the key a future commit computes for a fact already in the
+    DB: layer-2 dedup misses and the same fact lands twice. This walks the record
+    tables and re-derives each key, so stored rows keep deduping after a dictionary
+    edit. Values, provenance and row ids are untouched — only ``dedup_key`` moves.
+
+    Dry-run by default: pass ``apply=True`` to write. If two rows in a table recompute
+    to the same key the new dictionary would merge two distinct facts (typically two
+    methods for one analyte off one draw), so nothing is written and
+    :class:`RekeyCollisionError` is raised — fix the dictionary, not the data.
+    """
+    db.require_migrated(conn)
+    report = RekeyReport(applied=False)
+
+    for record_type in KNOWN_TYPES:
+        pk = f"{record_type}_id"
+        rows = conn.execute(f"SELECT * FROM {record_type}").fetchall()
+        report.scanned[record_type] = len(rows)
+        seen: dict[str, sqlite3.Row] = {}
+        for row in rows:
+            payload = {name: row[name] for name in FIELD_SPECS[record_type]}
+            key = dedup_key(record_type, payload, row["person_id"], dictionary)
+            clash = seen.get(key)
+            if clash is not None:
+                raise RekeyCollisionError(
+                    f"{record_type}: {pk} {row[pk]} "
+                    f"({_rekey_label(record_type, row)!r}) and {pk} {clash[pk]} "
+                    f"({_rekey_label(record_type, clash)!r}) recompute to the same "
+                    "dedup_key - the dictionary maps two distinct facts onto one "
+                    "canonical name; nothing was written"
+                )
+            seen[key] = row
+            if key != row["dedup_key"]:
+                report.changes.append(RekeyChange(
+                    record_type, row[pk], _rekey_label(record_type, row),
+                    row["dedup_key"], key,
+                ))
+
+    if apply and report.changes:
+        # One transaction: a half-rekeyed table dedups inconsistently. Two passes,
+        # because `UNIQUE(dedup_key)` is enforced per statement: if two rows swap keys
+        # (or one takes a key another is about to vacate) a single-pass update trips
+        # the index mid-flight. Park every moving row on a unique placeholder first.
+        with conn:
+            for change in report.changes:
+                conn.execute(
+                    f"UPDATE {change.record_type} SET dedup_key = ? "
+                    f"WHERE {change.record_type}_id = ?",
+                    (f"rekey-pending-{change.record_type}-{change.row_id}",
+                     change.row_id),
+                )
+            for change in report.changes:
+                conn.execute(
+                    f"UPDATE {change.record_type} SET dedup_key = ? "
+                    f"WHERE {change.record_type}_id = ?",
+                    (change.new_key, change.row_id),
+                )
+    report.applied = apply
+    return report
+
+
 def _overwrite_record(
     conn: sqlite3.Connection,
     record_type: str,

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -302,7 +302,8 @@ def render_brief(
     now: datetime | None = None,
 ) -> str:
     """Markdown walk-in brief for one appointment: the appointment header, current meds,
-    recent labs (last N), procedures + observations, and an open-conflicts warning if any
+    recent labs (last N, newest draw first and abnormal-before-normal inside each draw),
+    procedures + observations, and an open-conflicts warning if any
     staged rows touch this person. Read-only.
 
     Med-interaction flags and suggested questions require external drug knowledge and are
@@ -339,11 +340,24 @@ def render_brief(
         freq = f" {m['frequency']}" if m["frequency"] else ""
         med_lines.append(f"- {m['name']}{dose}{freq}")
 
+    # Recency stays the primary axis, but a single draw can carry a 50+ analyte panel —
+    # a flat `LIMIT N` over `collected_at DESC, test_name` then returns the
+    # alphabetically-first N of that one draw and silently drops every abnormal in it.
+    # So rank abnormal-before-normal *within* each collection timestamp before the cut:
+    # the brief is the doc handed to a clinician, and the out-of-range values are the
+    # ones that must survive truncation. Abnormality is `_is_abnormal` (flag OR
+    # reference interval), which SQL can't express, so the cut happens here.
     lab_rows = conn.execute(
         "SELECT * FROM lab_result WHERE person_id = ? "
-        "ORDER BY collected_at DESC, test_name LIMIT ?",
-        (person_id, max(recent_labs, 0)),
+        "ORDER BY collected_at DESC, test_name",
+        (person_id,),
     ).fetchall()
+    draw_rank = {
+        ts: i for i, ts in enumerate(dict.fromkeys(r["collected_at"] for r in lab_rows))
+    }
+    # Stable sort -> test_name order survives inside each (draw, abnormal?) bucket.
+    lab_rows.sort(key=lambda r: (draw_rank[r["collected_at"]], not _is_abnormal(r)))
+    lab_rows = lab_rows[: max(recent_labs, 0)]
     lab_lines = []
     for r in lab_rows:
         flag = f" [{r['flag']}]" if r["flag"] else ""
@@ -405,7 +419,7 @@ def render_brief(
         header,
         appt_block,
         _section("Current Medications", med_lines),
-        _section(f"Recent Labs (last {recent_labs})", lab_lines),
+        _section(f"Recent Labs (last {recent_labs}, abnormal first)", lab_lines),
         _section("Procedures & Observations", ctx_lines),
         _section("Open Conflicts", conflict_lines, empty="_none_"),
         interaction,

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -96,3 +96,85 @@ def test_commit_bad_json_is_friendly(ready, capsys):
     bad.write_text("{not json", encoding="utf-8")
     assert _run(tmp_path, "commit-extraction", "--document", "1", "--json", str(bad)) == 1
     assert "not valid JSON" in capsys.readouterr().err
+
+
+# --- rekey (dictionary-edit maintenance) --------------------------------------
+
+def _dict_file(tmp_path, name, body):
+    p = tmp_path / name
+    p.write_text("[synonyms]\n" + body, encoding="utf-8")
+    return p
+
+
+def _seed_lab(ready, tmp_path, dictionary):
+    scan = tmp_path / "rekey-scan.txt"
+    scan.write_bytes(b"zzt 108")
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources")) == 0
+    doc = _document_id(tmp_path)[-1]["document_id"]
+    payload = _write_json(tmp_path, "rekey.json", {"lab_result": [
+        {"test_name": "ZZT", "collected_at": "2026-01-02", "value_num": 108},
+    ]})
+    assert _run(tmp_path, "commit-extraction", "--document", str(doc),
+                "--json", str(payload), "--dictionary", str(dictionary)) == 0
+    return payload
+
+
+def test_rekey_dry_run_then_apply(ready, capsys, tmp_path):
+    old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
+    new = _dict_file(tmp_path, "new.toml", '"zzt" = "zonulin_test"\n')
+    payload = _seed_lab(ready, tmp_path, old)
+    capsys.readouterr()
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new)) == 0
+    out = capsys.readouterr().out
+    assert "lab_result: 1/1 key(s) change" in out
+    assert "dry run: 1 row(s) would change" in out and "--apply" in out
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 0
+    assert "rekeyed 1 row(s)" in capsys.readouterr().out
+
+    # The point of the rekey: the same fact now dedups instead of doubling.
+    doc = _document_id(tmp_path)[-1]["document_id"]
+    assert _run(tmp_path, "commit-extraction", "--document", str(doc),
+                "--json", str(payload), "--dictionary", str(new)) == 0
+    assert "0 new, 1 duplicate" in capsys.readouterr().out
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new)) == 0
+    assert "all dedup keys already match" in capsys.readouterr().out
+
+
+def test_rekey_json_output(ready, capsys, tmp_path):
+    old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
+    new = _dict_file(tmp_path, "new.toml", '"zzt" = "zonulin_test"\n')
+    _seed_lab(ready, tmp_path, old)
+    capsys.readouterr()
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["applied"] is False
+    assert payload["scanned"]["lab_result"] == 1
+    change = payload["changed"][0]
+    assert change["label"] == "ZZT" and change["old_key"] != change["new_key"]
+
+
+def test_rekey_refuses_a_fusing_dictionary(ready, capsys, tmp_path):
+    """Exit 1 with a pointed message when the dictionary would merge two facts."""
+    old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
+    new = _dict_file(tmp_path, "fuse.toml", '"alb" = "albumin"\n')
+    scan = tmp_path / "fuse-scan.txt"
+    scan.write_bytes(b"alb 4.2 / albumin 3.6")
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources")) == 0
+    doc = _document_id(tmp_path)[-1]["document_id"]
+    payload = _write_json(tmp_path, "fuse.json", {"lab_result": [
+        {"test_name": "ALB", "collected_at": "2026-01-02", "value_num": 4.2},
+        {"test_name": "Albumin", "collected_at": "2026-01-02", "value_num": 3.6},
+    ]})
+    assert _run(tmp_path, "commit-extraction", "--document", str(doc),
+                "--json", str(payload), "--dictionary", str(old)) == 0
+    capsys.readouterr()
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 1
+    err = capsys.readouterr().err
+    assert "same dedup_key" in err and "nothing was written" in err

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -462,3 +462,118 @@ def test_observation_and_medication_commit(conn):
                          "key": "systolic", "value_num": 120}],
     })
     assert summary.counts["new"] == 2
+
+
+# --- rekey (dictionary-edit maintenance) --------------------------------------
+
+def _rekey_dict(**extra):
+    """Starter dictionary plus the synonyms a maintenance run is meant to pick up.
+
+    The added spellings are deliberately ones the shipped dictionary does NOT carry, so
+    the test stays green as `data/dictionary.example.toml` grows."""
+    d = dedup.load_dictionary(DICT_PATH)
+    d.update(extra)
+    return d
+
+
+def test_rekey_dry_run_reports_without_writing(conn):
+    doc = _make_document(conn)
+    # Committed with the shipped dictionary, where "cl" has no synonym.
+    dedup.commit_extraction(conn, doc, {"lab_result": [
+        {"test_name": "ZZT", "collected_at": "2026-01-02", "value_num": 108},
+        {"test_name": "HbA1c", "collected_at": "2026-01-02", "value_num": 5.7},
+    ]}, dedup.load_dictionary(DICT_PATH))
+    before = {r["test_name"]: r["dedup_key"]
+              for r in conn.execute("SELECT test_name, dedup_key FROM lab_result")}
+
+    report = dedup.rekey(conn, _rekey_dict(zzt="zonulin_test"))
+
+    assert report.applied is False
+    assert report.scanned["lab_result"] == 2
+    assert [(c.record_type, c.label) for c in report.changes] == [("lab_result", "ZZT")]
+    after = {r["test_name"]: r["dedup_key"]
+             for r in conn.execute("SELECT test_name, dedup_key FROM lab_result")}
+    assert after == before  # dry run touched nothing
+
+
+def test_rekey_apply_restores_dedup_for_a_renamed_analyte(conn):
+    d_old = dedup.load_dictionary(DICT_PATH)
+    d_new = _rekey_dict(zzt="zonulin_test")
+    doc = _make_document(conn)
+    row = {"test_name": "ZZT", "collected_at": "2026-01-02", "value_num": 108}
+    dedup.commit_extraction(conn, doc, {"lab_result": [row]}, d_old)
+
+    # Without a rekey the same fact, committed under the new dictionary, would not
+    # match the stored key and would land as a *second* row.
+    report = dedup.rekey(conn, d_new, apply=True)
+    assert report.applied is True and len(report.changes) == 1
+    change = report.changes[0]
+    assert change.old_key != change.new_key
+
+    doc2 = _make_document(conn)
+    summary = dedup.commit_extraction(conn, doc2, {"lab_result": [row]}, d_new)
+    assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
+
+
+def test_rekey_is_idempotent(conn):
+    doc = _make_document(conn)
+    dedup.commit_extraction(conn, doc, {"lab_result": [
+        {"test_name": "ZZT", "collected_at": "2026-01-02", "value_num": 108},
+    ]}, dedup.load_dictionary(DICT_PATH))
+    d_new = _rekey_dict(zzt="zonulin_test")
+    assert len(dedup.rekey(conn, d_new, apply=True).changes) == 1
+    assert dedup.rekey(conn, d_new, apply=True).changes == []
+
+
+def test_rekey_refuses_a_dictionary_that_fuses_two_facts(conn):
+    """Two methods for one analyte off one draw (CMP ALB vs SPEP Albumin) must not be
+    merged by a synonym: the run aborts whole, leaving every stored key untouched."""
+    doc = _make_document(conn)
+    dedup.commit_extraction(conn, doc, {"lab_result": [
+        {"test_name": "ALB", "collected_at": "2026-01-02", "value_num": 4.2},
+        {"test_name": "Albumin", "collected_at": "2026-01-02", "value_num": 3.6},
+    ]}, dedup.load_dictionary(DICT_PATH))
+    before = {r["lab_result_id"]: r["dedup_key"]
+              for r in conn.execute("SELECT lab_result_id, dedup_key FROM lab_result")}
+
+    with pytest.raises(dedup.RekeyCollisionError, match="same dedup_key"):
+        dedup.rekey(conn, _rekey_dict(alb="albumin"), apply=True)
+
+    after = {r["lab_result_id"]: r["dedup_key"]
+             for r in conn.execute("SELECT lab_result_id, dedup_key FROM lab_result")}
+    assert after == before
+
+
+def test_rekey_survives_two_rows_swapping_keys(conn):
+    """UNIQUE(dedup_key) is enforced per statement, so a swap must not trip the index
+    mid-write: A takes B's old key while B takes A's."""
+    doc = _make_document(conn)
+    dedup.commit_extraction(conn, doc, {"lab_result": [
+        {"test_name": "alpha", "collected_at": "2026-01-02", "value_num": 1},
+        {"test_name": "beta", "collected_at": "2026-01-02", "value_num": 2},
+    ]}, None)
+
+    report = dedup.rekey(conn, {"alpha": "beta", "beta": "alpha"}, apply=True)
+    assert len(report.changes) == 2
+    keys = {r["test_name"]: r["dedup_key"]
+            for r in conn.execute("SELECT test_name, dedup_key FROM lab_result")}
+    pid = conn.execute("SELECT person_id FROM person").fetchone()["person_id"]
+    assert keys["alpha"] == dedup.dedup_key(
+        "lab_result", {"test_name": "beta", "collected_at": "2026-01-02"}, pid
+    )
+    assert len(set(keys.values())) == 2
+
+
+def test_rekey_covers_every_record_type(conn):
+    doc = _make_document(conn)
+    dedup.commit_extraction(conn, doc, {
+        "lab_result": [_lab(5.7)],
+        "medication": [{"name": "Metformin", "dose": "500mg"}],
+        "procedure": [{"name": "Colonoscopy", "performed_on": "2025-06-01"}],
+        "appointment": [{"scheduled_for": "2026-03-01", "provider": "Dr. Smith"}],
+        "observation": [{"obs_type": "vital", "key": "bp", "observed_at": "2026-01-02"}],
+    })
+    report = dedup.rekey(conn, None)
+    assert report.scanned == {t: 1 for t in dedup.KNOWN_TYPES}
+    assert report.changes == []  # same dictionary (none) -> keys already current

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -211,6 +211,32 @@ def test_brief_flags_abnormal_labs_with_marker_and_ref(seeded):
     assert "[!]" not in lines["TSH"]
 
 
+def test_brief_recent_labs_keep_abnormals_within_the_limit(seeded):
+    """A single draw can carry a 50+ analyte panel; `LIMIT N` over an alphabetical order
+    used to return the first N names of that draw and drop every abnormal in it. Newest
+    draw still comes first, but abnormal beats normal inside a draw."""
+    doc = _doc(seeded, "jane-doe", ocr="big panel", category="labs")
+    # One draw, newer than every seeded lab: 8 normals sorting before the abnormal by name.
+    rows = [
+        {"test_name": f"Analyte {c}", "collected_at": "2026-06-01T09:00",
+         "value_num": 1.0, "ref_low": 0.0, "ref_high": 2.0}
+        for c in "ABCDEFGH"
+    ]
+    rows.append({"test_name": "Zinc", "collected_at": "2026-06-01T09:00",
+                 "value_num": 99.0, "ref_low": 0.0, "ref_high": 2.0})
+    dedup.commit_extraction(seeded, doc, {"lab_result": rows})
+
+    section = render.render_brief(
+        seeded, _upcoming_appt_id(seeded), recent_labs=3
+    ).split("## Recent Labs")[1].split("##")[0]
+    names = [ln.split("  ")[1] for ln in section.splitlines() if ln.startswith("- ")]
+    assert names[0] == "Zinc"                     # the only abnormal in the newest draw
+    assert "[!]" in section
+    assert names[1:] == ["Analyte A", "Analyte B"]  # then alphabetical within that draw
+    # Recency is still the primary axis: nothing from an older draw displaces the newest.
+    assert "Glucose, fasting" not in section
+
+
 def test_brief_has_interaction_placeholder(seeded):
     md = render.render_brief(seeded, _upcoming_appt_id(seeded))
     assert "## Medication Interaction Review" in md


### PR DESCRIPTION
Three related fixes found by driving the engine end-to-end against a real scanned-document corpus (6 PDFs: Georgia Cancer Specialists / Labcorp labs, a Vanderbilt PFT, an appointment confirmation).

### 1. `render brief` dropped every abnormal lab

`Recent Labs` was `ORDER BY collected_at DESC, test_name LIMIT N`. On a 58-analyte panel that returns the ten alphabetically-first analytes of the newest draw — all normal — and cuts every out-of-range value. On the test corpus the brief for a hematology/oncology appointment showed `A/G Ratio` through `BAS%` and hid the only flagged result.

Recency stays the primary axis; abnormal now beats normal inside each draw. `_is_abnormal` (flag OR reference interval) isn't expressible in SQL, so the cut moved into Python over a stable sort. Heading now reads `Recent Labs (last N, abnormal first)`.

### 2. Dictionary synonyms from the real corpus

CBC indices (`rbc`, `mcv`, `mch`, `mchc`, `rdw`, `mpv`), `chloride`, `co2`, `calcium`, the liver panel (`alt`/`sgpt`, `ast`/`sgot`, `alk phos`/`alp`, `bili t`, `ldh`), and `iga`/`igm` beside the existing `igg`.

`alb`->`albumin` and `tpro`->`protein_total` are deliberately **not** mapped, with the reasoning recorded in the TOML: a CMP and an SPEP off the same draw both report albumin and total protein by different methods, so one canonical token gives them one dedup key — the second row then stages as a conflict, or silently collapses when the numbers happen to agree.

### 3. `pemr rekey` — new maintenance command

A `dedup_key` is frozen at commit time, so the synonyms above change the key a *future* commit derives for a fact already stored: layer-2 dedup misses it and the same fact lands twice. This showed up immediately on a live DB (12 rows: CL, CA, BILI T, Alk Phos, IgA, IgM across two draws).

```
pemr rekey [--apply] [--dictionary F] [--json]
```

Dry run by default. Walks all five record tables, re-derives each key under the current dictionary; values, provenance and row ids untouched. Aborts whole when two rows recompute to one key — that means the dictionary fuses two distinct facts and the fix belongs in the TOML, not the data. Writes are one transaction in two passes: `UNIQUE(dedup_key)` is enforced per statement, so two rows swapping keys would otherwise trip the index mid-write. CLI-only, matching `backup`/`migrate`; the MCP surface stays the ingest/query verbs. Documented in `Architecture.md` §3 and the CLI surface list.

### Testing

262 passed, 1 skipped. 10 new tests: abnormal survives the `Recent Labs` cut with recency still primary; rekey dry-run/apply/idempotence, fusing-dictionary abort leaves keys intact, key-swap survives the unique index, all five record types scanned, JSON shape, exit 1 + message on collision.

Also verified against the live corpus: post-rekey, re-committing a document reports `0 new, 58 duplicate`, and `trends --test "alkaline phosphatase"` resolves 127 -> 102 U/L across two draws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
