### PR TITLE
docs: mark `pemr due` as unimplemented in the Architecture CLI surface

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -276,7 +276,7 @@ pemr query timeline --person jane --since 2024-01-01     # merged event stream
 pemr find --person jane "cholesterol"                    # full-text over ocr_text + records
 pemr find "mmr booster"                                  # omit --person: whole-household, slug-prefixed hits
 pemr trends --person jane --test hba1c                   # min/max/latest/slope
-pemr due --person jane                                   # screening/vaccine gaps (rules)
+pemr due --person jane                                   # screening/vaccine gaps — NOT IMPLEMENTED (phase 7)
 pemr render summary --person jane        > exports/jane-summary.md
 pemr render brief --appointment <id>     > exports/brief.md
 pemr render journal --person jane        > exports/jane-journal.md
@@ -284,6 +284,11 @@ pemr backup                                              # VACUUM INTO snapshot
 pemr migrate                                             # apply pending migrations
 pemr rekey [--apply]                                     # re-derive dedup keys after a dictionary edit
 ```
+
+Every line above is implemented and parses today **except** the one flagged `NOT IMPLEMENTED`.
+`pemr due` is phase 7 (§9) — the `screening`/`immunization` `observation` rows that
+`data/dictionary.example.toml` and `AGENTS.md` tell extraction agents to emit are accruing
+ahead of their reader, by design. Flag any future entry the same way rather than listing it bare.
 
 Invoke as `pemr <cmd>` (console script) or `python -m pemr <cmd>` (`pemr/__main__.py`,
 delegating to `cli.main`) — the latter is the portable fallback when the console-script
@@ -326,8 +331,8 @@ Because they regenerate from truth, they never drift. Old exports are disposable
 
 - One DB, `person_id` everywhere → adding a family member is `pemr person add`, nothing
   else. Same tools, same dictionary, zero code duplication.
-- Cross-person queries fall out for free: `pemr due --all`, "who's overdue for a
-  physical," family-wide med lists.
+- Cross-person queries fall out for free: `pemr due --all` (phase 7, not implemented),
+  "who's overdue for a physical," family-wide med lists.
 - New record *type*: add rows to `observation` immediately; promote to a typed table
   with a migration only when it earns its keep. Neither requires touching agents.
 


### PR DESCRIPTION
## Summary
- `docs/Architecture.md` §5 listed `pemr due --person jane` in the "CLI (the tested engine)" block with no marker distinguishing it from commands that actually exist — it does not parse (`pemr: error: argument command: invalid choice: 'due'`), since care-gap rules are phase 7 and still unbuilt.
- Marks the §5 `pemr due --person jane` line `NOT IMPLEMENTED (phase 7)`, matching the existing "implemented phase 5" convention used for the MCP section.
- Adds a short paragraph clarifying every other line in the block is implemented and parses today, and that the `screening`/`immunization` `observation` rows the dictionary/AGENTS.md tell extraction agents to emit are accruing ahead of their phase-7 reader by design.
- Also marks the §7 "Multi-person extensibility" mention of `pemr due --all` (same defect, same page).

Docs-only change (`docs/Architecture.md`, +8/-3); no code touched.

## Verification
- Build/verify/audit passes on issue #56 independently re-derived the parser sweep (every documented invocation fed through `pemr.cli.build_parser().parse_args()`); `due` was confirmed the only unmarked line that fails to parse.
- `pytest` (262 passed), `npm test` (4 passed), `npm run check:meta-drift` all green in the worktree.
- Full trail: intake → build → verify → audit reports on the issue.

## Test plan
- [x] `pytest` — 262 passed
- [x] `npm test` — 4 passed
- [x] `npm run check:meta-drift` — passed
- [x] Manual: `python -m pemr due --person jane` exits 2 with argparse "invalid choice" error, matching the new doc annotation

Closes #56