### PR TITLE
feat: Open Conflicts section in render summary

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -322,7 +322,10 @@ extracting; dictionary additions go through human review, never agent-direct edi
 `render.py` produces your current deliverables as pure functions of DB state:
 
 - **master summary** — active meds, conditions, allergies, latest vitals, recent
-  abnormal labs, open follow-ups. One query bundle → Markdown.
+  abnormal labs, open follow-ups, open conflicts. One query bundle → Markdown. The
+  conflicts section is not decoration: an open conflict means a stored value is disputed
+  and its correction is still staged, so the summary would otherwise print the stale
+  value silently (the brief carries the same section, but it is per-appointment).
 - **appointment brief** — for a given upcoming appointment: relevant history for that
   specialty, recent labs/imaging, current meds, med-interaction flags, suggested
   questions. This is your "walk-in readiness" as a repeatable command.

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -176,6 +176,24 @@ def _row_counts(conn: sqlite3.Connection, person_id: int) -> dict[str, int]:
     return counts
 
 
+def _open_conflict_lines(conn: sqlite3.Connection, person_id: int) -> list[str]:
+    """Bullet lines for this person's open (unresolved) conflicts.
+
+    Shared by the summary and the brief: a staged correction means "a value in this
+    record is disputed and the corrected one is not committed yet", so every rendered
+    view that a reader treats as current has to say so (issue #59)."""
+    rows = conn.execute(
+        "SELECT * FROM conflict WHERE person_id = ? AND status = 'open' "
+        "ORDER BY conflict_id",
+        (person_id,),
+    ).fetchall()
+    return [
+        f"- conflict #{c['conflict_id']} ({c['record_type']}) - resolve with "
+        "`pemr review-conflicts`"
+        for c in rows
+    ]
+
+
 def _appt_who(row: sqlite3.Row | dict) -> str:
     return " ".join(p for p in (row["provider"], row["specialty"]) if p)
 
@@ -211,8 +229,13 @@ def render_summary(
     now: datetime | None = None,
 ) -> str:
     """Markdown master summary for a person: active meds, conditions, allergies, latest
-    vitals, recent abnormal labs, upcoming/open appointments -- with a self-identifying
-    header (name, DOB, generated-at, source row counts). Read-only.
+    vitals, recent abnormal labs, upcoming/open appointments, and any open conflicts --
+    with a self-identifying header (name, DOB, generated-at, source row counts).
+    Read-only.
+
+    The summary is the document read *between* appointments, so an open conflict has to
+    surface here too: without it a staged correction is invisible and the summary prints
+    the stale value with no hint that a corrected one is pending (issue #59).
 
     Raises :class:`query.PersonNotFoundError` for an unknown slug (friendly rc=1)."""
     person_id = query.resolve_person_id(conn, slug)
@@ -285,6 +308,9 @@ def render_summary(
         _section("Latest Vitals", vital_lines),
         _section("Recent Abnormal Labs", lab_lines, empty="_none flagged_"),
         _section("Upcoming / Open Appointments", appt_lines),
+        _section(
+            "Open Conflicts", _open_conflict_lines(conn, person_id), empty="_none_"
+        ),
     ]
     return "\n".join(parts).rstrip() + "\n"
 
@@ -394,16 +420,7 @@ def render_brief(
             f"- {_date_part(o['observed_at']) or '(undated)'}  {detail}{val}"
         )
 
-    open_conflicts = conn.execute(
-        "SELECT * FROM conflict WHERE person_id = ? AND status = 'open' "
-        "ORDER BY conflict_id",
-        (person_id,),
-    ).fetchall()
-    conflict_lines = [
-        f"- conflict #{c['conflict_id']} ({c['record_type']}) - resolve with "
-        "`pemr review-conflicts`"
-        for c in open_conflicts
-    ]
+    conflict_lines = _open_conflict_lines(conn, person_id)
 
     interaction = _section(
         "Medication Interaction Review",

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -33,6 +33,21 @@ def _doc(conn, slug, ocr=None, doc_date="2026-01-01", category=None, provider=No
     return cur.lastrowid
 
 
+def _stage_conflict(conn, slug, *, record_type="lab_result", status="open"):
+    """Stage one conflict row for `slug` (the shape `dedup` writes on a key collision)."""
+    cur = conn.execute(
+        "INSERT INTO conflict (record_type, dedup_key, person_id, existing_json, "
+        "incoming_json, status, resolution, detected_at, resolved_at) VALUES "
+        "(?, 'k', (SELECT person_id FROM person WHERE slug = ?), '{}', '{}', ?, ?, "
+        "'2026-01-01', ?)",
+        (record_type, slug, status,
+         "keep-incoming" if status == "resolved" else None,
+         "2026-01-02" if status == "resolved" else None),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
 def _row_counts(conn):
     return {t: conn.execute(f"SELECT COUNT(*) AS n FROM {t}").fetchone()["n"] for t in _TABLES}
 
@@ -163,10 +178,37 @@ def test_summary_abnormal_lab_selection(seeded):
 
 def test_summary_upcoming_and_open_appointments(seeded):
     md = render.render_summary(seeded, "jane-doe")
-    section = md.split("## Upcoming / Open Appointments")[1]
+    section = md.split("## Upcoming / Open Appointments")[1].split("\n## ")[0]
     assert "Dr. Smith" in section    # upcoming
     assert "Dr. Open" in section     # past but no summary -> open
     assert "Dr. Past" not in section  # past + documented -> closed
+
+
+def test_summary_open_conflicts_section(seeded):
+    """The summary is the doc read between appointments, so a staged correction must be
+    visible there and not only in `review-conflicts` / a per-appointment brief: without
+    it the summary prints the stale value with no hint a correction is pending (#59)."""
+    cid = _stage_conflict(seeded, "jane-doe")
+    md = render.render_summary(seeded, "jane-doe")
+    section = md.split("## Open Conflicts")[1].split("\n## ")[0]
+    assert f"conflict #{cid} (lab_result)" in section
+    assert "`pemr review-conflicts`" in section       # tells the reader how to clear it
+
+
+def test_summary_open_conflicts_empty_state_and_scoping(seeded):
+    """Empty state is explicit (`_none_`, matching the brief), resolved conflicts drop
+    out of the section, and another person's conflict never leaks in."""
+    md = render.render_summary(seeded, "jane-doe")
+    assert "_none_" in md.split("## Open Conflicts")[1].split("\n## ")[0]
+
+    resolved = _stage_conflict(seeded, "jane-doe", status="resolved")
+    johns = _stage_conflict(seeded, "john-doe")
+    section = render.render_summary(
+        seeded, "jane-doe"
+    ).split("## Open Conflicts")[1].split("\n## ")[0]
+    assert f"conflict #{resolved}" not in section     # resolved -> not open
+    assert f"conflict #{johns}" not in section        # other person's conflict
+    assert "_none_" in section
 
 
 def test_summary_empty_sections_are_explicit(seeded):
@@ -245,13 +287,7 @@ def test_brief_has_interaction_placeholder(seeded):
 
 def test_brief_open_conflict_warning(seeded):
     # stage an open conflict for jane, then confirm the brief warns about it
-    seeded.execute(
-        "INSERT INTO conflict (record_type, dedup_key, person_id, existing_json, "
-        "incoming_json, status, detected_at) VALUES "
-        "('lab_result', 'k', (SELECT person_id FROM person WHERE slug='jane-doe'), "
-        "'{}', '{}', 'open', '2026-01-01')"
-    )
-    seeded.commit()
+    _stage_conflict(seeded, "jane-doe")
     md = render.render_brief(seeded, _upcoming_appt_id(seeded))
     section = md.split("## Open Conflicts")[1].split("##")[0]
     assert "review-conflicts" in section


### PR DESCRIPTION
## Summary
- `pemr render summary` gains an `## Open Conflicts` section — person-scoped, open-only, listing
  each pending conflict as `conflict #<id> (<record_type>) - resolve with \`pemr review-conflicts\``
  so a staged correction (e.g. a re-abstracted lab value) is no longer invisible in the summary the
  way it already isn't in the brief.
- The block is shared with `render_brief`'s existing implementation via extraction, so the two
  formats cannot drift; both were checked byte-identical before/after on the same DB.
- MCP `render_summary()` returns the section too, with the same trailing single-`\n` contract.
- `docs/Architecture.md` §6 updated with the new section.

Closes #59

## Test plan
- [x] `tests/test_render.py` updated/added; one pre-existing test tightened (sliced to end-of-
      document, now stops at the next `##`) so a future appended section can't be silently
      swallowed by it
- [x] Full suite: `python -m pytest` — 351 passed; `npm test` — 4 passed; `npm run check:meta-drift`
      — passed
- [x] Real-run verification: seeded a scratch DB with open lab_result and medication conflicts,
      confirmed person-scoping, empty-state `_none_`, ordering, and that resolving a conflict
      (via the real `review-conflicts` path) clears it from the section
- [x] Independent verify + audit passes both confirmed, including a byte-identical hash check on
      the brief's refactored extraction path
- [x] `origin/dev` is an ancestor of the branch tip — no merge needed, no conflicts

Audit flagged two pre-existing, non-blocking issues inherited from `dev` and unrelated to this
branch's diff (confirmed via empty `git diff origin/dev...HEAD -- .github .claude` /
reproduction on `dev` itself), recorded here for visibility rather than fixed in this PR:
- `db.is_migrated()` only checks the 001 sentinel, so a 001-only DB raises a raw
  `sqlite3.OperationalError` instead of a friendly `run pemr migrate first` message on any
  002+-table command, including this one. Recommend filing separately.
- `npm run sync:claude-config:check` is currently red on `dev` (7 stale `.claude/agents/*` mirrors)
  — this PR's check may show red for that pre-existing reason, not for anything in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)