### PR TITLE
feat: --keep both resolution for genuine same-day draws

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,10 @@ Agents never resolve staged conflicts silently.
 - The listing reports `occurrences` — how many rows already sit under that identity. More than one
   means a repeat was admitted before, so check whether the incoming row is a re-read of one of them
   before proposing anything.
+- `keep incoming` overwrites the stored row the conflict is anchored to. If every row under that
+  identity was removed in the meantime (the source document was deleted or reassigned), it is
+  **refused** — never silently applied to nothing. Report the refusal to the human; `keep both`
+  admits the staged row as a fresh record if they want the value kept.
 - `commit_extraction` **rejects** two rows of one submission that derive the same key and disagree;
   that is an extraction error, not a conflict. Re-read the source for collection times; if there
   genuinely are none, submit them separately and ask the human about `keep both`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,11 +139,23 @@ Agents never resolve staged conflicts silently.
 
 - `review_conflicts` with no `resolve` id **lists** conflicts — call it freely.
 - **Resolution requires explicit human sign-off.** The human must have named the specific conflict
-  and the chosen resolution (`keep existing` / `keep incoming`) in the current session. "Clean this
-  up", silence, or a standing general instruction is **not** sign-off.
+  and the chosen resolution (`keep existing` / `keep incoming` / `keep both`) in the current
+  session. "Clean this up", silence, or a standing general instruction is **not** sign-off.
 - Mechanically: `review_conflicts(resolve=…)` requires a non-empty `signoff` param quoting the
   human's instruction verbatim; the wrapper refuses the write otherwise and stores the sign-off
   text with the resolution.
+- `keep both` is the odd one out: it **admits a row** rather than choosing between two. Use it only
+  for a genuine repeat the source cannot distinguish — two same-day draws on a report that prints
+  no collection times (see §6). It inserts the incoming row alongside the stored one as the next
+  *occurrence* of that identity; a later re-commit of that same payload then dedups against it. If
+  the source *did* give distinct times and the extraction dropped them, the fix is a corrected
+  extraction, not `keep both`.
+- The listing reports `occurrences` — how many rows already sit under that identity. More than one
+  means a repeat was admitted before, so check whether the incoming row is a re-read of one of them
+  before proposing anything.
+- `commit_extraction` **rejects** two rows of one submission that derive the same key and disagree;
+  that is an extraction error, not a conflict. Re-read the source for collection times; if there
+  genuinely are none, submit them separately and ask the human about `keep both`.
 
 ### 5. Medication-interaction section
 
@@ -177,6 +189,9 @@ day or month the source didn't state, and never fall back to stashing an impreci
   ISO prefix first.
 - A partial and a later full date of the same event stay **distinct rows** (the dedup layer never
   guesses that one refines the other); reconciling them is a human conflict-review action.
+- Date-only precision is also why two genuine same-day results collide: they derive one key, so the
+  second stages a conflict. Emitting a time you invented is never the fix — the recovery path is
+  `keep both` under human sign-off (§4).
 
 ## Privacy posture
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -258,6 +258,16 @@ commit of an already-admitted draw from forking again. `dedup_base` is denormali
 purpose: the family is one indexed lookup instead of probing `hash(base|1)`, `hash(base|2)`
 … which breaks on holes when a sibling is removed.
 
+**A conflict's key is the family base, not a row's key.** `conflict.dedup_key` always
+holds the `dedup_base`, and the conflict is anchored to the family's lowest surviving
+occurrence. Resolutions therefore address that row by **primary key** — never by
+`WHERE dedup_key = conflict.dedup_key`. Once occurrence 0 is gone (`document rm` or
+`document reassign` of the document that owned it) the anchor's own key is
+`hash(base | n)`, so a key-targeted write would match nothing while the conflict was
+stamped `resolved`, silently discarding the staged value. If nothing is left in the family
+at all, `keep incoming` **refuses** rather than reporting a success that wrote nothing;
+`keep both` still admits the staged row, at occurrence 0.
+
 **Intra-payload collisions are rejected, not staged.** Two rows in *one* submission that
 derive the same key and disagree fail validation (pass 1) and roll the batch back, naming
 the identity and the recovery path. A conflict whose "existing" side was inserted

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -268,6 +268,18 @@ stamped `resolved`, silently discarding the staged value. If nothing is left in 
 at all, `keep incoming` **refuses** rather than reporting a success that wrote nothing;
 `keep both` still admits the staged row, at occurrence 0.
 
+The stored `conflict.dedup_key` is also only the *current* base while the dictionary holds
+still: `rekey` rewrites keys on the record tables and does not touch the `conflict` table,
+so a dictionary edit made while a conflict is open strands it on a base no row carries.
+Resolutions therefore **re-derive** the base from the conflict's own payload under the
+current dictionary (`review-conflicts --dictionary`, mirroring `rekey`) and only fall back
+to the stored key when the derived base has no rows — i.e. when the dictionary changed but
+`rekey` has not run yet, where the stored rows are still the live family. Numbering an
+admitted row on a stale base instead would give it a key not derivable from its own
+columns, which collides the family on the next `rekey` and — because `rekey` is
+all-or-nothing across every table — blocks every later dictionary edit, `document reassign`
+included.
+
 **Intra-payload collisions are rejected, not staged.** Two rows in *one* submission that
 derive the same key and disagree fail validation (pass 1) and roll the batch back, naming
 the identity and the recovery path. A conflict whose "existing" side was inserted
@@ -318,7 +330,7 @@ giving the agent text to work from instead of re-reading pixels every time.
 pemr person add|list|show|edit|deactivate|reactivate|remove
 pemr ingest <file> --person <slug> [--ocr tesseract]
 pemr commit-extraction --document <id> --json <file>
-pemr review-conflicts [--resolve <id> --keep existing|incoming|both [--note ...]]
+pemr review-conflicts [--resolve <id> --keep existing|incoming|both [--note ...]] [--dictionary <toml>]
 pemr document list [--person <slug>]                     # newest first; omit --person for everyone
 pemr document edit <id> [--doc-date|--category|--provider ...]   # partial update; "" clears a field
 pemr document reassign <id> --person <slug> [--apply]    # move a misfiled document + records; dry run by default

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -272,13 +272,17 @@ The stored `conflict.dedup_key` is also only the *current* base while the dictio
 still: `rekey` rewrites keys on the record tables and does not touch the `conflict` table,
 so a dictionary edit made while a conflict is open strands it on a base no row carries.
 Resolutions therefore **re-derive** the base from the conflict's own payload under the
-current dictionary (`review-conflicts --dictionary`, mirroring `rekey`) and only fall back
-to the stored key when the derived base has no rows — i.e. when the dictionary changed but
-`rekey` has not run yet, where the stored rows are still the live family. Numbering an
-admitted row on a stale base instead would give it a key not derivable from its own
-columns, which collides the family on the next `rekey` and — because `rekey` is
-all-or-nothing across every table — blocks every later dictionary edit, `document reassign`
-included.
+current dictionary (`review-conflicts --dictionary`, mirroring `rekey`) — but the *staged*
+key still wins whenever it has rows, and the re-derived base is used only when it does not.
+The staged key names the family the conflict was actually staged against; the re-derivation
+exists only for the case where `rekey` has already moved that family off it. Preferring the
+derived base would misfire on a dictionary edit that **fuses two identities**: the derived
+base then holds a different, pre-existing family, and the resolution would overwrite (or
+join) an unrelated record while the conflict's own row went untouched — and `rekey` refuses
+to run in that state, so the database stays there. Conversely, numbering an admitted row on
+a stale base that no row carries would give it a key not derivable from its own columns,
+which collides the family on the next `rekey` and — because `rekey` is all-or-nothing across
+every table — blocks every later dictionary edit, `document reassign` included.
 
 **Intra-payload collisions are rejected, not staged.** Two rows in *one* submission that
 derive the same key and disagree fail validation (pass 1) and roll the batch back, naming

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -95,7 +95,9 @@ CREATE TABLE document (
 );
 ```
 
-High-value typed tables (each carries `document_id` provenance + a `dedup_key`):
+High-value typed tables (each carries `document_id` provenance + a `dedup_key`; migration
+005 added `dedup_base`/`dedup_occurrence` to every one of them — see the occurrence model
+in §3, omitted from the DDL below to keep the shapes readable):
 
 ```sql
 CREATE TABLE lab_result (
@@ -233,6 +235,43 @@ of the key, this fires for *any* magnitude of value change on a matching draw �
 headline `Glucose 92 → 95` (or `92 → 130`) case that previously slipped through as a silent
 new row now stages a conflict.
 
+**Occurrence model (`--keep both`).** The date-only safety bias above is only recoverable
+if a resolution can say "both of these are real." `review-conflicts --resolve --keep both`
+admits the incoming row *alongside* the stored one, so every identity is a **family** of
+one or more occurrences rather than a single row:
+
+```
+dedup_base       = hash(person_id | identity fields…)   -- shared by the family
+dedup_occurrence = 0 for the first row, 1, 2, … for admitted repeats
+dedup_key        = dedup_base                    when occurrence = 0
+                 = hash(dedup_base | occurrence) when occurrence > 0
+```
+
+Occurrence 0 reproduces the pre-005 key byte-for-byte, so the migration was a pure column
+copy — no rekey, no re-commit. The disambiguator lives in a **column**, not in a
+resolution-time suffix, because `pemr rekey` re-derives every key from payload columns: a
+suffix it could not see would recompute to the base, collide with its sibling, and abort
+the rekey. Commit-time matching is therefore family-aware — an incoming row that is
+payload-equal to *any* sibling is a duplicate, and only a genuinely different value on
+that identity stages a new conflict (against occurrence 0). That is what stops a third
+commit of an already-admitted draw from forking again. `dedup_base` is denormalized on
+purpose: the family is one indexed lookup instead of probing `hash(base|1)`, `hash(base|2)`
+… which breaks on holes when a sibling is removed.
+
+**Intra-payload collisions are rejected, not staged.** Two rows in *one* submission that
+derive the same key and disagree fail validation (pass 1) and roll the batch back, naming
+the identity and the recovery path. A conflict whose "existing" side was inserted
+milliseconds earlier in the same batch has no independent provenance to adjudicate
+against; the overwhelmingly likely cause is a collection time the source did give and the
+extraction dropped. Two *identical* rows in one payload stay benign (first inserts, second
+reports `duplicate`) — that is an agent listing one fact twice. Genuine untimestampable
+repeats go through two submissions plus `--keep both`, which keeps the human sign-off in
+the loop rather than letting an agent self-admit near-duplicates.
+
+Because siblings legitimately share a date, every same-date ordering is tie-broken by row
+id (`query labs`, the summary/brief lab sections): the admitted row sorts as the later
+point, so `trends` deltas and "latest value" stay deterministic.
+
 ---
 
 ## 4. Ingestion pipeline
@@ -269,7 +308,7 @@ giving the agent text to work from instead of re-reading pixels every time.
 pemr person add|list|show|edit|deactivate|reactivate|remove
 pemr ingest <file> --person <slug> [--ocr tesseract]
 pemr commit-extraction --document <id> --json <file>
-pemr review-conflicts [--resolve ...]
+pemr review-conflicts [--resolve <id> --keep existing|incoming|both [--note ...]]
 pemr document list [--person <slug>]                     # newest first; omit --person for everyone
 pemr document edit <id> [--doc-date|--category|--provider ...]   # partial update; "" clears a field
 pemr document reassign <id> --person <slug> [--apply]    # move a misfiled document + records; dry run by default

--- a/migrations/005_dedup_occurrence.sql
+++ b/migrations/005_dedup_occurrence.sql
@@ -1,0 +1,45 @@
+-- 005_dedup_occurrence: occurrence numbering on the dedup identity family (issue #58).
+--
+-- `review-conflicts --resolve --keep both` admits a genuine repeat (two same-day draws on
+-- a report that prints no collection times) alongside the row it collided with. The two
+-- rows share an identity but cannot share a `dedup_key` (it is UNIQUE), so the family gets
+-- an explicit numbering:
+--
+--   dedup_base       = hash(person_id | identity fields...)   -- shared by the whole family
+--   dedup_occurrence = 0 for the first row, 1, 2, ... for admitted repeats
+--   dedup_key        = dedup_base                    when occurrence = 0
+--                    = hash(dedup_base | occurrence) when occurrence > 0
+--
+-- Occurrence 0 reproduces today's key byte-for-byte, so this migration is a pure column
+-- copy: no rekey, no re-commit, no invalidated data.
+--
+-- `dedup_base` is denormalized (it is recomputable from the payload) on purpose: it makes
+-- "the occurrence family" one indexed lookup instead of probing hash(base|1), hash(base|2)
+-- ... which breaks on holes if a sibling is ever removed. `pemr.dedup` maintains the
+-- invariant `dedup_base IS NOT NULL` on every write path (insert / rekey / reassign), and
+-- the commit-time family lookup relies on it.
+
+ALTER TABLE lab_result  ADD COLUMN dedup_base       TEXT;
+ALTER TABLE lab_result  ADD COLUMN dedup_occurrence INTEGER NOT NULL DEFAULT 0;
+UPDATE lab_result  SET dedup_base = dedup_key;
+CREATE INDEX idx_lab_result_dedup_base  ON lab_result(dedup_base);
+
+ALTER TABLE medication  ADD COLUMN dedup_base       TEXT;
+ALTER TABLE medication  ADD COLUMN dedup_occurrence INTEGER NOT NULL DEFAULT 0;
+UPDATE medication  SET dedup_base = dedup_key;
+CREATE INDEX idx_medication_dedup_base  ON medication(dedup_base);
+
+ALTER TABLE procedure   ADD COLUMN dedup_base       TEXT;
+ALTER TABLE procedure   ADD COLUMN dedup_occurrence INTEGER NOT NULL DEFAULT 0;
+UPDATE procedure   SET dedup_base = dedup_key;
+CREATE INDEX idx_procedure_dedup_base   ON procedure(dedup_base);
+
+ALTER TABLE appointment ADD COLUMN dedup_base       TEXT;
+ALTER TABLE appointment ADD COLUMN dedup_occurrence INTEGER NOT NULL DEFAULT 0;
+UPDATE appointment SET dedup_base = dedup_key;
+CREATE INDEX idx_appointment_dedup_base ON appointment(dedup_base);
+
+ALTER TABLE observation ADD COLUMN dedup_base       TEXT;
+ALTER TABLE observation ADD COLUMN dedup_occurrence INTEGER NOT NULL DEFAULT 0;
+UPDATE observation SET dedup_base = dedup_key;
+CREATE INDEX idx_observation_dedup_base ON observation(dedup_base);

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -671,18 +671,27 @@ def _cmd_review_conflicts(args: argparse.Namespace) -> int:
     try:
         try:
             if args.resolve is not None:
-                dedup.resolve_conflict(
+                result = dedup.resolve_conflict(
                     conn, args.resolve, keep=args.keep, note=args.note
                 )
-                print(f"resolved conflict #{args.resolve} (keep-{args.keep})")
+                print(f"resolved conflict #{args.resolve} ({_resolved_as(result)})")
                 return 0
             conflicts = dedup.list_conflicts(
                 conn, status=None if args.all else "open"
             )
+            # Family size per conflict, read before the connection closes: it is the
+            # minimum a reviewer needs to tell "re-commit of an already-admitted draw"
+            # from "genuine third draw" (richer rendering is issue #59).
+            occurrences = {
+                row["conflict_id"]: dedup.count_occurrences(
+                    conn, row["record_type"], row["dedup_key"]
+                )
+                for row in conflicts
+            }
         except db.NotMigratedError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 1
-        except ValueError as exc:
+        except ValueError as exc:   # includes ValidationError from a keep-both payload
             print(f"error: {exc}", file=sys.stderr)
             return 1
     finally:
@@ -698,11 +707,29 @@ def _cmd_review_conflicts(args: argparse.Namespace) -> int:
         )
         print(f"    existing: {row['existing_json']}")
         print(f"    incoming: {row['incoming_json']}")
+        count = occurrences.get(row["conflict_id"], 0)
+        if count > 1:
+            print(f"    occurrences: {count} rows already stored under this key")
     print(
-        "\nresolve: `pemr review-conflicts --resolve <id> --keep existing|incoming "
-        "[--note ...]`"
+        "\nresolve: `pemr review-conflicts --resolve <id> --keep "
+        "existing|incoming|both [--note ...]`"
     )
     return 0
+
+
+def _resolved_as(result: dedup.ResolveResult) -> str:
+    """How a resolution reports itself on the success line."""
+    if result.kept != "both":
+        return f"keep-{result.kept}"
+    if result.no_op:
+        return (
+            f"keep-both, no-op: already stored as {result.record_type} "
+            f"#{result.row_id}"
+        )
+    return (
+        f"keep-both -> {result.record_type} #{result.row_id}, "
+        f"occurrence {result.occurrence}"
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -710,7 +737,7 @@ def _cmd_review_conflicts(args: argparse.Namespace) -> int:
 # --------------------------------------------------------------------------- #
 
 # Internal columns never emitted in --json (unstable / not part of the contract).
-_HIDDEN_FIELDS = ("dedup_key",)
+_HIDDEN_FIELDS = dedup.INTERNAL_COLUMNS
 
 
 def _clean(row: dict) -> dict:
@@ -1261,8 +1288,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--resolve", type=int, metavar="CONFLICT_ID", help="resolve one conflict"
     )
     p_review.add_argument(
-        "--keep", choices=["existing", "incoming"], default="existing",
-        help="on --resolve: keep stored row or overwrite with incoming (default existing)",
+        "--keep", choices=list(dedup.KEEP_CHOICES), default="existing",
+        help="on --resolve: keep the stored row, overwrite it with the incoming one, "
+             "or 'both' = admit the incoming row alongside the stored one as a new "
+             "occurrence of the same identity (use for a genuine repeat the source "
+             "cannot timestamp). Default existing",
     )
     p_review.add_argument("--note", help="optional resolution note")
     p_review.add_argument(

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -670,9 +670,14 @@ def _cmd_review_conflicts(args: argparse.Namespace) -> int:
     conn = _connect_db(args)
     try:
         try:
+            # Resolutions re-derive the conflict's identity family under the current
+            # dictionary; a conflict staged before a dictionary edit carries a key no
+            # row still holds (issue #58).
+            dictionary = dedup.load_dictionary(_resolve_dictionary_path(args))
             if args.resolve is not None:
                 result = dedup.resolve_conflict(
-                    conn, args.resolve, keep=args.keep, note=args.note
+                    conn, args.resolve, keep=args.keep, note=args.note,
+                    dictionary=dictionary,
                 )
                 print(f"resolved conflict #{args.resolve} ({_resolved_as(result)})")
                 return 0
@@ -683,9 +688,7 @@ def _cmd_review_conflicts(args: argparse.Namespace) -> int:
             # minimum a reviewer needs to tell "re-commit of an already-admitted draw"
             # from "genuine third draw" (richer rendering is issue #59).
             occurrences = {
-                row["conflict_id"]: dedup.count_occurrences(
-                    conn, row["record_type"], row["dedup_key"]
-                )
+                row["conflict_id"]: dedup.conflict_occurrences(conn, row, dictionary)
                 for row in conflicts
             }
         except db.NotMigratedError as exc:
@@ -1295,6 +1298,11 @@ def build_parser() -> argparse.ArgumentParser:
              "cannot timestamp). Default existing",
     )
     p_review.add_argument("--note", help="optional resolution note")
+    p_review.add_argument(
+        "--dictionary",
+        help="synonym dictionary TOML (overrides default); a resolution re-derives "
+             "the conflict's identity through it",
+    )
     p_review.add_argument(
         "--all", action="store_true", help="list resolved conflicts too"
     )

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -779,22 +779,33 @@ def _conflict_family(
 ) -> tuple[str, list[sqlite3.Row]]:
     """``(base, rows)`` — the identity family a resolution of this conflict acts on.
 
-    The re-derived base wins whenever it has rows: that is the post-``rekey`` world,
-    and the whole point of deriving. When it is empty and differs from the staged
-    key, the record rows have *not* been rekeyed yet and still sit under the staged
-    key; staying with them keeps an admitted sibling in the same family, so a later
-    ``rekey`` moves the whole family together instead of colliding two rows onto one
-    key.
+    **The staged key wins whenever it still has rows.** ``conflict["dedup_key"]``
+    names the family the conflict was actually staged against, so preferring it is
+    correct by construction. Re-derivation (:func:`_derive_base`) is only needed for
+    the case it was added for — ``rekey`` having moved that family off the staged key
+    — so it applies only when the staged key is empty.
+
+    Preferring the derived base instead would be wrong whenever the derived base
+    holds a *different, pre-existing* family, which is exactly what a dictionary edit
+    that fuses two identities produces (and ``rekey`` refuses to run in that state, so
+    the database stays there): the resolution would overwrite, or join, an unrelated
+    record. The five states this covers:
+
+    * no drift — derived base == staged key, same family either way;
+    * drift with ``rekey`` applied — staged key empty, fall through to the live family;
+    * drift without ``rekey`` — staged key still has the rows, stay with them so a
+      later ``rekey`` moves the whole family together instead of colliding two rows;
+    * fusing drift — staged key still has the rows, so the conflict's own anchor wins
+      over the unrelated family sitting on the derived base;
+    * family fully removed — both empty, and :func:`_anchor_row` refuses.
     """
     record_type = conflict["record_type"]
     base = _derive_base(conflict, dictionary)
-    family = load_family(conn, record_type, base)
-    if family or base == conflict["dedup_key"]:
-        return base, family
-    stale = load_family(conn, record_type, conflict["dedup_key"])
-    if stale:
-        return conflict["dedup_key"], stale
-    return base, []
+    if base != conflict["dedup_key"]:
+        staged = load_family(conn, record_type, conflict["dedup_key"])
+        if staged:
+            return conflict["dedup_key"], staged
+    return base, load_family(conn, record_type, base)
 
 
 def _anchor_row(
@@ -988,7 +999,8 @@ def _overwrite_record(
 
     Primary key, not ``dedup_key``: see :func:`_anchor_row`. A zero-row UPDATE is an
     error, never a silent success - it would discard the incoming row while the
-    conflict is marked resolved.
+    conflict is marked resolved. The guard only catches *no* row, not the *wrong*
+    row; picking the right one is :func:`_conflict_family`'s job.
     """
     assignments = ["document_id = ?"]
     values: list[object] = [document_id]

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -615,9 +615,11 @@ def list_conflicts(
 class ResolveResult:
     """Outcome of :func:`resolve_conflict`.
 
-    ``row_id``/``occurrence`` describe the *admitted* row and are set only for
-    ``keep='both'``; the other resolutions choose between rows rather than adding
-    one. ``dedup_key`` is the key of the row the resolution landed on.
+    ``row_id``/``occurrence`` describe the row the resolution landed on: the
+    *admitted* row for ``keep='both'``, the *overwritten* one for
+    ``keep='incoming'``. ``keep='existing'`` writes nothing, so it leaves them
+    unset. ``dedup_key`` is that row's key (which for an occurrence >= 1 row is
+    *not* the conflict's key — see :func:`_anchor_row`).
     """
     kept: str
     record_type: str = ""
@@ -665,19 +667,31 @@ def resolve_conflict(
         raise ValueError(f"conflict {conflict_id} is already {row['status']}")
 
     record_type = row["record_type"]
-    result = (
-        _plan_keep_both(conn, row) if keep == "both"
-        else ResolveResult(
+    if keep == "both":
+        result = _plan_keep_both(conn, row)
+    elif keep == "incoming":
+        # Resolve the target *before* the transaction: a family with no rows left
+        # can no longer be overwritten, and that must refuse rather than resolve.
+        anchor = _anchor_row(
+            conn, record_type, row["dedup_key"], int(row["conflict_id"])
+        )
+        result = ResolveResult(
+            kept=keep, record_type=record_type,
+            row_id=int(anchor[f"{record_type}_id"]),
+            occurrence=int(anchor["dedup_occurrence"]),
+            dedup_key=anchor["dedup_key"],
+        )
+    else:
+        result = ResolveResult(
             kept=keep, record_type=record_type, dedup_key=row["dedup_key"]
         )
-    )
     resolved_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
 
     with conn:
         if keep == "incoming":
             incoming = json.loads(row["incoming_json"])
             _overwrite_record(
-                conn, record_type, row["dedup_key"], row["document_id"], incoming
+                conn, record_type, int(result.row_id), row["document_id"], incoming
             )
         elif keep == "both" and not result.no_op:
             result.row_id = _insert_record(
@@ -705,6 +719,29 @@ def _resolution_text(result: ResolveResult) -> str:
         f"keep-both -> {result.record_type} #{result.row_id} "
         f"occurrence={result.occurrence} key={(result.dedup_key or '')[:12]}..."
     )
+
+
+def _anchor_row(
+    conn: sqlite3.Connection, record_type: str, base: str, conflict_id: int
+) -> sqlite3.Row:
+    """The stored row a conflict is anchored to: occurrence 0, or the lowest
+    surviving occurrence of its identity family.
+
+    A conflict's ``dedup_key`` is always the family *base*, never the anchor row's
+    own key once occurrence 0 is gone (an occurrence >= 1 row keys on
+    ``hash(base|n)``). So resolutions must reach the row through the family, by
+    primary key - targeting ``WHERE dedup_key = <conflict key>`` matches nothing in
+    an orphaned family and would report success while writing nothing.
+    """
+    family = load_family(conn, record_type, base)
+    if not family:
+        raise ValueError(
+            f"conflict {conflict_id} has no stored {record_type} row left to "
+            "overwrite - every occurrence of that identity was removed after the "
+            "conflict was staged. Resolve with keep 'both' to admit the incoming "
+            "row as a new record instead."
+        )
+    return family[0]
 
 
 def _plan_keep_both(conn: sqlite3.Connection, conflict: sqlite3.Row) -> ResolveResult:
@@ -855,17 +892,29 @@ def rekey(
 def _overwrite_record(
     conn: sqlite3.Connection,
     record_type: str,
-    key: str,
+    row_id: int,
     document_id: int | None,
     incoming: dict,
 ) -> None:
+    """Overwrite one stored row's payload columns, addressed by primary key.
+
+    Primary key, not ``dedup_key``: see :func:`_anchor_row`. A zero-row UPDATE is an
+    error, never a silent success - it would discard the incoming row while the
+    conflict is marked resolved.
+    """
     assignments = ["document_id = ?"]
     values: list[object] = [document_id]
     for name in _COMPARE_FIELDS[record_type]:
         assignments.append(f"{name} = ?")
         values.append(incoming.get(name))
-    values.append(key)
-    conn.execute(
-        f"UPDATE {record_type} SET {', '.join(assignments)} WHERE dedup_key = ?",
+    values.append(row_id)
+    cur = conn.execute(
+        f"UPDATE {record_type} SET {', '.join(assignments)} "
+        f"WHERE {record_type}_id = ?",
         values,
     )
+    if cur.rowcount != 1:
+        raise ValueError(
+            f"keep-incoming matched no {record_type} row (id {row_id}) - refusing to "
+            "resolve the conflict, the incoming row would have been discarded"
+        )

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -544,6 +544,20 @@ def count_occurrences(conn: sqlite3.Connection, record_type: str, base: str) -> 
     return int(row["n"])
 
 
+def conflict_occurrences(
+    conn: sqlite3.Connection,
+    conflict: sqlite3.Row,
+    dictionary: dict[str, str] | None = None,
+) -> int:
+    """Family size for a conflict's identity, resolved the same way a resolution
+    resolves it (:func:`_conflict_family`) — a conflict staged before a dictionary
+    edit carries a key no row still holds, and counting on it reads 0 for a family
+    that exists."""
+    if conflict["record_type"] not in FIELD_SPECS:
+        return 0
+    return len(_conflict_family(conn, conflict, dictionary)[1])
+
+
 def _insert_record(
     conn: sqlite3.Connection,
     record_type: str,
@@ -619,13 +633,16 @@ class ResolveResult:
     *admitted* row for ``keep='both'``, the *overwritten* one for
     ``keep='incoming'``. ``keep='existing'`` writes nothing, so it leaves them
     unset. ``dedup_key`` is that row's key (which for an occurrence >= 1 row is
-    *not* the conflict's key — see :func:`_anchor_row`).
+    *not* the conflict's key — see :func:`_anchor_row`); ``dedup_base`` is the
+    family it joined, re-derived under the current dictionary rather than taken
+    from the conflict (see :func:`_derive_base`).
     """
     kept: str
     record_type: str = ""
     row_id: int | None = None
     occurrence: int | None = None
     dedup_key: str | None = None
+    dedup_base: str | None = None
     no_op: bool = False          # keep-both that matched an existing sibling
 
 
@@ -637,6 +654,7 @@ def resolve_conflict(
     conflict_id: int,
     keep: str,
     note: str | None = None,
+    dictionary: dict[str, str] | None = None,
 ) -> ResolveResult:
     """Resolve a staged conflict. ``keep`` is 'existing' (drop the incoming row),
     'incoming' (overwrite the stored record's payload fields with the incoming row) or
@@ -653,6 +671,11 @@ def resolve_conflict(
     idempotent by payload: if a sibling already carries that exact payload (two
     conflicts staged from one submission, both resolved 'both') nothing is inserted
     and the resolution records the no-op.
+
+    ``dictionary`` is the *current* synonym dictionary. Both writing resolutions
+    re-derive the conflict's identity family through it rather than trusting the
+    key frozen on the conflict row (:func:`_derive_base`) — pass the same dictionary
+    the caller would pass to :func:`commit_extraction` / :func:`rekey`.
     """
     db.require_migrated(conn)
     if keep not in KEEP_CHOICES:
@@ -668,18 +691,16 @@ def resolve_conflict(
 
     record_type = row["record_type"]
     if keep == "both":
-        result = _plan_keep_both(conn, row)
+        result = _plan_keep_both(conn, row, dictionary)
     elif keep == "incoming":
         # Resolve the target *before* the transaction: a family with no rows left
         # can no longer be overwritten, and that must refuse rather than resolve.
-        anchor = _anchor_row(
-            conn, record_type, row["dedup_key"], int(row["conflict_id"])
-        )
+        anchor = _anchor_row(conn, row, dictionary)
         result = ResolveResult(
             kept=keep, record_type=record_type,
             row_id=int(anchor[f"{record_type}_id"]),
             occurrence=int(anchor["dedup_occurrence"]),
-            dedup_key=anchor["dedup_key"],
+            dedup_key=anchor["dedup_key"], dedup_base=anchor["dedup_base"],
         )
     else:
         result = ResolveResult(
@@ -697,7 +718,7 @@ def resolve_conflict(
             result.row_id = _insert_record(
                 conn, record_type, json.loads(row["incoming_json"]),
                 row["person_id"], row["document_id"],
-                row["dedup_key"], result.occurrence or 0,
+                result.dedup_base or row["dedup_key"], result.occurrence or 0,
             )
         resolution = _resolution_text(result) + (f": {note}" if note else "")
         conn.execute(
@@ -721,30 +742,98 @@ def _resolution_text(result: ResolveResult) -> str:
     )
 
 
+def _derive_base(
+    conflict: sqlite3.Row, dictionary: dict[str, str] | None
+) -> str:
+    """The ``dedup_base`` this conflict's identity hashes to under the *current*
+    dictionary.
+
+    ``conflict["dedup_key"]`` is only the live base while the dictionary is
+    unchanged: ``rekey`` rewrites the record tables' keys and leaves the ``conflict``
+    table alone, so a dictionary edit made while a conflict sits open strands that
+    conflict on a base no row carries. Re-deriving from the payload is what keeps a
+    resolution landing in the live family instead of minting an underivable key
+    (which would wedge every later ``rekey``).
+
+    Falls back to the stored key when the payload cannot produce one (no
+    ``person_id``, unparseable JSON, unknown type) — those cases are refused, or
+    handled, further along by the callers.
+    """
+    if conflict["person_id"] is None:
+        return conflict["dedup_key"]
+    try:
+        incoming = json.loads(conflict["incoming_json"])
+        if not isinstance(incoming, dict):
+            return conflict["dedup_key"]
+        return dedup_key(
+            conflict["record_type"], incoming, int(conflict["person_id"]), dictionary
+        )
+    except (ValueError, TypeError):     # includes ValidationError, JSONDecodeError
+        return conflict["dedup_key"]
+
+
+def _conflict_family(
+    conn: sqlite3.Connection,
+    conflict: sqlite3.Row,
+    dictionary: dict[str, str] | None,
+) -> tuple[str, list[sqlite3.Row]]:
+    """``(base, rows)`` — the identity family a resolution of this conflict acts on.
+
+    The re-derived base wins whenever it has rows: that is the post-``rekey`` world,
+    and the whole point of deriving. When it is empty and differs from the staged
+    key, the record rows have *not* been rekeyed yet and still sit under the staged
+    key; staying with them keeps an admitted sibling in the same family, so a later
+    ``rekey`` moves the whole family together instead of colliding two rows onto one
+    key.
+    """
+    record_type = conflict["record_type"]
+    base = _derive_base(conflict, dictionary)
+    family = load_family(conn, record_type, base)
+    if family or base == conflict["dedup_key"]:
+        return base, family
+    stale = load_family(conn, record_type, conflict["dedup_key"])
+    if stale:
+        return conflict["dedup_key"], stale
+    return base, []
+
+
 def _anchor_row(
-    conn: sqlite3.Connection, record_type: str, base: str, conflict_id: int
+    conn: sqlite3.Connection,
+    conflict: sqlite3.Row,
+    dictionary: dict[str, str] | None,
 ) -> sqlite3.Row:
     """The stored row a conflict is anchored to: occurrence 0, or the lowest
     surviving occurrence of its identity family.
 
-    A conflict's ``dedup_key`` is always the family *base*, never the anchor row's
+    A conflict's ``dedup_key`` is always a family *base*, never the anchor row's
     own key once occurrence 0 is gone (an occurrence >= 1 row keys on
     ``hash(base|n)``). So resolutions must reach the row through the family, by
     primary key - targeting ``WHERE dedup_key = <conflict key>`` matches nothing in
     an orphaned family and would report success while writing nothing.
     """
-    family = load_family(conn, record_type, base)
+    base, family = _conflict_family(conn, conflict, dictionary)
     if not family:
+        drifted = ""
+        if base != conflict["dedup_key"]:
+            drifted = (
+                " (the dictionary also changed since it was staged, so its key was "
+                "re-derived; neither key has rows)"
+            )
         raise ValueError(
-            f"conflict {conflict_id} has no stored {record_type} row left to "
-            "overwrite - every occurrence of that identity was removed after the "
-            "conflict was staged. Resolve with keep 'both' to admit the incoming "
-            "row as a new record instead."
+            f"conflict {conflict['conflict_id']} has no stored "
+            f"{conflict['record_type']} row left to overwrite - every occurrence of "
+            f"that identity was removed after the conflict was staged{drifted}. "
+            "Resolve with keep 'both' to admit the incoming row as a new record "
+            "instead."
         )
     return family[0]
 
 
-def _plan_keep_both(conn: sqlite3.Connection, conflict: sqlite3.Row) -> ResolveResult:
+def _plan_keep_both(
+    conn: sqlite3.Connection,
+    conflict: sqlite3.Row,
+    dictionary: dict[str, str] | None,
+) -> ResolveResult:
     """Validate + number the row a ``keep='both'`` resolution would admit.
 
     Everything that can refuse the resolution happens here, before the transaction
@@ -760,8 +849,7 @@ def _plan_keep_both(conn: sqlite3.Connection, conflict: sqlite3.Row) -> ResolveR
             "incoming row as a new record"
         )
 
-    base = conflict["dedup_key"]
-    family = load_family(conn, record_type, base)
+    base, family = _conflict_family(conn, conflict, dictionary)
     pk = f"{record_type}_id"
     twin = next((f for f in family if _rows_equal(record_type, f, incoming)), None)
     if twin is not None:
@@ -770,7 +858,7 @@ def _plan_keep_both(conn: sqlite3.Connection, conflict: sqlite3.Row) -> ResolveR
         return ResolveResult(
             kept="both", record_type=record_type, row_id=int(twin[pk]),
             occurrence=int(twin["dedup_occurrence"]),
-            dedup_key=twin["dedup_key"], no_op=True,
+            dedup_key=twin["dedup_key"], dedup_base=twin["dedup_base"], no_op=True,
         )
 
     # Occurrence numbers are monotonic over the family and never reused, so a removed
@@ -778,7 +866,7 @@ def _plan_keep_both(conn: sqlite3.Connection, conflict: sqlite3.Row) -> ResolveR
     occurrence = max((int(f["dedup_occurrence"]) for f in family), default=-1) + 1
     return ResolveResult(
         kept="both", record_type=record_type, occurrence=occurrence,
-        dedup_key=occurrence_key(base, occurrence),
+        dedup_key=occurrence_key(base, occurrence), dedup_base=base,
     )
 
 

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -81,6 +81,10 @@ FIELD_SPECS: dict[str, dict[str, tuple[object, bool]]] = {
 
 KNOWN_TYPES = tuple(FIELD_SPECS)
 
+# Key-machinery columns on every record table. Internal: they are stripped from the
+# CLI `--json` and MCP read payloads (unstable, not part of either contract).
+INTERNAL_COLUMNS = ("dedup_key", "dedup_base", "dedup_occurrence")
+
 # Date-typed fields per record type. These feed timeline sort / trends date math and
 # the dedup_key (via _date_only), all of which assume a lexically-sortable ISO date —
 # so validate_row enforces ISO on them, not just the base `str` type. A partial
@@ -231,29 +235,71 @@ def _hash_parts(parts: list[object]) -> str:
     return hashlib.sha256(joined.encode("utf-8")).hexdigest()
 
 
-def dedup_key(
+def _key_parts(
     record_type: str, row: dict, person_id: int, dictionary: dict[str, str] | None = None
-) -> str:
-    """Deterministic semantic key per Architecture.md §3. Same clinical fact from
-    two different documents -> identical key -> collapses to one row."""
+) -> list[object]:
+    """The normalized identity tuple a ``dedup_base`` hashes (Architecture.md §3).
+
+    Kept separate from the hashing so an error message can name *why* two rows
+    collide (see :func:`identity_label`) instead of quoting a bare hash.
+    """
     def n(field_name: str) -> str:
         return norm(row.get(field_name), dictionary)
 
     if record_type == "lab_result":
-        parts = [person_id, n("test_name"), _norm_ts(row.get("collected_at"))]
-    elif record_type == "medication":
-        parts = [person_id, n("name"), _collapse(str(row.get("dose") or "")),
-                 _date_only(row.get("started_on"))]
-    elif record_type == "procedure":
-        parts = [person_id, n("name"), _date_only(row.get("performed_on"))]
-    elif record_type == "appointment":
-        parts = [person_id, n("provider"), _date_only(row.get("scheduled_for"))]
-    elif record_type == "observation":
-        parts = [person_id, n("obs_type"), _norm_ts(row.get("observed_at")),
-                 n("key")]
-    else:  # pragma: no cover - guarded by validate()
-        raise ValidationError(f"unknown record type: {record_type}")
-    return _hash_parts(parts)
+        return [person_id, n("test_name"), _norm_ts(row.get("collected_at"))]
+    if record_type == "medication":
+        return [person_id, n("name"), _collapse(str(row.get("dose") or "")),
+                _date_only(row.get("started_on"))]
+    if record_type == "procedure":
+        return [person_id, n("name"), _date_only(row.get("performed_on"))]
+    if record_type == "appointment":
+        return [person_id, n("provider"), _date_only(row.get("scheduled_for"))]
+    if record_type == "observation":
+        return [person_id, n("obs_type"), _norm_ts(row.get("observed_at")), n("key")]
+    raise ValidationError(f"unknown record type: {record_type}")  # guarded by validate()
+
+
+def identity_label(
+    record_type: str, row: dict, person_id: int, dictionary: dict[str, str] | None = None
+) -> str:
+    """Human-readable rendering of the identity tuple, e.g.
+    ``person 1 | glucose | 2024-04-01``."""
+    parts = _key_parts(record_type, row, person_id, dictionary)
+    return " | ".join([f"person {parts[0]}"] + [str(p) for p in parts[1:]])
+
+
+def occurrence_key(base: str, occurrence: int) -> str:
+    """``dedup_key`` for occurrence *n* of an identity family.
+
+    Occurrence 0 IS the base, byte-for-byte — every row committed before
+    migration 005 is occurrence 0, so the numbering added no key churn. Repeats
+    admitted by ``--keep both`` hash the base together with their occurrence, which
+    keeps the key a pure function of persisted columns and therefore survives
+    :func:`rekey` (a resolution-time suffix would not).
+    """
+    if not occurrence:
+        return base
+    return _hash_parts([base, occurrence])
+
+
+def dedup_key(
+    record_type: str,
+    row: dict,
+    person_id: int,
+    dictionary: dict[str, str] | None = None,
+    occurrence: int = 0,
+) -> str:
+    """Deterministic semantic key per Architecture.md §3. Same clinical fact from
+    two different documents -> identical key -> collapses to one row.
+
+    With the default ``occurrence=0`` this returns the family's ``dedup_base``; a
+    non-zero ``occurrence`` returns the key of that sibling (see
+    :func:`occurrence_key`).
+    """
+    return occurrence_key(
+        _hash_parts(_key_parts(record_type, row, person_id, dictionary)), occurrence
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -348,9 +394,14 @@ def _norm_unit(value: object) -> str:
     return "" if value is None else str(value).strip().lower()
 
 
-def _rows_equal(record_type: str, existing: sqlite3.Row, incoming: dict) -> bool:
-    """True when two rows with a matching dedup_key are the *same fact* (a duplicate)
-    rather than a conflicting one — i.e. their payload fields all agree."""
+def _rows_equal(
+    record_type: str, existing: sqlite3.Row | dict, incoming: dict
+) -> bool:
+    """True when two rows in one identity family are the *same fact* (a duplicate)
+    rather than a conflicting one — i.e. their payload fields all agree.
+
+    ``existing`` is a stored row (or, in the pass-1 intra-payload check, an earlier
+    row of the same submission)."""
     existing_map = dict(existing)
     for name in _COMPARE_FIELDS[record_type]:
         ev = existing_map.get(name)
@@ -410,8 +461,30 @@ def commit_extraction(
             )
         if not isinstance(rows, list):
             raise ValidationError(f"{record_type}: value must be a list of records")
-        for row in rows:
+        # Two rows of ONE submission deriving one key and disagreeing on the payload is
+        # an extraction error, not a conflict for a human to adjudicate: the "existing"
+        # side would have been inserted milliseconds earlier in the same batch, so it
+        # carries no independent provenance. Reject up front (issue #58). Two *identical*
+        # rows stay benign — that is an agent listing one fact twice, and pass 2 reports
+        # it as a duplicate.
+        seen: dict[str, tuple[int, dict]] = {}
+        for index, row in enumerate(rows):
             validate_row(record_type, row)
+            base = dedup_key(record_type, row, person_id, dictionary)
+            prior = seen.get(base)
+            if prior is None:
+                seen[base] = (index, row)
+            elif not _rows_equal(record_type, prior[1], row):
+                raise ValidationError(
+                    f"{record_type}: rows {prior[0]} and {index} of this submission "
+                    f"derive the same dedup_key "
+                    f"({identity_label(record_type, row, person_id, dictionary)}) "
+                    "but carry different values. If the source gives distinct "
+                    "collection times, add them (AGENTS.md date-precision rule). If "
+                    "these are two genuine same-day results the source cannot "
+                    "timestamp, commit them in separate submissions and resolve the "
+                    "conflict with `--keep both`"
+                )
 
     summary = CommitSummary()
     detected_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -420,24 +493,55 @@ def commit_extraction(
     with conn:
         for record_type, rows in records.items():
             for row in rows:
-                key = dedup_key(record_type, row, person_id, dictionary)
-                existing = conn.execute(
-                    f"SELECT * FROM {record_type} WHERE dedup_key = ?", (key,)
-                ).fetchone()
-                if existing is None:
+                base = dedup_key(record_type, row, person_id, dictionary)
+                # Match against the whole occurrence FAMILY, not one row: once
+                # `--keep both` has admitted a repeat, a third commit of that same
+                # payload must dedup against the sibling rather than fork or re-stage.
+                family = load_family(conn, record_type, base)
+                if not family:
                     row_id = _insert_record(
-                        conn, record_type, row, person_id, document_id, key
+                        conn, record_type, row, person_id, document_id, base
                     )
                     summary.new.append((record_type, row_id))
-                elif _rows_equal(record_type, existing, row):
-                    summary.duplicate.append((record_type, key))
+                    continue
+                twin = next(
+                    (f for f in family if _rows_equal(record_type, f, row)), None
+                )
+                if twin is not None:
+                    summary.duplicate.append((record_type, twin["dedup_key"]))
                 else:
+                    # Stage against occurrence 0: it is the row the conflict's
+                    # dedup_key anchors to, and the reviewer sees the family size.
                     conflict_id = _stage_conflict(
-                        conn, record_type, key, person_id, document_id,
-                        existing, row, detected_at,
+                        conn, record_type, base, person_id, document_id,
+                        family[0], row, detected_at,
                     )
                     summary.conflict.append((record_type, conflict_id))
     return summary
+
+
+def load_family(
+    conn: sqlite3.Connection, record_type: str, base: str
+) -> list[sqlite3.Row]:
+    """Every stored row sharing one ``dedup_base``, occurrence order (0 first).
+
+    Relies on migration 005's invariant that ``dedup_base`` is populated on every
+    row; every write path here maintains it.
+    """
+    return conn.execute(
+        f"SELECT * FROM {record_type} WHERE dedup_base = ? ORDER BY dedup_occurrence",
+        (base,),
+    ).fetchall()
+
+
+def count_occurrences(conn: sqlite3.Connection, record_type: str, base: str) -> int:
+    """How many rows are already stored under one identity (family size)."""
+    if record_type not in FIELD_SPECS:
+        return 0
+    row = conn.execute(
+        f"SELECT COUNT(*) AS n FROM {record_type} WHERE dedup_base = ?", (base,)
+    ).fetchone()
+    return int(row["n"])
 
 
 def _insert_record(
@@ -445,11 +549,14 @@ def _insert_record(
     record_type: str,
     row: dict,
     person_id: int,
-    document_id: int,
-    key: str,
+    document_id: int | None,
+    base: str,
+    occurrence: int = 0,
 ) -> int:
-    columns = ["person_id", "document_id", "dedup_key"]
-    values: list[object] = [person_id, document_id, key]
+    columns = ["person_id", "document_id", "dedup_key", "dedup_base", "dedup_occurrence"]
+    values: list[object] = [
+        person_id, document_id, occurrence_key(base, occurrence), base, occurrence,
+    ]
     for name in FIELD_SPECS[record_type]:
         if name in row and row[name] is not None:
             columns.append(name)
@@ -504,23 +611,50 @@ def list_conflicts(
     ).fetchall()
 
 
+@dataclass
+class ResolveResult:
+    """Outcome of :func:`resolve_conflict`.
+
+    ``row_id``/``occurrence`` describe the *admitted* row and are set only for
+    ``keep='both'``; the other resolutions choose between rows rather than adding
+    one. ``dedup_key`` is the key of the row the resolution landed on.
+    """
+    kept: str
+    record_type: str = ""
+    row_id: int | None = None
+    occurrence: int | None = None
+    dedup_key: str | None = None
+    no_op: bool = False          # keep-both that matched an existing sibling
+
+
+KEEP_CHOICES = ("existing", "incoming", "both")
+
+
 def resolve_conflict(
     conn: sqlite3.Connection,
     conflict_id: int,
     keep: str,
     note: str | None = None,
-) -> None:
-    """Resolve a staged conflict. ``keep`` is 'existing' (drop the incoming row) or
-    'incoming' (overwrite the stored record's payload fields with the incoming row).
+) -> ResolveResult:
+    """Resolve a staged conflict. ``keep`` is 'existing' (drop the incoming row),
+    'incoming' (overwrite the stored record's payload fields with the incoming row) or
+    'both' (admit the incoming row *alongside* the stored one as the next occurrence of
+    that identity — the recovery path for a genuine repeat the source cannot timestamp,
+    issue #58).
 
     Overwriting touches only the payload columns (``_COMPARE_FIELDS``) whose
     disagreement defined the conflict, plus provenance ``document_id``. Identity
     fields keep their stored display form (they are equal after norm() by
     construction, but may differ in casing/spacing); the dedup_key stays put.
+
+    ``keep='both'`` re-validates the staged JSON before it becomes a row, and is
+    idempotent by payload: if a sibling already carries that exact payload (two
+    conflicts staged from one submission, both resolved 'both') nothing is inserted
+    and the resolution records the no-op.
     """
     db.require_migrated(conn)
-    if keep not in ("existing", "incoming"):
-        raise ValueError("keep must be 'existing' or 'incoming'")
+    if keep not in KEEP_CHOICES:
+        raise ValueError("keep must be 'existing', 'incoming' or 'both'")
 
     row = conn.execute(
         "SELECT * FROM conflict WHERE conflict_id = ?", (conflict_id,)
@@ -531,7 +665,12 @@ def resolve_conflict(
         raise ValueError(f"conflict {conflict_id} is already {row['status']}")
 
     record_type = row["record_type"]
-    resolution = f"keep-{keep}" + (f": {note}" if note else "")
+    result = (
+        _plan_keep_both(conn, row) if keep == "both"
+        else ResolveResult(
+            kept=keep, record_type=record_type, dedup_key=row["dedup_key"]
+        )
+    )
     resolved_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
 
     with conn:
@@ -540,11 +679,70 @@ def resolve_conflict(
             _overwrite_record(
                 conn, record_type, row["dedup_key"], row["document_id"], incoming
             )
+        elif keep == "both" and not result.no_op:
+            result.row_id = _insert_record(
+                conn, record_type, json.loads(row["incoming_json"]),
+                row["person_id"], row["document_id"],
+                row["dedup_key"], result.occurrence or 0,
+            )
+        resolution = _resolution_text(result) + (f": {note}" if note else "")
         conn.execute(
             "UPDATE conflict SET status='resolved', resolution=?, resolved_at=? "
             "WHERE conflict_id=?",
             (resolution, resolved_at, conflict_id),
         )
+    return result
+
+
+def _resolution_text(result: ResolveResult) -> str:
+    """The auditable resolution string stored on the conflict row. keep-both records
+    which row it admitted (or matched) so the decision stays reconstructable."""
+    if result.kept != "both":
+        return f"keep-{result.kept}"
+    if result.no_op:
+        return f"keep-both (no-op: matches {result.record_type} #{result.row_id})"
+    return (
+        f"keep-both -> {result.record_type} #{result.row_id} "
+        f"occurrence={result.occurrence} key={(result.dedup_key or '')[:12]}..."
+    )
+
+
+def _plan_keep_both(conn: sqlite3.Connection, conflict: sqlite3.Row) -> ResolveResult:
+    """Validate + number the row a ``keep='both'`` resolution would admit.
+
+    Everything that can refuse the resolution happens here, before the transaction
+    opens.
+    """
+    record_type = conflict["record_type"]
+    incoming = json.loads(conflict["incoming_json"])
+    validate_row(record_type, incoming)
+
+    if conflict["person_id"] is None:
+        raise ValueError(
+            f"conflict {conflict['conflict_id']} has no person_id - cannot admit the "
+            "incoming row as a new record"
+        )
+
+    base = conflict["dedup_key"]
+    family = load_family(conn, record_type, base)
+    pk = f"{record_type}_id"
+    twin = next((f for f in family if _rows_equal(record_type, f, incoming)), None)
+    if twin is not None:
+        # Two conflicts staged from one payload, both resolved 'both': the second
+        # must not produce a twin row.
+        return ResolveResult(
+            kept="both", record_type=record_type, row_id=int(twin[pk]),
+            occurrence=int(twin["dedup_occurrence"]),
+            dedup_key=twin["dedup_key"], no_op=True,
+        )
+
+    # Occurrence numbers are monotonic over the family and never reused, so a removed
+    # sibling leaves a hole rather than letting a later row inherit its key.
+    occurrence = max((int(f["dedup_occurrence"]) for f in family), default=-1) + 1
+    return ResolveResult(
+        kept="both", record_type=record_type, occurrence=occurrence,
+        dedup_key=occurrence_key(base, occurrence),
+    )
 
 
 def _rekey_label(record_type: str, row: sqlite3.Row) -> str:
@@ -565,6 +763,7 @@ class RekeyChange:
     label: str
     old_key: str
     new_key: str
+    new_base: str = ""      # recomputed dedup_base (new_key == new_base at occurrence 0)
 
 
 @dataclass
@@ -607,7 +806,11 @@ def rekey(
         seen: dict[str, sqlite3.Row] = {}
         for row in rows:
             payload = {name: row[name] for name in FIELD_SPECS[record_type]}
-            key = dedup_key(record_type, payload, row["person_id"], dictionary)
+            # The occurrence is a stored column, so an admitted repeat (`--keep both`)
+            # recomputes to its own key rather than colliding with its sibling.
+            occurrence = int(row["dedup_occurrence"] or 0)
+            base = dedup_key(record_type, payload, row["person_id"], dictionary)
+            key = occurrence_key(base, occurrence)
             clash = seen.get(key)
             if clash is not None:
                 raise RekeyCollisionError(
@@ -621,7 +824,7 @@ def rekey(
             if key != row["dedup_key"]:
                 report.changes.append(RekeyChange(
                     record_type, row[pk], _rekey_label(record_type, row),
-                    row["dedup_key"], key,
+                    row["dedup_key"], key, base,
                 ))
 
     if apply and report.changes:
@@ -638,10 +841,12 @@ def rekey(
                      change.row_id),
                 )
             for change in report.changes:
+                # dedup_base moves with the key: base and key are injective in each
+                # other for a fixed occurrence, so a changed key means a changed base.
                 conn.execute(
-                    f"UPDATE {change.record_type} SET dedup_key = ? "
+                    f"UPDATE {change.record_type} SET dedup_key = ?, dedup_base = ? "
                     f"WHERE {change.record_type}_id = ?",
-                    (change.new_key, change.row_id),
+                    (change.new_key, change.new_base, change.row_id),
                 )
     report.applied = apply
     return report

--- a/pemr/documents.py
+++ b/pemr/documents.py
@@ -433,9 +433,10 @@ def remove_document(
     landed and their document is going away), resolved ones keep their audit trail
     with ``document_id`` nulled out. Open conflicts *anchored to* a row this document
     owns (:func:`_conflicts_anchored_to`) are deleted too and counted separately — the
-    row they were staged against is going away, so they cannot be resolved either way,
-    and leaving them would make a later `keep incoming` discard the staged value in
-    silence. Every count is in the dry-run report: the blast radius is the safety
+    row they were staged against is going away, so leaving them would strand a conflict
+    whose only remaining resolution is `keep both` (`keep incoming` refuses loudly once
+    the family is empty — :func:`dedup._anchor_row`). Every count is in the dry-run
+    report: the blast radius is the safety
     mechanism here, so it has to be truthful.
 
     The scan under ``sources_dir`` is **kept** unless ``purge_blob`` is set — it is the

--- a/pemr/documents.py
+++ b/pemr/documents.py
@@ -113,10 +113,17 @@ def _conflicts_anchored_to(conn: sqlite3.Connection, document_id: int) -> list[i
     **incoming** row collided; ``conflict.dedup_key`` anchors it to the **stored**
     row — which a *different* document usually created. Only the first end is
     reachable from ``document_id``, so removing or reassigning the owner of the
-    stored row silently orphans the anchor: a later `keep incoming` resolution runs
-    ``UPDATE ... WHERE dedup_key = ?`` (:func:`dedup._overwrite_record`), matches
-    zero rows, and stamps the conflict ``resolved`` while discarding the staged
-    value with rc 0. Both `rm` and `reassign` therefore have to see this end too.
+    stored row orphans the anchor and leaves a conflict that `keep incoming` can no
+    longer resolve. Both `rm` and `reassign` therefore have to see this end too.
+
+    Matching on ``dedup_key`` finds the anchor exactly while occurrence 0 is alive,
+    which is every family a conflict is normally staged against
+    (:func:`dedup._stage_conflict` anchors to ``family[0]``). It misses the residual
+    case where occurrence 0 is already gone and the anchor is an occurrence >= 1
+    sibling, whose key is ``hash(base|n)`` rather than the base: that document can
+    still be removed without a warning. The consequence is bounded — a later
+    `keep incoming` refuses loudly rather than discarding the staged value
+    (:func:`dedup._anchor_row`), and `keep both` still admits it.
     """
     ids: list[int] = []
     for record_type in dedup.KNOWN_TYPES:
@@ -269,8 +276,8 @@ def reassign_document(
       owned by the *old* person; resolving it after a move would write data into
       records the document no longer owns. One *anchored to* a row this document owns
       (staged by some other document — see :func:`_conflicts_anchored_to`) would have
-      its ``dedup_key`` re-derived out from under it, and resolve to nothing. Resolve
-      them first (`pemr review-conflicts`).
+      its ``dedup_key`` re-derived out from under it, leaving nothing to resolve
+      against. Resolve them first (`pemr review-conflicts`).
     * **dictionary drift** (:class:`DictionaryDriftError`) — a stored key that does not
       match its recompute under the current dictionary means a reassign would silently
       perform a `rekey` too. Run `pemr rekey --apply` first; reassign changes ownership
@@ -309,7 +316,7 @@ def reassign_document(
             f"'{from_slug}' - raised by this document, or anchored to a row it owns. "
             "Resolving one after the move would write this document's data into "
             "records it no longer owns, or target a dedup_key the move re-derives "
-            "(silently discarding the staged value). Resolve them first with "
+            "(leaving the staged value unresolvable). Resolve them first with "
             "`pemr review-conflicts`; nothing was written"
         )
 

--- a/pemr/documents.py
+++ b/pemr/documents.py
@@ -226,6 +226,7 @@ class ReassignChange:
     label: str
     old_key: str
     new_key: str
+    new_base: str = ""   # recomputed dedup_base (== new_key at occurrence 0)
 
 
 @dataclass
@@ -322,8 +323,13 @@ def reassign_document(
         for row in rows:
             label = dedup._rekey_label(record_type, row)
             payload = {name: row[name] for name in dedup.FIELD_SPECS[record_type]}
+            # A row admitted by `review-conflicts --keep both` is occurrence >0 of its
+            # identity family; its key hashes the base together with that stored
+            # occurrence, so the recompute has to carry it or every sibling would read
+            # as dictionary drift.
+            occurrence = int(row["dedup_occurrence"] or 0)
             current = dedup.dedup_key(
-                record_type, payload, row["person_id"], dictionary
+                record_type, payload, row["person_id"], dictionary, occurrence
             )
             if current != row["dedup_key"]:
                 raise DictionaryDriftError(
@@ -332,9 +338,10 @@ def reassign_document(
                     "changed since it was committed. Run `pemr rekey --apply` first, "
                     "then retry; nothing was written"
                 )
-            new_key = dedup.dedup_key(
+            new_base = dedup.dedup_key(
                 record_type, payload, target.person_id, dictionary
             )
+            new_key = dedup.occurrence_key(new_base, occurrence)
             # Every moving row shares one old person_id and one new one, and the drift
             # check above proves the stored keys are injective under the current
             # dictionary — so new keys cannot collide with each other or with the
@@ -352,7 +359,7 @@ def reassign_document(
                 )
             report.changes.append(
                 ReassignChange(
-                    record_type, row[pk], label, row["dedup_key"], new_key
+                    record_type, row[pk], label, row["dedup_key"], new_key, new_base
                 )
             )
 
@@ -365,9 +372,9 @@ def reassign_document(
             )
             for change in report.changes:
                 conn.execute(
-                    f"UPDATE {change.record_type} SET person_id = ?, dedup_key = ? "
-                    f"WHERE {change.record_type}_id = ?",
-                    (target.person_id, change.new_key, change.row_id),
+                    f"UPDATE {change.record_type} SET person_id = ?, dedup_key = ?, "
+                    f"dedup_base = ? WHERE {change.record_type}_id = ?",
+                    (target.person_id, change.new_key, change.new_base, change.row_id),
                 )
     report.applied = apply
     return report

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -232,10 +232,17 @@ def review_conflicts(
 ) -> Any:
     """[read to list / write to resolve] List or resolve staged dedup conflicts.
 
+    Listing is free, and reports ``occurrences`` — how many rows are already stored
+    under the conflict's identity. Resolution takes ``keep`` = ``"existing"`` (drop the
+    incoming row), ``"incoming"`` (overwrite the stored one) or ``"both"`` (admit the
+    incoming row *alongside* the stored one as a new occurrence of that identity — for a
+    genuine repeat, e.g. two same-day draws on a report that prints no collection times).
+
     Listing is free. **Resolution requires explicit human sign-off** (``AGENTS.md``
-    conflict discipline): ``signoff`` must quote the human's instruction verbatim, or the
-    write is refused. The sign-off text is threaded into the stored resolution note so the
-    record shows who authorized it.
+    conflict discipline) — ``"both"`` included, it admits a row rather than choosing one:
+    ``signoff`` must quote the human's instruction verbatim, or the write is refused. The
+    sign-off text is threaded into the stored resolution note so the record shows who
+    authorized it.
     """
     if resolve is not None:
         if not (signoff and signoff.strip()):
@@ -246,16 +253,33 @@ def review_conflicts(
             )
         merged_note = f"signoff: {signoff.strip()}" + (f" — {note}" if note else "")
         try:
-            _dedup.resolve_conflict(conn, resolve, keep=keep, note=merged_note)
+            result = _dedup.resolve_conflict(conn, resolve, keep=keep, note=merged_note)
+        # ValueError covers ValidationError, raised when a keep-both payload no longer
+        # validates as a row.
         except (db.NotMigratedError, ValueError) as exc:
             raise _friendly(exc) from exc
-        return {"resolved": resolve, "keep": keep, "signoff": signoff.strip()}
+        payload = {"resolved": resolve, "keep": keep, "signoff": signoff.strip()}
+        if keep == "both":
+            payload |= {
+                "record_type": result.record_type,
+                "row_id": result.row_id,
+                "occurrence": result.occurrence,
+                "no_op": result.no_op,
+            }
+        return payload
 
     try:
         rows = _dedup.list_conflicts(conn, status=None if all else "open")
+        return [
+            dict(r) | {
+                "occurrences": _dedup.count_occurrences(
+                    conn, r["record_type"], r["dedup_key"]
+                )
+            }
+            for r in rows
+        ]
     except db.NotMigratedError as exc:
         raise _friendly(exc) from exc
-    return [dict(r) for r in rows]
 
 
 # --- structured reads -------------------------------------------------------
@@ -283,7 +307,10 @@ def query(
             raise ToolError(f"unknown query kind '{kind}' (known: labs, meds, timeline)")
     except (db.NotMigratedError, _query.PersonNotFoundError) as exc:
         raise _friendly(exc) from exc
-    return [{k: v for k, v in r.items() if k != "dedup_key"} for r in rows]
+    return [
+        {k: v for k, v in r.items() if k not in _dedup.INTERNAL_COLUMNS}
+        for r in rows
+    ]
 
 
 def find(

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -253,7 +253,9 @@ def review_conflicts(
             )
         merged_note = f"signoff: {signoff.strip()}" + (f" — {note}" if note else "")
         try:
-            result = _dedup.resolve_conflict(conn, resolve, keep=keep, note=merged_note)
+            result = _dedup.resolve_conflict(
+                conn, resolve, keep=keep, note=merged_note, dictionary=_dictionary()
+            )
         # ValueError covers ValidationError, raised when a keep-both payload no longer
         # validates as a row.
         except (db.NotMigratedError, ValueError) as exc:
@@ -270,11 +272,10 @@ def review_conflicts(
 
     try:
         rows = _dedup.list_conflicts(conn, status=None if all else "open")
+        dictionary = _dictionary()
         return [
             dict(r) | {
-                "occurrences": _dedup.count_occurrences(
-                    conn, r["record_type"], r["dedup_key"]
-                )
+                "occurrences": _dedup.conflict_occurrences(conn, r, dictionary)
             }
             for r in rows
         ]

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -95,7 +95,9 @@ def query_labs(
     if since:
         sql += " AND date(collected_at) >= date(?)"
         params.append(since)
-    sql += " ORDER BY collected_at, test_name"
+    # Row id breaks same-timestamp ties: `--keep both` admits a second draw under the
+    # same date, and "later row id = later point" keeps the order deterministic.
+    sql += " ORDER BY collected_at, test_name, lab_result_id"
     rows = [dict(r) for r in conn.execute(sql, params).fetchall()]
     if test:
         target = norm(test, dictionary)

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -140,8 +140,10 @@ def _latest_vitals(
 
 def _abnormal_labs(conn: sqlite3.Connection, person_id: int) -> list[dict]:
     rows = conn.execute(
+        # lab_result_id DESC breaks same-timestamp ties (a `--keep both` sibling shares
+        # its date): newest-first ordering treats the later row id as the later point.
         "SELECT * FROM lab_result WHERE person_id = ? "
-        "ORDER BY collected_at DESC, test_name",
+        "ORDER BY collected_at DESC, test_name, lab_result_id DESC",
         (person_id,),
     ).fetchall()
     return [dict(r) for r in rows if _is_abnormal(r)]
@@ -349,7 +351,7 @@ def render_brief(
     # reference interval), which SQL can't express, so the cut happens here.
     lab_rows = conn.execute(
         "SELECT * FROM lab_result WHERE person_id = ? "
-        "ORDER BY collected_at DESC, test_name",
+        "ORDER BY collected_at DESC, test_name, lab_result_id DESC",
         (person_id,),
     ).fetchall()
     draw_rank = {

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -69,6 +69,86 @@ def test_ingest_commit_review_roundtrip(ready, capsys):
     assert "resolved conflict #1" in capsys.readouterr().out
 
 
+def _stage_repeat_draw(tmp_path, capsys):
+    """The issue #58 repro through the CLI: two genuine same-day draws, one document
+    each (a single submission carrying both is now rejected up front)."""
+    sources = tmp_path / "sources"
+    for i, (value, text) in enumerate(((95, "fasting"), (148, "post-prandial")), start=1):
+        scan = tmp_path / f"g{i}.txt"
+        scan.write_bytes(f"glucose {value}".encode())
+        assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                    "--sources", str(sources)) == 0
+        payload = _write_json(tmp_path, f"g{i}.json", {"lab_result": [
+            {"test_name": "glucose", "collected_at": "2024-04-01",
+             "value_num": value, "value_text": text},
+        ]})
+        assert _run(tmp_path, "commit-extraction", "--document", str(i),
+                    "--json", str(payload)) == 0
+    capsys.readouterr()
+
+
+def test_review_conflicts_keep_both_admits_the_repeat(ready, capsys):
+    tmp_path = ready
+    _stage_repeat_draw(tmp_path, capsys)
+
+    assert _run(tmp_path, "review-conflicts", "--resolve", "1", "--keep", "both",
+                "--note", "Jane confirms two draws") == 0
+    out = capsys.readouterr().out
+    assert "resolved conflict #1 (keep-both -> lab_result #2, occurrence 1)" in out
+    assert out.isascii()
+
+    capsys.readouterr()
+    assert _run(tmp_path, "query", "labs", "--person", "jane-doe", "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [r["value_num"] for r in payload] == [95, 148]   # both queryable, in row order
+    for row in payload:                                      # internals stay internal
+        assert not {"dedup_key", "dedup_base", "dedup_occurrence"} & set(row)
+
+
+def test_review_conflicts_listing_shows_occurrences_and_the_both_hint(ready, capsys):
+    tmp_path = ready
+    _stage_repeat_draw(tmp_path, capsys)
+    assert _run(tmp_path, "review-conflicts") == 0
+    out = capsys.readouterr().out
+    assert "--keep existing|incoming|both" in out
+    assert "occurrences:" not in out          # family of 1 -> nothing to say yet
+
+    assert _run(tmp_path, "review-conflicts", "--resolve", "1", "--keep", "both") == 0
+    scan = tmp_path / "g3.txt"
+    scan.write_bytes(b"glucose 210")
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources")) == 0
+    payload = _write_json(tmp_path, "g3.json", {"lab_result": [
+        {"test_name": "glucose", "collected_at": "2024-04-01", "value_num": 210},
+    ]})
+    assert _run(tmp_path, "commit-extraction", "--document", "3",
+                "--json", str(payload)) == 0
+    capsys.readouterr()
+
+    assert _run(tmp_path, "review-conflicts") == 0
+    out = capsys.readouterr().out
+    assert "occurrences: 2 rows already stored under this key" in out
+    assert out.isascii()
+
+
+def test_commit_extraction_rejects_an_intra_payload_collision(ready, capsys):
+    tmp_path = ready
+    scan = tmp_path / "g.txt"
+    scan.write_bytes(b"glucose x2")
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources")) == 0
+    payload = _write_json(tmp_path, "g.json", {"lab_result": [
+        {"test_name": "glucose", "collected_at": "2024-04-01", "value_num": 95},
+        {"test_name": "glucose", "collected_at": "2024-04-01", "value_num": 148},
+    ]})
+    capsys.readouterr()
+    assert _run(tmp_path, "commit-extraction", "--document", "1",
+                "--json", str(payload)) == 1
+    err = capsys.readouterr().err
+    assert "rows 0 and 1" in err and "--keep both" in err
+    assert err.isascii()
+
+
 def test_ingest_duplicate_reports_cleanly(ready, capsys):
     tmp_path = ready
     scan = tmp_path / "s.txt"

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -131,6 +131,38 @@ def test_review_conflicts_listing_shows_occurrences_and_the_both_hint(ready, cap
     assert out.isascii()
 
 
+def test_keep_both_after_a_rekey_does_not_wedge_rekey(ready, capsys):
+    """The audit repro: a dictionary edit + `rekey --apply` while a conflict is open
+    leaves the conflict on a stale key. Resolving `--keep both` off that key inserted a
+    row whose key no longer derives from its own columns, which made every later `rekey`
+    - for every table - fail with a collision and left `document reassign` with no exit.
+    """
+    tmp_path = ready
+    _stage_repeat_draw(tmp_path, capsys)
+    dictionary = tmp_path / "dict.toml"
+    dictionary.write_text('[synonyms]\n"glucose" = "glucose, plasma"\n', encoding="utf-8")
+
+    assert _run(tmp_path, "rekey", "--apply", "--dictionary", str(dictionary)) == 0
+    assert "rekeyed 1 row(s)" in capsys.readouterr().out
+
+    assert _run(tmp_path, "review-conflicts", "--resolve", "1", "--keep", "both",
+                "--dictionary", str(dictionary)) == 0
+    assert "occurrence 1" in capsys.readouterr().out      # joined the live family
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(dictionary)) == 0
+    assert "all dedup keys already match" in capsys.readouterr().out
+
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        rows = conn.execute(
+            "SELECT * FROM lab_result ORDER BY lab_result_id"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert [r["value_num"] for r in rows] == [95, 148]
+    assert rows[0]["dedup_base"] == rows[1]["dedup_base"]
+
+
 def test_commit_extraction_rejects_an_intra_payload_collision(ready, capsys):
     tmp_path = ready
     scan = tmp_path / "g.txt"

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -349,6 +349,95 @@ def test_keep_existing_still_resolves_an_empty_family(conn, orphaned_family):
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 0
 
 
+# --- dictionary drift: a conflict's stored key is not the live base -----------
+#
+# `rekey` rewrites dedup_key/dedup_base on the record tables and does not touch the
+# `conflict` table, so a dictionary edit made while a conflict is open strands it on a
+# key no row carries. Resolutions must re-derive the base from the payload: numbering a
+# keep-both row on the stale key inserts a row whose key is not derivable from its own
+# columns, which wedges `rekey` (and therefore `document reassign`) for the whole DB.
+
+_RENAMED = {"glucose": "glucose, plasma"}
+
+
+@pytest.fixture()
+def drifted(conn, repeat_draw):
+    """The `repeat_draw` conflict, with the dictionary changed and `rekey` applied
+    underneath it: the stored row moved to a new base, the conflict did not."""
+    report = dedup.rekey(conn, _RENAMED, apply=True)
+    assert report.applied and len(report.changes) == 1
+    conflict = dedup.list_conflicts(conn)[0]
+    stored = conn.execute("SELECT * FROM lab_result").fetchone()
+    # The premise: the conflict's key is stale, nothing carries it any more.
+    assert conflict["dedup_key"] != stored["dedup_base"]
+    return conflict["conflict_id"]
+
+
+def test_keep_both_after_rekey_joins_the_live_family(conn, drifted):
+    """Regression: the admitted row used to land at the stale base as occurrence 0,
+    forking the identity and making both rows recompute to one key."""
+    result = dedup.resolve_conflict(conn, drifted, keep="both", dictionary=_RENAMED)
+
+    rows = conn.execute("SELECT * FROM lab_result ORDER BY lab_result_id").fetchall()
+    assert [r["value_num"] for r in rows] == [95.0, 148.0]
+    assert [r["dedup_occurrence"] for r in rows] == [0, 1]
+    assert rows[0]["dedup_base"] == rows[1]["dedup_base"]     # one family, not two
+    assert (result.occurrence, result.dedup_key) == (1, rows[1]["dedup_key"])
+
+
+def test_rekey_still_works_after_a_drifted_keep_both(conn, drifted):
+    """The wedge itself: an underivable key made `rekey` raise a collision on every
+    later dictionary edit, for every table, with no CLI way out."""
+    dedup.resolve_conflict(conn, drifted, keep="both", dictionary=_RENAMED)
+
+    assert dedup.rekey(conn, _RENAMED).changes == []          # already canonical
+    later = dedup.rekey(conn, {"glucose": "glu"}, apply=True)  # a further edit
+    assert len(later.changes) == 2                             # family moves together
+    rows = conn.execute("SELECT * FROM lab_result ORDER BY lab_result_id").fetchall()
+    assert rows[0]["dedup_base"] == rows[1]["dedup_base"]
+    assert rows[0]["dedup_key"] != rows[1]["dedup_key"]
+
+
+def test_keep_incoming_after_rekey_overwrites_the_live_row(conn, drifted):
+    """`keep incoming` refused a drifted conflict outright (empty family at the stale
+    key) and pointed the operator at the broken keep-both path."""
+    result = dedup.resolve_conflict(conn, drifted, keep="incoming", dictionary=_RENAMED)
+
+    rows = conn.execute("SELECT * FROM lab_result").fetchall()
+    assert len(rows) == 1 and rows[0]["value_num"] == 148.0
+    assert result.row_id == rows[0]["lab_result_id"]
+
+
+def test_conflict_occurrences_counts_the_live_family(conn, drifted):
+    """The CLI/MCP listing hint read 0 occurrences for a family that exists."""
+    conflict = dedup.list_conflicts(conn)[0]
+    assert dedup.conflict_occurrences(conn, conflict, _RENAMED) == 1
+    dedup.resolve_conflict(conn, drifted, keep="both", dictionary=_RENAMED)
+    staged_again = dedup.commit_extraction(
+        conn, _doc(conn, "draw-6"),
+        {"lab_result": [_glucose(210, "third draw")]}, _RENAMED,
+    )
+    assert staged_again.counts["conflict"] == 1
+    assert dedup.conflict_occurrences(
+        conn, dedup.list_conflicts(conn)[0], _RENAMED
+    ) == 2
+
+
+def test_keep_both_before_rekey_stays_with_the_stored_family(conn, repeat_draw):
+    """Dictionary edited but `rekey` not yet run: the stored rows still carry the
+    staged key, so the admitted sibling must join *them* — splitting it off onto the
+    freshly derived base would collide the two the moment `rekey` runs."""
+    result = dedup.resolve_conflict(
+        conn, repeat_draw, keep="both", dictionary=_RENAMED
+    )
+    assert result.occurrence == 1
+
+    rows = conn.execute("SELECT * FROM lab_result ORDER BY lab_result_id").fetchall()
+    assert rows[0]["dedup_base"] == rows[1]["dedup_base"]
+    report = dedup.rekey(conn, _RENAMED, apply=True)           # no collision
+    assert len(report.changes) == 2
+
+
 def test_keep_existing_and_incoming_still_return_a_result(conn, staged):
     """Source compatibility: the return type changed from None, but the older
     resolutions still add no row."""

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -254,6 +254,101 @@ def test_keep_both_works_for_observation_rows(conn):
     )] == ["left", "right"]
 
 
+# --- orphaned families: the conflict key is the base, not the anchor's key ----
+
+def _drop_occurrence(conn, occurrence):
+    """Remove one sibling the way `document rm --apply` would (its owning document
+    went away), leaving a hole in the family."""
+    conn.execute("DELETE FROM lab_result WHERE dedup_occurrence = ?", (occurrence,))
+    conn.commit()
+
+
+@pytest.fixture()
+def orphaned_family(conn, repeat_draw):
+    """A family whose occurrence 0 is gone, with a fresh conflict staged against the
+    surviving occurrence-1 sibling.
+
+    The conflict's ``dedup_key`` is the family *base*; the anchor row's own key is
+    ``hash(base|1)``. Any resolution addressing the row by the conflict's key matches
+    nothing here.
+    """
+    dedup.resolve_conflict(conn, repeat_draw, keep="both")
+    _drop_occurrence(conn, 0)
+    summary = dedup.commit_extraction(
+        conn, _doc(conn, "draw-5"), {"lab_result": [_glucose(210, "third draw")]}
+    )
+    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    conflict = dedup.list_conflicts(conn)[0]
+    survivor = conn.execute("SELECT * FROM lab_result").fetchone()
+    # The premise of the regression: key-targeted writes cannot find this row.
+    assert conflict["dedup_key"] == survivor["dedup_base"] != survivor["dedup_key"]
+    return conflict["conflict_id"]
+
+
+def test_keep_incoming_overwrites_the_anchor_when_occurrence_zero_is_gone(
+    conn, orphaned_family
+):
+    """Regression: keep-incoming used to UPDATE ... WHERE dedup_key = <conflict key>,
+    which matches zero rows once occurrence 0 is gone - the conflict was stamped
+    `resolved` and the incoming value silently vanished."""
+    result = dedup.resolve_conflict(conn, orphaned_family, keep="incoming")
+
+    rows = conn.execute("SELECT * FROM lab_result").fetchall()
+    assert len(rows) == 1                       # overwrite, not insert
+    assert rows[0]["value_num"] == 210.0        # the staged value actually landed
+    assert rows[0]["dedup_occurrence"] == 1     # on the surviving sibling
+    assert (result.kept, result.row_id) == ("incoming", rows[0]["lab_result_id"])
+    assert (result.occurrence, result.dedup_key) == (1, rows[0]["dedup_key"])
+    assert conn.execute(
+        "SELECT status FROM conflict WHERE conflict_id=?", (orphaned_family,)
+    ).fetchone()["status"] == "resolved"
+
+
+def test_keep_both_still_admits_into_an_orphaned_family(conn, orphaned_family):
+    """The other half of the shape: max(occurrence)+1 already handled the hole, and
+    must keep doing so."""
+    result = dedup.resolve_conflict(conn, orphaned_family, keep="both")
+    assert result.occurrence == 2
+    assert [(r["dedup_occurrence"], r["value_num"]) for r in conn.execute(
+        "SELECT * FROM lab_result ORDER BY lab_result_id"
+    )] == [(1, 148.0), (2, 210.0)]
+
+
+def test_keep_incoming_refuses_when_the_family_is_empty(conn, orphaned_family):
+    """Nothing left to overwrite is a refusal, never a reported success: resolving
+    would otherwise discard the staged value with rc 0."""
+    _drop_occurrence(conn, 1)
+    with pytest.raises(ValueError, match="no stored lab_result row left"):
+        dedup.resolve_conflict(conn, orphaned_family, keep="incoming")
+    row = conn.execute(
+        "SELECT * FROM conflict WHERE conflict_id=?", (orphaned_family,)
+    ).fetchone()
+    assert (row["status"], row["resolved_at"]) == ("open", None)
+
+
+def test_empty_family_refusal_names_the_keep_both_recovery(conn, orphaned_family):
+    """The refusal is a dead end unless it points somewhere: keep-both admits the row
+    at occurrence 0 and is the operator's way out."""
+    _drop_occurrence(conn, 1)
+    with pytest.raises(ValueError) as exc:
+        dedup.resolve_conflict(conn, orphaned_family, keep="incoming")
+    assert "keep 'both'" in str(exc.value)
+    assert str(exc.value).isascii()          # printed by the CLI (issue #23)
+
+    result = dedup.resolve_conflict(conn, orphaned_family, keep="both")
+    assert (result.occurrence, result.no_op) == (0, False)
+    assert conn.execute("SELECT value_num FROM lab_result").fetchone()["value_num"] == 210.0
+
+
+def test_keep_existing_still_resolves_an_empty_family(conn, orphaned_family):
+    """keep-existing drops the incoming row by design, so it stays a legal resolution
+    even with nothing stored - it writes nothing either way."""
+    _drop_occurrence(conn, 1)
+    result = dedup.resolve_conflict(conn, orphaned_family, keep="existing")
+    assert result.kept == "existing"
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 0
+
+
 def test_keep_existing_and_incoming_still_return_a_result(conn, staged):
     """Source compatibility: the return type changed from None, but the older
     resolutions still add no row."""

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -95,3 +95,168 @@ def test_resolve_already_resolved_raises(conn, staged):
 def test_resolve_bad_keep_raises(conn, staged):
     with pytest.raises(ValueError, match="keep must be"):
         dedup.resolve_conflict(conn, staged, keep="whatever")
+
+
+# --- keep both: admitting a genuine repeat (issue #58) ------------------------
+
+def _glucose(value, text):
+    """The issue's exact repro: two legitimate same-day draws on a date-only report."""
+    return {"test_name": "glucose", "collected_at": "2024-04-01",
+            "value_num": value, "value_text": text}
+
+
+@pytest.fixture()
+def repeat_draw(conn):
+    """One open conflict from two genuine same-day draws, submitted separately."""
+    dedup.commit_extraction(conn, _doc(conn, "draw-1"),
+                            {"lab_result": [_glucose(95, "fasting draw")]})
+    summary = dedup.commit_extraction(
+        conn, _doc(conn, "draw-2"),
+        {"lab_result": [_glucose(148, "2-hour post-prandial draw")]},
+    )
+    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    return dedup.list_conflicts(conn)[0]["conflict_id"]
+
+
+def test_keep_both_admits_the_second_draw(conn, repeat_draw):
+    result = dedup.resolve_conflict(conn, repeat_draw, keep="both")
+
+    rows = conn.execute(
+        "SELECT * FROM lab_result ORDER BY lab_result_id"
+    ).fetchall()
+    assert [r["value_num"] for r in rows] == [95.0, 148.0]   # both queryable
+    assert [r["dedup_occurrence"] for r in rows] == [0, 1]
+    assert rows[0]["dedup_base"] == rows[1]["dedup_base"]    # one identity family
+    assert rows[0]["dedup_key"] != rows[1]["dedup_key"]      # distinct keys (UNIQUE)
+    assert rows[1]["dedup_key"] == dedup.occurrence_key(rows[1]["dedup_base"], 1)
+
+    assert (result.kept, result.record_type) == ("both", "lab_result")
+    assert (result.row_id, result.occurrence) == (rows[1]["lab_result_id"], 1)
+    assert result.no_op is False
+
+
+def test_keep_both_records_an_auditable_resolution(conn, repeat_draw):
+    dedup.resolve_conflict(conn, repeat_draw, keep="both", note="both draws are real")
+    row = conn.execute(
+        "SELECT * FROM conflict WHERE conflict_id=?", (repeat_draw,)
+    ).fetchone()
+    assert row["status"] == "resolved" and row["resolved_at"] is not None
+    resolution = row["resolution"]
+    assert resolution.startswith("keep-both -> lab_result #2 occurrence=1 key=")
+    assert "both draws are real" in resolution
+    assert resolution.isascii()      # stored *and* printed; cp1252 console (issue #23)
+
+
+def test_keep_both_carries_provenance_from_the_conflict(conn, repeat_draw):
+    """The admitted row belongs to the document that submitted it, not to the one that
+    produced the sibling."""
+    dedup.resolve_conflict(conn, repeat_draw, keep="both")
+    conflict = conn.execute(
+        "SELECT * FROM conflict WHERE conflict_id=?", (repeat_draw,)
+    ).fetchone()
+    admitted = conn.execute(
+        "SELECT * FROM lab_result WHERE dedup_occurrence = 1"
+    ).fetchone()
+    assert admitted["document_id"] == conflict["document_id"]
+    assert admitted["person_id"] == conflict["person_id"]
+
+
+def test_recommit_of_an_admitted_draw_dedups_instead_of_forking(conn, repeat_draw):
+    """The point of family-aware matching: a third commit of the already-admitted
+    payload must report `duplicate`, not fork a new occurrence or re-stage a conflict."""
+    dedup.resolve_conflict(conn, repeat_draw, keep="both")
+    summary = dedup.commit_extraction(
+        conn, _doc(conn, "draw-3"),
+        {"lab_result": [_glucose(148, "2-hour post-prandial draw")]},
+    )
+    assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
+    # It deduped against the sibling, not against occurrence 0.
+    sibling_key = conn.execute(
+        "SELECT dedup_key FROM lab_result WHERE dedup_occurrence = 1"
+    ).fetchone()["dedup_key"]
+    assert summary.duplicate == [("lab_result", sibling_key)]
+
+
+def test_a_changed_value_on_an_admitted_identity_restages_a_conflict(conn, repeat_draw):
+    """Family matching must not swallow genuinely new facts: a third *different* value
+    on that identity is still a conflict for a human to adjudicate."""
+    dedup.resolve_conflict(conn, repeat_draw, keep="both")
+    summary = dedup.commit_extraction(
+        conn, _doc(conn, "draw-4"),
+        {"lab_result": [_glucose(210, "third draw")]},
+    )
+    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
+
+
+def test_keep_both_numbers_a_third_occurrence(conn, repeat_draw):
+    dedup.resolve_conflict(conn, repeat_draw, keep="both")
+    dedup.commit_extraction(conn, _doc(conn, "draw-4"),
+                            {"lab_result": [_glucose(210, "third draw")]})
+    third = dedup.list_conflicts(conn)[0]["conflict_id"]
+    result = dedup.resolve_conflict(conn, third, keep="both")
+    assert result.occurrence == 2
+    assert [r["dedup_occurrence"] for r in conn.execute(
+        "SELECT dedup_occurrence FROM lab_result ORDER BY lab_result_id"
+    )] == [0, 1, 2]
+
+
+def test_keep_both_is_idempotent_across_conflicts_from_one_payload(conn):
+    """Two documents each staging the same repeat: resolving both `keep both` must not
+    produce twin rows."""
+    dedup.commit_extraction(conn, _doc(conn, "d1"),
+                            {"lab_result": [_glucose(95, "fasting draw")]})
+    payload = {"lab_result": [_glucose(148, "2-hour post-prandial draw")]}
+    dedup.commit_extraction(conn, _doc(conn, "d2"), payload)
+    dedup.commit_extraction(conn, _doc(conn, "d3"), payload)
+    first, second = [c["conflict_id"] for c in dedup.list_conflicts(conn)]
+
+    dedup.resolve_conflict(conn, first, keep="both")
+    result = dedup.resolve_conflict(conn, second, keep="both")
+
+    assert result.no_op is True
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
+    resolution = conn.execute(
+        "SELECT resolution FROM conflict WHERE conflict_id=?", (second,)
+    ).fetchone()["resolution"]
+    assert resolution == "keep-both (no-op: matches lab_result #2)"
+
+
+def test_keep_both_revalidates_the_staged_payload(conn, repeat_draw):
+    """The staged JSON becomes a row, so it is re-validated at resolution time — a
+    conflict hand-edited to something unschematic must not land."""
+    conn.execute(
+        "UPDATE conflict SET incoming_json = ? WHERE conflict_id = ?",
+        ('{"test_name": "glucose", "collected_at": "not-a-date"}', repeat_draw),
+    )
+    conn.commit()
+    with pytest.raises(dedup.ValidationError, match="collected_at"):
+        dedup.resolve_conflict(conn, repeat_draw, keep="both")
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
+    assert conn.execute(
+        "SELECT status FROM conflict WHERE conflict_id=?", (repeat_draw,)
+    ).fetchone()["status"] == "open"
+
+
+def test_keep_both_works_for_observation_rows(conn):
+    """#56-era screening/immunization rows carry the same date-only exposure."""
+    obs = {"obs_type": "screening", "key": "mammogram", "observed_at": "2024-04-01"}
+    dedup.commit_extraction(conn, _doc(conn, "o1"),
+                            {"observation": [obs | {"value_text": "left"}]})
+    dedup.commit_extraction(conn, _doc(conn, "o2"),
+                            {"observation": [obs | {"value_text": "right"}]})
+    conflict_id = dedup.list_conflicts(conn)[0]["conflict_id"]
+    result = dedup.resolve_conflict(conn, conflict_id, keep="both")
+    assert result.occurrence == 1
+    assert [r["value_text"] for r in conn.execute(
+        "SELECT value_text FROM observation ORDER BY observation_id"
+    )] == ["left", "right"]
+
+
+def test_keep_existing_and_incoming_still_return_a_result(conn, staged):
+    """Source compatibility: the return type changed from None, but the older
+    resolutions still add no row."""
+    result = dedup.resolve_conflict(conn, staged, keep="existing")
+    assert (result.kept, result.row_id, result.occurrence) == ("existing", None, None)
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -438,6 +438,85 @@ def test_keep_both_before_rekey_stays_with_the_stored_family(conn, repeat_draw):
     assert len(report.changes) == 2
 
 
+# --- fusing drift: the derived base holds someone *else's* family --------------
+#
+# A dictionary edit that maps two distinct analytes onto one canonical name puts an
+# unrelated, pre-existing family on the base a conflict re-derives to. `rekey` refuses
+# to run in that state, so the database stays there. The conflict's own staged key must
+# win whenever it still has rows, or a resolution acts on the wrong record.
+
+_FUSED = {"a1c": "hba1c"}
+
+
+def _named(test_name, value):
+    return {"test_name": test_name, "collected_at": "2026-01-02", "value_num": value}
+
+
+@pytest.fixture()
+def fused(conn):
+    """Two distinct identities — `a1c` (one row) and `hba1c` (two occurrences) — plus
+    an open conflict staged against the *a1c* row, under a dictionary that fuses the
+    two names. The families are deliberately different sizes so every assertion below
+    names which one was read."""
+    dedup.commit_extraction(conn, _doc(conn, "fuse-a"),
+                            {"lab_result": [_named("a1c", 5.7)]})
+    dedup.commit_extraction(conn, _doc(conn, "fuse-b"),
+                            {"lab_result": [_named("hba1c", 9.9)]})
+    dedup.commit_extraction(conn, _doc(conn, "fuse-c"),
+                            {"lab_result": [_named("hba1c", 10.4)]})
+    dedup.resolve_conflict(conn, dedup.list_conflicts(conn)[0]["conflict_id"],
+                           keep="both")               # hba1c family: occurrences 0, 1
+    summary = dedup.commit_extraction(conn, _doc(conn, "fuse-d"),
+                                      {"lab_result": [_named("a1c", 6.2)]})
+    assert summary.counts["conflict"] == 1
+
+    conflict = dedup.list_conflicts(conn)[0]
+    a1c, hba1c = conn.execute(
+        "SELECT * FROM lab_result ORDER BY lab_result_id"
+    ).fetchall()[:2]
+    # The premise: under _FUSED the conflict re-derives onto the *hba1c* family's base,
+    # while its own staged key still names the a1c row.
+    assert conflict["dedup_key"] == a1c["dedup_base"] != hba1c["dedup_base"]
+    assert dedup._derive_base(conflict, _FUSED) == hba1c["dedup_base"]
+    with pytest.raises(dedup.RekeyCollisionError):
+        dedup.rekey(conn, _FUSED)          # the state itself: rekey cannot clear it
+    return conflict["conflict_id"]
+
+
+def test_keep_incoming_under_fusing_drift_overwrites_the_conflicts_own_row(conn, fused):
+    """Regression: preferring the re-derived base overwrote an unrelated `hba1c`
+    result — destroying a real value and reprovenancing it — while the row the operator
+    asked to overwrite stayed untouched, all at rc 0."""
+    result = dedup.resolve_conflict(conn, fused, keep="incoming", dictionary=_FUSED)
+
+    rows = conn.execute("SELECT * FROM lab_result ORDER BY lab_result_id").fetchall()
+    assert [(r["test_name"], r["value_num"]) for r in rows] == [
+        ("a1c", 6.2), ("hba1c", 9.9), ("hba1c", 10.4),
+    ]
+    assert result.row_id == rows[0]["lab_result_id"]
+    assert [r["document_id"] for r in rows[1:]] == [2, 3]   # bystanders' provenance
+
+
+def test_keep_both_under_fusing_drift_joins_the_staged_family(conn, fused):
+    """The admitted repeat belongs to the identity the conflict was staged against,
+    not to the unrelated family the fused name points at."""
+    result = dedup.resolve_conflict(conn, fused, keep="both", dictionary=_FUSED)
+
+    rows = conn.execute("SELECT * FROM lab_result ORDER BY lab_result_id").fetchall()
+    assert len(rows) == 4
+    a1c, hba1c, admitted = rows[0], rows[1], rows[3]
+    assert admitted["dedup_base"] == a1c["dedup_base"] != hba1c["dedup_base"]
+    assert (result.occurrence, admitted["dedup_occurrence"]) == (1, 1)
+    assert [r["value_num"] for r in rows[1:3]] == [9.9, 10.4]     # untouched
+
+
+def test_conflict_occurrences_under_fusing_drift_counts_the_staged_family(conn, fused):
+    """The listing hint counted the unrelated family (2) instead of the conflict's
+    own (1)."""
+    conflict = dedup.list_conflicts(conn)[0]
+    assert dedup.conflict_occurrences(conn, conflict, _FUSED) == 1
+
+
 def test_keep_existing_and_incoming_still_return_a_result(conn, staged):
     """Source compatibility: the return type changed from None, but the older
     resolutions still add no row."""

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -36,7 +36,11 @@ ALL_MIGRATIONS = [
     "002_conflict.sql",
     "003_fts.sql",
     "004_person_deactivate.sql",
+    "005_dedup_occurrence.sql",
 ]
+
+# Every record table carries the occurrence-family columns (migration 005).
+RECORD_TABLES = ("lab_result", "medication", "procedure", "appointment", "observation")
 
 
 def test_migrate_creates_all_tables(conn):
@@ -65,6 +69,25 @@ def test_person_has_deactivated_at_column(conn):
     db.migrate(conn)
     cols = {row[1] for row in conn.execute("PRAGMA table_info(person)").fetchall()}
     assert "deactivated_at" in cols
+
+
+def test_record_tables_have_occurrence_columns(conn):
+    db.migrate(conn)
+    for table in RECORD_TABLES:
+        cols = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+        assert {"dedup_base", "dedup_occurrence"} <= cols, table
+
+
+def test_occurrence_defaults_to_zero_for_a_bare_insert(conn):
+    """A row written without naming the column is occurrence 0 - the pre-005 shape."""
+    db.migrate(conn)
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane', 'Jane')")
+    conn.execute(
+        "INSERT INTO lab_result (person_id, test_name, collected_at, dedup_key) "
+        "VALUES (1, 'hba1c', '2026-01-01', 'k1')"
+    )
+    row = conn.execute("SELECT dedup_occurrence FROM lab_result").fetchone()
+    assert row["dedup_occurrence"] == 0
 
 
 def test_multi_statement_migration_rolls_back_partial_ddl(conn, tmp_path):

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -429,6 +429,115 @@ def test_serial_same_day_observations_are_distinct_rows(conn):
     assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 2
 
 
+# --- intra-payload collisions (issue #58) -------------------------------------
+
+def test_intra_payload_collision_with_differing_values_is_rejected(conn):
+    """Two rows of ONE submission deriving one key and disagreeing is an extraction
+    error, not a conflict: the 'existing' side would have been inserted milliseconds
+    earlier in the same batch, so there is nothing independent to adjudicate."""
+    doc = _make_document(conn)
+    with pytest.raises(dedup.ValidationError) as exc:
+        dedup.commit_extraction(conn, doc, {"lab_result": [
+            {"test_name": "Glucose", "collected_at": "2024-04-01", "value_num": 95,
+             "value_text": "fasting draw"},
+            {"test_name": "Glucose", "collected_at": "2024-04-01", "value_num": 148,
+             "value_text": "2-hour post-prandial draw"},
+        ]})
+    message = str(exc.value)
+    assert "rows 0 and 1" in message
+    assert "person 1 | glucose | 2024-04-01" in message   # the identity, not a hash
+    assert "--keep both" in message                       # names the recovery path
+    assert message.isascii()                              # cp1252 console (issue #23)
+    # Atomic: nothing of the batch landed.
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 0
+
+
+def test_intra_payload_identical_rows_still_report_duplicate(conn):
+    """An agent listing one fact twice is benign, not an error."""
+    doc = _make_document(conn)
+    row = {"test_name": "Glucose", "collected_at": "2024-04-01", "value_num": 95}
+    summary = dedup.commit_extraction(conn, doc, {"lab_result": [dict(row), dict(row)]})
+    assert summary.counts == {"new": 1, "duplicate": 1, "conflict": 0}
+
+
+def test_intra_payload_collision_checked_per_record_type(conn):
+    """Distinct types never collide with each other, and a same-key observation pair is
+    caught the same way a lab pair is."""
+    doc = _make_document(conn)
+    with pytest.raises(dedup.ValidationError, match="observation: rows 0 and 1"):
+        dedup.commit_extraction(conn, doc, {"observation": [
+            {"obs_type": "vital", "key": "systolic", "observed_at": "2024-04-01",
+             "value_num": 120},
+            {"obs_type": "vital", "key": "systolic", "observed_at": "2024-04-01",
+             "value_num": 138},
+        ]})
+
+
+# --- occurrence numbering -----------------------------------------------------
+
+def test_occurrence_zero_key_is_the_base_byte_for_byte(conn):
+    """Migration 005 is a pure column copy only because occurrence 0 reproduces the
+    pre-005 key exactly - anything else would invalidate every stored key."""
+    row = {"test_name": "hba1c", "collected_at": "2026-01-02"}
+    base = dedup.dedup_key("lab_result", row, 1)
+    assert dedup.dedup_key("lab_result", row, 1, None, 0) == base
+    assert dedup.occurrence_key(base, 0) == base
+    assert dedup.occurrence_key(base, 1) != base
+    assert dedup.dedup_key("lab_result", row, 1, None, 1) == dedup.occurrence_key(base, 1)
+
+
+def test_migration_005_preserves_pre_existing_keys(tmp_path):
+    """The upgrade path: a database written before the occurrence columns existed must
+    come through 005 with every stored key byte-identical, and must keep deduping."""
+    import shutil
+
+    staged = tmp_path / "migrations"
+    staged.mkdir()
+    all_migrations = sorted(db.DEFAULT_MIGRATIONS_DIR.glob("*.sql"))
+    pre_005 = [p for p in all_migrations if not p.name.startswith("005_")]
+    for path in pre_005:
+        shutil.copy(path, staged / path.name)
+
+    conn = db.connect(tmp_path / "legacy.db")
+    try:
+        db.migrate(conn, staged)
+        persons.add_person(conn, "jane-doe", "Jane Doe")
+        pid = conn.execute("SELECT person_id FROM person").fetchone()["person_id"]
+        row = {"test_name": "hba1c", "collected_at": "2026-01-02", "value_num": 5.7}
+        legacy_key = dedup.dedup_key("lab_result", row, pid)
+        conn.execute(
+            "INSERT INTO lab_result (person_id, test_name, collected_at, value_num, "
+            "dedup_key) VALUES (?, ?, ?, ?, ?)",
+            (pid, row["test_name"], row["collected_at"], row["value_num"], legacy_key),
+        )
+        conn.commit()
+
+        for path in all_migrations:
+            shutil.copy(path, staged / path.name)
+        assert db.migrate(conn, staged) == ["005_dedup_occurrence.sql"]
+
+        stored = conn.execute("SELECT * FROM lab_result").fetchone()
+        assert stored["dedup_key"] == legacy_key      # no key churn
+        assert stored["dedup_base"] == legacy_key     # backfilled from the key
+        assert stored["dedup_occurrence"] == 0
+
+        # And the pre-005 row still dedups against a fresh commit of the same fact.
+        doc = _make_document(conn)
+        summary = dedup.commit_extraction(conn, doc, {"lab_result": [row]})
+        assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
+    finally:
+        conn.close()
+
+
+def test_commit_stores_dedup_base_for_every_row(conn):
+    """The family lookup keys off dedup_base, so no write path may leave it null."""
+    doc = _make_document(conn)
+    dedup.commit_extraction(conn, doc, {"lab_result": [_lab(5.7)]})
+    row = conn.execute("SELECT * FROM lab_result").fetchone()
+    assert row["dedup_base"] == row["dedup_key"]
+    assert row["dedup_occurrence"] == 0
+
+
 def test_commit_unknown_type_rolls_back(conn):
     doc = _make_document(conn)
     with pytest.raises(dedup.ValidationError):
@@ -577,3 +686,34 @@ def test_rekey_covers_every_record_type(conn):
     report = dedup.rekey(conn, None)
     assert report.scanned == {t: 1 for t in dedup.KNOWN_TYPES}
     assert report.changes == []  # same dictionary (none) -> keys already current
+
+
+def test_rekey_is_a_no_op_over_a_keep_both_family(conn):
+    """The whole reason occurrence lives in a column: `rekey` re-derives keys from
+    payload, so siblings must recompute to their own keys rather than collide."""
+    doc = _make_document(conn)
+    d = dedup.load_dictionary(DICT_PATH)
+    dedup.commit_extraction(conn, doc, {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2024-04-01", "value_num": 95}]}, d)
+    dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2024-04-01", "value_num": 148}]}, d)
+    conflict_id = dedup.list_conflicts(conn)[0]["conflict_id"]
+    dedup.resolve_conflict(conn, conflict_id, keep="both")
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
+
+    report = dedup.rekey(conn, d, apply=True)
+    assert report.changes == []            # no RekeyCollisionError, no key churn
+    keys = [r["dedup_key"] for r in conn.execute("SELECT * FROM lab_result")]
+    assert len(set(keys)) == 2
+
+
+def test_rekey_moves_dedup_base_with_the_key(conn):
+    """A dictionary edit must not leave dedup_base pointing at the old family, or the
+    commit-time family lookup would miss."""
+    doc = _make_document(conn)
+    dedup.commit_extraction(conn, doc, {"lab_result": [
+        {"test_name": "ZZT", "collected_at": "2026-01-02", "value_num": 108}]},
+        dedup.load_dictionary(DICT_PATH))
+    dedup.rekey(conn, _rekey_dict(zzt="zonulin_test"), apply=True)
+    row = conn.execute("SELECT * FROM lab_result").fetchone()
+    assert row["dedup_base"] == row["dedup_key"]   # occurrence 0: base IS the key

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -278,12 +278,15 @@ def test_reassign_refused_when_another_document_conflicts_with_its_rows(seeded):
 
 
 def test_reassign_refusal_lists_a_two_ended_conflict_once(seeded):
-    """A conflict raised by *and* anchored to the same document (two colliding rows in
-    one extraction) appears once in the refusal, not twice."""
+    """A conflict raised by *and* anchored to the same document (a re-commit against the
+    same document collides with the row it already produced) appears once in the
+    refusal, not twice."""
     conn = seeded["conn"]
     other = _insert_document(conn, seeded["jane"].person_id, "dd99")
-    summary = dedup.commit_extraction(conn, other, {"lab_result": [
+    dedup.commit_extraction(conn, other, {"lab_result": [
         {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 88},
+    ]})
+    summary = dedup.commit_extraction(conn, other, {"lab_result": [
         {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 99},
     ]})
     assert summary.counts["conflict"] == 1
@@ -291,6 +294,37 @@ def test_reassign_refusal_lists_a_two_ended_conflict_once(seeded):
     with pytest.raises(documents.OpenConflictsError) as exc:
         documents.reassign_document(conn, other, "john-doe", apply=True)
     assert str(exc.value).count("#1") == 1
+
+
+def test_reassign_moves_a_keep_both_family_intact(seeded):
+    """A row admitted by `review-conflicts --keep both` is occurrence >0 of its family:
+    its key hashes the base together with that stored occurrence, so a move has to carry
+    the occurrence (else the recompute reads as dictionary drift) and re-derive both
+    dedup_key and dedup_base under the new owner."""
+    conn = seeded["conn"]
+    doc = _insert_document(conn, seeded["john"].person_id, "ff77ee88")
+    draw = {"test_name": "glucose", "collected_at": "2024-04-01"}
+    dedup.commit_extraction(conn, doc, {"lab_result": [draw | {"value_num": 95}]})
+    dedup.commit_extraction(conn, doc, {"lab_result": [draw | {"value_num": 148}]})
+    conflict_id = dedup.list_conflicts(conn)[0]["conflict_id"]
+    dedup.resolve_conflict(conn, conflict_id, keep="both")
+
+    report = documents.reassign_document(conn, doc, "jane-doe", apply=True)
+    assert len(report.changes) == 2
+
+    rows = conn.execute(
+        "SELECT * FROM lab_result WHERE test_name = 'glucose' ORDER BY lab_result_id"
+    ).fetchall()
+    assert [r["person_id"] for r in rows] == [seeded["jane"].person_id] * 2
+    assert [r["dedup_occurrence"] for r in rows] == [0, 1]
+    assert rows[0]["dedup_base"] == rows[1]["dedup_base"]      # family stayed together
+    assert rows[0]["dedup_key"] == rows[0]["dedup_base"]       # occurrence 0
+    assert rows[1]["dedup_key"] == dedup.occurrence_key(rows[1]["dedup_base"], 1)
+    # Keys are Jane's now, and the family still dedups a re-commit of the admitted draw.
+    summary = dedup.commit_extraction(
+        conn, seeded["doc"], {"lab_result": [draw | {"value_num": 148}]}
+    )
+    assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
 
 
 def test_reassign_refused_on_dictionary_drift(seeded):
@@ -393,8 +427,10 @@ def test_rm_counts_a_two_ended_conflict_once(seeded):
     only, and deleted exactly once."""
     conn = seeded["conn"]
     other = _insert_document(conn, seeded["jane"].person_id, "dd99")
-    summary = dedup.commit_extraction(conn, other, {"lab_result": [
+    dedup.commit_extraction(conn, other, {"lab_result": [
         {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 88},
+    ]})
+    summary = dedup.commit_extraction(conn, other, {"lab_result": [
         {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 99},
     ]})
     assert summary.counts["conflict"] == 1

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -226,6 +226,75 @@ def test_review_conflicts_lists_and_requires_signoff(seeded, tmp_path, monkeypat
     assert "Jane said keep" in row["resolution"]
 
 
+def _stage_repeat_draw(seeded, tmp_path, monkeypatch) -> int:
+    """One open conflict from two genuine same-day draws (issue #58); returns its id."""
+    monkeypatch.setenv("PEMR_SOURCES", str(tmp_path / "sources"))
+    draw = {"test_name": "glucose", "collected_at": "2024-04-01"}
+    for name, value_text, value_num in (("g1.txt", "fasting", 95),
+                                        ("g2.txt", "post-prandial", 148)):
+        scan = tmp_path / name
+        scan.write_bytes(name.encode())
+        doc = mcp_server.ingest_document(seeded, file=str(scan), person="jane-doe",
+                                         ocr_text="glucose")["document"]["document_id"]
+        mcp_server.commit_extraction(seeded, document_id=doc, records={
+            "lab_result": [draw | {"value_num": value_num, "value_text": value_text}],
+        })
+    return mcp_server.review_conflicts(seeded)[0]["conflict_id"]
+
+
+def test_review_conflicts_keep_both_requires_signoff(seeded, tmp_path, monkeypatch):
+    """`both` admits a row rather than choosing one, so it goes through the *same*
+    sign-off gate - no new bypass (AGENTS.md conflict discipline)."""
+    cid = _stage_repeat_draw(seeded, tmp_path, monkeypatch)
+    with pytest.raises(mcp_server.ToolError, match="sign-off"):
+        mcp_server.review_conflicts(seeded, resolve=cid, keep="both")
+    assert seeded.execute(
+        "SELECT status FROM conflict WHERE conflict_id=?", (cid,)
+    ).fetchone()["status"] == "open"
+
+
+def test_review_conflicts_keep_both_reports_the_admitted_row(seeded, tmp_path,
+                                                             monkeypatch):
+    cid = _stage_repeat_draw(seeded, tmp_path, monkeypatch)
+    res = mcp_server.review_conflicts(
+        seeded, resolve=cid, keep="both",
+        signoff="Jane confirmed both draws are real",
+    )
+    assert res["keep"] == "both" and res["record_type"] == "lab_result"
+    assert res["occurrence"] == 1 and res["no_op"] is False
+    row = seeded.execute(
+        "SELECT * FROM lab_result WHERE lab_result_id = ?", (res["row_id"],)
+    ).fetchone()
+    assert row["value_num"] == 148.0
+    assert "Jane confirmed" in seeded.execute(
+        "SELECT resolution FROM conflict WHERE conflict_id=?", (cid,)
+    ).fetchone()["resolution"]
+
+
+def test_review_conflicts_listing_reports_family_size(seeded, tmp_path, monkeypatch):
+    cid = _stage_repeat_draw(seeded, tmp_path, monkeypatch)
+    assert mcp_server.review_conflicts(seeded)[0]["occurrences"] == 1
+    mcp_server.review_conflicts(seeded, resolve=cid, keep="both",
+                                signoff="Jane confirmed both draws are real")
+    # A later conflict on that identity now shows the reviewer that a repeat was admitted.
+    scan = tmp_path / "g3.txt"
+    scan.write_bytes(b"g3")
+    doc = mcp_server.ingest_document(seeded, file=str(scan), person="jane-doe",
+                                     ocr_text="glucose")["document"]["document_id"]
+    mcp_server.commit_extraction(seeded, document_id=doc, records={
+        "lab_result": [{"test_name": "glucose", "collected_at": "2024-04-01",
+                        "value_num": 210, "value_text": "third"}],
+    })
+    assert mcp_server.review_conflicts(seeded)[0]["occurrences"] == 2
+
+
+def test_review_conflicts_rejects_an_unknown_keep(seeded, tmp_path, monkeypatch):
+    cid = _stage_repeat_draw(seeded, tmp_path, monkeypatch)
+    with pytest.raises(mcp_server.ToolError, match="keep must be"):
+        mcp_server.review_conflicts(seeded, resolve=cid, keep="neither",
+                                    signoff="Jane said neither")
+
+
 def test_write_tools_refused_on_unmigrated_db(tmp_path):
     fresh = db.connect(tmp_path / "empty.db")
     try:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -336,6 +336,22 @@ def test_trends_distinct_intraday_times_are_not_a_tie(seeded):
     assert t["latest"] == 5.4 and t["latest_tie"] == 1
 
 
+def test_query_labs_same_date_siblings_order_by_row_id(seeded):
+    """`--keep both` (#58) admits a second draw under the same date, so
+    `collected_at, test_name` no longer totally orders lab rows. Row id breaks the
+    tie: the later-admitted sibling reads as the later point."""
+    first = _insert_lab(seeded, "jane-doe", test_name="Glucose", value_num=95.0,
+                        unit="mg/dL", collected_at="2024-04-01")
+    second = _insert_lab(seeded, "jane-doe", test_name="Glucose", value_num=148.0,
+                         unit="mg/dL", collected_at="2024-04-01")
+    same_day = [
+        r for r in query.query_labs(seeded, "jane-doe")
+        if r["collected_at"] == "2024-04-01"
+    ]
+    assert [r["lab_result_id"] for r in same_day] == [first, second]
+    assert [r["value_num"] for r in same_day] == [95.0, 148.0]
+
+
 # --- error surfaces -----------------------------------------------------------
 
 def test_unknown_person_raises(seeded):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -161,6 +161,24 @@ def test_summary_abnormal_lab_selection(seeded):
     assert section.index("Glucose") < section.index("LDL")
 
 
+def test_summary_same_date_lab_siblings_order_by_row_id(seeded):
+    """A `--keep both` sibling (#58) shares its date with the row it was admitted
+    beside, so newest-first ordering needs a row-id tiebreak to stay deterministic:
+    the later-admitted row reads as the later point."""
+    d = dedup.load_dictionary(DICT_PATH)
+    dedup.commit_extraction(seeded, _doc(seeded, "jane-doe"), {"lab_result": [
+        {"test_name": "Glucose, fasting", "collected_at": "2026-01-01",
+         "value_num": 320, "unit": "mg/dL", "ref_high": 100},
+    ]}, d)
+    conflict_id = dedup.list_conflicts(seeded)[0]["conflict_id"]
+    admitted = dedup.resolve_conflict(seeded, conflict_id, keep="both")
+    assert admitted.occurrence == 1
+
+    md = render.render_summary(seeded, "jane-doe", dictionary=d)
+    section = md.split("## Recent Abnormal Labs")[1].split("##")[0]
+    assert section.index("320.0") < section.index("200.0")
+
+
 def test_summary_upcoming_and_open_appointments(seeded):
     md = render.render_summary(seeded, "jane-doe")
     section = md.split("## Upcoming / Open Appointments")[1]


### PR DESCRIPTION
## Summary
- `review-conflicts --resolve` gains `--keep both`: admits the incoming row alongside the
  existing one under a disambiguated, deterministic `dedup_key` (occurrence-suffixed) instead of
  forcing the operator to pick a winner between two genuine same-day draws.
- Fixes a bystander bug found along the way: `--keep incoming` targeted the conflict's raw key
  instead of the resolved anchor row, and did not re-derive the conflict's identity family under
  the *current* dictionary (a fusing rekey could leave `keep incoming` overwriting the wrong row).
  A conflict's own staged key now wins over the re-derived base when both exist.
- MCP `review_conflicts` tool takes the same `keep` values, including `"both"`, and enforces the
  AGENTS.md §4 sign-off gate identically to the CLI.
- `migrations/005_dedup_occurrence.sql` adds the occurrence column; `docs/Architecture.md` §3
  documents the staged-key-first precedence rule.

Closes #58

## Test plan
- [x] `pemr/dedup.py`, `pemr/cli.py`, `pemr/documents.py`, `pemr/mcp_server.py`, `pemr/query.py`,
      `pemr/render.py` unit tests updated/added (`tests/test_conflict.py`, `tests/test_dedup.py`,
      `tests/test_cli_phase2.py`, `tests/test_db.py`, `tests/test_documents.py`,
      `tests/test_mcp_server.py`, `tests/test_query.py`, `tests/test_render.py`)
- [x] Full suite: `python -m pytest` — 393 passed
- [x] Independent verify + audit passes confirmed the fix on both the CLI and MCP front doors,
      including a fusing-dictionary repro of the original bug
- [x] `origin/dev` is an ancestor of the branch tip — no merge needed, no conflicts

Audit noted one non-blocking residual (a narrow `keep incoming` overwrite reachable only via a
six-link operator sequence involving two `document rm --apply` calls and a fusing dictionary edit
after both occurrences of a family are removed) — recorded on #58 with a fix shape, intentionally
not riding along on this PR; it should get its own follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)