### PR TITLE
fix(#61): verify document owner against --person at ingest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,19 @@ to `find` (FTS5); an ingest without it is silently unsearchable.
   the ingest as incomplete and supply text before moving on. (The engine only *warns* here rather
   than hard-failing, because a human at the CLI may legitimately defer — but the agent MUST not.)
 
+**Owner verification.** Because you supply the text, you are the primary consumer of the
+ingest-time owner check: it scans that text for the claimed person's name/DOB and returns
+`owner_check: {verdict, matched_slug, evidence}` — `match`, `mismatch` (the text names a
+*different* roster person), `suspect` (a patient-identity header naming nobody on the roster), or
+`unverified` (no text, or no identity anchor in it). `mismatch`/`suspect` **refuse the ingest**
+before anything is written.
+
+- On a refusal, the agent MUST surface the verdict and the `evidence` snippet to the human and get
+  an **explicit go-ahead** before retrying with `force=true`. Never force on your own judgment.
+- Unlike §4 conflict resolution, this is not mechanically gated on a `signoff` param. The
+  asymmetry is deliberate: a wrongly-forced ingest is recoverable (`pemr document reassign`),
+  whereas a wrongly-resolved conflict destroys the losing value.
+
 ### 4. Conflict discipline
 
 Agents never resolve staged conflicts silently.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,8 +137,9 @@ to `find` (FTS5); an ingest without it is silently unsearchable.
 ingest-time owner check: it scans that text for the claimed person's name/DOB and returns
 `owner_check: {verdict, matched_slug, evidence}` — `match`, `mismatch` (the text names a
 *different* roster person), `suspect` (a patient-identity header naming nobody on the roster), or
-`unverified` (no text, or no identity anchor in it). `mismatch`/`suspect` **refuse the ingest**
-before anything is written.
+`unverified` (no text, no identity anchor in it, or a claimed person whose name is too short to
+carry a signal — their absence from the text is ignorance, not evidence). `mismatch`/`suspect`
+**refuse the ingest** before anything is written.
 
 - On a refusal, the agent MUST surface the verdict and the `evidence` snippet to the human and get
   an **explicit go-ahead** before retrying with `force=true`. Never force on your own judgment.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -241,14 +241,17 @@ new row now stages a conflict.
 inbox/scan.pdf
   → pemr ingest inbox/scan.pdf --person jane-doe
       1. hash bytes; if known → report duplicate, stop
-      2. move blob → sources/<sha>/<sha>.pdf   (immutable)
-      3. insert document row (category/provider left null for now)
+      2. resolve document text (agent-supplied, or --ocr), then verify the owner:
+         text naming a different roster person, or a patient-identity header
+         naming nobody on the roster → refuse pre-write (--force overrides)
+      3. move blob → sources/<sha>/<sha>.pdf   (immutable)
+      4. insert document row (category/provider left null for now)
   → AGENT step (vision): read the source, emit proposed rows as JSON
       matching the record schemas (lab_result[], medication[], observation[]...)
   → pemr commit-extraction --document <id> --json extracted.json
-      4. validate JSON against schema (types, required fields)
-      5. compute dedup_keys; split into {new, duplicate, conflict}
-      6. insert new; report the rest
+      5. validate JSON against schema (types, required fields)
+      6. compute dedup_keys; split into {new, duplicate, conflict}
+      7. insert new; report the rest
   → pemr review-conflicts   (if any)
 ```
 
@@ -267,7 +270,7 @@ giving the agent text to work from instead of re-reading pixels every time.
 
 ```
 pemr person add|list|show|edit|deactivate|reactivate|remove
-pemr ingest <file> --person <slug> [--ocr tesseract]
+pemr ingest <file> --person <slug> [--ocr tesseract] [--force]   # --force: skip owner verification
 pemr commit-extraction --document <id> --json <file>
 pemr review-conflicts [--resolve ...]
 pemr document list [--person <slug>]                     # newest first; omit --person for everyone

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -522,6 +522,33 @@ def _cmd_document_rm(args: argparse.Namespace) -> int:
     return _with_document_conn(args, work)
 
 
+def _report_owner_check(
+    check: "ingest.OwnerCheck | None", person_slug: str, document_id: int
+) -> None:
+    """Print the issue-#61 owner-verification verdict for a successful ingest.
+
+    A blocking verdict only reaches here when the human passed ``--force`` (otherwise
+    `ingest_document` raised pre-write), so that branch points at the undo path.
+    """
+    if check is None:  # duplicate path: nothing written, nothing checked
+        return
+    if check.verdict == "match":
+        print(f"owner verified: matched '{person_slug}' in document text")
+    elif check.blocks:
+        print(
+            f"warning: owner verification was overridden with --force "
+            f"(verdict: {check.verdict}). Filed under '{person_slug}' anyway; undo "
+            f"with `pemr document reassign {document_id} --person <slug> --apply`.",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "note: owner not verified - no document text available (or no patient "
+            f"identity found in it). Filed under '{person_slug}' on your say-so.",
+            file=sys.stderr,
+        )
+
+
 def _cmd_ingest(args: argparse.Namespace) -> int:
     ocr_text = None
     if getattr(args, "ocr_text_file", None):
@@ -545,6 +572,7 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
                 provider=args.provider,
                 ocr=(args.ocr == "tesseract"),
                 ocr_text=ocr_text,
+                force=args.force,
             )
         except db.NotMigratedError as exc:
             print(f"error: {exc}", file=sys.stderr)
@@ -566,6 +594,7 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
         f"ingested document #{doc.document_id} (sha256 {doc.sha256[:12]}...) "
         f"-> sources/{doc.source_path}"
     )
+    _report_owner_check(result.owner_check, args.person, doc.document_id)
     if not result.ocr_text_populated:
         print(
             "note: no ocr_text stored - `find` (full-text search) will not see this "
@@ -1226,6 +1255,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--ocr-text-file",
         dest="ocr_text_file",
         help="file of agent-supplied document text to store as ocr_text (wins over --ocr)",
+    )
+    p_ingest.add_argument(
+        "--force",
+        action="store_true",
+        help="ingest even if the document text does not name --person",
     )
     p_ingest.set_defaults(func=_cmd_ingest)
 

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -9,31 +9,55 @@ The deterministic first half of the ingestion pipeline (Architecture.md §4):
 The agent's vision/extraction step and layer-2 dedup happen later, through
 `commit-extraction` (see dedup.py). This module never runs the LLM — it only lays
 the deterministic rails a document travels before extraction.
+
+Issue #61 adds a pre-write **owner check**: when document text is available, it is
+scanned for the claimed person's name/DOB and the ingest is refused (pre-write, so a
+refusal is a clean no-op) when the text affirmatively points somewhere else. See
+:func:`check_owner`.
 """
 
 from __future__ import annotations
 
 import hashlib
+import re
 import shutil
 import subprocess
 import sqlite3
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
+from typing import Sequence
 
 from . import db
-from .models import Document
+from .models import Document, Person
 
 
 class IngestError(RuntimeError):
     """Raised for unrecoverable ingest problems (missing file/person)."""
 
 
+class OwnerMismatchError(IngestError):
+    """Raised when the document text does not look like it belongs to ``--person``.
+
+    Carries the :class:`OwnerCheck` that triggered the refusal so a structured caller
+    (MCP) can report the verdict; ``str(exc)`` is the full human-facing refusal text.
+    Subclasses :class:`IngestError` so existing ``except IngestError`` handlers keep
+    working.
+    """
+
+    def __init__(self, message: str, check: "OwnerCheck") -> None:
+        super().__init__(message)
+        self.check = check
+
+
 @dataclass(frozen=True)
 class IngestResult:
     status: str  # "new" | "duplicate"
     document: Document
+    # None on the duplicate path: a layer-1 duplicate returns before any check runs
+    # (nothing is written, so there is nothing to misfile).
+    owner_check: "OwnerCheck | None" = None
 
     @property
     def is_duplicate(self) -> bool:
@@ -104,6 +128,192 @@ def run_ocr(path: str | Path) -> str | None:
     return text or None
 
 
+# --------------------------------------------------------------------------- #
+# Owner verification (issue #61) — pure, DB-free, table-testable.
+#
+# Exact, whole-token, normalized matching only: no fuzzy/edit-distance scoring. A
+# similarity threshold tuned against a sample of one produces *confident* wrong
+# answers in both directions, which is worse than the honest "unverified" verdict.
+# Normalization absorbs the variation that actually occurs in scanned headers (case,
+# punctuation, `LAST, FIRST` ordering, collapsed whitespace); genuine OCR corruption
+# of a name lands in "suspect" for a human to adjudicate.
+# --------------------------------------------------------------------------- #
+
+# Deliberately *not* dedup.norm(): that strips parenthetical qualifiers and applies
+# dictionary synonym mapping, both wrong for identity matching.
+_NON_ALNUM = re.compile(r"[^0-9a-z]+")
+
+# Name-token noise: middle initials are dropped by the length-1 rule; these are the
+# suffixes/credentials that show up appended to a printed patient name.
+_NAME_NOISE = frozenset({"jr", "sr", "ii", "iii", "iv", "md", "do", "phd"})
+
+# An "identity anchor" is what turns *absence* of the claimed owner's name from
+# meaningless (lab result page 3, an imaging CD label) into evidence that the document
+# names somebody. Matched against the raw text, case-insensitively — `name` only counts
+# with its colon, otherwise every prose use of the word would anchor.
+_ANCHOR = re.compile(
+    r"\bpatient\b|\bname\s*:|\bdob\b|\bdate\s+of\s+birth\b|\bbirth\s*date\b|\bmrn\b",
+    re.IGNORECASE,
+)
+
+_EVIDENCE_WINDOW = 120
+
+_MONTHS = (
+    ("Jan", "January"), ("Feb", "February"), ("Mar", "March"), ("Apr", "April"),
+    ("May", "May"), ("Jun", "June"), ("Jul", "July"), ("Aug", "August"),
+    ("Sep", "September"), ("Oct", "October"), ("Nov", "November"), ("Dec", "December"),
+)
+
+
+@dataclass(frozen=True)
+class OwnerCheck:
+    """Verdict of matching document text against the claimed owner.
+
+    * ``match`` — the claimed person's name or DOB is present in the text.
+    * ``mismatch`` — a *different* roster person matched and the claimed one did not.
+    * ``suspect`` — the text carries a patient-identity anchor but names nobody on
+      the roster. This is the case that actually happened (a legible ``Patient:`` /
+      ``DOB:`` header for someone who is not on the roster at all).
+    * ``unverified`` — no text, or text with no identity anchor and no matches.
+    """
+
+    verdict: str  # "match" | "mismatch" | "suspect" | "unverified"
+    matched_slug: str | None = None  # who the text points at, when known
+    evidence: str | None = None      # ~120-char window around the identity anchor
+
+    @property
+    def blocks(self) -> bool:
+        """Whether this verdict refuses the ingest (overridable with ``force``)."""
+        return self.verdict in ("mismatch", "suspect")
+
+
+def normalize_text(text: str) -> str:
+    """Lowercase, non-alphanumerics → space, collapse runs, space-pad the ends.
+
+    The padding lets callers test whole-token membership with a plain ``in`` against
+    ``f" {token} "`` — no per-token regex compile over a page of OCR.
+    """
+    return f" {_NON_ALNUM.sub(' ', text.lower()).strip()} "
+
+
+def name_tokens(full_name: str) -> list[str]:
+    """Match-usable tokens of a person's name, or ``[]`` when the name is unusable.
+
+    Drops single characters (middle initials) and suffix/credential noise. Returns
+    ``[]`` — the "no name signal" answer — when fewer than two tokens survive or any
+    survivor is under 3 characters, since short tokens collide with ordinary words.
+    Such a person can still match on DOB; they can never produce a false ``suspect``
+    verdict on the strength of a two-letter surname.
+    """
+    tokens = [
+        tok for tok in _NON_ALNUM.sub(" ", full_name.lower()).split()
+        if len(tok) > 1 and tok not in _NAME_NOISE
+    ]
+    if len(tokens) < 2 or any(len(tok) < 3 for tok in tokens):
+        return []
+    return tokens
+
+
+def dob_candidates(dob: str | None) -> list[str]:
+    """Renderings of an ISO ``YYYY-MM-DD`` DOB to look for in raw document text.
+
+    Day-first forms (``DD/MM/YYYY``) are deliberately excluded: they collide with the
+    month-first forms and would manufacture false matches. A partial-precision dob
+    (``YYYY`` / ``YYYY-MM``) yields no candidates — a bare year is not evidence.
+    """
+    if not dob:
+        return []
+    try:
+        parsed = date.fromisoformat(dob.strip()[:10])
+    except ValueError:
+        return []
+    y, m, d = parsed.year, parsed.month, parsed.day
+    out = [
+        f"{y:04d}-{m:02d}-{d:02d}",
+        f"{m:02d}/{d:02d}/{y:04d}",
+        f"{m}/{d}/{y:04d}",
+        f"{m:02d}-{d:02d}-{y:04d}",
+    ]
+    for month in _MONTHS[m - 1]:
+        out.append(f"{month} {d}, {y:04d}")
+        out.append(f"{d} {month} {y:04d}")
+    return out
+
+
+def _person_matches(person: Person, raw: str, normalized: str) -> bool:
+    """Whether ``person``'s name (all tokens, order-independent) or DOB is in the text."""
+    tokens = name_tokens(person.full_name)
+    if tokens and all(f" {tok} " in normalized for tok in tokens):
+        return True
+    lowered = raw.lower()
+    return any(cand.lower() in lowered for cand in dob_candidates(person.dob))
+
+
+def _evidence(raw: str) -> str | None:
+    """Whitespace-collapsed ~120-char window around the first identity anchor.
+
+    Quoted in the refusal so a human can adjudicate an OCR-mangled name without
+    opening the file.
+    """
+    hit = _ANCHOR.search(raw)
+    if hit is None:
+        return None
+    mid = (hit.start() + hit.end()) // 2
+    half = _EVIDENCE_WINDOW // 2
+    return " ".join(raw[max(0, mid - half):mid + half].split()) or None
+
+
+def check_owner(
+    text: str | None, claimed: Person, roster: Sequence[Person]
+) -> OwnerCheck:
+    """Does ``text`` look like it belongs to ``claimed``? See :class:`OwnerCheck`."""
+    if not text or not text.strip():
+        return OwnerCheck(verdict="unverified")
+
+    normalized = normalize_text(text)
+    if _person_matches(claimed, text, normalized):
+        return OwnerCheck(
+            verdict="match", matched_slug=claimed.slug, evidence=_evidence(text)
+        )
+
+    for person in roster:
+        if person.slug == claimed.slug:
+            continue
+        if _person_matches(person, text, normalized):
+            return OwnerCheck(
+                verdict="mismatch",
+                matched_slug=person.slug,
+                evidence=_evidence(text),
+            )
+
+    evidence = _evidence(text)
+    if evidence is not None:
+        return OwnerCheck(verdict="suspect", evidence=evidence)
+    return OwnerCheck(verdict="unverified")
+
+
+def refusal_message(
+    check: OwnerCheck, claimed: Person, roster: Sequence[Person]
+) -> str:
+    """Human-facing text for a blocking verdict (the ``OwnerMismatchError`` message)."""
+    lines = [
+        "owner verification failed - this document does not look like it belongs to",
+        f"  '{claimed.slug}' ({claimed.full_name}).",
+    ]
+    if check.verdict == "mismatch":
+        other = next(
+            (p for p in roster if p.slug == check.matched_slug), None
+        )
+        named = f"'{check.matched_slug}'"
+        if other is not None:
+            named += f" ({other.full_name})"
+        lines.append(f"  text matches a different roster person: {named}")
+    if check.evidence:
+        lines.append(f'  found in document text: "{check.evidence}"')
+    lines.append("  Nothing was ingested. If this is correct, re-run with --force.")
+    return "\n".join(lines)
+
+
 def get_document(conn: sqlite3.Connection, sha256: str) -> Document | None:
     row = conn.execute(
         "SELECT * FROM document WHERE sha256 = ?", (sha256,)
@@ -118,15 +328,24 @@ def get_document_by_id(conn: sqlite3.Connection, document_id: int) -> Document |
     return Document.from_row(row) if row is not None else None
 
 
-def _person_id_for_slug(conn: sqlite3.Connection, slug: str) -> int:
+def _person_for_slug(conn: sqlite3.Connection, slug: str) -> Person:
     row = conn.execute(
-        "SELECT person_id FROM person WHERE slug = ?", (slug.strip().lower(),)
+        "SELECT * FROM person WHERE slug = ?", (slug.strip().lower(),)
     ).fetchone()
     if row is None:
         raise IngestError(
             f"no person with slug '{slug}' - add them first: `pemr person add`"
         )
-    return row["person_id"]
+    return Person.from_row(row)
+
+
+def _roster(conn: sqlite3.Connection) -> list[Person]:
+    """Everyone on the roster, **including deactivated people** — a deactivated person
+    is still a real person whose documents must not land on someone else."""
+    return [
+        Person.from_row(row)
+        for row in conn.execute("SELECT * FROM person ORDER BY slug").fetchall()
+    ]
 
 
 def ingest_document(
@@ -140,8 +359,9 @@ def ingest_document(
     provider: str | None = None,
     ocr: bool = False,
     ocr_text: str | None = None,
+    force: bool = False,
 ) -> IngestResult:
-    """Ingest one document: hash, layer-1 dedup, blob store, insert `document`.
+    """Ingest one document: hash, layer-1 dedup, owner check, blob store, insert row.
 
     On a content-hash hit (layer 1), the existing document is returned with
     status "duplicate" and nothing is written. Otherwise the blob is copied into
@@ -153,6 +373,12 @@ def ingest_document(
     pass. An empty/whitespace-only string is treated as absent. Populating text here
     is what makes a document findable via FTS (`find`), so it is a warning-not-error
     when it ends up empty — see :attr:`IngestResult.ocr_text_populated`.
+
+    When text is available it is also checked against the claimed owner (issue #61).
+    A blocking verdict raises :class:`OwnerMismatchError` **before** anything is
+    written, so a refused ingest is a clean no-op and ``force=True`` is the whole
+    recovery. The verdict rides back on :attr:`IngestResult.owner_check` so callers
+    report it without a second pass.
     """
     db.require_migrated(conn)
 
@@ -160,12 +386,27 @@ def ingest_document(
     if not src.is_file():
         raise IngestError(f"file not found: {src}")
 
-    person_id = _person_id_for_slug(conn, person_slug)
+    person = _person_for_slug(conn, person_slug)
     sha = hash_file(src)
 
     existing = get_document(conn, sha)
     if existing is not None:
+        # Layer-1 duplicate: nothing is written, so there is nothing to misfile. A
+        # duplicate already filed under the wrong owner is `pemr document reassign`'s
+        # job, not a reason to fail a no-op.
         return IngestResult(status="duplicate", document=existing)
+
+    # Resolve the text *before* the blob copy so the owner check is pre-write. OCR
+    # runs on `src` rather than the copied blob — identical bytes, same result.
+    supplied = ocr_text.strip() if ocr_text else None
+    ocr_text = supplied or (run_ocr(src) if ocr else None)
+
+    roster = _roster(conn)
+    owner_check = check_owner(ocr_text, person, roster)
+    if owner_check.blocks and not force:
+        raise OwnerMismatchError(
+            refusal_message(owner_check, person, roster), owner_check
+        )
 
     ext = src.suffix.lower()
     dest = blob_dest(sources_dir, sha, ext)
@@ -176,9 +417,6 @@ def ingest_document(
     blob_created = not dest.exists()
     if blob_created:
         shutil.copy2(src, dest)
-
-    supplied = ocr_text.strip() if ocr_text else None
-    ocr_text = supplied or (run_ocr(dest) if ocr else None)
 
     try:
         with conn:
@@ -191,7 +429,7 @@ def ingest_document(
                 """,
                 (
                     sha,
-                    person_id,
+                    person.person_id,
                     doc_date,
                     category,
                     provider,
@@ -206,4 +444,4 @@ def ingest_document(
         raise
     document = get_document_by_id(conn, cur.lastrowid)
     assert document is not None  # just inserted
-    return IngestResult(status="new", document=document)
+    return IngestResult(status="new", document=document, owner_check=owner_check)

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -245,8 +245,14 @@ def _person_matches(person: Person, raw: str, normalized: str) -> bool:
     tokens = name_tokens(person.full_name)
     if tokens and all(f" {tok} " in normalized for tok in tokens):
         return True
-    lowered = raw.lower()
-    return any(cand.lower() in lowered for cand in dob_candidates(person.dob))
+    return any(
+        # Digit boundaries, not a bare substring: without them the unpadded
+        # `M/D/YYYY` rendering is a *tail* of the day-first form, so `25/4/1978`
+        # would "match" a 1978-05-04 person — a silent misfile, the exact failure
+        # this check exists to prevent. Same guard kills accession-number tails.
+        re.search(rf"(?<![0-9]){re.escape(cand)}(?![0-9])", raw, re.IGNORECASE)
+        for cand in dob_candidates(person.dob)
+    )
 
 
 def _evidence(raw: str) -> str | None:
@@ -287,7 +293,15 @@ def check_owner(
             )
 
     evidence = _evidence(text)
-    if evidence is not None:
+    # `suspect` means "this document names somebody, and it isn't you" — a conclusion
+    # only available when we could have recognised the claimed person by name in the
+    # first place. With no usable name signal (a two-letter surname, a mononym), the
+    # claimed person's absence is ignorance, not evidence, so blocking here would
+    # refuse *every* anchored document for them and train the human to pass --force
+    # reflexively. A DOB doesn't rescue it either: most documents simply don't print
+    # one, so its absence proves nothing. `mismatch` above is untouched — affirmative
+    # evidence pointing at another roster person still blocks.
+    if evidence is not None and name_tokens(claimed.full_name):
         return OwnerCheck(verdict="suspect", evidence=evidence)
     return OwnerCheck(verdict="unverified")
 

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -170,12 +170,19 @@ def ingest_document(
     category: str | None = None,
     provider: str | None = None,
     ocr: bool = False,
+    force: bool = False,
 ) -> dict[str, Any]:
     """[write] Ingest a document (hash, blob-store, layer-1 dedup). Mirrors ``pemr ingest``.
 
     ``ocr_text`` is the agent's own transcription — the ``AGENTS.md`` default path.
     The response's ``ocr_text_populated`` lets the agent self-check the FTS-visibility
     contract without a follow-up read.
+
+    When text is present it is checked against the claimed owner; the verdict comes
+    back as ``owner_check`` (``null`` on a duplicate, which is never checked). A
+    ``mismatch``/``suspect`` verdict refuses the ingest pre-write — per ``AGENTS.md``
+    §3, surface the verdict and its evidence to the human and get an explicit
+    go-ahead before retrying with ``force=true``.
     """
     try:
         sources_dir = cli._resolve_sources_dir(_ARGS)
@@ -185,7 +192,7 @@ def ingest_document(
         result = _ingest.ingest_document(
             conn, file, person_slug=person, sources_dir=sources_dir,
             doc_date=doc_date, category=category, provider=provider,
-            ocr=ocr, ocr_text=ocr_text,
+            ocr=ocr, ocr_text=ocr_text, force=force,
         )
     except (db.NotMigratedError, _ingest.IngestError) as exc:
         raise _friendly(exc) from exc
@@ -193,6 +200,9 @@ def ingest_document(
         "status": result.status,
         "is_duplicate": result.is_duplicate,
         "ocr_text_populated": result.ocr_text_populated,
+        "owner_check": (
+            asdict(result.owner_check) if result.owner_check is not None else None
+        ),
         "document": asdict(result.document),
     }
 
@@ -444,9 +454,11 @@ def build_server():  # pragma: no cover - exercised only with the mcp SDK instal
     @server.tool(name="ingest", annotations=rw)
     def ingest_tool(file: str, person: str, ocr_text: str | None = None,
                     doc_date: str | None = None, category: str | None = None,
-                    provider: str | None = None, ocr: bool = False) -> dict:
+                    provider: str | None = None, ocr: bool = False,
+                    force: bool = False) -> dict:
         return _run(ingest_document, file=file, person=person, ocr_text=ocr_text,
-                    doc_date=doc_date, category=category, provider=provider, ocr=ocr)
+                    doc_date=doc_date, category=category, provider=provider, ocr=ocr,
+                    force=force)
 
     @server.tool(name="commit_extraction", annotations=rw)
     def commit_extraction_tool(document_id: int, records: dict) -> dict:

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -93,6 +93,66 @@ def test_ingest_on_unmigrated_db_is_friendly(tmp_path, capsys, unmigrated_db):
     assert "migrate" in capsys.readouterr().err
 
 
+# --- owner verification at ingest (issue #61) ---------------------------------
+
+def _ocr_file(tmp_path, text):
+    p = tmp_path / "ocr.txt"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_ingest_refuses_a_document_naming_someone_else(ready, capsys):
+    tmp_path = ready
+    scan = tmp_path / "wrong-owner.txt"
+    scan.write_bytes(b"a summary for a different patient")
+    ocr = _ocr_file(tmp_path, "Patient: SMITH, KAREN A    DOB: 09/09/1971")
+
+    rc = _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+              "--sources", str(tmp_path / "sources"), "--ocr-text-file", str(ocr))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "owner verification failed" in err
+    assert "SMITH, KAREN A" in err  # the evidence window, for human adjudication
+    assert "--force" in err
+    assert not _document_id(tmp_path)  # pre-write refusal: nothing landed
+
+
+def test_ingest_force_overrides_the_refusal(ready, capsys):
+    tmp_path = ready
+    scan = tmp_path / "forced.txt"
+    scan.write_bytes(b"forced anyway")
+    ocr = _ocr_file(tmp_path, "Patient: SMITH, KAREN A    DOB: 09/09/1971")
+
+    rc = _run(tmp_path, "ingest", str(scan), "--person", "jane-doe", "--force",
+              "--sources", str(tmp_path / "sources"), "--ocr-text-file", str(ocr))
+    assert rc == 0
+    out = capsys.readouterr()
+    assert "ingested document #1" in out.out
+    assert "--force" in out.err and "reassign" in out.err  # points at the undo path
+    assert len(_document_id(tmp_path)) == 1
+
+
+def test_ingest_reports_a_verified_owner(ready, capsys):
+    tmp_path = ready
+    scan = tmp_path / "hers.txt"
+    scan.write_bytes(b"her own labs")
+    ocr = _ocr_file(tmp_path, "Patient Name: DOE, JANE\nSodium 140 mmol/L")
+
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources"),
+                "--ocr-text-file", str(ocr)) == 0
+    assert "owner verified" in capsys.readouterr().out
+
+
+def test_ingest_without_text_notes_the_owner_was_not_verified(ready, capsys):
+    tmp_path = ready
+    scan = tmp_path / "untexted.txt"
+    scan.write_bytes(b"no text supplied")
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources")) == 0
+    assert "owner not verified" in capsys.readouterr().err
+
+
 def test_commit_bad_json_is_friendly(ready, capsys):
     tmp_path = ready
     bad = tmp_path / "bad.json"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -174,12 +174,65 @@ def test_unusable_name_never_produces_a_false_suspect(full_name):
     in `unverified`, never `suspect`, or every document would refuse."""
     person = Person(person_id=9, slug="short", full_name=full_name)
     assert ingest.name_tokens(full_name) == []
+    # An anchor is present and nobody matched, but we could never have recognised
+    # this person by name, so their absence is ignorance rather than evidence.
     check = ingest.check_owner("Patient: Jane Doe  DOB: 03/14/1962", person, [person])
-    assert check.verdict == "suspect"  # anchor present, nobody matched
-    # ...but with no anchor, absence of a name signal is not evidence:
+    assert check.verdict == "unverified"
+    assert check.blocks is False
+    # ...and with no anchor either, likewise:
     assert ingest.check_owner("routine bloodwork", person, [person]).verdict == (
         "unverified"
     )
+
+
+def test_unusable_name_with_a_dob_is_not_blocked_by_a_dobless_document():
+    """Most documents don't print a DOB; its absence is not evidence of a misfile.
+
+    Regression for the "Michael Vu" case: a two-letter surname erases the name
+    signal, and refusing every DOB-less document would make `ingest` unusable
+    without --force for anyone with a short name.
+    """
+    vu = Person(person_id=9, slug="michael-vu", full_name="Michael Vu", dob="1990-09-09")
+    correctly_named = ingest.check_owner(
+        "Patient: VU, MICHAEL   chest x-ray, two views", vu, [vu]
+    )
+    assert correctly_named.verdict == "unverified"
+    assert correctly_named.blocks is False
+    # the DOB still carries them to a positive verdict when it *is* printed
+    assert ingest.check_owner(
+        "Patient: VU, MICHAEL   DOB: 09/09/1990", vu, [vu]
+    ).verdict == "match"
+
+
+def test_unusable_name_still_bounces_off_another_roster_person():
+    """No name signal weakens `suspect`, not `mismatch`: affirmative evidence that the
+    text names *someone else on the roster* still blocks."""
+    vu = Person(person_id=9, slug="michael-vu", full_name="Michael Vu")
+    check = ingest.check_owner("Patient: DOE, JANE A   DOB: 03/14/1962", vu, [vu, JANE])
+    assert check.verdict == "mismatch"
+    assert check.matched_slug == "jane-doe"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Patient: DOE, JOHN Q   DOB: 25/4/1978",   # day-first, unpadded
+        "Patient: DOE, JOHN Q   DOB: 15/4/1978",
+        "Patient: DOE, JOHN Q   accession 15/4/1978x",
+        "Patient: DOE, JOHN Q   DOB: 05/04/19780",  # trailing digit
+    ],
+)
+def test_dob_needs_digit_boundaries(text):
+    """A candidate rendering that is merely a *substring* of a longer digit run is not
+    a DOB match — otherwise a day-first `25/4/1978` silently verifies a 1978-05-04
+    person and the document is misfiled with an `owner verified` line to reassure."""
+    mike = Person(
+        person_id=9, slug="michael-dickinson", full_name="Michael Dickinson",
+        dob="1978-05-04",
+    )
+    check = ingest.check_owner(text, mike, [mike])
+    assert check.verdict == "suspect"
+    assert check.matched_slug is None
 
 
 def test_partial_precision_dob_is_not_a_signal():

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -5,6 +5,7 @@ import sqlite3
 import pytest
 
 from pemr import db, ingest, persons
+from pemr.models import Person
 
 
 @pytest.fixture()
@@ -112,3 +113,164 @@ def test_ocr_degrades_when_tesseract_absent(conn, tmp_path, sources, monkeypatch
     assert result.status == "new"
     assert result.document.ocr_text is None
     assert "tesseract" in capsys.readouterr().err
+
+
+# --- owner verification (issue #61) -------------------------------------------
+
+JANE = Person(person_id=1, slug="jane-doe", full_name="Jane Doe", dob="1962-03-14")
+BOB = Person(person_id=2, slug="bob-roe", full_name="Robert Alan Roe", dob="1955-11-02")
+ROSTER = (JANE, BOB)
+
+
+@pytest.mark.parametrize(
+    "text, verdict, matched",
+    [
+        # --- match: name, in the orderings scanned headers actually use
+        ("Patient: Jane Doe   MRN 44812", "match", "jane-doe"),
+        ("Patient Name: DOE, JANE A", "match", "jane-doe"),
+        ("PATIENT\nDOE\nJANE\nDOB 01/01/1900", "match", "jane-doe"),
+        # middle initial in the text but not the roster, and vice versa
+        ("Patient: Jane Q. Doe", "match", "jane-doe"),
+        # every token must be present: 'Alan' missing -> Bob does *not* match either
+        ("Patient: Robert Roe", "suspect", None),
+        # --- match: DOB alone is high-entropy enough
+        ("Patient: unreadable smudge   DOB: 03/14/1962", "match", "jane-doe"),
+        ("date of birth 3/14/1962", "match", "jane-doe"),
+        ("DOB 1962-03-14", "match", "jane-doe"),
+        ("DOB 03-14-1962", "match", "jane-doe"),
+        ("DOB Mar 14, 1962", "match", "jane-doe"),
+        ("DOB March 14, 1962", "match", "jane-doe"),
+        ("DOB 14 Mar 1962", "match", "jane-doe"),
+        # day-first is deliberately not parsed: 14/03/1962 is not a match
+        ("DOB 14/03/1962", "suspect", None),
+        # --- mismatch: the text names a *different* roster person
+        ("Patient: ROE, ROBERT ALAN    DOB: 11/02/1955", "mismatch", "bob-roe"),
+        # --- suspect: an identity header naming nobody on the roster (the 2026-08-01
+        # incident: a Piedmont summary for a non-roster patient)
+        ("Patient: SMITH, JANE A    DOB: 03/14/1900", "suspect", None),
+        ("MRN 99812  Name: Karen Fields", "suspect", None),
+        # --- unverified: no identity anchor at all, or nothing to go on
+        ("Sodium 140 mmol/L; potassium 4.1", "unverified", None),
+        ("", "unverified", None),
+        ("   \n\t ", "unverified", None),
+        (None, "unverified", None),
+        # 'name' without a colon is prose, not an anchor
+        ("the brand name is atorvastatin", "unverified", None),
+    ],
+)
+def test_check_owner_verdicts(text, verdict, matched):
+    check = ingest.check_owner(text, JANE, ROSTER)
+    assert check.verdict == verdict
+    assert check.matched_slug == matched
+    assert check.blocks is (verdict in ("mismatch", "suspect"))
+
+
+@pytest.mark.parametrize(
+    "full_name",
+    ["Cher", "Al Wu", "J Doe"],  # <2 usable tokens, or a survivor under 3 chars
+)
+def test_unusable_name_never_produces_a_false_suspect(full_name):
+    """A one-word or very short name carries no name signal — such a person must land
+    in `unverified`, never `suspect`, or every document would refuse."""
+    person = Person(person_id=9, slug="short", full_name=full_name)
+    assert ingest.name_tokens(full_name) == []
+    check = ingest.check_owner("Patient: Jane Doe  DOB: 03/14/1962", person, [person])
+    assert check.verdict == "suspect"  # anchor present, nobody matched
+    # ...but with no anchor, absence of a name signal is not evidence:
+    assert ingest.check_owner("routine bloodwork", person, [person]).verdict == (
+        "unverified"
+    )
+
+
+def test_partial_precision_dob_is_not_a_signal():
+    person = Person(person_id=9, slug="p", full_name="Ann Zed", dob="1962")
+    assert ingest.dob_candidates("1962") == []
+    assert ingest.dob_candidates(None) == []
+    assert ingest.check_owner("Patient: someone  DOB: 1962", person, [person]).verdict == (
+        "suspect"
+    )
+
+
+def test_evidence_quotes_the_window_around_the_anchor():
+    text = "PIEDMONT HEALTHCARE\n" * 3 + "Patient: SMITH, JANE A    DOB: 03/14/1900\n"
+    check = ingest.check_owner(text, JANE, ROSTER)
+    assert check.verdict == "suspect"
+    assert "SMITH, JANE A" in check.evidence
+    assert "\n" not in check.evidence  # whitespace collapsed for a one-line message
+
+
+def test_refusal_message_names_the_other_roster_person():
+    check = ingest.check_owner("Patient: ROE, ROBERT ALAN", JANE, ROSTER)
+    msg = ingest.refusal_message(check, JANE, ROSTER)
+    assert "'bob-roe' (Robert Alan Roe)" in msg
+    assert "'jane-doe' (Jane Doe)" in msg
+    assert "--force" in msg
+
+
+def _seed_roster(conn):
+    persons.update_person(conn, "jane-doe", dob="1962-03-14")
+    persons.add_person(conn, "bob-roe", "Robert Alan Roe", dob="1955-11-02")
+
+
+def test_ingest_refuses_and_writes_nothing(conn, tmp_path, sources):
+    _seed_roster(conn)
+    src = _make_file(tmp_path, "wrong.txt", b"scan of somebody else")
+    sha = ingest.hash_file(src)
+
+    with pytest.raises(ingest.OwnerMismatchError) as excinfo:
+        ingest.ingest_document(
+            conn, src, "jane-doe", sources,
+            ocr_text="Patient: SMITH, KAREN    DOB: 09/09/1971",
+        )
+    assert excinfo.value.check.verdict == "suspect"
+    # pre-write: no blob, no row -> re-running with force is the whole recovery
+    assert not (sources / sha[:2] / f"{sha}.txt").exists()
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 0
+    # OwnerMismatchError is an IngestError, so existing handlers still catch it
+    assert isinstance(excinfo.value, ingest.IngestError)
+
+
+def test_ingest_force_overrides_and_still_reports_the_verdict(conn, tmp_path, sources):
+    _seed_roster(conn)
+    result = ingest.ingest_document(
+        conn, _make_file(tmp_path, "forced.txt", b"forced bytes"), "jane-doe", sources,
+        ocr_text="Patient: ROE, ROBERT ALAN", force=True,
+    )
+    assert result.status == "new"
+    assert result.owner_check.verdict == "mismatch"
+    assert result.owner_check.matched_slug == "bob-roe"
+
+
+def test_ingest_reports_a_match(conn, tmp_path, sources):
+    _seed_roster(conn)
+    result = ingest.ingest_document(
+        conn, _make_file(tmp_path, "ok.txt", b"good bytes"), "jane-doe", sources,
+        ocr_text="Patient: DOE, JANE    DOB: 03/14/1962",
+    )
+    assert result.owner_check.verdict == "match"
+    assert result.owner_check.blocks is False
+
+
+def test_deactivated_people_still_count_as_roster(conn, tmp_path, sources):
+    """A deactivated person is still a real person whose documents must not land on
+    someone else — the text naming them is a `mismatch`, not a `suspect`."""
+    _seed_roster(conn)
+    persons.deactivate_person(conn, "bob-roe")
+    with pytest.raises(ingest.OwnerMismatchError) as excinfo:
+        ingest.ingest_document(
+            conn, _make_file(tmp_path, "d.txt", b"deact"), "jane-doe", sources,
+            ocr_text="Patient: ROE, ROBERT ALAN",
+        )
+    assert excinfo.value.check.verdict == "mismatch"
+
+
+def test_layer1_duplicate_is_unaffected_by_mismatching_text(conn, tmp_path, sources):
+    _seed_roster(conn)
+    src = _make_file(tmp_path, "dup.txt", b"same bytes twice")
+    first = ingest.ingest_document(conn, src, "jane-doe", sources)
+    again = ingest.ingest_document(
+        conn, src, "jane-doe", sources, ocr_text="Patient: ROE, ROBERT ALAN"
+    )
+    assert again.status == "duplicate"
+    assert again.document.document_id == first.document.document_id
+    assert again.owner_check is None  # nothing written -> nothing checked

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -179,6 +179,31 @@ def test_ingest_with_agent_ocr_text(seeded, tmp_path, monkeypatch):
     assert out["status"] == "new"
     assert out["ocr_text_populated"] is True
     assert out["document"]["ocr_text"].startswith("Sodium")
+    # issue #61: the owner verdict rides back on every ingest. No identity anchor in a
+    # bare lab line -> "unverified", which proceeds.
+    assert out["owner_check"]["verdict"] == "unverified"
+
+
+def test_ingest_refuses_a_mismatched_owner(seeded, tmp_path, monkeypatch):
+    """Issue #61 via MCP: a blocking verdict surfaces as a ToolError, and `force`
+    is the documented (human-signed-off) override."""
+    monkeypatch.setenv("PEMR_SOURCES", str(tmp_path / "sources"))
+    scan = tmp_path / "someone-else.txt"
+    scan.write_bytes(b"not her record")
+    header = "Patient: SMITH, KAREN A    DOB: 09/09/1971"
+
+    with pytest.raises(mcp_server.ToolError, match="owner verification failed"):
+        mcp_server.ingest_document(seeded, file=str(scan), person="jane-doe",
+                                   ocr_text=header)
+    assert seeded.execute(
+        "SELECT COUNT(*) FROM document WHERE source_path != 'aa/x.pdf'"
+    ).fetchone()[0] == 0
+
+    out = mcp_server.ingest_document(seeded, file=str(scan), person="jane-doe",
+                                     ocr_text=header, force=True)
+    assert out["status"] == "new"
+    assert out["owner_check"]["verdict"] == "suspect"
+    assert "SMITH, KAREN A" in out["owner_check"]["evidence"]
 
 
 def test_commit_extraction_via_wrapper(seeded, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

A Piedmont "Patient Health Summary" belonging to a different person was ingested with
`--person alex-carter` and silently filed under the wrong owner — nothing in the ingest
path inspected document content. This adds a pre-write owner check.

- `ingest` now runs `check_owner()` whenever document text is available (`--ocr` /
  `--ocr-text-file`), producing one of four verdicts: `match`, `mismatch` (a different roster
  person's identity matched), `suspect` (an identity anchor names nobody on the roster), or
  `unverified` (no text, or no identity anchor) — proceed except on `mismatch`/`suspect`, which
  refuse pre-write (no blob, no row) unless `--force` is passed.
- Matching is exact/normalized (case, punctuation, name ordering, fixed DOB renderings) —
  deliberately no fuzzy scoring, since a tuned similarity threshold produces confident wrong
  answers in both directions.
- A follow-up fix closes two defects found in verify: names with any token under 3 characters
  (mononyms, initials) no longer produce a false `suspect`, and DOB candidates now require
  non-digit boundaries so they can't match as a substring of a longer digit run.
- `pemr/cli.py` / `pemr/mcp_server.py` expose `--force` / `force=` and surface the verdict.
- `AGENTS.md` §3 and `docs/Architecture.md` §4 updated to document the new pre-write step and the
  agent obligation to surface refusals and get explicit human go-ahead before retrying with force.

Merged `dev` in to pick up the concurrent dedup/query/render work (#54/#55); auto-merged cleanly,
full test suite green post-merge.

Closes #61

## Test plan
- [x] `pytest tests/test_ingest.py tests/test_cli_phase2.py tests/test_mcp_server.py` — targeted
- [x] `pytest` — full suite green post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
