### PR TITLE
fix: a past ended_on ends a med course regardless of status

### DIFF
--- a/pemr/query.py
+++ b/pemr/query.py
@@ -14,9 +14,10 @@ Python over the candidate rows rather than in SQL.
 
 from __future__ import annotations
 
+import calendar
 import re
 import sqlite3
-from datetime import date
+from datetime import date, datetime
 
 from . import db
 from .dedup import norm
@@ -40,18 +41,54 @@ def _row_get(row: sqlite3.Row | dict, key: str) -> object:
         return None
 
 
-def med_is_current(row: sqlite3.Row | dict) -> bool:
-    """True when a medication is still current: no end date *and* no terminal status.
+def _end_of_period(value: object) -> date | None:
+    """Last day covered by an ``ended_on``, or ``None`` when it can't be parsed.
 
-    An explicit ``status='active'`` always counts as current (even alongside an end
-    date). A terminal status (:data:`TERMINAL_MED_STATUSES`) ends the course even when
-    no ``ended_on`` was extracted — the contradiction behind issue #21, where a
-    ``completed`` med with a null ``ended_on`` rendered as ``(current)``."""
+    ``ended_on`` is stored at year (``2024``), month (``2024-01``) or full precision
+    (``2024-01-01``, possibly as a timestamp) — see ``dedup.DATE_FIELDS``. A coarse
+    date is widened to the **end** of the period it names (``2024`` -> ``2024-12-31``),
+    so a course only counts as over once every day it could have covered is past. That
+    direction is deliberate: dropping a med the record may still cover is the worse
+    error in a document handed to a clinician.
+    """
+    text = str(value).strip().replace("T", " ").split(" ")[0]
+    parts = text.split("-")
+    try:
+        if len(parts) == 1:
+            return date(int(parts[0]), 12, 31)
+        if len(parts) == 2:
+            year, month = int(parts[0]), int(parts[1])
+            return date(year, month, calendar.monthrange(year, month)[1])
+        return date(int(parts[0]), int(parts[1]), int(parts[2]))
+    except (ValueError, TypeError):
+        return None
+
+
+def med_is_current(row: sqlite3.Row | dict, *, now: datetime | None = None) -> bool:
+    """True when a medication is still current: the course hasn't ended and no terminal
+    status ended it.
+
+    A past ``ended_on`` ends the course whatever the ``status`` says (issue #57):
+    printed med lists head a section "Active", so a faithful extraction of a 2024 visit
+    note carries ``status='active'`` on a finished ten-day antibiotic course, and that
+    stale label must not outrank an explicit end date. ``status='active'`` wins only
+    when ``ended_on`` is absent, still in the future, or unparseable (the prior-auth
+    case: approved *through* a future date). Any other end date still ends the course
+    as before — only ``status='active'`` overrides a future one.
+
+    A terminal status (:data:`TERMINAL_MED_STATUSES`) ends the course even when no
+    ``ended_on`` was extracted — the contradiction behind issue #21, where a
+    ``completed`` med with a null ``ended_on`` rendered as ``(current)``.
+
+    ``now`` is injectable for deterministic tests/renders, like the ``render`` layer's.
+    """
     status = str(_row_get(row, "status") or "").strip().lower()
-    if status == "active":
-        return True
-    if _row_get(row, "ended_on"):
-        return False
+    ended_on = _row_get(row, "ended_on")
+    if ended_on:
+        end = _end_of_period(ended_on)
+        if end is not None and end < (now or datetime.now()).date():
+            return False
+        return status == "active"
     return status not in TERMINAL_MED_STATUSES
 
 
@@ -104,18 +141,25 @@ def query_labs(
 
 
 def query_meds(
-    conn: sqlite3.Connection, slug: str, active: bool = False
+    conn: sqlite3.Connection,
+    slug: str,
+    active: bool = False,
+    *,
+    now: datetime | None = None,
 ) -> list[dict]:
     """Medications for a person. ``active`` keeps only current ones — no end date and
-    no terminal status, or an explicit ``status='active'`` (Architecture.md §5). A
-    terminal status (completed/stopped/discontinued) ends the course even without an
-    ``ended_on``, so such rows are excluded from ``active`` (issue #21)."""
+    no terminal status, or a still-future end date with ``status='active'``
+    (Architecture.md §5, :func:`med_is_current`). A terminal status
+    (completed/stopped/discontinued) ends the course even without an ``ended_on``
+    (issue #21), and a *past* ``ended_on`` ends it even under ``status='active'``
+    (issue #57), so both are excluded from ``active``. ``now`` is injectable so the
+    render layer's deterministic clock reaches the currency test."""
     person_id = resolve_person_id(conn, slug)
     sql = ("SELECT * FROM medication WHERE person_id = ? "
            "ORDER BY (started_on IS NULL), started_on, name")
     rows = [dict(r) for r in conn.execute(sql, (person_id,)).fetchall()]
     if active:
-        rows = [r for r in rows if med_is_current(r)]
+        rows = [r for r in rows if med_is_current(r, now=now)]
     return rows
 
 

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -233,7 +233,7 @@ def render_summary(
         f"observations={counts['observation']}\n"
     )
 
-    meds = query.query_meds(conn, slug, active=True)
+    meds = query.query_meds(conn, slug, active=True, now=now)
     med_lines = []
     for m in meds:
         dose = f" {m['dose']}" if m["dose"] else ""
@@ -333,7 +333,7 @@ def render_brief(
         f"- Reason: {appt['reason'] or '(none given)'}",
     ])
 
-    meds = query.query_meds(conn, person["slug"], active=True)
+    meds = query.query_meds(conn, person["slug"], active=True, now=now)
     med_lines = []
     for m in meds:
         dose = f" {m['dose']}" if m["dose"] else ""

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -114,6 +114,28 @@ def test_query_meds_terminal_status_renders_ended_not_current(ready, capsys):
     assert "(current)" in metformin
 
 
+def test_query_meds_active_drops_expired_course_labelled_active(ready, capsys):
+    """Issue #57 repro: a 2024 ten-day course carrying status='active' must not come
+    back from `query meds --active`; a future end date under the same status must."""
+    conn = db.connect(ready / "cli.db")
+    d = dedup.load_dictionary(DICT_ARG[1])
+    doc = conn.execute("SELECT document_id FROM document LIMIT 1").fetchone()["document_id"]
+    dedup.commit_extraction(conn, doc, {
+        "medication": [
+            {"name": "Amoxicillin", "dose": "500mg", "frequency": "TID",
+             "started_on": "2024-01-01", "ended_on": "2024-01-10", "status": "active"},
+            {"name": "Skyrizi", "dose": "150mg", "frequency": "q8w",
+             "started_on": "2025-09-04", "ended_on": "2099-09-04", "status": "active"},
+        ],
+    }, d)
+    conn.close()
+
+    assert _run(ready, "query", "meds", "--person", "jane-doe", "--active", "--json") == 0
+    names = [m["name"] for m in json.loads(capsys.readouterr().out)]
+    assert "Amoxicillin" not in names
+    assert "Skyrizi" in names
+
+
 def test_query_timeline_json(ready, capsys):
     assert _run(ready, "query", "timeline", "--person", "jane-doe", "--json") == 0
     events = json.loads(capsys.readouterr().out)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -3,6 +3,7 @@ FTS backfill on migrate, trends math, dictionary normalization, and person isola
 
 import shutil
 import uuid
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -110,19 +111,48 @@ def test_query_meds_all_vs_active(seeded):
     assert [m["name"] for m in active] == ["Metformin"]  # Lisinopril is ended
 
 
+NOW = datetime(2026, 8, 2, 9, 30)  # fixed "today" so the currency tests never age out
+
+
 @pytest.mark.parametrize("row, expected", [
     ({"status": None, "ended_on": None}, True),          # nothing set -> current
     ({"status": "", "ended_on": None}, True),            # blank status -> current
     ({"status": "active", "ended_on": None}, True),      # explicitly active
-    ({"status": "active", "ended_on": "2024-01-01"}, True),  # explicit active wins over end
     ({"status": "prn", "ended_on": None}, True),         # prn is not terminal
     ({"status": "completed", "ended_on": None}, False),  # issue #21: terminal, no end date
     ({"status": "Stopped", "ended_on": None}, False),    # case-insensitive
     ({"status": " discontinued ", "ended_on": None}, False),  # trimmed
     ({"status": None, "ended_on": "2024-06-01"}, False), # explicit end date
+    # issue #57: a past end date ends the course whatever the status label says.
+    ({"status": "active", "ended_on": "2024-01-10"}, False),
+    ({"status": "Active", "ended_on": "2026-08-01"}, False),   # ended yesterday
+    ({"status": "active", "ended_on": "2026-08-02"}, True),    # ends today -> still on it
+    ({"status": "active", "ended_on": "2026-09-04"}, True),    # prior auth through a future date
+    ({"status": "active", "ended_on": "2026-08-02T00:00:00"}, True),  # timestamp form
+    # Partial precision widens to the END of the period it names, so a course only
+    # expires once every day it could have covered is past.
+    ({"status": "active", "ended_on": "2024"}, False),         # 2024-12-31 < today
+    ({"status": "active", "ended_on": "2026"}, True),          # 2026-12-31 >= today
+    ({"status": "active", "ended_on": "2026-07"}, False),      # 2026-07-31 < today
+    ({"status": "active", "ended_on": "2026-08"}, True),       # 2026-08-31 >= today
+    ({"status": "active", "ended_on": "2026-02"}, False),      # leap-month end, still past
+    ({"status": "active", "ended_on": "not-a-date"}, True),    # unparseable -> active wins
+    ({"status": None, "ended_on": "not-a-date"}, False),       # ...but only for 'active'
+    # Unchanged: a bare end date still ends the course; only status='active' overrides
+    # a future one.
+    ({"status": None, "ended_on": "2026-09-04"}, False),
+    ({"status": "completed", "ended_on": "2026-09-04"}, False),
 ])
 def test_med_is_current(row, expected):
-    assert query.med_is_current(row) is expected
+    assert query.med_is_current(row, now=NOW) is expected
+
+
+def test_med_is_current_defaults_to_the_real_clock():
+    """Without an injected ``now`` the currency test uses today (the CLI/MCP path)."""
+    past = (datetime.now() - timedelta(days=1)).date().isoformat()
+    future = (datetime.now() + timedelta(days=365)).date().isoformat()
+    assert query.med_is_current({"status": "active", "ended_on": past}) is False
+    assert query.med_is_current({"status": "active", "ended_on": future}) is True
 
 
 def test_query_meds_active_excludes_terminal_status_without_end(seeded):
@@ -138,6 +168,25 @@ def test_query_meds_active_excludes_terminal_status_without_end(seeded):
     assert "Amoxicillin" in names_all  # still listed by the unfiltered query
     names_active = {m["name"] for m in query.query_meds(seeded, "jane-doe", active=True)}
     assert "Amoxicillin" not in names_active
+
+
+def test_query_meds_active_excludes_expired_course_labelled_active(seeded):
+    """A finished course transcribed with status='active' is not current (issue #57);
+    a still-open one with a future end date is."""
+    doc = _doc(seeded, "jane-doe")
+    dedup.commit_extraction(seeded, doc, {
+        "medication": [
+            {"name": "Amoxicillin", "dose": "500mg", "frequency": "TID",
+             "started_on": "2024-01-01", "ended_on": "2024-01-10", "status": "active"},
+            {"name": "Skyrizi", "dose": "150mg", "frequency": "q8w",
+             "started_on": "2025-09-04", "ended_on": "2026-09-04", "status": "active"},
+        ],
+    }, dedup.load_dictionary(DICT_PATH))
+    names_all = {m["name"] for m in query.query_meds(seeded, "jane-doe")}
+    assert {"Amoxicillin", "Skyrizi"} <= names_all  # both still listed unfiltered
+    active = {m["name"] for m in query.query_meds(seeded, "jane-doe", active=True, now=NOW)}
+    assert "Amoxicillin" not in active
+    assert "Skyrizi" in active
 
 
 # --- structured: timeline -----------------------------------------------------

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -5,6 +5,7 @@ abnormal-lab selection, latest-vitals pick, brief scoping, journal ordering + pr
 footnotes, ASCII output (cp1252/cp437 console lesson), and the read-only guarantee
 (no row-count change after any render)."""
 
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -123,6 +124,35 @@ def test_summary_active_meds_only(seeded):
     md = render.render_summary(seeded, "jane-doe")
     assert "Metformin 500mg BID (since 2024-02-01)" in md
     assert "Lisinopril" not in md  # ended med excluded from the active list
+
+
+def _seed_expired_active_course(conn):
+    """A finished 2024 antibiotic course transcribed with status='active' (issue #57)."""
+    dedup.commit_extraction(conn, _doc(conn, "jane-doe"), {
+        "medication": [
+            {"name": "Amoxicillin", "dose": "500mg", "frequency": "TID",
+             "started_on": "2024-01-01", "ended_on": "2024-01-10", "status": "active"},
+        ],
+    }, dedup.load_dictionary(DICT_PATH))
+
+
+def test_summary_excludes_expired_course_labelled_active(seeded):
+    """Issue #57: a stale 'active' label must not keep a 2024 course in the summary --
+    and `now` has to reach the currency test, not just the generated-at stamp."""
+    _seed_expired_active_course(seeded)
+    md = render.render_summary(seeded, "jane-doe", now=datetime(2026, 8, 2, 9, 30))
+    assert "Amoxicillin" not in md
+    assert "Metformin" in md  # control: genuinely current med still listed
+
+
+def test_brief_excludes_expired_course_labelled_active(seeded):
+    """Same for the brief -- the document actually handed to a clinician (issue #57)."""
+    _seed_expired_active_course(seeded)
+    md = render.render_brief(
+        seeded, _upcoming_appt_id(seeded), now=datetime(2026, 8, 2, 9, 30)
+    )
+    assert "Amoxicillin" not in md
+    assert "Metformin" in md
 
 
 def test_summary_conditions_and_allergies(seeded):


### PR DESCRIPTION
## Summary
- `med_is_current` returned `True` on `status == 'active'` before ever checking `ended_on`, so a finished med course whose extraction carried `status='active'` never expired — a past ten-day antibiotic course kept rendering under **Current Medications** in the brief.
- `status='active'` now wins only when `ended_on` is absent, still in the future, or unparseable (the prior-auth "approved through <future date>" case); a past `ended_on` ends the course regardless of the status label. Issue #21's rule is untouched: a terminal status still ends a course that has no `ended_on`.
- `med_is_current` / `query_meds` now take an injectable `now`, threaded through from `render_summary` / `render_brief`'s existing deterministic generated-at clock.
- Partial `ended_on` precision (`2024`, `2024-01`) widens to the *end* of the period it names, so a course only expires once every day it could cover is past.

Closes #57

## Test plan
- [x] `pemr/query.py`, `pemr/render.py` unit tests updated (`tests/test_query.py`, `tests/test_render.py`, `tests/test_cli_phase3.py`)
- [x] Full suite: `python -m pytest` — 367 passed
- [x] Merged latest `dev` into the branch (brings in #55's restore/verify/document work); merge was clean, no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)