### PR TITLE
restore/verify: add a tested restore path for pemr backup snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Full design — schema, dedup algorithm, ingest pipeline, tool surface, backup �
 
 Design is locked; build proceeds in phases (skeleton → ingest/dedup → query → render → MCP →
 backup → care-gap rules) per the Architecture doc. **Phase 1 (skeleton) is done**: package
-layout, `migrations/001_init.sql`, `pemr migrate`, `pemr person add|list|show`, config, CI.
+layout, `migrations/001_init.sql`, `pemr migrate --create` (bootstrap a new archive; plain
+`pemr migrate` applies migrations to an existing one and will never create a database),
+`pemr person add|list|show`, config, CI.
 **Phase 2 (ingest + two-layer dedup) is done**: content-hash blob store + commit-extraction
 (`pemr ingest`), semantic dedup keys with conflict staging (`migrations/002_conflict.sql`,
 `pemr review-conflicts`), starter analyte/name dictionary. **Phase 3 (query layer) is done**:
@@ -52,7 +54,12 @@ fields (`migrations/003_fts.sql`, `pemr find`), and lab `pemr trends` — all wi
 ## Data / privacy posture
 
 Local-first. The live `pemr.db` sits on a **non-synced** local path (WAL sidecars corrupt
-under cloud sync); only clean `VACUUM INTO` snapshots sync to Drive/OneDrive. Private-ish,
+under cloud sync); only clean `VACUUM INTO` snapshots sync to Drive/OneDrive. Going the
+other way is `pemr restore latest` — it validates the snapshot, banks a rescue copy of
+whatever it replaces, clears stale WAL sidecars, migrates forward, and reports row counts
+plus source-blob resolution (`pemr verify` runs that report on its own). What backups do
+*not* cover — same-day loss, and pinning a snapshot against rotation — is spelled out in
+[Architecture §8](docs/Architecture.md#8-backup--safety). Private-ish,
 not encrypted-at-rest by default — an encrypted-snapshot upgrade is a drop-in later. No
 HIPAA/PHI compliance layer and no provider interoperability; this is a personal archive, and
 it assists appointment prep and research — it does not give clinical advice.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -281,7 +281,9 @@ pemr render summary --person jane        > exports/jane-summary.md
 pemr render brief --appointment <id>     > exports/brief.md
 pemr render journal --person jane        > exports/jane-journal.md
 pemr backup                                              # VACUUM INTO snapshot
-pemr migrate                                             # apply pending migrations
+pemr restore latest [--force]                            # install a snapshot back over pemr.db (§8)
+pemr verify                                              # integrity + row counts + source-blob resolution
+pemr migrate [--create]                                  # apply pending migrations (--create bootstraps a new DB)
 pemr rekey [--apply]                                     # re-derive dedup keys after a dictionary edit
 ```
 
@@ -343,14 +345,74 @@ Because they regenerate from truth, they never drift. Old exports are disposable
 - Live `pemr.db` on a **local-only** path (out of the sync root) — WAL mode means
   `-wal`/`-shm` sidecars that cloud sync loves to corrupt mid-write.
 - `pemr backup` → `VACUUM INTO backups/pemr-YYYYMMDD-HHMM.sqlite` (a clean,
-  single-file, consistent snapshot), then the file lands in the synced folder. Point-in-
-  time restore = copy a snapshot back.
+  single-file, consistent snapshot), then the file lands in the synced folder. Every
+  snapshot is `integrity_check`ed at *write* time, before rotation can run — an
+  unreadable backup discovered at restore time is the classic failure mode, so a bad
+  snapshot is unlinked and the command fails instead of pruning good snapshots to make
+  room for a worthless one.
 - Rotation: keep last N daily + M weekly; prune older.
 - Optional: run `pemr backup` from Windows Task Scheduler nightly.
 - `sources/` (content-addressed originals) can also sync — they're immutable blobs, safe
   for sync, and give you off-machine copies of the irreplaceable scans.
 - Exposure posture per your call: private-ish, not encrypted-at-rest. Easy upgrade later
   — snapshot to an encrypted 7-Zip/age file before it syncs — without touching the schema.
+
+### Restore
+
+`pemr restore <snapshot|latest> [--force]` is the other direction. It is a command
+rather than a runbook because every failure mode here is operator error under pressure,
+and a command is testable (§5, "the tested engine"):
+
+1. **Validate the source first.** Opens as SQLite, passes `integrity_check`, and has a
+   pemr schema. Any failure aborts with the live DB untouched.
+2. **Guard the destination.** No live DB (the actual disaster) → proceeds with no flag;
+   the ergonomics are deliberately easiest when the user is panicking. A live DB present
+   → requires `--force`.
+3. **Rescue copy.** With `--force`, the current database is snapshotted to
+   `pemr-prerestore-YYYYMMDD-HHMMSS.sqlite` *before* anything is overwritten; if that
+   fails, the restore aborts. Restore is therefore non-destructive by construction.
+4. **Clear the sidecars.** `pemr.db-wal` / `pemr.db-shm` are deleted, so SQLite cannot
+   replay a stale WAL over the restored file.
+5. **Install atomically.** Staged as `pemr.db.restore-tmp` in the destination directory,
+   then `os.replace`d — a crash mid-install never leaves a half-written database.
+6. **Migrate.** A snapshot older than the code is the *normal* case; making the operator
+   remember this step is exactly the trap.
+7. **Verify.** Prints the `pemr verify` report: integrity, migrations, per-table row
+   counts, and blob resolution.
+
+`pemr verify` runs step 7 on its own, any time. Blob checking is exact rather than
+heuristic — `document` stores both `sha256` and a relative content-addressed
+`source_path`, so verify resolves `sources_dir/source_path`, re-hashes, and reports
+*missing* separately from *mismatched* (a corrupted blob is a different problem from an
+unsynced one). Blob problems are a **warning at rc=0** during restore: the database
+restore genuinely succeeded, and `sources/` may simply be mid-sync. `verify` reports,
+it never repairs.
+
+**`migrate` will not create a database.** Before this existed, a user whose `pemr.db`
+had vanished was told `run pemr migrate first` by every read command — and following
+that advice built a brand-new empty database and reported success, manufacturing a
+convincing empty archive. Worse, that empty DB was then a valid backup source, so the
+next `pemr backup` snapshotted it and rotation could prune the real snapshots. `migrate`
+now refuses when there is no database (or a zero-byte one) and points at
+`pemr restore latest`; `pemr migrate --create` is the explicit bootstrap for a genuinely
+new archive.
+
+### What backups do not protect you from
+
+- **Same-day loss.** Rotation keeps the *newest* snapshot per calendar day, so intra-day
+  snapshots collapse: "I corrupted the DB an hour ago" is generally **not** recoverable
+  from backups alone, because today's earlier snapshots are already gone. Take a
+  snapshot before any bulk or destructive operation (`rekey --apply`, bulk ingest) —
+  that is necessary, not optional, since it is protected only until the next backup of
+  the same day.
+- **Pinning a snapshot** is the escape hatch: rotation only ever parses and prunes names
+  matching `pemr-<8 digits>-<4|6 digits>.sqlite`, so *renaming* a snapshot off that
+  pattern makes it permanent. This is the same mechanism that makes
+  `pemr-prerestore-*.sqlite` rescue copies immune to rotation by construction.
+- **Blobs.** The DB and `sources/` are separate; a DB restored from a snapshot newer
+  than the sources backup references blobs that aren't there. `pemr restore` and
+  `pemr verify` report this, but restoring `sources/` itself is out of scope — blobs are
+  immutable and separately synced.
 
 ---
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -371,22 +371,30 @@ and a command is testable (§5, "the tested engine"):
 3. **Rescue copy.** With `--force`, the current database is snapshotted to
    `pemr-prerestore-YYYYMMDD-HHMMSS.sqlite` *before* anything is overwritten; if that
    fails, the restore aborts. Restore is therefore non-destructive by construction.
-4. **Clear the sidecars.** `pemr.db-wal` / `pemr.db-shm` are deleted, so SQLite cannot
-   replay a stale WAL over the restored file.
-5. **Install atomically.** Staged as `pemr.db.restore-tmp` in the destination directory,
-   then `os.replace`d — a crash mid-install never leaves a half-written database.
+4. **Install atomically.** Staged as `pemr.db.restore-tmp` in the destination directory,
+   then `os.replace`d — a crash mid-install never leaves a half-written database, and a
+   failed *copy* has destroyed nothing.
+5. **Clear the sidecars**, and only now. `pemr.db-wal` / `pemr.db-shm` are deleted, so
+   SQLite cannot replay a stale WAL over the restored file. Deliberately after the
+   install rather than before: a stale `-wal` holds committed-but-uncheckpointed
+   transactions, so deleting it on a path that then failed to install would be the one
+   way this command could lose data. Nothing opens the database in between.
 6. **Migrate.** A snapshot older than the code is the *normal* case; making the operator
    remember this step is exactly the trap.
 7. **Verify.** Prints the `pemr verify` report: integrity, migrations, per-table row
    counts, and blob resolution.
+
+Every abort path up to and including step 4 leaves the live database exactly as it was.
 
 `pemr verify` runs step 7 on its own, any time. Blob checking is exact rather than
 heuristic — `document` stores both `sha256` and a relative content-addressed
 `source_path`, so verify resolves `sources_dir/source_path`, re-hashes, and reports
 *missing* separately from *mismatched* (a corrupted blob is a different problem from an
 unsynced one). Blob problems are a **warning at rc=0** during restore: the database
-restore genuinely succeeded, and `sources/` may simply be mid-sync. `verify` reports,
-it never repairs.
+restore genuinely succeeded, and `sources/` may simply be mid-sync. Standalone `pemr
+verify` is the opposite — it exits **1** whenever the report lists a problem, in `--json`
+mode exactly as in console mode, because `--json` is the mode a monitoring job picks and
+the exit code is what such a job checks. `verify` reports, it never repairs.
 
 **`migrate` will not create a database.** Before this existed, a user whose `pemr.db`
 had vanished was told `run pemr migrate first` by every read command — and following
@@ -396,6 +404,15 @@ next `pemr backup` snapshotted it and rotation could prune the real snapshots. `
 now refuses when there is no database (or a zero-byte one) and points at
 `pemr restore latest`; `pemr migrate --create` is the explicit bootstrap for a genuinely
 new archive.
+
+**And an empty database is not a backup source.** Closing the `migrate` route above only
+closed the first link of that chain — a zero-byte or schema-less `pemr.db` arriving any
+other way (an interrupted copy, cloud-sync debris, `type nul > pemr.db`) would still have
+been snapshotted happily, because `VACUUM INTO` on an empty file produces a structurally
+valid, integrity-clean 4 KB database that rotation then treats as the newest snapshot of
+the day. `pemr backup` therefore refuses a database that does not exist, is zero bytes,
+or has no pemr schema, *before* writing anything — so rotation is never reached and the
+real snapshots survive.
 
 ### What backups do not protect you from
 

--- a/pemr/backup.py
+++ b/pemr/backup.py
@@ -74,7 +74,14 @@ def integrity_check(path: str | Path) -> str:
 
     A file that will not even open as SQLite reports the sqlite error text, so callers
     have a single string to test against ``"ok"``.
+
+    A path that does not exist is a failure, not ``"ok"``: ``sqlite3.connect`` creates
+    eagerly and an empty database passes ``integrity_check``, so without this guard the
+    function would answer "healthy" *and* leave behind the zero-byte debris that
+    :func:`pemr.db.database_exists` exists to reject.
     """
+    if not Path(path).is_file():
+        return f"no such file: {path}"
     try:
         conn = sqlite3.connect(path)
         try:

--- a/pemr/backup.py
+++ b/pemr/backup.py
@@ -14,6 +14,11 @@ part of the contract, not incidental:
   protected snapshot is always retained.
 * Prune only ever deletes files whose names match the ``pemr-*.sqlite`` pattern this
   command creates — anything else in the directory is out of scope by construction.
+* Every snapshot is read back and ``PRAGMA integrity_check``-ed *before*
+  :func:`snapshot` returns, so a corrupt snapshot can never reach :func:`rotate` and
+  prune good snapshots to make room for a worthless one (issue #55). An unreadable
+  backup discovered at restore time is the classic backup failure; this is the check
+  that makes it discovered at write time instead.
 
 Timestamps are **local time** (single-machine personal tool; Task Scheduler fires on
 wall-clock and "daily/weekly" should track the user's calendar) and are parsed from
@@ -64,8 +69,37 @@ def _parse_ts(name: str) -> datetime | None:
         return None
 
 
+def integrity_check(path: str | Path) -> str:
+    """``PRAGMA integrity_check`` on ``path``; returns ``"ok"`` or the failure text.
+
+    A file that will not even open as SQLite reports the sqlite error text, so callers
+    have a single string to test against ``"ok"``.
+    """
+    try:
+        conn = sqlite3.connect(path)
+        try:
+            row = conn.execute("PRAGMA integrity_check").fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        return f"cannot open as sqlite: {exc}"
+    if not row or not row[0]:
+        return "integrity_check returned nothing"
+    return str(row[0])
+
+
+def _unlink_quietly(path: Path) -> None:
+    try:
+        path.unlink()
+    except OSError:  # already gone / locked - nothing useful to do here
+        pass
+
+
 def snapshot(
-    db_path: str | Path, backup_dir: str | Path, now: datetime | None = None
+    db_path: str | Path,
+    backup_dir: str | Path,
+    now: datetime | None = None,
+    name: str | None = None,
 ) -> tuple[Path, int]:
     """Write a ``VACUUM INTO`` snapshot of ``db_path`` into ``backup_dir``.
 
@@ -75,7 +109,18 @@ def snapshot(
     the seconds-precision name exists the underlying error propagates as
     :class:`BackupError` rather than clobbering a file.
 
-    Raises :class:`BackupError` if the DB file is missing or the vacuum fails.
+    ``name`` overrides the generated filename verbatim (no timestamp, no collision
+    fallback), keeping the refuse-to-overwrite behavior. :mod:`pemr.restore` uses it
+    for the ``pemr-prerestore-*.sqlite`` rescue copy: that name deliberately does not
+    match :data:`_SNAPSHOT_RE`, so by the module contract above rotation can never
+    parse or prune it.
+
+    The written snapshot is verified (:func:`integrity_check`) before returning; a
+    snapshot that fails is unlinked and raises :class:`BackupError`, so a corrupt
+    file never survives to be rotated against.
+
+    Raises :class:`BackupError` if the DB file is missing, the vacuum fails, or the
+    result does not verify.
     """
     db_path = Path(db_path)
     if not db_path.is_file():
@@ -88,9 +133,16 @@ def snapshot(
         raise BackupError(f"cannot create backup dir {backup_dir}: {exc}") from exc
 
     now = now or datetime.now()
-    target = backup_dir / _snapshot_name(now, seconds=False)
-    if target.exists():
-        target = backup_dir / _snapshot_name(now, seconds=True)
+    if name is not None:
+        target = backup_dir / name
+    else:
+        target = backup_dir / _snapshot_name(now, seconds=False)
+        if target.exists():
+            target = backup_dir / _snapshot_name(now, seconds=True)
+
+    # Whether the target predates this call decides whether a failure may clean it up:
+    # never unlink a file we did not write (that is the never-overwrite contract).
+    pre_existing = target.exists()
 
     conn = sqlite3.connect(db_path)
     try:
@@ -98,9 +150,16 @@ def snapshot(
         # INSERT/UPDATE/DELETE/REPLACE) and refuses to overwrite an existing target.
         conn.execute("VACUUM INTO ?", (str(target),))
     except sqlite3.Error as exc:
+        if not pre_existing and target.exists():
+            _unlink_quietly(target)  # partial write from a failed vacuum
         raise BackupError(f"snapshot failed: {exc}") from exc
     finally:
         conn.close()
+
+    result = integrity_check(target)
+    if result != "ok":
+        _unlink_quietly(target)
+        raise BackupError(f"snapshot failed verification: {result}")
 
     return target, target.stat().st_size
 

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sqlite3
 import sys
 import tomllib
 from dataclasses import asdict
@@ -728,9 +729,56 @@ def _cmd_render_journal(args: argparse.Namespace) -> int:
 # Phase 6: backup (VACUUM INTO snapshot + rotation)
 # --------------------------------------------------------------------------- #
 
+def _backup_source_problem(db_path: Path) -> str | None:
+    """None if ``db_path`` is a real archive, else the refusal to print.
+
+    Returns text rather than raising so `backup` keeps its established rc=1 shape.
+
+    Issue #55: `backup.snapshot` only checks that the file *exists*, so a zero-byte or
+    schema-less `pemr.db` used to produce a structurally valid (and therefore
+    integrity-clean) 4 KB snapshot at rc=0 - which then became a legitimate rotation
+    candidate and could prune the real snapshots. That is the exact chain the issue's
+    drill describes: an empty archive becomes a valid backup source and eats the
+    backups. The `migrate` gate closed the route that manufactured the empty database;
+    this closes every other route into it.
+
+    Deliberately not inside `backup.snapshot`: `pemr restore --force` snapshots the
+    live database as a rescue copy precisely when that database may be damaged, and
+    banking a damaged database is still better than discarding it.
+    """
+    if not db.database_exists(db_path):
+        return _no_database_message(db_path)
+    # A bare sqlite3 connection, not db.connect: this must not flip journal_mode on a
+    # database it is about to refuse, and a file that will not read at all is not this
+    # function's story to tell - backup.snapshot reports the real sqlite error.
+    try:
+        conn = sqlite3.connect(db_path)
+    except sqlite3.Error:
+        return None
+    try:
+        migrated = db.is_migrated(conn)
+    except sqlite3.DatabaseError:
+        return None
+    finally:
+        conn.close()
+    if migrated:
+        return None
+    return (
+        f"error: {db_path} has no pemr schema - refusing to snapshot it\n"
+        "a snapshot of an empty database is worthless, and rotation could prune your "
+        "real snapshots to keep it.\n"
+        "  - restoring after data loss?  pemr restore latest\n"
+        "  - starting a new archive?     pemr migrate --create"
+    )
+
+
 def _cmd_backup(args: argparse.Namespace) -> int:
     db_path = _resolve_db_path(args)
     backup_dir = _resolve_backup_dir(args)
+    problem = _backup_source_problem(db_path)
+    if problem is not None:
+        print(problem, file=sys.stderr)
+        return 1
     try:
         snap, size = backup.snapshot(db_path, backup_dir)
     except backup.BackupError as exc:
@@ -826,11 +874,14 @@ def _cmd_verify(args: argparse.Namespace) -> int:
         report = verify.verify_report(conn, _resolve_sources_dir_optional(args))
     finally:
         conn.close()
+    # Both modes share the exit code: `--json` is what a monitoring cron picks, and a
+    # verification command that reports success on a failed verification is worse than
+    # useless there (the `ok` field is not what scripts check).
     if args.json:
         _print_json(report.as_dict())
-        return 0
-    for line in verify.format_report(report):
-        print(line)
+    else:
+        for line in verify.format_report(report):
+            print(line)
     return 0 if report.ok else 1
 
 

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -15,7 +15,7 @@ import tomllib
 from dataclasses import asdict
 from pathlib import Path
 
-from . import __version__, backup, db, dedup, ingest, persons, query, render
+from . import __version__, backup, db, dedup, ingest, persons, query, render, restore, verify
 
 # Shipped starter analyte/name dictionary (framework, not user data — see .gitignore).
 _DEFAULT_DICTIONARY = Path(__file__).resolve().parent.parent / "data" / "dictionary.example.toml"
@@ -52,7 +52,52 @@ def _resolve_db_path(args: argparse.Namespace) -> Path:
     )
 
 
+def _no_database_message(db_path: Path) -> str:
+    """The refusal shown when a command needs a database and there isn't one.
+
+    Issue #55: the old advice here was `pemr migrate`, which happily created a brand-new
+    empty database and reported success - manufacturing a convincing empty archive for
+    the exact user whose data just vanished (and then feeding it to the next `pemr
+    backup`, whose rotation could prune the real snapshots). ASCII only (issue #23).
+    """
+    return (
+        f"error: no database at {db_path}\n"
+        "nothing was created - pemr will not conjure an empty archive over a missing "
+        "database.\n"
+        "  - restoring after data loss?  pemr restore latest\n"
+        "  - starting a new archive?     pemr migrate --create"
+    )
+
+
+def _connect_db(args: argparse.Namespace):
+    """Resolve the DB path, refuse if there is no database there, then connect.
+
+    Every CLI command that reads or writes the archive goes through here; the MCP
+    wrapper applies the same gate (:func:`pemr.mcp_server._connect`). `pemr migrate
+    --create` is the one documented way past it.
+    """
+    db_path = _resolve_db_path(args)
+    if not db.database_exists(db_path):
+        raise SystemExit(_no_database_message(db_path))
+    return db.connect(db_path)
+
+
 def _resolve_sources_dir(args: argparse.Namespace) -> Path:
+    sources_dir = _resolve_sources_dir_optional(args)
+    if sources_dir is None:
+        raise SystemExit(
+            "error: no sources dir - pass --sources, set PEMR_SOURCES, or set "
+            "[paths].sources_dir in config.toml (see config.example.toml)"
+        )
+    return sources_dir
+
+
+def _resolve_sources_dir_optional(args: argparse.Namespace) -> Path | None:
+    """As :func:`_resolve_sources_dir`, but None instead of exiting.
+
+    `restore`/`verify` must still report on the database when `sources/` is
+    unconfigured - the blob pass is skipped with a note, not fatal.
+    """
     override = getattr(args, "sources", None)
     if override:
         return Path(override)
@@ -62,13 +107,11 @@ def _resolve_sources_dir(args: argparse.Namespace) -> Path:
     sources_dir = _load_config(args).get("paths", {}).get("sources_dir")
     if sources_dir:
         return Path(sources_dir)
-    raise SystemExit(
-        "error: no sources dir - pass --sources, set PEMR_SOURCES, or set "
-        "[paths].sources_dir in config.toml (see config.example.toml)"
-    )
+    return None
 
 
-def _resolve_backup_dir(args: argparse.Namespace) -> Path:
+def _resolve_backup_dir_optional(args: argparse.Namespace) -> Path | None:
+    """Backup dir if configured, else None (`restore <path>` does not need one)."""
     override = getattr(args, "backup_dir", None)
     if override:
         return Path(override)
@@ -78,10 +121,17 @@ def _resolve_backup_dir(args: argparse.Namespace) -> Path:
     backup_dir = _load_config(args).get("paths", {}).get("backup_dir")
     if backup_dir:
         return Path(backup_dir)
-    raise SystemExit(
-        "error: no backup dir — pass --backup-dir, set PEMR_BACKUP_DIR, or set "
-        "[paths].backup_dir in config.toml (see config.example.toml)"
-    )
+    return None
+
+
+def _resolve_backup_dir(args: argparse.Namespace) -> Path:
+    backup_dir = _resolve_backup_dir_optional(args)
+    if backup_dir is None:
+        raise SystemExit(
+            "error: no backup dir — pass --backup-dir, set PEMR_BACKUP_DIR, or set "
+            "[paths].backup_dir in config.toml (see config.example.toml)"
+        )
+    return backup_dir
 
 
 def _resolve_retention(args: argparse.Namespace) -> tuple[int, int]:
@@ -121,7 +171,12 @@ def _resolve_dictionary_path(args: argparse.Namespace) -> Path | None:
 
 
 def _cmd_migrate(args: argparse.Namespace) -> int:
-    conn = db.connect(_resolve_db_path(args))
+    # The one command allowed to create a database - and only with --create. Without it
+    # `migrate` applies migrations to an existing database and nothing else (issue #55).
+    db_path = _resolve_db_path(args)
+    if not db.database_exists(db_path) and not args.create:
+        raise SystemExit(_no_database_message(db_path))
+    conn = db.connect(db_path)
     try:
         applied = db.migrate(conn, args.migrations_dir or db.DEFAULT_MIGRATIONS_DIR)
     finally:
@@ -135,7 +190,7 @@ def _cmd_migrate(args: argparse.Namespace) -> int:
 
 
 def _cmd_person_add(args: argparse.Namespace) -> int:
-    conn = db.connect(_resolve_db_path(args))
+    conn = _connect_db(args)
     try:
         try:
             person = persons.add_person(
@@ -157,7 +212,7 @@ def _cmd_person_add(args: argparse.Namespace) -> int:
 
 
 def _cmd_person_list(args: argparse.Namespace) -> int:
-    conn = db.connect(_resolve_db_path(args))
+    conn = _connect_db(args)
     try:
         people = persons.list_people(conn, include_inactive=args.all_people)
     finally:
@@ -180,7 +235,7 @@ def _print_person(person) -> None:
 
 
 def _cmd_person_show(args: argparse.Namespace) -> int:
-    conn = db.connect(_resolve_db_path(args))
+    conn = _connect_db(args)
     try:
         person = persons.get_person(conn, args.slug)
     finally:
@@ -207,7 +262,7 @@ def _cmd_person_edit(args: argparse.Namespace) -> int:
     if args.notes is not None:
         fields["notes"] = args.notes
 
-    conn = db.connect(_resolve_db_path(args))
+    conn = _connect_db(args)
     try:
         try:
             person = persons.update_person(conn, args.slug, **fields)
@@ -224,7 +279,7 @@ def _cmd_person_edit(args: argparse.Namespace) -> int:
 
 
 def _cmd_person_deactivate(args: argparse.Namespace) -> int:
-    conn = db.connect(_resolve_db_path(args))
+    conn = _connect_db(args)
     try:
         try:
             person = persons.deactivate_person(conn, args.slug)
@@ -238,7 +293,7 @@ def _cmd_person_deactivate(args: argparse.Namespace) -> int:
 
 
 def _cmd_person_reactivate(args: argparse.Namespace) -> int:
-    conn = db.connect(_resolve_db_path(args))
+    conn = _connect_db(args)
     try:
         try:
             person = persons.reactivate_person(conn, args.slug)
@@ -252,7 +307,7 @@ def _cmd_person_reactivate(args: argparse.Namespace) -> int:
 
 
 def _cmd_person_remove(args: argparse.Namespace) -> int:
-    conn = db.connect(_resolve_db_path(args))
+    conn = _connect_db(args)
     try:
         try:
             person = persons.remove_person(conn, args.slug)
@@ -278,7 +333,7 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
             print(f"error: cannot read {args.ocr_text_file}: {exc}", file=sys.stderr)
             return 1
 
-    conn = db.connect(_resolve_db_path(args))
+    conn = _connect_db(args)
     try:
         try:
             result = ingest.ingest_document(
@@ -333,7 +388,7 @@ def _cmd_commit_extraction(args: argparse.Namespace) -> int:
         print(f"error: {args.json} is not valid JSON: {exc}", file=sys.stderr)
         return 1
 
-    conn = db.connect(_resolve_db_path(args))
+    conn = _connect_db(args)
     try:
         dictionary = dedup.load_dictionary(_resolve_dictionary_path(args))
         try:
@@ -363,7 +418,7 @@ def _cmd_commit_extraction(args: argparse.Namespace) -> int:
 
 
 def _cmd_rekey(args: argparse.Namespace) -> int:
-    conn = db.connect(_resolve_db_path(args))
+    conn = _connect_db(args)
     try:
         dictionary = dedup.load_dictionary(_resolve_dictionary_path(args))
         try:
@@ -413,7 +468,7 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
 
 
 def _cmd_review_conflicts(args: argparse.Namespace) -> int:
-    conn = db.connect(_resolve_db_path(args))
+    conn = _connect_db(args)
     try:
         try:
             if args.resolve is not None:
@@ -475,7 +530,7 @@ def _fmt(value: object) -> str:
 def _with_conn_person(args: argparse.Namespace, work):
     """Open the DB, run ``work(conn)``, translating the two friendly failure modes
     (un-migrated DB, unknown person slug) into an rc=1 stderr message."""
-    conn = db.connect(_resolve_db_path(args))
+    conn = _connect_db(args)
     try:
         try:
             return work(conn)
@@ -629,7 +684,7 @@ def _emit_markdown(markdown: str, out: str | None) -> int:
 def _render_with_conn(args: argparse.Namespace, work) -> int:
     """Open the DB, run ``work(conn)``, translating render's friendly failures
     (un-migrated DB, unknown person slug, unknown appointment id) into rc=1 stderr."""
-    conn = db.connect(_resolve_db_path(args))
+    conn = _connect_db(args)
     try:
         try:
             return work(conn)
@@ -711,6 +766,74 @@ def _cmd_backup(args: argparse.Namespace) -> int:
     return 0
 
 
+# --------------------------------------------------------------------------- #
+# Issue #55: restore (the other direction) + verify (DB + blob health)
+# --------------------------------------------------------------------------- #
+
+def _cmd_restore(args: argparse.Namespace) -> int:
+    db_path = _resolve_db_path(args)
+    try:
+        result = restore.restore(
+            args.snapshot,
+            db_path,
+            backup_dir=_resolve_backup_dir_optional(args),
+            sources_dir=_resolve_sources_dir_optional(args),
+            migrations_dir=args.migrations_dir,
+            force=args.force,
+        )
+    except restore.RestoreError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    report = result.report
+    if args.json:
+        _print_json({
+            "snapshot": str(result.snapshot),
+            "database": str(result.db_path),
+            "rescue": str(result.rescue) if result.rescue else None,
+            "cleared_sidecars": [str(p) for p in result.cleared_sidecars],
+            "applied_migrations": result.applied_migrations,
+            "report": report.as_dict() if report else None,
+        })
+        return 0
+
+    if result.rescue:
+        print(f"rescue copy of the previous database: {result.rescue}")
+    for sidecar in result.cleared_sidecars:
+        print(f"cleared stale sidecar {sidecar.name}")
+    print(f"restored {result.db_path} from {result.snapshot}")
+    if result.applied_migrations:
+        for name in result.applied_migrations:
+            print(f"applied {name}")
+    else:
+        print("migrations up to date")
+    if report is not None:
+        for line in verify.format_report(report):
+            print(line)
+        if not report.ok:
+            # Blob problems are a warning, not a failure: the database restore
+            # genuinely succeeded, and `sources/` may simply be mid-sync.
+            print(
+                "warning: the database restored, but the checks above found problems",
+                file=sys.stderr,
+            )
+    return 0
+
+
+def _cmd_verify(args: argparse.Namespace) -> int:
+    conn = _connect_db(args)
+    try:
+        report = verify.verify_report(conn, _resolve_sources_dir_optional(args))
+    finally:
+        conn.close()
+    if args.json:
+        _print_json(report.as_dict())
+        return 0
+    for line in verify.format_report(report):
+        print(line)
+    return 0 if report.ok else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="pemr", description="Personal EMR engine - SQLite is truth."
@@ -720,9 +843,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--config", help="path to config.toml (default ./config.toml)")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    p_migrate = sub.add_parser("migrate", help="apply pending migrations")
+    p_migrate = sub.add_parser(
+        "migrate", help="apply pending migrations to an existing database"
+    )
     p_migrate.add_argument(
         "--migrations-dir", help="override migrations directory (mainly for tests)"
+    )
+    p_migrate.add_argument(
+        "--create", action="store_true",
+        help="bootstrap a brand-new empty database (required when none exists)",
     )
     p_migrate.set_defaults(func=_cmd_migrate)
 
@@ -935,6 +1064,39 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_backup.add_argument("--json", action="store_true", help="machine-readable output")
     p_backup.set_defaults(func=_cmd_backup)
+
+    # --- issue #55: restore + verify --------------------------------------
+    p_restore = sub.add_parser(
+        "restore",
+        help="install a backup snapshot over the live database (then migrate + verify)",
+    )
+    p_restore.add_argument(
+        "snapshot",
+        help="snapshot path, a bare filename inside the backup dir, or 'latest'",
+    )
+    p_restore.add_argument(
+        "--force", action="store_true",
+        help="allow replacing an existing database (a pemr-prerestore-*.sqlite "
+             "rescue copy is taken first)",
+    )
+    p_restore.add_argument(
+        "--backup-dir", dest="backup_dir",
+        help="where snapshots live (overrides PEMR_BACKUP_DIR / [paths].backup_dir)",
+    )
+    p_restore.add_argument("--sources", help="sources blob dir (overrides config)")
+    p_restore.add_argument(
+        "--migrations-dir", help="override migrations directory (mainly for tests)"
+    )
+    p_restore.add_argument("--json", action="store_true", help="machine-readable output")
+    p_restore.set_defaults(func=_cmd_restore)
+
+    p_verify = sub.add_parser(
+        "verify",
+        help="integrity + migrations + row counts + source blob resolution (read-only)",
+    )
+    p_verify.add_argument("--sources", help="sources blob dir (overrides config)")
+    p_verify.add_argument("--json", action="store_true", help="machine-readable output")
+    p_verify.set_defaults(func=_cmd_verify)
 
     return parser
 

--- a/pemr/db.py
+++ b/pemr/db.py
@@ -25,8 +25,33 @@ class NotMigratedError(RuntimeError):
         super().__init__(message)
 
 
+def database_exists(db_path: str | Path) -> bool:
+    """True if ``db_path`` names a real, non-empty database file.
+
+    Size matters, not just presence: ``sqlite3.connect`` creates the file eagerly and
+    leaves a **zero-byte** file behind when nothing is written, so a stale 0-byte
+    ``pemr.db`` must not be mistaken for an archive. Callers (CLI/MCP) use this to
+    refuse to silently manufacture an empty database over a missing one (issue #55).
+
+    ``:memory:`` is always "existing" — it is the in-process primitive used by tests.
+    """
+    if str(db_path) == ":memory:":
+        return True
+    path = Path(db_path)
+    try:
+        return path.is_file() and path.stat().st_size > 0
+    except OSError:
+        return False
+
+
 def connect(db_path: str | Path) -> sqlite3.Connection:
-    """Open a connection with PEMR's required pragmas applied."""
+    """Open a connection with PEMR's required pragmas applied.
+
+    Deliberately still *creates on connect* — this is the low-level primitive, used
+    with ``:memory:`` and scratch paths throughout the tests. The "refuse to create a
+    database that should already exist" gate lives one layer up, in the CLI/MCP entry
+    points (:func:`database_exists`).
+    """
     db_path = Path(db_path)
     if str(db_path) != ":memory:":
         db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -66,7 +66,16 @@ def _dictionary() -> dict[str, str]:
 
 
 def _connect() -> sqlite3.Connection:
-    return db.connect(_db_path())
+    """Same missing-database gate the CLI applies, raised as a tool error (issue #55).
+
+    Both front doors must give the same answer: neither may silently create an empty
+    archive over a database that has gone missing. The message is shared verbatim with
+    ``cli._connect_db``; only the exception type differs (a server must not SystemExit).
+    """
+    path = _db_path()
+    if not db.database_exists(path):
+        raise ToolError(cli._no_database_message(path))
+    return db.connect(path)
 
 
 def _friendly(exc: Exception) -> ToolError:

--- a/pemr/restore.py
+++ b/pemr/restore.py
@@ -1,0 +1,223 @@
+"""`pemr restore` — install a `pemr backup` snapshot back over the live database.
+
+Issue #55: the backup half was tested, the half that matters on the day the DB is gone
+never had been. A drill proved the *copy* works, so what this module actually buys is
+the operator-error protection the drill exposed, in a form that is testable:
+
+* stale ``-wal`` / ``-shm`` sidecars next to the destination are cleared, so SQLite
+  cannot replay a stale WAL over the freshly restored file;
+* ``migrate`` runs afterwards, because a snapshot older than the code is the normal
+  case and remembering that step is exactly the trap;
+* the source is validated (opens, ``integrity_check``, has a schema) **before**
+  anything on disk is touched, so a corrupt snapshot cannot destroy a live database;
+* restoring over an existing database requires ``--force`` *and* first banks a rescue
+  copy of that database, which makes restore non-destructive by construction.
+
+**The rescue copy's off-pattern name is load-bearing.** :data:`pemr.backup._SNAPSHOT_RE`
+matches only ``pemr-<8 digits>-<4|6 digits>.sqlite``, and the backup module's contract
+guarantees anything else is never parsed and never pruned. So
+``pemr-prerestore-YYYYMMDD-HHMMSS.sqlite`` is immune to rotation by construction --
+including the same-calendar-day collapse that would otherwise eat it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from . import backup, db, verify
+
+# Rescue-copy filename: deliberately outside backup._SNAPSHOT_RE, so rotation is
+# structurally incapable of pruning it (see the module docstring).
+RESCUE_PREFIX = "pemr-prerestore-"
+
+LATEST = "latest"
+
+_SIDECAR_SUFFIXES = ("-wal", "-shm")
+
+
+class RestoreError(RuntimeError):
+    """A restore could not be performed. The live database is left as it was."""
+
+
+@dataclass
+class RestoreResult:
+    snapshot: Path
+    db_path: Path
+    rescue: Path | None = None
+    applied_migrations: list[str] = field(default_factory=list)
+    cleared_sidecars: list[Path] = field(default_factory=list)
+    report: verify.VerifyReport | None = None
+
+
+def latest_snapshot(backup_dir: str | Path) -> Path | None:
+    """Newest snapshot in ``backup_dir`` by *filename* timestamp, or None.
+
+    Filename, never mtime — the backup module's contract, and the only ordering that
+    survives a cloud-sync round trip.
+    """
+    backup_dir = Path(backup_dir)
+    if not backup_dir.is_dir():
+        return None
+    dated: list[tuple[datetime, Path]] = []
+    for path in backup_dir.glob("pemr-*.sqlite"):
+        ts = backup._parse_ts(path.name)
+        if ts is not None:
+            dated.append((ts, path))
+    if not dated:
+        return None
+    dated.sort(key=lambda e: e[0], reverse=True)
+    return dated[0][1]
+
+
+def resolve_snapshot(spec: str, backup_dir: str | Path | None) -> Path:
+    """Resolve the positional arg: an existing path, a bare name, or ``latest``."""
+    if spec == LATEST:
+        if backup_dir is None:
+            raise RestoreError(
+                "`restore latest` needs a backup dir - pass --backup-dir, set "
+                "PEMR_BACKUP_DIR, or set [paths].backup_dir in config.toml"
+            )
+        found = latest_snapshot(backup_dir)
+        if found is None:
+            raise RestoreError(f"no snapshots found in {Path(backup_dir)}")
+        return found
+
+    direct = Path(spec)
+    if direct.is_file():
+        return direct
+    if backup_dir is not None:
+        in_dir = Path(backup_dir) / spec
+        if in_dir.is_file():
+            return in_dir
+    raise RestoreError(f"no such snapshot: {spec}")
+
+
+def _validate_snapshot(snapshot: Path) -> list[str]:
+    """Integrity + schema checks on the source. Returns its applied migrations."""
+    result = backup.integrity_check(snapshot)
+    if result != "ok":
+        raise RestoreError(f"snapshot failed integrity_check: {result}")
+    conn = sqlite3.connect(snapshot)
+    try:
+        conn.row_factory = sqlite3.Row
+        if not db.is_migrated(conn):
+            raise RestoreError(
+                f"{snapshot} has no pemr schema - it is not a pemr snapshot"
+            )
+        return sorted(db.applied_versions(conn))
+    except sqlite3.Error as exc:
+        raise RestoreError(f"cannot read {snapshot}: {exc}") from exc
+    finally:
+        conn.close()
+
+
+def _live_row_total(db_path: Path) -> int | None:
+    """Total rows across the counted tables, for the refuse-without---force message."""
+    try:
+        conn = sqlite3.connect(db_path)
+    except sqlite3.Error:
+        return None
+    try:
+        return sum(verify.row_counts(conn).values())
+    except sqlite3.Error:
+        return None
+    finally:
+        conn.close()
+
+
+def _sidecars(db_path: Path) -> list[Path]:
+    return [db_path.with_name(db_path.name + suffix) for suffix in _SIDECAR_SUFFIXES]
+
+
+def restore(
+    snapshot_spec: str,
+    db_path: str | Path,
+    *,
+    backup_dir: str | Path | None = None,
+    sources_dir: str | Path | None = None,
+    migrations_dir: str | Path | None = None,
+    force: bool = False,
+    now: datetime | None = None,
+) -> RestoreResult:
+    """Install ``snapshot_spec`` over ``db_path``. See the module docstring for order.
+
+    Every abort path leaves the live database exactly as it was. Blob problems are
+    *reported*, never fatal: the database restore genuinely succeeded, and failing
+    there would be wrong when `sources/` is merely mid-sync.
+    """
+    db_path = Path(db_path)
+    snapshot = resolve_snapshot(snapshot_spec, backup_dir)
+
+    # 1. Validate the source before touching anything.
+    if db_path.exists() and snapshot.resolve() == db_path.resolve():
+        raise RestoreError(f"{snapshot} is the live database - nothing to restore from")
+    _validate_snapshot(snapshot)
+
+    result = RestoreResult(snapshot=snapshot, db_path=db_path)
+
+    # 2/3. Guard the destination, and bank a rescue copy before overwriting it.
+    if db.database_exists(db_path):
+        if not force:
+            total = _live_row_total(db_path)
+            rows = "unreadable" if total is None else f"{total} row(s)"
+            raise RestoreError(
+                f"{db_path} already exists ({rows}) - restoring would replace it. "
+                "Re-run with --force (a pemr-prerestore-*.sqlite rescue copy of the "
+                "current database is taken first)."
+            )
+        # Rescue copies land next to the other snapshots; if no backup dir is
+        # configured, the snapshot's own directory is the obvious fallback.
+        rescue_dir = Path(backup_dir) if backup_dir is not None else snapshot.parent
+        stamp = (now or datetime.now()).strftime("%Y%m%d-%H%M%S")
+        try:
+            rescue, _ = backup.snapshot(
+                db_path, rescue_dir, name=f"{RESCUE_PREFIX}{stamp}.sqlite"
+            )
+        except backup.BackupError as exc:
+            raise RestoreError(
+                f"aborted: could not take a rescue copy of {db_path}: {exc}"
+            ) from exc
+        result.rescue = rescue
+
+    # 4/5. Stage the copy first, then clear sidecars and swap it in atomically.
+    # Staging before any deletion means a failed copy destroys nothing; os.replace on
+    # the same filesystem means a crash mid-install never leaves a half-written DB.
+    tmp = db_path.with_name(db_path.name + ".restore-tmp")
+    try:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        if tmp.exists():
+            tmp.unlink()
+        shutil.copyfile(snapshot, tmp)
+    except OSError as exc:
+        raise RestoreError(f"cannot stage {snapshot} next to {db_path}: {exc}") from exc
+
+    try:
+        for sidecar in _sidecars(db_path):
+            if sidecar.exists():
+                sidecar.unlink()
+                result.cleared_sidecars.append(sidecar)
+        os.replace(tmp, db_path)
+    except OSError as exc:
+        backup._unlink_quietly(tmp)
+        raise RestoreError(f"cannot install {snapshot} as {db_path}: {exc}") from exc
+
+    # 6/7. Migrate forward (a snapshot older than the code is the normal case), then
+    # report on what landed.
+    conn = db.connect(db_path)
+    try:
+        result.applied_migrations = db.migrate(
+            conn, migrations_dir or db.DEFAULT_MIGRATIONS_DIR
+        )
+        result.report = verify.verify_report(conn, sources_dir)
+    except (sqlite3.Error, RuntimeError) as exc:
+        raise RestoreError(
+            f"restored {db_path} but migrate failed: {exc}"
+        ) from exc
+    finally:
+        conn.close()
+    return result

--- a/pemr/restore.py
+++ b/pemr/restore.py
@@ -41,7 +41,12 @@ _SIDECAR_SUFFIXES = ("-wal", "-shm")
 
 
 class RestoreError(RuntimeError):
-    """A restore could not be performed. The live database is left as it was."""
+    """A restore could not be performed.
+
+    Every failure path up to and including the install leaves the live database
+    exactly as it was. The single exception is a stale sidecar that will not delete
+    *after* a successful install; that message says so explicitly and names the file.
+    """
 
 
 @dataclass
@@ -134,6 +139,24 @@ def _sidecars(db_path: Path) -> list[Path]:
     return [db_path.with_name(db_path.name + suffix) for suffix in _SIDECAR_SUFFIXES]
 
 
+def _rescue_name(rescue_dir: Path, now: datetime) -> str:
+    """A free rescue filename, still outside :data:`backup._SNAPSHOT_RE`.
+
+    ``backup.snapshot(name=...)`` deliberately has no collision fallback, so two
+    ``restore --force`` runs inside one wall-clock second would otherwise abort with
+    "could not take a rescue copy" - fail-safe, but mid-incident that reads as the
+    restore mechanism itself being broken. The ``-2``/``-3`` suffix keeps the name off
+    the rotation pattern just as the second-precision stamp does.
+    """
+    stamp = now.strftime("%Y%m%d-%H%M%S")
+    candidate = f"{RESCUE_PREFIX}{stamp}.sqlite"
+    counter = 2
+    while (rescue_dir / candidate).exists():
+        candidate = f"{RESCUE_PREFIX}{stamp}-{counter}.sqlite"
+        counter += 1
+    return candidate
+
+
 def restore(
     snapshot_spec: str,
     db_path: str | Path,
@@ -173,20 +196,21 @@ def restore(
         # Rescue copies land next to the other snapshots; if no backup dir is
         # configured, the snapshot's own directory is the obvious fallback.
         rescue_dir = Path(backup_dir) if backup_dir is not None else snapshot.parent
-        stamp = (now or datetime.now()).strftime("%Y%m%d-%H%M%S")
         try:
             rescue, _ = backup.snapshot(
-                db_path, rescue_dir, name=f"{RESCUE_PREFIX}{stamp}.sqlite"
+                db_path, rescue_dir, name=_rescue_name(rescue_dir, now or datetime.now())
             )
         except backup.BackupError as exc:
             raise RestoreError(
-                f"aborted: could not take a rescue copy of {db_path}: {exc}"
+                f"aborted before touching {db_path}: no rescue copy of it could be "
+                f"written to {rescue_dir}: {exc}. The live database is unchanged - "
+                "move it aside and re-run (restoring onto an absent database needs no "
+                "--force)."
             ) from exc
         result.rescue = rescue
 
-    # 4/5. Stage the copy first, then clear sidecars and swap it in atomically.
-    # Staging before any deletion means a failed copy destroys nothing; os.replace on
-    # the same filesystem means a crash mid-install never leaves a half-written DB.
+    # 4. Stage the copy first: a failed copy then destroys nothing (under the reverse
+    # order a copy failure would leave the operator with no live database at all).
     tmp = db_path.with_name(db_path.name + ".restore-tmp")
     try:
         db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -196,17 +220,33 @@ def restore(
     except OSError as exc:
         raise RestoreError(f"cannot stage {snapshot} next to {db_path}: {exc}") from exc
 
+    # 5. Install atomically - same filesystem, so a crash mid-install can never leave
+    # a half-written database in place.
     try:
-        for sidecar in _sidecars(db_path):
-            if sidecar.exists():
-                sidecar.unlink()
-                result.cleared_sidecars.append(sidecar)
         os.replace(tmp, db_path)
     except OSError as exc:
         backup._unlink_quietly(tmp)
         raise RestoreError(f"cannot install {snapshot} as {db_path}: {exc}") from exc
 
-    # 6/7. Migrate forward (a snapshot older than the code is the normal case), then
+    # 6. Only now clear the sidecars. A stale `-wal` holds committed-but-uncheckpointed
+    # transactions, so deleting it on a path that then fails to install would be the
+    # one way this code loses data; doing it after the swap makes "every abort leaves
+    # the live database as it was" true by construction. Nothing opens the database in
+    # between, so SQLite never sees the restored file next to a foreign WAL.
+    for sidecar in _sidecars(db_path):
+        if not sidecar.exists():
+            continue
+        try:
+            sidecar.unlink()
+        except OSError as exc:
+            raise RestoreError(
+                f"restored {db_path} from {snapshot}, but the stale sidecar "
+                f"{sidecar.name} could not be removed: {exc}. Delete it by hand before "
+                "opening the database - SQLite may otherwise replay it over the restore."
+            ) from exc
+        result.cleared_sidecars.append(sidecar)
+
+    # 7/8. Migrate forward (a snapshot older than the code is the normal case), then
     # report on what landed.
     conn = db.connect(db_path)
     try:

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -1,0 +1,195 @@
+"""`pemr verify` — read-only health report over a database and its source blobs.
+
+Issue #55: a restore is only *complete* if the blobs the restored rows point at are
+still there. `document` stores both a content hash and a relative, content-addressed
+`source_path`, so the check is exact rather than heuristic: resolve
+``sources_dir / source_path``, confirm it exists, re-hash it, compare to
+``document.sha256``.
+
+One function, two callers: `pemr verify` prints this report, and `pemr restore` prints
+the same report as its tail so the issue's acceptance drill is a single command
+afterwards.
+
+**Reports, never repairs.** No FTS rebuild, no blob refetch, no orphan sweep (blobs in
+`sources/` with no `document` row) — those are deliberate non-goals, see the issue's
+design comment.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import db, ingest
+
+# Row counts reported, in a stable order. A table missing from the schema (a snapshot
+# predating its migration, checked before `restore` runs `migrate`) is simply omitted.
+COUNTED_TABLES = (
+    "person",
+    "document",
+    "lab_result",
+    "medication",
+    "procedure",
+    "appointment",
+    "observation",
+    "conflict",
+    "record_fts",
+)
+
+# Problems are all retained on the report; printers show at most this many.
+PROBLEM_DISPLAY_LIMIT = 10
+
+
+@dataclass
+class VerifyReport:
+    """Structured result of :func:`verify_report` (also the ``--json`` payload shape)."""
+
+    integrity: str
+    migrations: list[str] = field(default_factory=list)
+    row_counts: dict[str, int] = field(default_factory=dict)
+    blobs_checked: int = 0
+    blobs_ok: int = 0
+    blobs_missing: int = 0
+    blobs_mismatched: int = 0
+    blobs_skipped: str | None = None  # why the blob pass was skipped, if it was
+    problems: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """True when nothing needs a human: schema intact and every blob resolved."""
+        return (
+            self.integrity == "ok"
+            and self.blobs_missing == 0
+            and self.blobs_mismatched == 0
+        )
+
+    def as_dict(self) -> dict:
+        return {
+            "integrity": self.integrity,
+            "migrations": list(self.migrations),
+            "row_counts": dict(self.row_counts),
+            "blobs": {
+                "checked": self.blobs_checked,
+                "ok": self.blobs_ok,
+                "missing": self.blobs_missing,
+                "mismatched": self.blobs_mismatched,
+                "skipped": self.blobs_skipped,
+            },
+            "problems": list(self.problems),
+            "ok": self.ok,
+        }
+
+
+def _existing_tables(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type IN ('table','view')"
+    ).fetchall()
+    return {row[0] for row in rows}
+
+
+def row_counts(conn: sqlite3.Connection) -> dict[str, int]:
+    """``{table: count}`` for the tables in :data:`COUNTED_TABLES` that exist."""
+    present = _existing_tables(conn)
+    counts: dict[str, int] = {}
+    for table in COUNTED_TABLES:
+        if table not in present:
+            continue
+        # Table names come from the module-level constant, never from user input.
+        counts[table] = conn.execute(f"SELECT count(*) FROM {table}").fetchone()[0]
+    return counts
+
+
+def _check_blobs(
+    conn: sqlite3.Connection, sources_dir: Path, report: VerifyReport
+) -> None:
+    rows = conn.execute(
+        "SELECT document_id, sha256, source_path FROM document ORDER BY document_id"
+    ).fetchall()
+    for row in rows:
+        report.blobs_checked += 1
+        doc_id, sha, rel = row[0], row[1], row[2]
+        blob = sources_dir / rel
+        if not blob.is_file():
+            report.blobs_missing += 1
+            report.problems.append(f"document #{doc_id}: blob missing at {blob}")
+            continue
+        try:
+            actual = ingest.hash_file(blob)
+        except OSError as exc:
+            report.blobs_missing += 1
+            report.problems.append(f"document #{doc_id}: cannot read {blob}: {exc}")
+            continue
+        if actual != sha:
+            report.blobs_mismatched += 1
+            report.problems.append(
+                f"document #{doc_id}: sha256 mismatch at {blob} "
+                f"(recorded {sha[:12]}..., on disk {actual[:12]}...)"
+            )
+            continue
+        report.blobs_ok += 1
+
+
+def verify_report(
+    conn: sqlite3.Connection, sources_dir: str | Path | None = None
+) -> VerifyReport:
+    """Integrity + migrations + row counts (+ blob resolution when ``sources_dir``).
+
+    ``sources_dir=None`` skips the blob pass with a recorded reason rather than
+    failing: a restore must still report on the database when `sources/` is
+    unconfigured or mid-sync.
+    """
+    integrity_row = conn.execute("PRAGMA integrity_check").fetchone()
+    integrity = str(integrity_row[0]) if integrity_row else "integrity_check returned nothing"
+    report = VerifyReport(integrity=integrity)
+    if integrity != "ok":
+        report.problems.append(f"integrity_check: {integrity}")
+
+    if db.is_migrated(conn):
+        report.migrations = sorted(db.applied_versions(conn))
+    else:
+        report.problems.append("database has no schema applied")
+
+    report.row_counts = row_counts(conn)
+
+    if sources_dir is None:
+        report.blobs_skipped = "no sources dir configured"
+    else:
+        sources_dir = Path(sources_dir)
+        if not sources_dir.is_dir():
+            report.blobs_skipped = f"sources dir not found: {sources_dir}"
+        elif "document" not in report.row_counts:
+            report.blobs_skipped = "no document table"
+        else:
+            _check_blobs(conn, sources_dir, report)
+    return report
+
+
+def format_report(report: VerifyReport) -> list[str]:
+    """ASCII-only console lines for ``pemr verify`` / the tail of ``pemr restore``.
+
+    ASCII by construction (issue #23): a cp437/cp1252 Windows console must not garble
+    or crash on this output.
+    """
+    lines = [f"integrity      {report.integrity}"]
+    lines.append(
+        f"migrations     {len(report.migrations)} applied"
+        + (f" (latest {report.migrations[-1]})" if report.migrations else "")
+    )
+    for table, count in report.row_counts.items():
+        lines.append(f"  {table:14} {count}")
+    if report.blobs_skipped:
+        lines.append(f"blobs          skipped ({report.blobs_skipped})")
+    else:
+        lines.append(
+            f"blobs          {report.blobs_ok}/{report.blobs_checked} ok, "
+            f"{report.blobs_missing} missing, {report.blobs_mismatched} mismatched"
+        )
+    if report.problems:
+        lines.append(f"problems       {len(report.problems)}")
+        for problem in report.problems[:PROBLEM_DISPLAY_LIMIT]:
+            lines.append(f"  - {problem}")
+        hidden = len(report.problems) - PROBLEM_DISPLAY_LIMIT
+        if hidden > 0:
+            lines.append(f"  ... and {hidden} more (use --json for the full list)")
+    return lines

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -57,12 +57,14 @@ class VerifyReport:
 
     @property
     def ok(self) -> bool:
-        """True when nothing needs a human: schema intact and every blob resolved."""
-        return (
-            self.integrity == "ok"
-            and self.blobs_missing == 0
-            and self.blobs_mismatched == 0
-        )
+        """True when nothing needs a human.
+
+        Every failure this module knows about appends to :attr:`problems` - failed
+        integrity, an un-migrated database, a missing or mismatched blob - so that list
+        is the single source of truth. A *skipped* blob pass is deliberately not a
+        problem: unconfigured or mid-sync `sources/` must not fail a restore.
+        """
+        return not self.problems
 
     def as_dict(self) -> dict:
         return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Shared test helpers.
+
+Issue #55 gave the CLI/MCP a missing-database gate, which makes "no database file" and
+"database file with no schema" genuinely different states. Tests that mean the *latter*
+must therefore put a real file on disk rather than pointing at a nonexistent path.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def make_unmigrated_db(path: str | Path) -> Path:
+    """A real, non-empty SQLite file with no pemr schema applied."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("CREATE TABLE _not_pemr (x)")
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+@pytest.fixture()
+def unmigrated_db():
+    """Factory fixture: ``unmigrated_db(tmp_path / "cli.db")``."""
+    return make_unmigrated_db

--- a/tests/test_cli_ascii.py
+++ b/tests/test_cli_ascii.py
@@ -23,13 +23,13 @@ def _assert_console_safe(text: str) -> None:
 @pytest.fixture()
 def ready(tmp_path):
     """Migrated DB + a person, ready for ingest."""
-    assert _run(tmp_path, "migrate") == 0
+    assert _run(tmp_path, "migrate", "--create") == 0
     assert _run(tmp_path, "person", "add", "--slug", "jane-doe", "--name", "Jane Doe") == 0
     return tmp_path
 
 
 def test_empty_person_list_is_console_safe(tmp_path, capsys):
-    assert _run(tmp_path, "migrate") == 0
+    assert _run(tmp_path, "migrate", "--create") == 0
     capsys.readouterr()
     assert _run(tmp_path, "person", "list") == 0
     out = capsys.readouterr().out
@@ -89,7 +89,8 @@ def test_conflict_note_is_console_safe(ready, capsys):
     _assert_console_safe(out)
 
 
-def test_unmigrated_error_is_console_safe(tmp_path, capsys):
+def test_unmigrated_error_is_console_safe(tmp_path, capsys, unmigrated_db):
+    unmigrated_db(tmp_path / "cli.db")  # exists, no schema (issue #55 gate is earlier)
     scan = tmp_path / "s.txt"
     scan.write_bytes(b"x")
     assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
@@ -97,6 +98,30 @@ def test_unmigrated_error_is_console_safe(tmp_path, capsys):
     err = capsys.readouterr().err
     assert "not migrated" in err
     _assert_console_safe(err)
+
+
+def test_missing_database_message_is_console_safe(tmp_path):
+    # The issue #55 refusal is what a panicking user reads first; it must not garble.
+    with pytest.raises(SystemExit) as exc:
+        _run(tmp_path, "person", "list")
+    _assert_console_safe(str(exc.value))
+    assert "no database at" in str(exc.value)
+
+
+def test_restore_and_verify_output_is_console_safe(tmp_path, capsys):
+    src = tmp_path / "src"
+    assert cli.main(["--db", str(src / "cli.db"), "migrate", "--create"]) == 0
+    backups = tmp_path / "backups"
+    assert cli.main(["--db", str(src / "cli.db"), "backup",
+                     "--backup-dir", str(backups)]) == 0
+    capsys.readouterr()
+    assert _run(tmp_path, "restore", "latest", "--backup-dir", str(backups)) == 0
+    captured = capsys.readouterr()
+    _assert_console_safe(captured.out)
+    _assert_console_safe(captured.err)
+    capsys.readouterr()
+    _run(tmp_path, "verify")
+    _assert_console_safe(capsys.readouterr().out)
 
 
 def test_unknown_slug_error_is_console_safe(ready, capsys):

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -20,7 +20,7 @@ def _write_json(tmp_path, name, obj):
 @pytest.fixture()
 def ready(tmp_path):
     """Migrated DB + a person, ready for ingest."""
-    assert _run(tmp_path, "migrate") == 0
+    assert _run(tmp_path, "migrate", "--create") == 0
     assert _run(tmp_path, "person", "add", "--slug", "jane-doe", "--name", "Jane Doe") == 0
     return tmp_path
 
@@ -81,7 +81,10 @@ def test_ingest_duplicate_reports_cleanly(ready, capsys):
     assert "duplicate" in capsys.readouterr().out
 
 
-def test_ingest_on_unmigrated_db_is_friendly(tmp_path, capsys):
+def test_ingest_on_unmigrated_db_is_friendly(tmp_path, capsys, unmigrated_db):
+    # A DB file that exists but has no schema. Issue #55 made this distinct from "no DB
+    # file at all", which the missing-database gate refuses earlier and differently.
+    unmigrated_db(tmp_path / "cli.db")
     scan = tmp_path / "s.txt"
     scan.write_bytes(b"x")
     rc = _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -34,7 +34,7 @@ def _doc(conn, slug, ocr=None, doc_date="2026-01-01"):
 @pytest.fixture()
 def ready(tmp_path):
     """Migrated DB + jane with a few labs, a med, and an OCR'd document."""
-    assert _run(tmp_path, "migrate") == 0
+    assert _run(tmp_path, "migrate", "--create") == 0
     assert _run(tmp_path, "person", "add", "--slug", "jane-doe", "--name", "Jane Doe") == 0
     conn = db.connect(tmp_path / "cli.db")
     d = dedup.load_dictionary(DICT_ARG[1])
@@ -204,7 +204,9 @@ def test_unknown_person_is_friendly_rc1(ready, capsys):
     assert "ghost" in capsys.readouterr().err
 
 
-def test_query_on_unmigrated_db_is_friendly(tmp_path, capsys):
+def test_query_on_unmigrated_db_is_friendly(tmp_path, capsys, unmigrated_db):
+    # Schema-less DB file, not an absent one - see issue #55's missing-database gate.
+    unmigrated_db(tmp_path / "cli.db")
     rc = _run(tmp_path, "query", "labs", "--person", "jane-doe")
     assert rc == 1
     assert "migrate" in capsys.readouterr().err

--- a/tests/test_cli_phase4.py
+++ b/tests/test_cli_phase4.py
@@ -20,7 +20,7 @@ def _run(tmp_path, *argv):
 @pytest.fixture()
 def ready(tmp_path):
     """Migrated DB + jane with a med, an abnormal lab and one upcoming appointment."""
-    assert _run(tmp_path, "migrate") == 0
+    assert _run(tmp_path, "migrate", "--create") == 0
     assert _run(tmp_path, "person", "add", "--slug", "jane-doe",
                 "--name", "Jane Doe", "--dob", "1980-01-01") == 0
     conn = db.connect(tmp_path / "cli.db")
@@ -88,7 +88,9 @@ def test_render_unknown_appointment_is_friendly_rc1(ready, capsys):
     assert "99999" in capsys.readouterr().err
 
 
-def test_render_on_unmigrated_db_is_friendly(tmp_path, capsys):
+def test_render_on_unmigrated_db_is_friendly(tmp_path, capsys, unmigrated_db):
+    # Schema-less DB file, not an absent one - see issue #55's missing-database gate.
+    unmigrated_db(tmp_path / "cli.db")
     rc = _run(tmp_path, "render", "summary", "--person", "jane-doe")
     assert rc == 1
     assert "migrate" in capsys.readouterr().err

--- a/tests/test_persons.py
+++ b/tests/test_persons.py
@@ -160,7 +160,7 @@ def _run(tmp_path, *argv):
 
 
 def test_cli_migrate_then_person_roundtrip(tmp_path, capsys):
-    assert _run(tmp_path, "migrate") == 0
+    assert _run(tmp_path, "migrate", "--create") == 0
     assert _run(
         tmp_path, "person", "add", "--slug", "jane-doe", "--name", "Jane Doe"
     ) == 0
@@ -172,20 +172,20 @@ def test_cli_migrate_then_person_roundtrip(tmp_path, capsys):
 
 
 def test_cli_show_unknown_slug_fails(tmp_path, capsys):
-    assert _run(tmp_path, "migrate") == 0
+    assert _run(tmp_path, "migrate", "--create") == 0
     assert _run(tmp_path, "person", "show", "nobody") == 1
     assert "no person" in capsys.readouterr().err
 
 
 def test_cli_duplicate_add_fails_cleanly(tmp_path, capsys):
-    _run(tmp_path, "migrate")
+    _run(tmp_path, "migrate", "--create")
     _run(tmp_path, "person", "add", "--slug", "j", "--name", "J")
     assert _run(tmp_path, "person", "add", "--slug", "j", "--name", "J2") == 1
     assert "already exists" in capsys.readouterr().err
 
 
 def test_cli_person_edit_updates_field(tmp_path, capsys):
-    _run(tmp_path, "migrate")
+    _run(tmp_path, "migrate", "--create")
     _run(tmp_path, "person", "add", "--slug", "jane", "--name", "Jane",
          "--dob", "1980-01-01")
     assert _run(tmp_path, "person", "edit", "jane", "--dob", "1981-02-03") == 0
@@ -194,7 +194,7 @@ def test_cli_person_edit_updates_field(tmp_path, capsys):
 
 
 def test_cli_person_edit_clears_nullable(tmp_path, capsys):
-    _run(tmp_path, "migrate")
+    _run(tmp_path, "migrate", "--create")
     _run(tmp_path, "person", "add", "--slug", "jane", "--name", "Jane",
          "--dob", "1980-01-01")
     assert _run(tmp_path, "person", "edit", "jane", "--dob", "") == 0
@@ -204,20 +204,20 @@ def test_cli_person_edit_clears_nullable(tmp_path, capsys):
 
 
 def test_cli_person_edit_no_fields_fails(tmp_path, capsys):
-    _run(tmp_path, "migrate")
+    _run(tmp_path, "migrate", "--create")
     _run(tmp_path, "person", "add", "--slug", "jane", "--name", "Jane")
     assert _run(tmp_path, "person", "edit", "jane") == 1
     assert "nothing to update" in capsys.readouterr().err
 
 
 def test_cli_person_edit_unknown_slug_fails(tmp_path, capsys):
-    _run(tmp_path, "migrate")
+    _run(tmp_path, "migrate", "--create")
     assert _run(tmp_path, "person", "edit", "nobody", "--name", "X") == 1
     assert "no person" in capsys.readouterr().err
 
 
 def test_cli_person_deactivate_reactivate_and_list_all(tmp_path, capsys):
-    _run(tmp_path, "migrate")
+    _run(tmp_path, "migrate", "--create")
     _run(tmp_path, "person", "add", "--slug", "jane", "--name", "Jane")
     assert _run(tmp_path, "person", "deactivate", "jane") == 0
     capsys.readouterr()  # drain output from the setup commands above
@@ -237,7 +237,7 @@ def test_cli_person_deactivate_reactivate_and_list_all(tmp_path, capsys):
 
 
 def test_cli_person_remove_childless(tmp_path, capsys):
-    _run(tmp_path, "migrate")
+    _run(tmp_path, "migrate", "--create")
     _run(tmp_path, "person", "add", "--slug", "typo", "--name", "Typo")
     assert _run(tmp_path, "person", "remove", "typo") == 0
     assert "removed person" in capsys.readouterr().out

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -19,6 +19,7 @@ a command at all:
 
 import json
 import sqlite3
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -206,6 +207,53 @@ def test_force_restore_banks_a_rescue_copy_rotation_cannot_prune(tmp_path):
 
     # And it is a real, usable database - not just a file with the right name.
     assert backup.integrity_check(rescue) == "ok"
+
+
+def test_two_force_restores_in_the_same_second_both_keep_their_rescue_copy(tmp_path):
+    """The rescue name collides at second precision; that must not abort a restore."""
+    db_path, sources = _populated(tmp_path)
+    backups = tmp_path / "backups"
+    assert _run(db_path, "backup", "--backup-dir", str(backups)) == 0
+    frozen = datetime(2026, 8, 2, 4, 8, 15)
+
+    for _ in range(2):
+        restore.restore("latest", db_path, backup_dir=backups, sources_dir=sources,
+                        force=True, now=frozen)
+
+    rescues = {p.name for p in backups.glob(f"{restore.RESCUE_PREFIX}*.sqlite")}
+    assert rescues == {
+        "pemr-prerestore-20260802-040815.sqlite",
+        "pemr-prerestore-20260802-040815-2.sqlite",
+    }
+    # The collision suffix must stay off the rotation pattern, like the base name.
+    assert all(backup._parse_ts(name) is None for name in rescues)
+
+
+def test_a_failed_install_leaves_the_sidecars_intact(tmp_path, monkeypatch):
+    """A stale -wal holds committed transactions: it must outlive an aborted install.
+
+    Hence the unlink runs *after* `os.replace`, not before: deleting the sidecars on a
+    path that then fails to install is the one way this code could lose data.
+    """
+    db_path, sources = _populated(tmp_path)
+    backups = tmp_path / "backups"
+    assert _run(db_path, "backup", "--backup-dir", str(backups)) == 0
+    db_path.unlink()
+    wal = db_path.with_name(db_path.name + "-wal")
+    shm = db_path.with_name(db_path.name + "-shm")
+    wal.write_bytes(b"stale wal holding committed transactions")
+    shm.write_bytes(b"stale shm")
+
+    def boom(src, dst):
+        raise OSError(5, "Access is denied")
+
+    monkeypatch.setattr(restore.os, "replace", boom)
+    with pytest.raises(restore.RestoreError, match="cannot install"):
+        restore.restore("latest", db_path, backup_dir=backups, sources_dir=sources)
+
+    assert wal.read_bytes() == b"stale wal holding committed transactions"
+    assert shm.exists()
+    assert not list(tmp_path.glob("*.restore-tmp"))
 
 
 def test_restore_clears_stale_wal_and_shm_sidecars(tmp_path):
@@ -414,6 +462,16 @@ def test_verify_on_unmigrated_db_is_not_ok(tmp_path, capsys, unmigrated_db):
     assert "no schema applied" in out
 
 
+def test_verify_json_exit_code_matches_the_console_one(tmp_path, capsys, unmigrated_db):
+    """`--json` is the mode a monitoring cron picks; it must not report rc=0 here."""
+    db_path = unmigrated_db(tmp_path / "pemr.db")
+    capsys.readouterr()
+    rc = _run(db_path, "verify", "--json", "--sources", str(tmp_path / "sources"))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert rc == 1
+
+
 def test_verify_report_caps_displayed_problems(tmp_path):
     report = verify.VerifyReport(integrity="ok")
     report.problems = [f"problem {i}" for i in range(verify.PROBLEM_DISPLAY_LIMIT + 5)]
@@ -460,6 +518,51 @@ def test_corrupt_db_backup_never_reaches_rotation(tmp_path, capsys):
     assert rc == 1
     assert "snapshot failed" in capsys.readouterr().err
     assert good.exists(), "rotation must never have run"
+
+
+def test_backup_of_zero_byte_db_refuses_and_spares_the_real_snapshots(tmp_path, capsys):
+    """The drill's chain, link 2: an empty archive must not become a backup source.
+
+    `VACUUM INTO` on a 0-byte file writes a structurally valid (integrity-clean) 4 KB
+    database, so the write-time verification cannot catch this - only refusing the
+    *source* can. Until it did, one `pemr backup` here rotated the real snapshot away.
+    """
+    backups = tmp_path / "backups"
+    backups.mkdir()
+    real = backups / "pemr-20260101-1200.sqlite"
+    real.write_bytes(b"the irreplaceable one")
+    db_path = tmp_path / "pemr.db"
+    db_path.touch()
+
+    rc = _run(db_path, "backup", "--backup-dir", str(backups),
+              "--keep-daily", "0", "--keep-weekly", "0")
+    assert rc == 1
+    assert "no database at" in capsys.readouterr().err
+    assert list(backups.glob("pemr-*.sqlite")) == [real], "rotation must never have run"
+    assert db_path.stat().st_size == 0
+
+
+def test_backup_of_unmigrated_db_refuses_and_spares_the_real_snapshots(tmp_path, capsys,
+                                                                       unmigrated_db):
+    """Same chain from the other route: a real file with no pemr schema."""
+    backups = tmp_path / "backups"
+    backups.mkdir()
+    real = backups / "pemr-20260101-1200.sqlite"
+    real.write_bytes(b"the irreplaceable one")
+    db_path = unmigrated_db(tmp_path / "pemr.db")
+
+    rc = _run(db_path, "backup", "--backup-dir", str(backups),
+              "--keep-daily", "0", "--keep-weekly", "0")
+    assert rc == 1
+    assert "no pemr schema" in capsys.readouterr().err
+    assert list(backups.glob("pemr-*.sqlite")) == [real]
+
+
+def test_integrity_check_of_a_missing_file_is_not_ok(tmp_path):
+    """It must not answer "healthy" - nor leave 0-byte sqlite3.connect debris behind."""
+    missing = tmp_path / "gone.sqlite"
+    assert backup.integrity_check(missing) != "ok"
+    assert not missing.exists()
 
 
 def test_snapshot_name_override_is_verbatim_and_never_overwrites(tmp_path):

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -404,6 +404,16 @@ def test_verify_json_and_skipped_blob_pass(tmp_path, capsys, monkeypatch):
     assert payload["migrations"]
 
 
+def test_verify_on_unmigrated_db_is_not_ok(tmp_path, capsys, unmigrated_db):
+    """A schema-less file is a real problem, even though integrity_check says ok."""
+    db_path = unmigrated_db(tmp_path / "pemr.db")
+    capsys.readouterr()
+    rc = _run(db_path, "verify", "--sources", str(tmp_path / "sources"))
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "no schema applied" in out
+
+
 def test_verify_report_caps_displayed_problems(tmp_path):
     report = verify.VerifyReport(integrity="ok")
     report.problems = [f"problem {i}" for i in range(verify.PROBLEM_DISPLAY_LIMIT + 5)]

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -157,6 +157,43 @@ def test_read_commands_refuse_on_missing_db(tmp_path):
     assert not db_path.exists()
 
 
+@pytest.mark.parametrize("argv", [
+    ("document", "list"),
+    ("document", "edit", "1", "--category", "labs"),
+    ("document", "reassign", "1", "--person", "jane-doe"),
+    ("document", "rm", "1"),
+])
+def test_document_commands_refuse_on_missing_db(tmp_path, argv):
+    """Issue #54's `document` subcommands landed after this gate was designed and
+    opened the archive themselves, so on `dev` `pemr document list` against an absent
+    `pemr.db` created a schema-less 4 KB file and then advised `pemr migrate` - the
+    manufacture-an-empty-archive chain this issue exists to close, reopened by a
+    *read* command. They go through `cli._connect_db` like every other command.
+    """
+    db_path = tmp_path / "pemr.db"
+    with pytest.raises(SystemExit) as exc:
+        _run(db_path, *argv)
+    assert "no database at" in str(exc.value)
+    assert not db_path.exists(), "a read command must never manufacture an archive"
+
+
+def test_no_cli_command_bypasses_the_connect_gate():
+    """Structural guard on the invariant above.
+
+    The gate is only as good as its coverage: one new `db.connect(_resolve_db_path(
+    args))` call site silently reopens the hole (that is exactly how #54's `document`
+    commands arrived). `_cmd_migrate` is the single documented exception - it must be
+    able to create a database under `--create`.
+    """
+    source = Path(cli.__file__).read_text(encoding="utf-8")
+    assert "db.connect(_resolve_db_path(args))" not in source, (
+        "a CLI command connects without going through cli._connect_db - route it "
+        "through the gate (issue #55)"
+    )
+    # Two legitimate `db.connect(` sites remain: inside _connect_db, and _cmd_migrate.
+    assert source.count("db.connect(") == 2
+
+
 def test_database_exists_semantics(tmp_path):
     missing = tmp_path / "nope.db"
     assert not db.database_exists(missing)

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -1,0 +1,464 @@
+"""Issue #55: `pemr restore` / `pemr verify` + the `migrate` bootstrap gate.
+
+This is the issue's own recovery drill, automated: seed a populated DB, `pemr backup`,
+delete `pemr.db`, `pemr restore latest`, and assert the row counts, `schema_migrations`
+state and `document.source_path` blob resolution all match pre-delete.
+
+Around that, the failure modes the manual drill exposed - which are the point of having
+a command at all:
+
+* `pemr migrate` on a missing (or zero-byte) DB must refuse instead of manufacturing a
+  convincing empty archive that the next `pemr backup` would then snapshot;
+* restoring over a live DB requires `--force` and banks a `pemr-prerestore-*.sqlite`
+  rescue copy that rotation is structurally unable to prune;
+* stale `-wal`/`-shm` sidecars are cleared, so SQLite cannot replay a stale WAL over
+  the restored file;
+* a corrupt/foreign snapshot is rejected before the live DB is touched;
+* missing blobs are reported as a warning, not a failure.
+"""
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from pemr import backup, cli, db, restore, verify
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+
+def _run(db_path: Path, *argv) -> int:
+    # --config points at a file that does not exist so a stray ./config.toml in the
+    # working dir can never leak into resolution.
+    return cli.main(
+        ["--db", str(db_path), "--config", str(db_path.parent / "absent.toml"), *argv]
+    )
+
+
+def _populated(tmp_path: Path) -> tuple[Path, Path]:
+    """A migrated DB with a person and a real ingested document (so blobs exist)."""
+    db_path = tmp_path / "pemr.db"
+    sources = tmp_path / "sources"
+    assert _run(db_path, "migrate", "--create") == 0
+    assert _run(db_path, "person", "add", "--slug", "jane-doe", "--name", "Jane Doe") == 0
+    scan = tmp_path / "scan.txt"
+    scan.write_bytes(b"hba1c 5.7 percent")
+    assert _run(db_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(sources)) == 0
+    return db_path, sources
+
+
+def _snapshot_state(db_path: Path) -> tuple[dict[str, int], list[str]]:
+    conn = db.connect(db_path)
+    try:
+        return verify.row_counts(conn), sorted(db.applied_versions(conn))
+    finally:
+        conn.close()
+
+
+def _corrupt_file(path: Path) -> Path:
+    path.write_bytes(b"this is not a sqlite database at all" * 8)
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# the drill (the issue's acceptance criterion)
+# --------------------------------------------------------------------------- #
+
+def test_full_restore_drill(tmp_path, capsys):
+    db_path, sources = _populated(tmp_path)
+    backups = tmp_path / "backups"
+    before_counts, before_migrations = _snapshot_state(db_path)
+
+    assert _run(db_path, "backup", "--backup-dir", str(backups)) == 0
+
+    # The disaster: the live DB (and its sidecars) are gone.
+    for path in [db_path, *[db_path.with_name(db_path.name + s) for s in ("-wal", "-shm")]]:
+        if path.exists():
+            path.unlink()
+    assert not db_path.exists()
+
+    capsys.readouterr()
+    rc = _run(db_path, "restore", "latest", "--backup-dir", str(backups),
+              "--sources", str(sources))
+    out = capsys.readouterr()
+    assert rc == 0, out.err
+    assert db_path.is_file()
+
+    after_counts, after_migrations = _snapshot_state(db_path)
+    assert after_counts == before_counts
+    assert after_migrations == before_migrations
+    assert before_counts["document"] >= 1  # the drill would be vacuous otherwise
+
+    # Every document.source_path still resolves with a matching sha256.
+    assert "0 missing, 0 mismatched" in out.out
+    assert "warning" not in out.err
+
+
+def test_restore_of_absent_db_needs_no_force(tmp_path):
+    """Ergonomics are deliberately easiest in the case where the user is panicking."""
+    db_path, sources = _populated(tmp_path)
+    backups = tmp_path / "backups"
+    assert _run(db_path, "backup", "--backup-dir", str(backups)) == 0
+    db_path.unlink()
+    assert _run(db_path, "restore", "latest", "--backup-dir", str(backups),
+                "--sources", str(sources)) == 0
+
+
+# --------------------------------------------------------------------------- #
+# migrate bootstrap gate
+# --------------------------------------------------------------------------- #
+
+def test_migrate_on_missing_db_refuses_and_creates_nothing(tmp_path, capsys):
+    db_path = tmp_path / "pemr.db"
+    with pytest.raises(SystemExit) as exc:
+        _run(db_path, "migrate")
+    message = str(exc.value)
+    assert "no database at" in message
+    assert "pemr migrate --create" in message
+    assert "pemr restore latest" in message
+    assert not db_path.exists(), "the refusal must not leave a database behind"
+
+
+def test_migrate_create_bootstraps(tmp_path, capsys):
+    db_path = tmp_path / "pemr.db"
+    assert _run(db_path, "migrate", "--create") == 0
+    assert "applied 001_init.sql" in capsys.readouterr().out
+    conn = db.connect(db_path)
+    try:
+        assert db.is_migrated(conn)
+    finally:
+        conn.close()
+    # Once it exists, plain `migrate` works again (idempotent, no --create needed).
+    assert _run(db_path, "migrate") == 0
+    assert "up to date" in capsys.readouterr().out
+
+
+def test_migrate_on_zero_byte_db_refuses(tmp_path):
+    """A 0-byte pemr.db is sqlite3.connect debris, not an archive (db.database_exists)."""
+    db_path = tmp_path / "pemr.db"
+    db_path.touch()
+    assert db_path.stat().st_size == 0
+    with pytest.raises(SystemExit) as exc:
+        _run(db_path, "migrate")
+    assert "no database at" in str(exc.value)
+    assert db_path.stat().st_size == 0, "must not have been silently populated"
+
+
+def test_read_commands_refuse_on_missing_db(tmp_path):
+    db_path = tmp_path / "pemr.db"
+    with pytest.raises(SystemExit) as exc:
+        _run(db_path, "person", "list")
+    assert "no database at" in str(exc.value)
+    assert not db_path.exists()
+
+
+def test_database_exists_semantics(tmp_path):
+    missing = tmp_path / "nope.db"
+    assert not db.database_exists(missing)
+    missing.touch()
+    assert not db.database_exists(missing)  # zero bytes
+    missing.write_bytes(b"x")
+    assert db.database_exists(missing)
+    assert not db.database_exists(tmp_path)  # a directory is not a database
+    assert db.database_exists(":memory:")
+
+
+# --------------------------------------------------------------------------- #
+# destination guard + rescue copy
+# --------------------------------------------------------------------------- #
+
+def test_restore_over_existing_db_requires_force(tmp_path, capsys):
+    db_path, sources = _populated(tmp_path)
+    backups = tmp_path / "backups"
+    assert _run(db_path, "backup", "--backup-dir", str(backups)) == 0
+    before = db_path.read_bytes()
+
+    capsys.readouterr()
+    rc = _run(db_path, "restore", "latest", "--backup-dir", str(backups),
+              "--sources", str(sources))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "already exists" in err and "--force" in err
+    assert db_path.read_bytes() == before, "a refused restore must change nothing"
+
+
+def test_force_restore_banks_a_rescue_copy_rotation_cannot_prune(tmp_path):
+    db_path, sources = _populated(tmp_path)
+    backups = tmp_path / "backups"
+    assert _run(db_path, "backup", "--backup-dir", str(backups)) == 0
+    assert _run(db_path, "restore", "latest", "--backup-dir", str(backups),
+                "--sources", str(sources), "--force") == 0
+
+    rescues = list(backups.glob(f"{restore.RESCUE_PREFIX}*.sqlite"))
+    assert len(rescues) == 1
+    rescue = rescues[0]
+
+    # The off-pattern name is the whole point: rotation cannot even parse it, so the
+    # most destructive retention setting there is leaves it alone.
+    assert backup._parse_ts(rescue.name) is None
+    assert _run(db_path, "backup", "--backup-dir", str(backups),
+                "--keep-daily", "0", "--keep-weekly", "0") == 0
+    assert rescue.exists()
+
+    # And it is a real, usable database - not just a file with the right name.
+    assert backup.integrity_check(rescue) == "ok"
+
+
+def test_restore_clears_stale_wal_and_shm_sidecars(tmp_path):
+    db_path, sources = _populated(tmp_path)
+    backups = tmp_path / "backups"
+    assert _run(db_path, "backup", "--backup-dir", str(backups)) == 0
+    wal = db_path.with_name(db_path.name + "-wal")
+    shm = db_path.with_name(db_path.name + "-shm")
+    wal.write_bytes(b"stale wal that sqlite must never replay")
+    shm.write_bytes(b"stale shm")
+
+    assert _run(db_path, "restore", "latest", "--backup-dir", str(backups),
+                "--sources", str(sources), "--force") == 0
+    assert not wal.exists() and not shm.exists()
+
+
+# --------------------------------------------------------------------------- #
+# source validation - nothing is touched until the snapshot proves itself
+# --------------------------------------------------------------------------- #
+
+def test_restore_of_corrupt_snapshot_leaves_live_db_untouched(tmp_path, capsys):
+    db_path, sources = _populated(tmp_path)
+    before = db_path.read_bytes()
+    bogus = _corrupt_file(tmp_path / "not-a-db.sqlite")
+
+    capsys.readouterr()
+    rc = _run(db_path, "restore", str(bogus), "--sources", str(sources), "--force")
+    assert rc == 1
+    assert "integrity_check" in capsys.readouterr().err
+    assert db_path.read_bytes() == before
+    assert not list(tmp_path.glob("*.restore-tmp"))
+
+
+def test_restore_of_valid_sqlite_without_pemr_schema_is_rejected(tmp_path, capsys):
+    db_path, sources = _populated(tmp_path)
+    before = db_path.read_bytes()
+    foreign = tmp_path / "foreign.sqlite"
+    conn = sqlite3.connect(foreign)
+    conn.execute("CREATE TABLE t (x)")
+    conn.commit()
+    conn.close()
+
+    capsys.readouterr()
+    rc = _run(db_path, "restore", str(foreign), "--sources", str(sources), "--force")
+    assert rc == 1
+    assert "not a pemr snapshot" in capsys.readouterr().err
+    assert db_path.read_bytes() == before
+
+
+def test_restore_unknown_snapshot_is_friendly(tmp_path, capsys):
+    db_path, _ = _populated(tmp_path)
+    capsys.readouterr()
+    assert _run(db_path, "restore", "nope.sqlite", "--backup-dir",
+                str(tmp_path / "backups"), "--force") == 1
+    assert "no such snapshot" in capsys.readouterr().err
+
+
+def test_restore_latest_with_no_snapshots_is_friendly(tmp_path, capsys):
+    db_path, _ = _populated(tmp_path)
+    backups = tmp_path / "backups"
+    backups.mkdir()
+    capsys.readouterr()
+    assert _run(db_path, "restore", "latest", "--backup-dir", str(backups),
+                "--force") == 1
+    assert "no snapshots found" in capsys.readouterr().err
+
+
+def test_restore_refuses_the_live_database_as_its_own_source(tmp_path, capsys):
+    db_path, _ = _populated(tmp_path)
+    capsys.readouterr()
+    assert _run(db_path, "restore", str(db_path), "--force") == 1
+    assert "is the live database" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# snapshot resolution + forward migration
+# --------------------------------------------------------------------------- #
+
+def test_resolve_snapshot_accepts_path_bare_name_and_latest(tmp_path):
+    db_path, _ = _populated(tmp_path)
+    backups = tmp_path / "backups"
+    assert _run(db_path, "backup", "--backup-dir", str(backups)) == 0
+    snap = next(backups.glob("pemr-*.sqlite"))
+
+    assert restore.resolve_snapshot(str(snap), None) == snap
+    assert restore.resolve_snapshot(snap.name, backups) == snap
+    assert restore.resolve_snapshot("latest", backups) == snap
+    with pytest.raises(restore.RestoreError, match="needs a backup dir"):
+        restore.resolve_snapshot("latest", None)
+
+
+def test_latest_snapshot_orders_by_filename_not_mtime(tmp_path):
+    backups = tmp_path / "backups"
+    backups.mkdir()
+    older = backups / "pemr-20260101-1200.sqlite"
+    newer = backups / "pemr-20260707-1200.sqlite"
+    newer.write_bytes(b"stub")
+    older.write_bytes(b"stub")  # written *last*, so mtime ordering would pick it
+    assert restore.latest_snapshot(backups) == newer
+
+
+def test_restore_of_snapshot_predating_a_migration_migrates_forward(tmp_path, capsys):
+    db_path, sources = _populated(tmp_path)
+    backups = tmp_path / "backups"
+    assert _run(db_path, "backup", "--backup-dir", str(backups)) == 0
+    db_path.unlink()
+
+    # A migrations dir that is the shipped set plus one new migration: the snapshot is
+    # now "older than the code", which is the normal restore case.
+    mdir = tmp_path / "migrations"
+    mdir.mkdir()
+    for src in sorted(Path(db.DEFAULT_MIGRATIONS_DIR).glob("*.sql")):
+        (mdir / src.name).write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    (mdir / "900_later.sql").write_text("CREATE TABLE later_table (x);", encoding="utf-8")
+
+    capsys.readouterr()
+    rc = _run(db_path, "restore", "latest", "--backup-dir", str(backups),
+              "--sources", str(sources), "--migrations-dir", str(mdir))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "applied 900_later.sql" in out
+    conn = db.connect(db_path)
+    try:
+        assert "900_later.sql" in db.applied_versions(conn)
+    finally:
+        conn.close()
+
+
+def test_restore_json_payload(tmp_path, capsys):
+    db_path, sources = _populated(tmp_path)
+    backups = tmp_path / "backups"
+    assert _run(db_path, "backup", "--backup-dir", str(backups)) == 0
+    capsys.readouterr()
+    assert _run(db_path, "restore", "latest", "--backup-dir", str(backups),
+                "--sources", str(sources), "--force", "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert Path(payload["database"]) == db_path
+    assert payload["rescue"] is not None
+    assert payload["report"]["ok"] is True
+    assert payload["report"]["row_counts"]["document"] >= 1
+
+
+# --------------------------------------------------------------------------- #
+# blob resolution (`pemr verify`, and the tail of `pemr restore`)
+# --------------------------------------------------------------------------- #
+
+def test_missing_blob_is_a_warning_not_a_failure(tmp_path, capsys):
+    db_path, sources = _populated(tmp_path)
+    backups = tmp_path / "backups"
+    assert _run(db_path, "backup", "--backup-dir", str(backups)) == 0
+    db_path.unlink()
+    for blob in sources.rglob("*"):
+        if blob.is_file():
+            blob.unlink()
+
+    capsys.readouterr()
+    rc = _run(db_path, "restore", "latest", "--backup-dir", str(backups),
+              "--sources", str(sources))
+    captured = capsys.readouterr()
+    assert rc == 0, "the database restore genuinely succeeded"
+    assert "blob missing" in captured.out
+    assert "warning" in captured.err
+
+
+def test_verify_reports_sha_mismatch(tmp_path, capsys):
+    db_path, sources = _populated(tmp_path)
+    blob = next(p for p in sources.rglob("*") if p.is_file())
+    blob.write_bytes(b"tampered content")
+
+    capsys.readouterr()
+    rc = _run(db_path, "verify", "--sources", str(sources))
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "sha256 mismatch" in out
+    assert "1 mismatched" in out
+
+
+def test_verify_ok_on_a_healthy_archive(tmp_path, capsys):
+    db_path, sources = _populated(tmp_path)
+    capsys.readouterr()
+    assert _run(db_path, "verify", "--sources", str(sources)) == 0
+    out = capsys.readouterr().out
+    assert "integrity      ok" in out
+    assert "0 missing, 0 mismatched" in out
+
+
+def test_verify_json_and_skipped_blob_pass(tmp_path, capsys, monkeypatch):
+    db_path, _ = _populated(tmp_path)
+    monkeypatch.delenv("PEMR_SOURCES", raising=False)
+    capsys.readouterr()
+    # No --sources and no config: the blob pass is skipped with a note, never fatal.
+    assert _run(db_path, "verify", "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["blobs"]["skipped"]
+    assert payload["ok"] is True
+    assert payload["migrations"]
+
+
+def test_verify_report_caps_displayed_problems(tmp_path):
+    report = verify.VerifyReport(integrity="ok")
+    report.problems = [f"problem {i}" for i in range(verify.PROBLEM_DISPLAY_LIMIT + 5)]
+    lines = "\n".join(verify.format_report(report))
+    assert "and 5 more" in lines
+    assert "problem 0" in lines
+    assert f"problem {verify.PROBLEM_DISPLAY_LIMIT}" not in lines
+
+
+# --------------------------------------------------------------------------- #
+# write-time snapshot verification (issue #55, backup side)
+# --------------------------------------------------------------------------- #
+
+def test_snapshot_of_corrupt_db_raises_and_leaves_no_target(tmp_path):
+    src = _corrupt_file(tmp_path / "pemr.db")
+    out = tmp_path / "backups"
+    with pytest.raises(backup.BackupError):
+        backup.snapshot(src, out)
+    assert list(out.glob("pemr-*.sqlite")) == []
+
+
+def test_snapshot_failing_verification_is_unlinked(tmp_path, monkeypatch):
+    """The verify step itself: a snapshot that does not check out never survives."""
+    db_path = tmp_path / "pemr.db"
+    assert _run(db_path, "migrate", "--create") == 0
+    out = tmp_path / "backups"
+    monkeypatch.setattr(backup, "integrity_check", lambda path: "*** in page 3")
+    with pytest.raises(backup.BackupError, match="failed verification"):
+        backup.snapshot(db_path, out)
+    assert list(out.glob("pemr-*.sqlite")) == []
+
+
+def test_corrupt_db_backup_never_reaches_rotation(tmp_path, capsys):
+    """Ordering is the point: rotation must not prune good snapshots for a bad one."""
+    out = tmp_path / "backups"
+    out.mkdir()
+    good = out / "pemr-20200101-1200.sqlite"
+    good.write_bytes(b"stub")
+    _corrupt_file(tmp_path / "pemr.db")
+
+    capsys.readouterr()
+    rc = _run(tmp_path / "pemr.db", "backup", "--backup-dir", str(out),
+              "--keep-daily", "0", "--keep-weekly", "0")
+    assert rc == 1
+    assert "snapshot failed" in capsys.readouterr().err
+    assert good.exists(), "rotation must never have run"
+
+
+def test_snapshot_name_override_is_verbatim_and_never_overwrites(tmp_path):
+    db_path = tmp_path / "pemr.db"
+    assert _run(db_path, "migrate", "--create") == 0
+    out = tmp_path / "backups"
+    snap, size = backup.snapshot(db_path, out, name="pemr-prerestore-20260101-000000.sqlite")
+    assert snap.name == "pemr-prerestore-20260101-000000.sqlite"
+    assert size > 0
+    with pytest.raises(backup.BackupError):
+        backup.snapshot(db_path, out, name=snap.name)
+    assert snap.exists(), "the refused second write must not clobber the first"


### PR DESCRIPTION
## Summary

Closes #55. `pemr backup` had no restore side — this adds one, plus the safety
gate the issue's drill showed was missing.

- **`pemr restore <snapshot|latest> [--force] [--json]`** — validates the
  source (opens, `integrity_check`, has a pemr schema, isn't the live DB)
  before touching anything; takes a `pemr-prerestore-*` rescue copy of the
  live DB when one exists (rotation-immune by construction); clears stale
  `-wal`/`-shm` sidecars; installs atomically (`os.replace`); runs `migrate`;
  reports via `pemr verify`.
- **`pemr verify [--json]`** — integrity, applied migrations, row counts, and
  blob resolution (`document.source_path` vs `sources_dir`, re-hashed).
  Console and `--json` exit codes now agree.
- **`migrate` bootstrap gate** — refuses to run on a missing or zero-byte
  database (previously it silently manufactured a convincing empty archive,
  which could then be backed up and prune real snapshots on rotation);
  `--create` bootstraps explicitly. Both CLI and MCP front doors share the
  same gate and message.
- **`pemr backup` refuses to snapshot** a missing, zero-byte, or schema-less
  database, closing the same empty-archive-then-rotate chain from the write
  side.
- Write-time snapshot verification: a corrupt `VACUUM INTO` result is
  detected and unlinked before rotation ever runs.
- `docs/Architecture.md` §5/§8 and `README.md` updated for the new commands,
  the restore sequence, and what backups do/don't protect against.

## Process notes for reviewers

This went through intake → design → build → verify → audit twice: the first
audit pass (at `b862212`) bounced two blocking findings (`backup` on a
zero-byte DB pruning real snapshots; `verify --json` exit code disagreeing
with console) plus three should-fix items, all closed in `a01529a` with
regression tests. A later merge of `dev` (bringing in #68's `pemr document`
subcommands) reopened the same connect-gate hole for the four new `document`
commands; closed in `4689b99`/`8f4ecde` with a structural regression test
(`test_no_cli_command_bypasses_the_connect_gate`) so the failure mode that
actually happened can't silently reopen.

Full history, evidence, and non-blocking findings are on the issue thread.

**Left as non-blocking, not pulled into this PR:** two docs-only polish notes
from the final audit pass (a message clause on the rare post-install
sidecar-unlink failure; naming the `-2` rescue-copy suffix and the
corrupt-live-DB workaround explicitly in §8 — the general case is already
covered there). Neither affects behavior or contradicts documented behavior;
happy to fold in on request.

## Test plan

- [x] `python -m pytest tests/` — 349 passed
- [x] `npm run check:meta-drift` passes
- [x] Issue's own drill run by hand end-to-end (backup → stale sidecars →
      delete `pemr.db` → `restore latest`): row counts, `schema_migrations`,
      and blob resolution all match pre-delete
- [x] All nine design acceptance cases + the connect-gate regression
      re-verified at HEAD (`8f4ecde`)