### PR TITLE
fix: MCP server advertises pemr's own version

### DIFF
--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -30,7 +30,7 @@ from typing import Any
 
 # Engine modules are underscore-aliased so the public tool named `query` (and any future
 # tool sharing a module name) can't shadow the module it delegates to.
-from . import cli, db
+from . import __version__, cli, db
 from . import dedup as _dedup
 from . import ingest as _ingest
 from . import persons as _persons
@@ -374,6 +374,14 @@ def build_server():  # pragma: no cover - exercised only with the mcp SDK instal
         ) from exc
 
     server = FastMCP("pemr")
+
+    # `serverInfo.version` — what a client UI shows the human. FastMCP takes no
+    # `version=` argument, and the low-level server it wraps falls back to the *SDK's*
+    # own package version, so an unset version advertises e.g. "pemr 1.28.1" (the `mcp`
+    # release) instead of pemr's — wrong, ahead of the real version, and useless for
+    # diagnosing a version mismatch (#60). The attribute is read at initialize time, so
+    # setting it after construction is equivalent to a constructor argument.
+    server._mcp_server.version = __version__
 
     def _run(fn, /, **kwargs):
         conn = _connect()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 
-from pemr import db, dedup, mcp_server, persons
+from pemr import __version__, db, dedup, mcp_server, persons
 
 REPO = Path(__file__).resolve().parent.parent
 DICT_PATH = REPO / "data" / "dictionary.example.toml"
@@ -271,3 +271,15 @@ def test_registered_tool_names_equal_contract():
     server = mcp_server.build_server()
     registered = {t.name for t in server._tool_manager.list_tools()}
     assert registered == set(mcp_server.TOOL_NAMES)
+
+
+def test_server_info_advertises_pemr_version():
+    """`serverInfo` must report pemr's version, not the `mcp` SDK's (#60).
+
+    Asserted on the initialize options the server actually puts on the wire, so this
+    also catches an SDK change to how the version is resolved.
+    """
+    pytest.importorskip("mcp")
+    opts = mcp_server.build_server()._mcp_server.create_initialization_options()
+    assert opts.server_name == "pemr"
+    assert opts.server_version == __version__


### PR DESCRIPTION
## Summary
- `build_server()` now sets `_mcp_server.version = pemr.__version__` after constructing
  `FastMCP("pemr")`, so `initialize`'s `serverInfo.version` reports `0.1.0` (pemr's own version)
  instead of the `mcp` SDK release (`1.28.1`).
- `FastMCP`'s constructor has no `version` parameter on the installed SDK — only the low-level
  `mcp.server.lowlevel.Server` does, and `_mcp_server` is FastMCP's already-used escape hatch for
  that server (also used to mount it into ASGI apps) — so this is the minimal fix rather than
  hand-wiring a low-level server.
- Single version source (`pemr/__init__.py`) now backs `serverInfo.version`, `pemr --version`, and
  package metadata identically.

Closes #60

## Test plan
- [x] `tests/test_mcp_server.py` — new assertion on `create_initialization_options()` (the wire
      value, not the private attribute) so an SDK change that ignores `_mcp_server.version` trips
      the test rather than passing on a stray attribute; `pytest.importorskip("mcp")` matches the
      neighbouring SDK-dependent test and skips cleanly when the `[mcp]` extra is absent (CI's
      current install)
- [x] Full suite: `python -m pytest` — 350 passed; `tests/test_mcp_server.py` — 21 passed
- [x] Live stdio `initialize` handshake against `python -m pemr.mcp_server` confirmed
      `serverInfo: {"name": "pemr", "version": "0.1.0"}` on the real wire
- [x] Independent verify + audit passes both confirmed, including a same-process A/B against a
      bare `FastMCP("pemr")` (`1.28.1`) to show the assertion is non-tautological
- [x] `origin/dev` is an ancestor of the branch tip — no merge needed, no conflicts

Audit confirmed the local `sync:claude-config:check` failure verify flagged is a CRLF checkout
artifact, not real drift — CI on `dev`'s merge-base is green including the `meta` job, so this PR
is not expected to inherit a red check there. Audit also noted, non-blocking and pre-existing:
CI's `pip install -e . pytest` omits the `[mcp]` extra, so this test (and the neighbouring tool-
name contract test) skip in CI rather than run — a separate CI-config fix, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)