### PR TITLE
add `pemr document list|edit|reassign|rm`: misfiled-document recovery

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -270,6 +270,10 @@ pemr person add|list|show|edit|deactivate|reactivate|remove
 pemr ingest <file> --person <slug> [--ocr tesseract]
 pemr commit-extraction --document <id> --json <file>
 pemr review-conflicts [--resolve ...]
+pemr document list [--person <slug>]                     # newest first; omit --person for everyone
+pemr document edit <id> [--doc-date|--category|--provider ...]   # partial update; "" clears a field
+pemr document reassign <id> --person <slug> [--apply]    # move a misfiled document + records; dry run by default
+pemr document rm <id> [--apply] [--purge-blob]           # delete a document + records; dry run by default
 pemr query labs --person jane --test hba1c --since 2023-01-01
 pemr query meds --person jane --active
 pemr query timeline --person jane --since 2024-01-01     # merged event stream

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -416,6 +416,7 @@ def _cmd_document_rm(args: argparse.Namespace) -> int:
                 "records": report.records,
                 "record_count": report.record_count,
                 "conflicts_deleted": report.conflicts_deleted,
+                "conflicts_anchored": report.conflicts_anchored,
                 "conflicts_detached": report.conflicts_detached,
                 "blob_path": report.blob_path,
                 "blob_purged": report.blob_purged,
@@ -431,14 +432,21 @@ def _cmd_document_rm(args: argparse.Namespace) -> int:
         print(f"  records: {report.record_count} total")
         if report.conflicts_deleted:
             print(f"  conflicts deleted (open): {report.conflicts_deleted}")
+        if report.conflicts_anchored:
+            print(
+                "  conflicts deleted (staged against these records): "
+                f"{report.conflicts_anchored}"
+            )
         if report.conflicts_detached:
             print(f"  conflicts detached (resolved): {report.conflicts_detached}")
-        if report.blob_purged:
-            print(f"  blob deleted: {report.blob_path}")
-        elif args.purge_blob:
-            print(f"  blob would be deleted: {report.blob_path}")
-        else:
+        if not args.purge_blob:
             print(f"  blob kept: {report.blob_path}")
+        elif report.blob_purged:
+            print(f"  blob deleted: {report.blob_path}")
+        elif report.applied:
+            print(f"  blob already gone: {report.blob_path}")
+        else:
+            print(f"  blob would be deleted: {report.blob_path}")
         if report.applied:
             print(f"removed document #{report.document_id}")
         else:

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -15,7 +15,9 @@ import tomllib
 from dataclasses import asdict
 from pathlib import Path
 
-from . import __version__, backup, db, dedup, ingest, persons, query, render
+from . import (
+    __version__, backup, db, dedup, documents, ingest, persons, query, render,
+)
 
 # Shipped starter analyte/name dictionary (framework, not user data — see .gitignore).
 _DEFAULT_DICTIONARY = Path(__file__).resolve().parent.parent / "data" / "dictionary.example.toml"
@@ -266,6 +268,187 @@ def _cmd_person_remove(args: argparse.Namespace) -> int:
         conn.close()
     print(f"removed person #{person.person_id}: {person.slug}")
     return 0
+
+
+# --------------------------------------------------------------------------- #
+# document recovery (list / edit / reassign / rm) - issue #54
+# --------------------------------------------------------------------------- #
+
+def _with_document_conn(args: argparse.Namespace, work):
+    """Open the DB, run ``work(conn)``, translating every friendly `document`
+    failure mode (un-migrated DB, unknown id/slug, refusal) into rc=1 on stderr."""
+    conn = db.connect(_resolve_db_path(args))
+    try:
+        try:
+            return work(conn)
+        except db.NotMigratedError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+        except (
+            documents.DocumentNotFoundError,
+            documents.OpenConflictsError,
+            documents.DictionaryDriftError,
+            documents.ReassignCollisionError,
+            persons.PersonNotFoundError,
+        ) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+    finally:
+        conn.close()
+
+
+def _cmd_document_list(args: argparse.Namespace) -> int:
+    def work(conn):
+        docs = documents.list_documents(conn, args.person)
+        if args.json:
+            _print_json(docs)
+            return 0
+        if not docs:
+            print("no documents yet - `pemr ingest <file> --person <slug>`")
+            return 0
+        for d in docs:
+            print(
+                f"#{d['document_id']:<5} {_fmt(d['doc_date']):11} "
+                f"{_fmt(d['category']):12} {_fmt(d['provider']):22} "
+                f"{_fmt(d['person']):16} {d['sha256'][:12]}  {d['record_count']} rec"
+            )
+        return 0
+
+    return _with_document_conn(args, work)
+
+
+def _cmd_document_edit(args: argparse.Namespace) -> int:
+    # A flag left unset is None -> not part of the update; an explicit empty string
+    # (e.g. --category "") clears that column (documents.py), same as `person edit`.
+    fields: dict[str, str] = {}
+    if args.doc_date is not None:
+        fields["doc_date"] = args.doc_date
+    if args.category is not None:
+        fields["category"] = args.category
+    if args.provider is not None:
+        fields["provider"] = args.provider
+
+    def work(conn):
+        doc = documents.edit_document(conn, args.document_id, **fields)
+        if args.json:
+            _print_json(doc)
+            return 0
+        for key in ("document_id", "person", "doc_date", "category", "provider",
+                    "source_path", "ingested_at", "record_count"):
+            print(f"{key:14} {_fmt(doc[key])}")
+        return 0
+
+    return _with_document_conn(args, work)
+
+
+def _cmd_document_reassign(args: argparse.Namespace) -> int:
+    def work(conn):
+        dictionary = dedup.load_dictionary(_resolve_dictionary_path(args))
+        report = documents.reassign_document(
+            conn, args.document_id, args.person, dictionary, apply=args.apply
+        )
+        if args.json:
+            _print_json({
+                "document_id": report.document_id,
+                "from": report.from_slug,
+                "to": report.to_slug,
+                "applied": report.applied,
+                "unchanged": report.unchanged,
+                "target_inactive": report.target_inactive,
+                "counts": report.counts,
+                "moved": [
+                    {
+                        "record_type": c.record_type,
+                        "row_id": c.row_id,
+                        "label": c.label,
+                        "old_key": c.old_key,
+                        "new_key": c.new_key,
+                    }
+                    for c in report.changes
+                ],
+            })
+            return 0
+        if report.unchanged:
+            print(
+                f"document #{report.document_id} is already owned by "
+                f"'{report.to_slug}' - nothing to do"
+            )
+            return 0
+        print(
+            f"document #{report.document_id}: {_fmt(report.from_slug) or '(none)'} "
+            f"-> {report.to_slug}"
+        )
+        for c in report.changes:
+            print(f"  {c.record_type} #{c.row_id}  {c.label}")
+        if report.target_inactive:
+            print(f"note: '{report.to_slug}' is deactivated (records still move)")
+        if report.applied:
+            print(f"reassigned {len(report.changes)} record(s)")
+        else:
+            print(
+                f"dry run: {len(report.changes)} record(s) would move - "
+                "re-run with --apply (back up first: `pemr backup`)"
+            )
+        return 0
+
+    return _with_document_conn(args, work)
+
+
+def _cmd_document_rm(args: argparse.Namespace) -> int:
+    # The sources dir is only needed to delete the blob; keeping it (the default)
+    # must not require configured paths.
+    sources_dir = _resolve_sources_dir(args) if args.purge_blob else None
+
+    def work(conn):
+        report = documents.remove_document(
+            conn, args.document_id, sources_dir=sources_dir,
+            purge_blob=args.purge_blob, apply=args.apply,
+        )
+        if args.json:
+            _print_json({
+                "document_id": report.document_id,
+                "person": report.person_slug,
+                "sha256": report.sha256,
+                "applied": report.applied,
+                "records": report.records,
+                "record_count": report.record_count,
+                "conflicts_deleted": report.conflicts_deleted,
+                "conflicts_detached": report.conflicts_detached,
+                "blob_path": report.blob_path,
+                "blob_purged": report.blob_purged,
+            })
+            return 0
+        print(
+            f"document #{report.document_id}  {_fmt(report.person_slug)}  "
+            f"{report.sha256[:12]}"
+        )
+        for record_type, count in report.records.items():
+            if count:
+                print(f"  {record_type}: {count} row(s)")
+        print(f"  records: {report.record_count} total")
+        if report.conflicts_deleted:
+            print(f"  conflicts deleted (open): {report.conflicts_deleted}")
+        if report.conflicts_detached:
+            print(f"  conflicts detached (resolved): {report.conflicts_detached}")
+        if report.blob_purged:
+            print(f"  blob deleted: {report.blob_path}")
+        elif args.purge_blob:
+            print(f"  blob would be deleted: {report.blob_path}")
+        else:
+            print(f"  blob kept: {report.blob_path}")
+        if report.applied:
+            print(f"removed document #{report.document_id}")
+        else:
+            print(
+                "dry run: nothing was deleted - re-run with --apply "
+                "(back up first: `pemr backup`)"
+            )
+        return 0
+
+    return _with_document_conn(args, work)
 
 
 def _cmd_ingest(args: argparse.Namespace) -> int:
@@ -777,6 +960,60 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_remove.add_argument("slug")
     p_remove.set_defaults(func=_cmd_person_remove)
+
+    # --- document recovery (misfiled document escape hatch, issue #54) ----
+    p_document = sub.add_parser(
+        "document", help="inspect and recover misfiled documents"
+    )
+    document_sub = p_document.add_subparsers(dest="document_command", required=True)
+
+    d_list = document_sub.add_parser(
+        "list", help="list ingested documents, newest first"
+    )
+    d_list.add_argument("--person", help="owner slug; omit to list every person's")
+    d_list.add_argument("--json", action="store_true", help="machine-readable output")
+    d_list.set_defaults(func=_cmd_document_list)
+
+    d_edit = document_sub.add_parser(
+        "edit", help="correct a document's date/category/provider (partial)"
+    )
+    d_edit.add_argument("document_id", type=int, metavar="ID")
+    d_edit.add_argument("--doc-date", dest="doc_date", help='pass "" to clear')
+    d_edit.add_argument("--category", help='pass "" to clear')
+    d_edit.add_argument("--provider", help='pass "" to clear')
+    d_edit.add_argument("--json", action="store_true", help="machine-readable output")
+    d_edit.set_defaults(func=_cmd_document_edit)
+
+    d_reassign = document_sub.add_parser(
+        "reassign",
+        help="move a document and its records to another person (dry run by default)",
+    )
+    d_reassign.add_argument("document_id", type=int, metavar="ID")
+    d_reassign.add_argument("--person", required=True, help="new owner slug")
+    d_reassign.add_argument(
+        "--apply", action="store_true", help="write the move (default: report only)"
+    )
+    d_reassign.add_argument(
+        "--dictionary", help="synonym dictionary TOML (overrides default)"
+    )
+    d_reassign.add_argument("--json", action="store_true", help="machine-readable output")
+    d_reassign.set_defaults(func=_cmd_document_reassign)
+
+    d_rm = document_sub.add_parser(
+        "rm",
+        help="delete a document and its records (dry run by default)",
+    )
+    d_rm.add_argument("document_id", type=int, metavar="ID")
+    d_rm.add_argument(
+        "--apply", action="store_true", help="write the delete (default: report only)"
+    )
+    d_rm.add_argument(
+        "--purge-blob", dest="purge_blob", action="store_true",
+        help="also delete the stored scan (irreversible; kept by default)",
+    )
+    d_rm.add_argument("--sources", help="sources blob dir (overrides config)")
+    d_rm.add_argument("--json", action="store_true", help="machine-readable output")
+    d_rm.set_defaults(func=_cmd_document_rm)
 
     p_ingest = sub.add_parser(
         "ingest", help="ingest a document (hash, blob store, layer-1 dedup)"

--- a/pemr/documents.py
+++ b/pemr/documents.py
@@ -94,6 +94,41 @@ def _record_counts(conn: sqlite3.Connection, document_id: int) -> dict[str, int]
     return counts
 
 
+def _conflicts_cited_by(conn: sqlite3.Connection, document_id: int) -> list[int]:
+    """Open conflicts this document *raised* — its incoming row lost the collision."""
+    return [
+        int(row["conflict_id"])
+        for row in conn.execute(
+            "SELECT conflict_id FROM conflict WHERE document_id = ? AND status = 'open' "
+            "ORDER BY conflict_id",
+            (document_id,),
+        ).fetchall()
+    ]
+
+
+def _conflicts_anchored_to(conn: sqlite3.Connection, document_id: int) -> list[int]:
+    """Open conflicts staged *against* rows this document owns.
+
+    A conflict has two ends. ``conflict.document_id`` names the document whose
+    **incoming** row collided; ``conflict.dedup_key`` anchors it to the **stored**
+    row — which a *different* document usually created. Only the first end is
+    reachable from ``document_id``, so removing or reassigning the owner of the
+    stored row silently orphans the anchor: a later `keep incoming` resolution runs
+    ``UPDATE ... WHERE dedup_key = ?`` (:func:`dedup._overwrite_record`), matches
+    zero rows, and stamps the conflict ``resolved`` while discarding the staged
+    value with rc 0. Both `rm` and `reassign` therefore have to see this end too.
+    """
+    ids: list[int] = []
+    for record_type in dedup.KNOWN_TYPES:
+        rows = conn.execute(
+            "SELECT conflict_id FROM conflict WHERE status = 'open' AND record_type = ? "
+            f"AND dedup_key IN (SELECT dedup_key FROM {record_type} WHERE document_id = ?)",
+            (record_type, document_id),
+        ).fetchall()
+        ids.extend(int(row["conflict_id"]) for row in rows)
+    return sorted(ids)
+
+
 def _document_view(conn: sqlite3.Connection, row: sqlite3.Row) -> dict:
     """One document as a JSON-safe dict. ``ocr_text`` is deliberately replaced by
     ``has_ocr_text`` — a full document transcription has no business in list output."""
@@ -228,10 +263,13 @@ def reassign_document(
     Dry-run by default: pass ``apply=True`` to write. Three refusals, all before any
     write, all leaving the database untouched:
 
-    * **open conflicts** citing this document (:class:`OpenConflictsError`) — such a
-      conflict pairs an incoming row from this document against a stored row owned by
-      the *old* person; resolving it after a move would write data into records the
-      document no longer owns. Resolve them first (`pemr review-conflicts`).
+    * **open conflicts** at either end of this document (:class:`OpenConflictsError`).
+      One *raised* by it pairs an incoming row from this document against a stored row
+      owned by the *old* person; resolving it after a move would write data into
+      records the document no longer owns. One *anchored to* a row this document owns
+      (staged by some other document — see :func:`_conflicts_anchored_to`) would have
+      its ``dedup_key`` re-derived out from under it, and resolve to nothing. Resolve
+      them first (`pemr review-conflicts`).
     * **dictionary drift** (:class:`DictionaryDriftError`) — a stored key that does not
       match its recompute under the current dictionary means a reassign would silently
       perform a `rekey` too. Run `pemr rekey --apply` first; reassign changes ownership
@@ -259,17 +297,18 @@ def reassign_document(
         report.applied = apply
         return report
 
-    open_conflicts = conn.execute(
-        "SELECT conflict_id FROM conflict WHERE document_id = ? AND status = 'open' "
-        "ORDER BY conflict_id",
-        (document_id,),
-    ).fetchall()
+    open_conflicts = sorted(
+        set(_conflicts_cited_by(conn, document_id))
+        | set(_conflicts_anchored_to(conn, document_id))
+    )
     if open_conflicts:
-        ids = ", ".join(f"#{row['conflict_id']}" for row in open_conflicts)
+        ids = ", ".join(f"#{cid}" for cid in open_conflicts)
         raise OpenConflictsError(
             f"document {document_id} has open conflict(s) {ids} staged against "
-            f"'{from_slug}'; resolving one after the move would write this document's "
-            "data into records it no longer owns. Resolve them first with "
+            f"'{from_slug}' - raised by this document, or anchored to a row it owns. "
+            "Resolving one after the move would write this document's data into "
+            "records it no longer owns, or target a dedup_key the move re-derives "
+            "(silently discarding the staged value). Resolve them first with "
             "`pemr review-conflicts`; nothing was written"
         )
 
@@ -345,9 +384,13 @@ class RemoveReport:
     sha256: str
     source_path: str
     records: dict[str, int] = field(default_factory=dict)
-    conflicts_deleted: int = 0      # open conflicts, removed with the document
+    conflicts_deleted: int = 0      # open conflicts raised by this document
+    conflicts_anchored: int = 0     # open conflicts staged against its rows (also deleted)
     conflicts_detached: int = 0     # resolved conflicts, document_id nulled
-    blob_path: str = ""             # absolute when a sources dir is known
+    # Absolute when a ``sources_dir`` was passed, else the store-relative
+    # `sources/<shard>/<sha><ext>` form `pemr ingest` echoes. The CLI only resolves a
+    # sources dir for `--purge-blob`, so its `blob kept:` line is always the latter.
+    blob_path: str = ""
     blob_purged: bool = False
     applied: bool = False
 
@@ -374,7 +417,12 @@ def remove_document(
 
     Conflicts citing the document: open ones are deleted (their incoming rows never
     landed and their document is going away), resolved ones keep their audit trail
-    with ``document_id`` nulled out. Both counts are reported.
+    with ``document_id`` nulled out. Open conflicts *anchored to* a row this document
+    owns (:func:`_conflicts_anchored_to`) are deleted too and counted separately — the
+    row they were staged against is going away, so they cannot be resolved either way,
+    and leaving them would make a later `keep incoming` discard the staged value in
+    silence. Every count is in the dry-run report: the blast radius is the safety
+    mechanism here, so it has to be truthful.
 
     The scan under ``sources_dir`` is **kept** unless ``purge_blob`` is set — it is the
     one thing here that cannot be regenerated, and an orphan blob is harmless
@@ -401,10 +449,13 @@ def remove_document(
         # `sources/<shard>/<sha>.<ext>` form `pemr ingest` echoes.
         blob_path=str(blob) if blob is not None else f"sources/{doc['source_path']}",
     )
-    report.conflicts_deleted = int(conn.execute(
-        "SELECT COUNT(*) AS n FROM conflict WHERE document_id = ? AND status = 'open'",
-        (document_id,),
-    ).fetchone()["n"])
+    cited = set(_conflicts_cited_by(conn, document_id))
+    # Rows are about to be deleted, so a conflict anchored to one can no longer be
+    # resolved either way; it goes with them. Counted separately because it is the
+    # surprising half of the blast radius (its `document_id` names another document).
+    anchored = set(_conflicts_anchored_to(conn, document_id)) - cited
+    report.conflicts_deleted = len(cited)
+    report.conflicts_anchored = len(anchored)
     report.conflicts_detached = int(conn.execute(
         "SELECT COUNT(*) AS n FROM conflict WHERE document_id = ? AND status != 'open'",
         (document_id,),
@@ -414,10 +465,13 @@ def remove_document(
         # Children first: foreign_keys=ON with NO ACTION means the document DELETE
         # raises while anything still references it. record_fts is trigger-maintained.
         with conn:
-            conn.execute(
-                "DELETE FROM conflict WHERE document_id = ? AND status = 'open'",
-                (document_id,),
-            )
+            doomed = sorted(cited | anchored)
+            if doomed:
+                placeholders = ", ".join("?" for _ in doomed)
+                conn.execute(
+                    f"DELETE FROM conflict WHERE conflict_id IN ({placeholders})",
+                    doomed,
+                )
             conn.execute(
                 "UPDATE conflict SET document_id = NULL WHERE document_id = ?",
                 (document_id,),
@@ -430,11 +484,12 @@ def remove_document(
                 "DELETE FROM document WHERE document_id = ?", (document_id,)
             )
         if purge_blob and blob is not None:
+            existed = blob.exists()     # don't claim a delete that never happened
             blob.unlink(missing_ok=True)
             try:
                 blob.parent.rmdir()   # drop the 2-char shard dir once it is empty
             except OSError:
                 pass                  # not empty (or gone) - leave it alone
-            report.blob_purged = True
+            report.blob_purged = existed
     report.applied = apply
     return report

--- a/pemr/documents.py
+++ b/pemr/documents.py
@@ -1,0 +1,438 @@
+"""Document recovery — `pemr document list|edit|reassign|rm`.
+
+The escape hatch for a misfiled document (issue #54). Once `ingest` +
+`commit-extraction` have run against the wrong person (or with the wrong
+doc-date/category), the rows are otherwise stuck: `person remove` correctly
+refuses once a person has records, and hand-editing SQLite means hand-fixing
+``dedup_key`` and the FTS index too.
+
+Four operations, mirroring `persons.py` in shape:
+
+    * ``list_documents``   — what is on file, with the blast-radius record count
+    * ``edit_document``    — correct doc_date/category/provider (no key impact)
+    * ``reassign_document``— right document, wrong owner: move the document and
+      every attached row, re-deriving each ``dedup_key`` (``person_id`` is part
+      of every key — see :func:`dedup.dedup_key`)
+    * ``remove_document``  — wrong file entirely: cascade-delete the attached
+      rows, then the document
+
+Safety idiom (matching `pemr rekey`): ``reassign`` and ``rm`` are **dry-run by
+default**; ``apply=True`` writes. ``record_fts`` needs no explicit maintenance —
+migration 003's AFTER UPDATE/DELETE triggers on each base table keep it in sync.
+
+Single-provenance semantics: ``document_id`` is a row's sole owner. A fact a
+second document also attests leaves no trace in the schema (``commit_extraction``
+reports layer-2 duplicates only in its in-memory summary), so ``rm`` cannot
+detect multi-document attestation and does not pretend to.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import db, dedup
+from .persons import PersonNotFoundError, get_person
+
+
+class DocumentNotFoundError(ValueError):
+    """Raised when a document id does not resolve (friendly rc=1 at the CLI)."""
+
+
+class ReassignCollisionError(RuntimeError):
+    """A moved row's recomputed key already exists for the target person."""
+
+
+class OpenConflictsError(ValueError):
+    """Raised when a reassign is refused because open conflicts cite the document."""
+
+
+class DictionaryDriftError(ValueError):
+    """Stored keys no longer match the current dictionary; `pemr rekey` comes first."""
+
+
+# Editable via `document edit`. None of these feed a dedup_key (keys are built from
+# record fields only), so correcting them is a pure metadata UPDATE. sha256 and
+# source_path are excluded by construction: the blob is content-addressed.
+_EDITABLE_FIELDS = ("doc_date", "category", "provider")
+
+
+# --------------------------------------------------------------------------- #
+# Shared helpers
+# --------------------------------------------------------------------------- #
+
+def _require_document(conn: sqlite3.Connection, document_id: int) -> sqlite3.Row:
+    row = conn.execute(
+        "SELECT * FROM document WHERE document_id = ?", (document_id,)
+    ).fetchone()
+    if row is None:
+        raise DocumentNotFoundError(
+            f"no document with id {document_id} - see `pemr document list`"
+        )
+    return row
+
+
+def _slug_for(conn: sqlite3.Connection, person_id: int | None) -> str | None:
+    if person_id is None:
+        return None
+    row = conn.execute(
+        "SELECT slug FROM person WHERE person_id = ?", (person_id,)
+    ).fetchone()
+    return row["slug"] if row is not None else None
+
+
+def _record_counts(conn: sqlite3.Connection, document_id: int) -> dict[str, int]:
+    """Rows attached to a document, per record type (stable key set for --json)."""
+    counts: dict[str, int] = {}
+    for record_type in dedup.KNOWN_TYPES:
+        row = conn.execute(
+            f"SELECT COUNT(*) AS n FROM {record_type} WHERE document_id = ?",
+            (document_id,),
+        ).fetchone()
+        counts[record_type] = int(row["n"])
+    return counts
+
+
+def _document_view(conn: sqlite3.Connection, row: sqlite3.Row) -> dict:
+    """One document as a JSON-safe dict. ``ocr_text`` is deliberately replaced by
+    ``has_ocr_text`` — a full document transcription has no business in list output."""
+    counts = _record_counts(conn, row["document_id"])
+    return {
+        "document_id": row["document_id"],
+        "sha256": row["sha256"],
+        "person_id": row["person_id"],
+        "person": _slug_for(conn, row["person_id"]),
+        "doc_date": row["doc_date"],
+        "category": row["category"],
+        "provider": row["provider"],
+        "source_path": row["source_path"],
+        "ingested_at": row["ingested_at"],
+        "has_ocr_text": bool(row["ocr_text"]),
+        "records": counts,
+        "record_count": sum(counts.values()),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# list / edit
+# --------------------------------------------------------------------------- #
+
+def list_documents(
+    conn: sqlite3.Connection, person_slug: str | None = None
+) -> list[dict]:
+    """Documents newest-first (``document_id`` DESC), optionally one person's only.
+
+    Newest-first because the recovery question is "which document did I just
+    misfile", not alphabetical browsing. Raises :class:`PersonNotFoundError` for an
+    unknown ``person_slug`` (an unknown slug is a typo, not an empty result).
+    """
+    db.require_migrated(conn)
+    params: list[object] = []
+    where = ""
+    if person_slug is not None:
+        person = get_person(conn, person_slug)
+        if person is None:
+            raise PersonNotFoundError(f"no person with slug '{person_slug}'")
+        where = " WHERE person_id = ?"
+        params.append(person.person_id)
+    rows = conn.execute(
+        f"SELECT * FROM document{where} ORDER BY document_id DESC", params
+    ).fetchall()
+    return [_document_view(conn, row) for row in rows]
+
+
+def get_document_view(conn: sqlite3.Connection, document_id: int) -> dict:
+    """One document in the :func:`list_documents` shape."""
+    db.require_migrated(conn)
+    return _document_view(conn, _require_document(conn, document_id))
+
+
+def edit_document(
+    conn: sqlite3.Connection, document_id: int, **fields: str | None
+) -> dict:
+    """Partial metadata update (``pemr document edit``) — the wrong-doc-date/category
+    half of misfiling. Only the fields passed change; an explicit empty string clears
+    the column to NULL. No ``dedup_key`` is affected (see :data:`_EDITABLE_FIELDS`).
+
+    Raises :class:`DocumentNotFoundError` for an unknown id and ``ValueError`` for an
+    unknown field or no fields to update.
+    """
+    db.require_migrated(conn)
+    unknown = set(fields) - set(_EDITABLE_FIELDS)
+    if unknown:
+        raise ValueError(f"cannot edit field(s): {', '.join(sorted(unknown))}")
+    if not fields:
+        raise ValueError("nothing to update - pass at least one field to change")
+
+    updates = {
+        name: (value if value not in (None, "") else None)
+        for name, value in fields.items()
+    }
+    _require_document(conn, document_id)
+    assignments = ", ".join(f"{name} = ?" for name in updates)
+    values = list(updates.values())
+    values.append(document_id)
+    with conn:
+        conn.execute(
+            f"UPDATE document SET {assignments} WHERE document_id = ?", values
+        )
+    return _document_view(conn, _require_document(conn, document_id))
+
+
+# --------------------------------------------------------------------------- #
+# reassign (right document, wrong owner)
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class ReassignChange:
+    record_type: str
+    row_id: int
+    label: str
+    old_key: str
+    new_key: str
+
+
+@dataclass
+class ReassignReport:
+    document_id: int
+    from_slug: str | None
+    to_slug: str
+    changes: list[ReassignChange] = field(default_factory=list)
+    applied: bool = False
+    unchanged: bool = False          # target already owns the document
+    target_inactive: bool = False    # allowed, but worth saying out loud
+
+    @property
+    def counts(self) -> dict[str, int]:
+        out: dict[str, int] = {}
+        for change in self.changes:
+            out[change.record_type] = out.get(change.record_type, 0) + 1
+        return out
+
+
+def reassign_document(
+    conn: sqlite3.Connection,
+    document_id: int,
+    person_slug: str,
+    dictionary: dict[str, str] | None = None,
+    *,
+    apply: bool = False,
+) -> ReassignReport:
+    """Move a document and every row it produced to another person.
+
+    ``person_id`` is part of every ``dedup_key`` (:func:`dedup.dedup_key`), so each
+    attached row's key is re-derived under the new owner; ``record_fts`` follows via
+    migration 003's AFTER UPDATE triggers, keeping `find --person` correct.
+
+    Dry-run by default: pass ``apply=True`` to write. Three refusals, all before any
+    write, all leaving the database untouched:
+
+    * **open conflicts** citing this document (:class:`OpenConflictsError`) — such a
+      conflict pairs an incoming row from this document against a stored row owned by
+      the *old* person; resolving it after a move would write data into records the
+      document no longer owns. Resolve them first (`pemr review-conflicts`).
+    * **dictionary drift** (:class:`DictionaryDriftError`) — a stored key that does not
+      match its recompute under the current dictionary means a reassign would silently
+      perform a `rekey` too. Run `pemr rekey --apply` first; reassign changes ownership
+      and nothing else.
+    * **collision** (:class:`ReassignCollisionError`) — the target person already has
+      that exact fact on file.
+
+    A reassign to the current owner is a reported no-op, not an error.
+    """
+    db.require_migrated(conn)
+    doc = _require_document(conn, document_id)
+    target = get_person(conn, person_slug)
+    if target is None:
+        raise PersonNotFoundError(f"no person with slug '{person_slug}'")
+
+    from_slug = _slug_for(conn, doc["person_id"])
+    report = ReassignReport(
+        document_id=document_id,
+        from_slug=from_slug,
+        to_slug=target.slug,
+        target_inactive=target.deactivated_at is not None,
+    )
+    if doc["person_id"] == target.person_id:
+        report.unchanged = True
+        report.applied = apply
+        return report
+
+    open_conflicts = conn.execute(
+        "SELECT conflict_id FROM conflict WHERE document_id = ? AND status = 'open' "
+        "ORDER BY conflict_id",
+        (document_id,),
+    ).fetchall()
+    if open_conflicts:
+        ids = ", ".join(f"#{row['conflict_id']}" for row in open_conflicts)
+        raise OpenConflictsError(
+            f"document {document_id} has open conflict(s) {ids} staged against "
+            f"'{from_slug}'; resolving one after the move would write this document's "
+            "data into records it no longer owns. Resolve them first with "
+            "`pemr review-conflicts`; nothing was written"
+        )
+
+    # Plan every move first: a refusal must leave the database untouched.
+    for record_type in dedup.KNOWN_TYPES:
+        pk = f"{record_type}_id"
+        rows = conn.execute(
+            f"SELECT * FROM {record_type} WHERE document_id = ? ORDER BY {pk}",
+            (document_id,),
+        ).fetchall()
+        for row in rows:
+            label = dedup._rekey_label(record_type, row)
+            payload = {name: row[name] for name in dedup.FIELD_SPECS[record_type]}
+            current = dedup.dedup_key(
+                record_type, payload, row["person_id"], dictionary
+            )
+            if current != row["dedup_key"]:
+                raise DictionaryDriftError(
+                    f"{record_type}: {pk} {row[pk]} ({label!r}) does not match its "
+                    "stored dedup_key under the current dictionary - the dictionary "
+                    "changed since it was committed. Run `pemr rekey --apply` first, "
+                    "then retry; nothing was written"
+                )
+            new_key = dedup.dedup_key(
+                record_type, payload, target.person_id, dictionary
+            )
+            # Every moving row shares one old person_id and one new one, and the drift
+            # check above proves the stored keys are injective under the current
+            # dictionary — so new keys cannot collide with each other or with the
+            # moving rows' own old keys. Any hit here is a non-moving row, i.e. a fact
+            # the target person already has. (No two-pass placeholder dance needed,
+            # unlike `dedup.rekey`, where arbitrary rows swap keys mid-flight.)
+            clash = conn.execute(
+                f"SELECT {pk} FROM {record_type} WHERE dedup_key = ?", (new_key,)
+            ).fetchone()
+            if clash is not None:
+                raise ReassignCollisionError(
+                    f"{record_type}: {pk} {row[pk]} ({label!r}) would collide with "
+                    f"{pk} {clash[pk]}, which '{target.slug}' already has on file - "
+                    "the same fact cannot land twice; nothing was written"
+                )
+            report.changes.append(
+                ReassignChange(
+                    record_type, row[pk], label, row["dedup_key"], new_key
+                )
+            )
+
+    if apply:
+        # One transaction: a half-moved document splits a person's history in two.
+        with conn:
+            conn.execute(
+                "UPDATE document SET person_id = ? WHERE document_id = ?",
+                (target.person_id, document_id),
+            )
+            for change in report.changes:
+                conn.execute(
+                    f"UPDATE {change.record_type} SET person_id = ?, dedup_key = ? "
+                    f"WHERE {change.record_type}_id = ?",
+                    (target.person_id, change.new_key, change.row_id),
+                )
+    report.applied = apply
+    return report
+
+
+# --------------------------------------------------------------------------- #
+# rm (wrong file entirely)
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class RemoveReport:
+    document_id: int
+    person_slug: str | None
+    sha256: str
+    source_path: str
+    records: dict[str, int] = field(default_factory=dict)
+    conflicts_deleted: int = 0      # open conflicts, removed with the document
+    conflicts_detached: int = 0     # resolved conflicts, document_id nulled
+    blob_path: str = ""             # absolute when a sources dir is known
+    blob_purged: bool = False
+    applied: bool = False
+
+    @property
+    def record_count(self) -> int:
+        return sum(self.records.values())
+
+
+def remove_document(
+    conn: sqlite3.Connection,
+    document_id: int,
+    *,
+    sources_dir: str | Path | None = None,
+    purge_blob: bool = False,
+    apply: bool = False,
+) -> RemoveReport:
+    """Delete a document and cascade to every row it produced.
+
+    Deliberately the opposite of :func:`persons.remove_person`, which refuses when
+    child rows exist: a person with records has a non-destructive alternative
+    (`person deactivate`), a misfiled document has none, so refusing would defeat the
+    command. The dry run (default) supplies the safety instead — it reports the exact
+    blast radius, and only ``apply=True`` writes.
+
+    Conflicts citing the document: open ones are deleted (their incoming rows never
+    landed and their document is going away), resolved ones keep their audit trail
+    with ``document_id`` nulled out. Both counts are reported.
+
+    The scan under ``sources_dir`` is **kept** unless ``purge_blob`` is set — it is the
+    one thing here that cannot be regenerated, and an orphan blob is harmless
+    (content-addressed; a later re-ingest of the same file reuses it). Deleting the
+    blob happens after the transaction commits, so a failed unlink leaves an orphan
+    file rather than a document row pointing at a file that no longer exists.
+    """
+    db.require_migrated(conn)
+    doc = _require_document(conn, document_id)
+    if purge_blob and sources_dir is None:
+        raise ValueError(
+            "purging the blob needs a sources dir - pass --sources, set PEMR_SOURCES, "
+            "or set [paths].sources_dir in config.toml"
+        )
+
+    blob = Path(sources_dir) / doc["source_path"] if sources_dir is not None else None
+    report = RemoveReport(
+        document_id=document_id,
+        person_slug=_slug_for(conn, doc["person_id"]),
+        sha256=doc["sha256"],
+        source_path=doc["source_path"],
+        records=_record_counts(conn, document_id),
+        blob_path=str(blob) if blob is not None else doc["source_path"],
+    )
+    report.conflicts_deleted = int(conn.execute(
+        "SELECT COUNT(*) AS n FROM conflict WHERE document_id = ? AND status = 'open'",
+        (document_id,),
+    ).fetchone()["n"])
+    report.conflicts_detached = int(conn.execute(
+        "SELECT COUNT(*) AS n FROM conflict WHERE document_id = ? AND status != 'open'",
+        (document_id,),
+    ).fetchone()["n"])
+
+    if apply:
+        # Children first: foreign_keys=ON with NO ACTION means the document DELETE
+        # raises while anything still references it. record_fts is trigger-maintained.
+        with conn:
+            conn.execute(
+                "DELETE FROM conflict WHERE document_id = ? AND status = 'open'",
+                (document_id,),
+            )
+            conn.execute(
+                "UPDATE conflict SET document_id = NULL WHERE document_id = ?",
+                (document_id,),
+            )
+            for record_type in dedup.KNOWN_TYPES:
+                conn.execute(
+                    f"DELETE FROM {record_type} WHERE document_id = ?", (document_id,)
+                )
+            conn.execute(
+                "DELETE FROM document WHERE document_id = ?", (document_id,)
+            )
+        if purge_blob and blob is not None:
+            blob.unlink(missing_ok=True)
+            try:
+                blob.parent.rmdir()   # drop the 2-char shard dir once it is empty
+            except OSError:
+                pass                  # not empty (or gone) - leave it alone
+            report.blob_purged = True
+    report.applied = apply
+    return report

--- a/pemr/documents.py
+++ b/pemr/documents.py
@@ -397,7 +397,9 @@ def remove_document(
         sha256=doc["sha256"],
         source_path=doc["source_path"],
         records=_record_counts(conn, document_id),
-        blob_path=str(blob) if blob is not None else doc["source_path"],
+        # No sources dir configured -> report the store-relative path, the same
+        # `sources/<shard>/<sha>.<ext>` form `pemr ingest` echoes.
+        blob_path=str(blob) if blob is not None else f"sources/{doc['source_path']}",
     )
     report.conflicts_deleted = int(conn.execute(
         "SELECT COUNT(*) AS n FROM conflict WHERE document_id = ? AND status = 'open'",

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -248,6 +248,51 @@ def test_reassign_refused_while_a_conflict_is_open(seeded):
     assert "review-conflicts" in str(exc.value)
 
 
+def test_reassign_refused_when_another_document_conflicts_with_its_rows(seeded):
+    """A conflict has two ends. ``conflict.document_id`` names the document whose
+    *incoming* row lost; the ``dedup_key`` anchors it to the *stored* row, which a
+    different document owns. Reassigning that owner re-derives the key out from under
+    the conflict, and a later `keep incoming` then writes nothing, silently (#54 audit).
+    """
+    conn = seeded["conn"]
+    other = _insert_document(conn, seeded["jane"].person_id, "ee55")
+    summary = dedup.commit_extraction(conn, other, {"lab_result": [
+        {"test_name": "HbA1c", "collected_at": "2026-01-02", "value_num": 7.4,
+         "unit": "%"},
+    ]})
+    assert summary.counts["conflict"] == 1
+    # The conflict cites `other`, NOT the document being moved - that is the point.
+    assert conn.execute(
+        "SELECT document_id FROM conflict WHERE conflict_id = 1"
+    ).fetchone()["document_id"] == other
+
+    with pytest.raises(documents.OpenConflictsError) as exc:
+        documents.reassign_document(conn, seeded["doc"], "john-doe", apply=True)
+    assert "#1" in str(exc.value) and "review-conflicts" in str(exc.value)
+    assert conn.execute(
+        "SELECT person_id FROM document WHERE document_id = ?", (seeded["doc"],)
+    ).fetchone()["person_id"] == seeded["jane"].person_id
+    assert [r["person_id"] for r in conn.execute(
+        "SELECT person_id FROM lab_result"
+    ).fetchall()] == [seeded["jane"].person_id]
+
+
+def test_reassign_refusal_lists_a_two_ended_conflict_once(seeded):
+    """A conflict raised by *and* anchored to the same document (two colliding rows in
+    one extraction) appears once in the refusal, not twice."""
+    conn = seeded["conn"]
+    other = _insert_document(conn, seeded["jane"].person_id, "dd99")
+    summary = dedup.commit_extraction(conn, other, {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 88},
+        {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 99},
+    ]})
+    assert summary.counts["conflict"] == 1
+
+    with pytest.raises(documents.OpenConflictsError) as exc:
+        documents.reassign_document(conn, other, "john-doe", apply=True)
+    assert str(exc.value).count("#1") == 1
+
+
 def test_reassign_refused_on_dictionary_drift(seeded):
     conn = seeded["conn"]
     # Keys were committed with no dictionary; this one renames the stored analyte,
@@ -319,6 +364,46 @@ def test_rm_deletes_open_conflicts_and_detaches_resolved_ones(seeded):
     ).fetchone()["n"] == 0
 
 
+def test_rm_reports_and_deletes_conflicts_staged_against_its_rows(seeded):
+    """The blast radius is `rm`'s only safety mechanism (dry run by default, no
+    --yes), so it has to count the conflicts anchored to the rows being destroyed -
+    not just the ones this document raised (#54 audit)."""
+    conn = seeded["conn"]
+    other = _insert_document(conn, seeded["jane"].person_id, "ee55")
+    dedup.commit_extraction(conn, other, {"lab_result": [
+        {"test_name": "HbA1c", "collected_at": "2026-01-02", "value_num": 7.4},
+    ]})
+
+    dry = documents.remove_document(conn, seeded["doc"])
+    assert (dry.conflicts_deleted, dry.conflicts_anchored) == (0, 1)
+    assert conn.execute(
+        "SELECT COUNT(*) AS n FROM conflict WHERE status = 'open'"
+    ).fetchone()["n"] == 1          # dry run wrote nothing
+
+    applied = documents.remove_document(conn, seeded["doc"], apply=True)
+    assert (applied.conflicts_deleted, applied.conflicts_anchored) == (0, 1)
+    assert conn.execute("SELECT COUNT(*) AS n FROM conflict").fetchone()["n"] == 0
+    # ...so the orphaned conflict can no longer resolve to a silent no-op.
+    with pytest.raises(ValueError):
+        dedup.resolve_conflict(conn, 1, keep="incoming")
+
+
+def test_rm_counts_a_two_ended_conflict_once(seeded):
+    """Raised by and anchored to the same document: counted on the `document_id` side
+    only, and deleted exactly once."""
+    conn = seeded["conn"]
+    other = _insert_document(conn, seeded["jane"].person_id, "dd99")
+    summary = dedup.commit_extraction(conn, other, {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 88},
+        {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 99},
+    ]})
+    assert summary.counts["conflict"] == 1
+
+    report = documents.remove_document(conn, other, apply=True)
+    assert (report.conflicts_deleted, report.conflicts_anchored) == (1, 0)
+    assert conn.execute("SELECT COUNT(*) AS n FROM conflict").fetchone()["n"] == 0
+
+
 def test_rm_keeps_the_blob_by_default(seeded, tmp_path):
     conn = seeded["conn"]
     sources = tmp_path / "sources"
@@ -353,6 +438,17 @@ def test_rm_purge_blob_unlinks_the_scan(seeded, tmp_path):
     assert report.blob_purged is True
     assert not blob.exists()
     assert not blob.parent.exists()      # empty shard dir cleaned up
+
+
+def test_rm_purge_blob_does_not_claim_a_delete_that_never_happened(seeded, tmp_path):
+    """`unlink(missing_ok=True)` on an already-missing blob is fine, but reporting it
+    as deleted is not (#54 audit, non-blocking item 3)."""
+    conn = seeded["conn"]
+    report = documents.remove_document(
+        conn, seeded["doc"], sources_dir=tmp_path / "sources",
+        purge_blob=True, apply=True,
+    )
+    assert report.applied is True and report.blob_purged is False
 
 
 def test_rm_purge_blob_without_a_sources_dir_is_refused(seeded):
@@ -484,6 +580,45 @@ def test_cli_document_rm_purge_blob(cli_ready, capsys):
                 "--sources", str(sources)) == 0
     assert "blob deleted" in capsys.readouterr().out
     assert not blobs[0].exists()
+
+
+def test_cli_document_rm_reports_conflicts_staged_against_its_rows(cli_ready, capsys):
+    scan2 = cli_ready / "scan2.txt"
+    scan2.write_bytes(b"hba1c 7.4 percent")
+    assert _run(cli_ready, "ingest", str(scan2), "--person", "jane-doe",
+                "--sources", str(cli_ready / "sources"),
+                "--ocr-text-file", str(scan2)) == 0
+    payload = cli_ready / "extract2.json"
+    payload.write_text(json.dumps({"lab_result": [
+        {"test_name": "HbA1c", "collected_at": "2026-01-02", "value_num": 7.4,
+         "unit": "%"},
+    ]}), encoding="utf-8")
+    assert _run(cli_ready, "commit-extraction", "--document", "2",
+                "--json", str(payload)) == 0
+
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "rm", "1") == 0
+    out = capsys.readouterr().out
+    assert "conflicts deleted (staged against these records): 1" in out
+    assert out.isascii(), repr(out)
+    out.encode("cp437")
+
+    # reassign refuses the same case rather than deleting anything.
+    assert _run(cli_ready, "document", "reassign", "1", "--person", "john-doe",
+                "--apply") == 1
+    assert "review-conflicts" in capsys.readouterr().err
+
+
+def test_cli_document_rm_purge_blob_already_gone(cli_ready, capsys):
+    sources = cli_ready / "sources"
+    for blob in [p for p in sources.rglob("*") if p.is_file()]:
+        blob.unlink()
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "rm", "1", "--apply", "--purge-blob",
+                "--sources", str(sources)) == 0
+    out = capsys.readouterr().out
+    assert "blob already gone" in out and "blob deleted" not in out
+    assert out.isascii(), repr(out)
 
 
 def test_cli_document_rm_unknown_id_fails(cli_ready, capsys):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,0 +1,507 @@
+"""Misfiled-document recovery: `pemr document list|edit|reassign|rm` (issue #54).
+
+Covers the module surface (pemr/documents.py) and the CLI wiring, in the shape
+test_persons.py uses for the `person` group.
+"""
+
+import json
+
+import pytest
+
+from pemr import cli, db, dedup, documents, persons
+
+RECORDS = {
+    "lab_result": [
+        {"test_name": "HbA1c", "collected_at": "2026-01-02", "value_num": 5.7,
+         "unit": "%"},
+    ],
+    "medication": [
+        {"name": "Metformin", "dose": "500 mg", "started_on": "2025-06-01"},
+    ],
+    "procedure": [
+        {"name": "Colonoscopy", "performed_on": "2025-03-04"},
+    ],
+    "appointment": [
+        {"scheduled_for": "2026-02-01", "provider": "Dr Who", "reason": "checkup"},
+    ],
+    "observation": [
+        {"obs_type": "blood_pressure", "observed_at": "2026-01-02",
+         "key": "systolic", "value_num": 120},
+    ],
+}
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    conn = db.connect(tmp_path / "test.db")
+    db.migrate(conn)
+    yield conn
+    conn.close()
+
+
+def _insert_document(conn, person_id, sha, *, doc_date="2026-03-15",
+                     category="labs", provider="Quest", ocr_text="scan text"):
+    cur = conn.execute(
+        """
+        INSERT INTO document
+          (sha256, person_id, doc_date, category, provider, source_path,
+           ocr_text, ingested_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (sha, person_id, doc_date, category, provider, f"{sha[:2]}/{sha}.pdf",
+         ocr_text, "2026-03-16T00:00:00"),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+@pytest.fixture()
+def seeded(conn):
+    """Jane owns document #1 with one row of every record type; John is empty."""
+    jane = persons.add_person(conn, "jane-doe", "Jane Doe")
+    john = persons.add_person(conn, "john-doe", "John Doe")
+    doc_id = _insert_document(conn, jane.person_id, "aa11bb22cc33dd44")
+    dedup.commit_extraction(conn, doc_id, RECORDS)
+    return {"conn": conn, "jane": jane, "john": john, "doc": doc_id}
+
+
+def _fts_person_ids(conn, source_table):
+    return [
+        row["person_id"] for row in conn.execute(
+            "SELECT person_id FROM record_fts WHERE source_table = ?", (source_table,)
+        ).fetchall()
+    ]
+
+
+# --- list -------------------------------------------------------------------
+
+
+def test_list_empty(conn):
+    assert documents.list_documents(conn) == []
+
+
+def test_list_newest_first_with_counts(seeded):
+    conn, jane = seeded["conn"], seeded["jane"]
+    second = _insert_document(conn, jane.person_id, "bb99")
+    views = documents.list_documents(conn)
+    assert [v["document_id"] for v in views] == [second, seeded["doc"]]
+    assert views[1]["record_count"] == 5
+    assert views[1]["records"]["lab_result"] == 1
+    assert views[0]["record_count"] == 0
+    assert views[1]["person"] == "jane-doe"
+
+
+def test_list_filtered_by_person(seeded):
+    conn, john = seeded["conn"], seeded["john"]
+    _insert_document(conn, john.person_id, "cc77")
+    assert [v["person"] for v in documents.list_documents(conn, "john-doe")] == [
+        "john-doe"
+    ]
+    assert len(documents.list_documents(conn, "jane-doe")) == 1
+
+
+def test_list_unknown_slug_raises(seeded):
+    with pytest.raises(persons.PersonNotFoundError):
+        documents.list_documents(seeded["conn"], "nobody")
+
+
+def test_list_replaces_ocr_text_with_a_flag(seeded):
+    view = documents.list_documents(seeded["conn"])[0]
+    assert "ocr_text" not in view
+    assert view["has_ocr_text"] is True
+
+
+# --- edit -------------------------------------------------------------------
+
+
+def test_edit_partial_update(seeded):
+    view = documents.edit_document(
+        seeded["conn"], seeded["doc"], doc_date="2026-04-01"
+    )
+    assert view["doc_date"] == "2026-04-01"
+    assert view["category"] == "labs"       # untouched
+    assert view["provider"] == "Quest"      # untouched
+
+
+def test_edit_clears_with_empty_string(seeded):
+    view = documents.edit_document(seeded["conn"], seeded["doc"], provider="")
+    assert view["provider"] is None
+
+
+def test_edit_requires_a_field(seeded):
+    with pytest.raises(ValueError):
+        documents.edit_document(seeded["conn"], seeded["doc"])
+
+
+def test_edit_rejects_unknown_field(seeded):
+    with pytest.raises(ValueError):
+        documents.edit_document(seeded["conn"], seeded["doc"], sha256="x")
+
+
+def test_edit_unknown_document_raises(conn):
+    with pytest.raises(documents.DocumentNotFoundError):
+        documents.edit_document(conn, 999, category="labs")
+
+
+def test_edit_does_not_move_dedup_keys(seeded):
+    conn = seeded["conn"]
+    before = conn.execute("SELECT dedup_key FROM lab_result").fetchone()["dedup_key"]
+    documents.edit_document(conn, seeded["doc"], category="imaging")
+    after = conn.execute("SELECT dedup_key FROM lab_result").fetchone()["dedup_key"]
+    assert before == after
+
+
+# --- reassign ---------------------------------------------------------------
+
+
+def test_reassign_moves_document_and_every_record_type(seeded):
+    conn, john = seeded["conn"], seeded["john"]
+    report = documents.reassign_document(
+        conn, seeded["doc"], "john-doe", apply=True
+    )
+    assert report.applied is True
+    assert sorted(report.counts) == sorted(dedup.KNOWN_TYPES)
+    assert len(report.changes) == 5
+
+    assert conn.execute(
+        "SELECT person_id FROM document WHERE document_id = ?", (seeded["doc"],)
+    ).fetchone()["person_id"] == john.person_id
+    for record_type in dedup.KNOWN_TYPES:
+        owners = [
+            r["person_id"] for r in conn.execute(
+                f"SELECT person_id FROM {record_type}"
+            ).fetchall()
+        ]
+        assert owners == [john.person_id], record_type
+        # FTS follows via migration 003's AFTER UPDATE triggers - `find --person`
+        # must not keep pointing at the old owner.
+        assert _fts_person_ids(conn, record_type) == [john.person_id], record_type
+    assert _fts_person_ids(conn, "document") == [john.person_id]
+
+
+def test_reassign_rederives_dedup_keys(seeded):
+    conn = seeded["conn"]
+    before = conn.execute("SELECT dedup_key FROM lab_result").fetchone()["dedup_key"]
+    report = documents.reassign_document(
+        conn, seeded["doc"], "john-doe", apply=True
+    )
+    after = conn.execute("SELECT dedup_key FROM lab_result").fetchone()["dedup_key"]
+    assert after != before
+    change = next(c for c in report.changes if c.record_type == "lab_result")
+    assert (change.old_key, change.new_key) == (before, after)
+
+
+def test_reassign_dry_run_writes_nothing(seeded):
+    conn, jane = seeded["conn"], seeded["jane"]
+    report = documents.reassign_document(conn, seeded["doc"], "john-doe")
+    assert report.applied is False and len(report.changes) == 5
+    assert conn.execute(
+        "SELECT person_id FROM document WHERE document_id = ?", (seeded["doc"],)
+    ).fetchone()["person_id"] == jane.person_id
+    assert [r["person_id"] for r in conn.execute(
+        "SELECT person_id FROM lab_result"
+    ).fetchall()] == [jane.person_id]
+
+
+def test_reassign_to_current_owner_is_a_noop(seeded):
+    report = documents.reassign_document(
+        seeded["conn"], seeded["doc"], "jane-doe", apply=True
+    )
+    assert report.unchanged is True and report.changes == []
+
+
+def test_reassign_to_deactivated_person_is_allowed_with_a_note(seeded):
+    conn = seeded["conn"]
+    persons.deactivate_person(conn, "john-doe")
+    report = documents.reassign_document(conn, seeded["doc"], "john-doe", apply=True)
+    assert report.target_inactive is True and report.applied is True
+
+
+def test_reassign_collision_refused_and_writes_nothing(seeded):
+    conn, jane, john = seeded["conn"], seeded["jane"], seeded["john"]
+    # John already has the same lab fact, from his own document.
+    john_doc = _insert_document(conn, john.person_id, "dd44")
+    dedup.commit_extraction(conn, john_doc, {"lab_result": RECORDS["lab_result"]})
+
+    with pytest.raises(documents.ReassignCollisionError) as exc:
+        documents.reassign_document(conn, seeded["doc"], "john-doe", apply=True)
+    assert "nothing was written" in str(exc.value)
+    assert conn.execute(
+        "SELECT person_id FROM document WHERE document_id = ?", (seeded["doc"],)
+    ).fetchone()["person_id"] == jane.person_id
+    assert [r["person_id"] for r in conn.execute(
+        "SELECT person_id FROM medication"
+    ).fetchall()] == [jane.person_id]
+
+
+def test_reassign_refused_while_a_conflict_is_open(seeded):
+    conn = seeded["conn"]
+    other = _insert_document(conn, seeded["jane"].person_id, "ee55")
+    summary = dedup.commit_extraction(conn, other, {"lab_result": [
+        {"test_name": "HbA1c", "collected_at": "2026-01-02", "value_num": 6.2,
+         "unit": "%"},
+    ]})
+    assert summary.counts["conflict"] == 1
+
+    with pytest.raises(documents.OpenConflictsError) as exc:
+        documents.reassign_document(conn, other, "john-doe", apply=True)
+    assert "review-conflicts" in str(exc.value)
+
+
+def test_reassign_refused_on_dictionary_drift(seeded):
+    conn = seeded["conn"]
+    # Keys were committed with no dictionary; this one renames the stored analyte,
+    # so a naive recompute would silently rekey as a side effect of the move.
+    with pytest.raises(documents.DictionaryDriftError) as exc:
+        documents.reassign_document(
+            conn, seeded["doc"], "john-doe", {"hba1c": "glycated_hemoglobin"},
+            apply=True,
+        )
+    assert "rekey" in str(exc.value)
+
+
+def test_reassign_unknown_document_and_slug(seeded):
+    conn = seeded["conn"]
+    with pytest.raises(documents.DocumentNotFoundError):
+        documents.reassign_document(conn, 999, "john-doe")
+    with pytest.raises(persons.PersonNotFoundError):
+        documents.reassign_document(conn, seeded["doc"], "nobody")
+
+
+# --- rm ---------------------------------------------------------------------
+
+
+def test_rm_dry_run_reports_but_deletes_nothing(seeded):
+    conn = seeded["conn"]
+    report = documents.remove_document(conn, seeded["doc"])
+    assert report.applied is False and report.record_count == 5
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 1
+
+
+def test_rm_apply_cascades_records_and_fts(seeded):
+    conn = seeded["conn"]
+    report = documents.remove_document(conn, seeded["doc"], apply=True)
+    assert report.applied is True and report.record_count == 5
+    for record_type in dedup.KNOWN_TYPES:
+        assert conn.execute(
+            f"SELECT COUNT(*) AS n FROM {record_type}"
+        ).fetchone()["n"] == 0, record_type
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 0
+    assert conn.execute("SELECT COUNT(*) AS n FROM record_fts").fetchone()["n"] == 0
+
+
+def test_rm_deletes_open_conflicts_and_detaches_resolved_ones(seeded):
+    conn = seeded["conn"]
+    other = _insert_document(conn, seeded["jane"].person_id, "ff66")
+    dedup.commit_extraction(conn, other, {"lab_result": [
+        {"test_name": "HbA1c", "collected_at": "2026-01-02", "value_num": 6.2},
+    ]})
+    third = _insert_document(conn, seeded["jane"].person_id, "aa77")
+    dedup.commit_extraction(conn, third, {"lab_result": [
+        {"test_name": "HbA1c", "collected_at": "2026-01-02", "value_num": 7.1},
+    ]})
+    # Resolve the first conflict (keep-existing leaves the stored row's provenance
+    # alone), leaving one open and one resolved conflict citing two documents.
+    dedup.resolve_conflict(conn, 1, keep="existing")
+
+    resolved = documents.remove_document(conn, other, apply=True)
+    assert (resolved.conflicts_deleted, resolved.conflicts_detached) == (0, 1)
+    row = conn.execute(
+        "SELECT document_id, status FROM conflict WHERE conflict_id = 1"
+    ).fetchone()
+    assert row["document_id"] is None and row["status"] == "resolved"
+
+    still_open = documents.remove_document(conn, third, apply=True)
+    assert (still_open.conflicts_deleted, still_open.conflicts_detached) == (1, 0)
+    assert conn.execute(
+        "SELECT COUNT(*) AS n FROM conflict WHERE status = 'open'"
+    ).fetchone()["n"] == 0
+
+
+def test_rm_keeps_the_blob_by_default(seeded, tmp_path):
+    conn = seeded["conn"]
+    sources = tmp_path / "sources"
+    doc = conn.execute(
+        "SELECT source_path FROM document WHERE document_id = ?", (seeded["doc"],)
+    ).fetchone()
+    blob = sources / doc["source_path"]
+    blob.parent.mkdir(parents=True)
+    blob.write_bytes(b"scan")
+
+    report = documents.remove_document(
+        conn, seeded["doc"], sources_dir=sources, apply=True
+    )
+    assert report.blob_purged is False
+    assert blob.exists()
+    assert report.blob_path == str(blob)
+
+
+def test_rm_purge_blob_unlinks_the_scan(seeded, tmp_path):
+    conn = seeded["conn"]
+    sources = tmp_path / "sources"
+    doc = conn.execute(
+        "SELECT source_path FROM document WHERE document_id = ?", (seeded["doc"],)
+    ).fetchone()
+    blob = sources / doc["source_path"]
+    blob.parent.mkdir(parents=True)
+    blob.write_bytes(b"scan")
+
+    report = documents.remove_document(
+        conn, seeded["doc"], sources_dir=sources, purge_blob=True, apply=True
+    )
+    assert report.blob_purged is True
+    assert not blob.exists()
+    assert not blob.parent.exists()      # empty shard dir cleaned up
+
+
+def test_rm_purge_blob_without_a_sources_dir_is_refused(seeded):
+    with pytest.raises(ValueError):
+        documents.remove_document(seeded["conn"], seeded["doc"], purge_blob=True)
+
+
+def test_rm_unknown_document_raises(conn):
+    with pytest.raises(documents.DocumentNotFoundError):
+        documents.remove_document(conn, 999)
+
+
+# --- CLI surface ------------------------------------------------------------
+
+
+def _run(tmp_path, *argv):
+    return cli.main(["--db", str(tmp_path / "cli.db"), *argv])
+
+
+@pytest.fixture()
+def cli_ready(tmp_path):
+    """Migrated DB, two people, one ingested+committed document owned by jane."""
+    assert _run(tmp_path, "migrate") == 0
+    assert _run(tmp_path, "person", "add", "--slug", "jane-doe", "--name", "Jane") == 0
+    assert _run(tmp_path, "person", "add", "--slug", "john-doe", "--name", "John") == 0
+    scan = tmp_path / "scan.txt"
+    scan.write_bytes(b"hba1c 5.7 percent")
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources"), "--ocr-text-file",
+                str(scan)) == 0
+    payload = tmp_path / "extract.json"
+    payload.write_text(json.dumps(RECORDS), encoding="utf-8")
+    assert _run(tmp_path, "commit-extraction", "--document", "1",
+                "--json", str(payload)) == 0
+    return tmp_path
+
+
+def test_cli_document_list_empty(tmp_path, capsys):
+    assert _run(tmp_path, "migrate") == 0
+    capsys.readouterr()
+    assert _run(tmp_path, "document", "list") == 0
+    assert "no documents yet" in capsys.readouterr().out
+
+
+def test_cli_document_list_and_json(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "list") == 0
+    out = capsys.readouterr().out
+    assert "#1" in out and "jane-doe" in out and "5 rec" in out
+
+    assert _run(cli_ready, "document", "list", "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["record_count"] == 5
+    assert payload[0]["has_ocr_text"] is True
+    assert "ocr_text" not in payload[0]
+
+
+def test_cli_document_list_unknown_person_fails(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "list", "--person", "nobody") == 1
+    assert "no person with slug" in capsys.readouterr().err
+
+
+def test_cli_document_edit(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "edit", "1", "--category", "imaging") == 0
+    assert "imaging" in capsys.readouterr().out
+    assert _run(cli_ready, "document", "edit", "1") == 1
+    assert "nothing to update" in capsys.readouterr().err
+    assert _run(cli_ready, "document", "edit", "999", "--category", "labs") == 1
+    assert "no document with id" in capsys.readouterr().err
+
+
+def test_cli_document_reassign_dry_run_then_apply(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "reassign", "1", "--person", "john-doe") == 0
+    out = capsys.readouterr().out
+    assert "jane-doe -> john-doe" in out
+    assert "dry run: 5 record(s) would move" in out and "--apply" in out
+
+    assert _run(cli_ready, "document", "reassign", "1", "--person", "john-doe",
+                "--apply") == 0
+    assert "reassigned 5 record(s)" in capsys.readouterr().out
+
+    # The move is visible to the person-scoped reads.
+    assert _run(cli_ready, "query", "labs", "--person", "john-doe") == 0
+    assert "HbA1c" in capsys.readouterr().out
+    assert _run(cli_ready, "query", "labs", "--person", "jane-doe") == 0
+    assert "no lab results" in capsys.readouterr().out
+
+    assert _run(cli_ready, "document", "reassign", "1", "--person", "john-doe") == 0
+    assert "already owned by" in capsys.readouterr().out
+
+
+def test_cli_document_reassign_json(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "reassign", "1", "--person", "john-doe",
+                "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["applied"] is False and payload["to"] == "john-doe"
+    assert len(payload["moved"]) == 5
+
+
+def test_cli_document_reassign_unknown_person_fails(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "reassign", "1", "--person", "nobody") == 1
+    assert "no person with slug" in capsys.readouterr().err
+
+
+def test_cli_document_rm_dry_run_then_apply(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "rm", "1") == 0
+    out = capsys.readouterr().out
+    assert "records: 5 total" in out and "blob kept" in out
+    assert "dry run: nothing was deleted" in out
+
+    assert _run(cli_ready, "document", "rm", "1", "--apply") == 0
+    assert "removed document #1" in capsys.readouterr().out
+    assert _run(cli_ready, "document", "list") == 0
+    assert "no documents yet" in capsys.readouterr().out
+
+
+def test_cli_document_rm_purge_blob(cli_ready, capsys):
+    sources = cli_ready / "sources"
+    blobs = [p for p in sources.rglob("*") if p.is_file()]
+    assert len(blobs) == 1
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "rm", "1", "--apply", "--purge-blob",
+                "--sources", str(sources)) == 0
+    assert "blob deleted" in capsys.readouterr().out
+    assert not blobs[0].exists()
+
+
+def test_cli_document_rm_unknown_id_fails(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "rm", "999") == 1
+    assert "no document with id" in capsys.readouterr().err
+
+
+def test_cli_document_output_is_console_safe(cli_ready, capsys):
+    """Issue #23 convention: static CLI strings must survive cp437/cp1252."""
+    capsys.readouterr()
+    for argv in (
+        ("document", "list"),
+        ("document", "reassign", "1", "--person", "john-doe"),
+        ("document", "rm", "1"),
+    ):
+        assert _run(cli_ready, *argv) == 0
+        captured = capsys.readouterr()
+        for text in (captured.out, captured.err):
+            assert text.isascii(), repr(text)
+            text.encode("cp437")


### PR DESCRIPTION
## Summary

Adds `pemr document list|edit|reassign|rm` — recovery for a misfiled document (wrong person, or wrong doc-date/category/provider). Closes #54.

- `document list [--person <slug>]` — newest first; omit `--person` to list every person's documents.
- `document edit <id> [--doc-date|--category|--provider ...]` — partial update; pass `""` to clear a field. `dedup_key` is untouched.
- `document reassign <id> --person <slug> [--apply]` — moves a document and its records to another person, re-deriving `dedup_key` for every attached row (dry run by default). Refuses on a dictionary-drift or collision the same way `rekey` does.
- `document rm <id> [--apply] [--purge-blob]` — cascade-deletes the attached records and FTS entries, and optionally the content-addressed blob (dry run by default; `--purge-blob` deletion is irreversible).

Both `reassign` and `rm` see conflicts staged **against** a document's rows, not just conflicts the document itself raised — `_conflicts_anchored_to()` closes the two-ended-conflict gap audit caught in `2adfb65`: a conflict has two ends (the document that raised it, and the document whose row it's anchored to via `dedup_key`), and only the raiser was reachable from `document_id` before this fix. `reassign` refuses on the union of both ends; `rm` reports and deletes the union, so no `rm`/`reassign` can leave an OPEN conflict pointing at a `dedup_key` that no longer matches a live row (the silent-loss route: a later `resolve --keep incoming` would `UPDATE` zero rows, stamp `resolved`, and return rc 0).

307 tests passing (45 in `tests/test_documents.py`, 7 new since the anchor fix). `npm run check:meta-drift` passes.

## Docs

`docs/Architecture.md` §5 CLI block updated with the four new commands (not enforced by `check:meta-drift`, so ship adds it by hand).

## Non-blocking items carried from audit (do not block this PR)

1. `rm --purge-blob` **dry run** still prints `blob would be deleted:` for a blob that's already missing (`cli.py:446` gates the correct `blob already gone:` branch on `report.applied`). Cosmetic — the `--apply` path (the one that matters) reports it correctly.
2. The new `DELETE FROM conflict WHERE conflict_id IN (…)` binds one variable per doomed conflict. Bundled SQLite is 3.45 (parameter limit 32766) — a theoretical ceiling only, not reachable at any realistic corpus size.

## Deferred — needs a human to file separately (out of #54's scope)

`dedup.resolve_conflict(keep='incoming')` silently `UPDATE`s zero rows (rc 0, no error) when its target row is already gone, and `dedup.rekey` does not rewrite `conflict.dedup_key` (`pemr/dedup.py` ~lines 632-666). Both #54-reachable routes into this hole are closed by `25d872a`, but the underlying shared-code gap in `dedup.py` remains and should be tracked as its own issue.

## Test plan

- [x] `python -m pytest -q` — 307 passed
- [x] `npm run check:meta-drift` — passed
- [x] Verify + audit both re-exercised the real CLI live (see issue #54 comments) — cross-document/two-ended conflict scenarios, collision/dictionary-drift refusals, blob purge paths, `record_fts` orphan checks
