### PR TITLE
feat(#62): add `pemr document show` and `document set-text`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,10 @@ Write tools (mutate the DB; the only tools that do):
   clear a nullable field).
 - `ingest` — hash + blob-store + layer-1 dedup a document.
 - `commit_extraction` — validate + dedup + commit extracted rows for a document.
+- `document_set_text` — attach a document's text (`ocr_text`) after ingest, when the ingest itself
+  didn't carry it (see §3). Fills an empty `ocr_text` only; **replacing** an existing transcription
+  is a human action at the CLI (`pemr document set-text <id> --ocr-text-file <path> --force`), so
+  the tool takes no `force` and refuses a populated document.
 - `review_conflicts` — lists conflicts read-only; **writes only when given a `resolve` id**, and
   then only with human sign-off (see below).
 
@@ -132,6 +136,8 @@ to `find` (FTS5); an ingest without it is silently unsearchable.
 - Self-check: the `ingest` response includes `ocr_text_populated: bool`. If it is `false`, treat
   the ingest as incomplete and supply text before moving on. (The engine only *warns* here rather
   than hard-failing, because a human at the CLI may legitimately defer — but the agent MUST not.)
+- **Remediation:** call `document_set_text(document_id, text)`. Re-ingesting will not work — the
+  layer-1 content hash matches, so `ingest` returns the existing document and writes nothing.
 
 ### 4. Conflict discipline
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -336,9 +336,11 @@ pemr ingest <file> --person <slug> [--ocr tesseract]
 pemr commit-extraction --document <id> --json <file>
 pemr review-conflicts [--resolve <id> --keep existing|incoming|both [--note ...]] [--dictionary <toml>]
 pemr document list [--person <slug>]                     # newest first; omit --person for everyone
+pemr document show <id> [--json | --text]                # one document's detail; --text dumps stored ocr_text
 pemr document edit <id> [--doc-date|--category|--provider ...]   # partial update; "" clears a field
 pemr document reassign <id> --person <slug> [--apply]    # move a misfiled document + records; dry run by default
 pemr document rm <id> [--apply] [--purge-blob]           # delete a document + records; dry run by default
+pemr document set-text <id> --ocr-text-file <path> [--force]     # attach/replace ocr_text after ingest; FTS follows via trigger
 pemr query labs --person jane --test hba1c --since 2023-01-01
 pemr query meds --person jane --active
 pemr query timeline --person jane --since 2024-01-01     # merged event stream
@@ -370,14 +372,15 @@ under a PEP 660 editable install); see issue #22.
 
 Read-only: `person_list`, `person_show`, `query` (`kind` = `labs`/`meds`/`timeline`), `find`,
 `trends`, `render_summary`, `render_brief`, `render_journal`. Write: `person_add`, `person_edit`,
-`ingest`, `commit_extraction`, `review_conflicts` (resolution gated on human sign-off). Each returns the
+`ingest`, `commit_extraction`, `document_set_text` (fills an empty `ocr_text` only — the `--force`
+replace is CLI-only), `review_conflicts` (resolution gated on human sign-off). Each returns the
 same `--json`-shaped payload as the CLI; the MCP server (`pemr/mcp_server.py`) parses args and
 calls the same Python functions the CLI calls — one implementation, two front doors. `readOnlyHint`
 annotations expose the read/write split to the client.
 
 `AGENTS.md` documents this contract so any agent (Cowork, Claude Code, local) knows to
 **call tools, not reinvent** — and specifically: never write to the DB except through
-`commit_extraction`/`person_add`/`person_edit`/`ingest`; always `ingest` (with `ocr_text` populated) before
+`commit_extraction`/`person_add`/`person_edit`/`ingest`/`document_set_text`; always `ingest` (with `ocr_text` populated) before
 extracting; dictionary additions go through human review, never agent-direct edits.
 
 ---

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -329,6 +329,7 @@ def _cmd_person_remove(args: argparse.Namespace) -> int:
 
 # --------------------------------------------------------------------------- #
 # document recovery (list / edit / reassign / rm) - issue #54
+# plus per-document detail + post-ingest text (show / set-text) - issue #62
 # --------------------------------------------------------------------------- #
 
 def _with_document_conn(args: argparse.Namespace, work):
@@ -352,6 +353,7 @@ def _with_document_conn(args: argparse.Namespace, work):
             documents.OpenConflictsError,
             documents.DictionaryDriftError,
             documents.ReassignCollisionError,
+            documents.OcrTextPresentError,
             persons.PersonNotFoundError,
         ) as exc:
             print(f"error: {exc}", file=sys.stderr)
@@ -378,6 +380,104 @@ def _cmd_document_list(args: argparse.Namespace) -> int:
                 f"{_fmt(d['category']):12} {_fmt(d['provider']):22} "
                 f"{_fmt(d['person']):16} {d['sha256'][:12]}  {d['record_count']} rec"
             )
+        return 0
+
+    return _with_document_conn(args, work)
+
+
+def _print_document_show(doc: dict) -> None:
+    """The aligned key/value detail block shared by `document show` and `set-text`.
+
+    The per-type `records` breakdown elides zeros for a human; ``--json`` keeps the full
+    stable ``_record_counts`` key set (`documents.py` commits to that for machine
+    consumers). Only static ASCII here — issue #23's console-safety convention.
+    """
+    counts = doc["records"]
+    breakdown = ", ".join(f"{name} {n}" for name, n in counts.items() if n)
+    records = f"{doc['record_count']}" + (f"  ({breakdown})" if breakdown else "")
+    chars = doc["ocr_text_chars"]
+    conflicts = (
+        ", ".join(f"#{cid}" for cid in doc["conflicts_open"])
+        + " open - resolve with `pemr review-conflicts`"
+        if doc["conflicts_open"]
+        else "none"
+    )
+    fields = [
+        ("document_id", doc["document_id"]),
+        ("person", _fmt(doc["person"])),
+        ("doc_date", _fmt(doc["doc_date"])),
+        ("category", _fmt(doc["category"])),
+        ("provider", _fmt(doc["provider"])),
+        ("sha256", f"{doc['sha256'][:12]}..."),
+        ("source_path", _fmt(doc["source_path"])),
+        ("ingested_at", _fmt(doc["ingested_at"])),
+        ("has_ocr_text", f"yes ({chars} chars)" if doc["has_ocr_text"] else "no"),
+        ("records", records),
+        ("conflicts", conflicts),
+    ]
+    for key, value in fields:
+        print(f"{key:14} {value}")
+
+
+def _cmd_document_show(args: argparse.Namespace) -> int:
+    def work(conn):
+        if args.text:
+            # Raw dump, nothing else, so `document show 7 --text > doc.txt` works like the
+            # `render ... > exports/...` redirect contract. This is the only CLI read path
+            # for ocr_text, which is what makes `set-text --force` reviewable.
+            text = documents.get_document_text(conn, args.document_id)
+            if not text:
+                print(
+                    f"note: document #{args.document_id} has no ocr_text stored",
+                    file=sys.stderr,
+                )
+                return 0
+            print(text)
+            return 0
+        doc = documents.get_document_view(conn, args.document_id)
+        if args.json:
+            _print_json(doc)
+            return 0
+        _print_document_show(doc)
+        return 0
+
+    return _with_document_conn(args, work)
+
+
+def _cmd_document_set_text(args: argparse.Namespace) -> int:
+    try:
+        with open(args.ocr_text_file, encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError as exc:
+        print(f"error: cannot read {args.ocr_text_file}: {exc}", file=sys.stderr)
+        return 1
+
+    def work(conn):
+        # Read first: the before-size feeds the status line, and resolving the id here
+        # means an unknown id outranks an empty file in the error the human sees.
+        before = documents.get_document_view(conn, args.document_id)
+        if not text.strip():
+            # documents.set_document_text guards this too (so MCP gets it); repeated here
+            # only to name the offending path, which the engine never sees.
+            raise ValueError(
+                f"{args.ocr_text_file} is empty - nothing to store; ocr_text unchanged"
+            )
+        doc = documents.set_document_text(
+            conn, args.document_id, text, force=args.force
+        )
+        if args.json:
+            _print_json(doc)
+            return 0
+        was = (
+            f"replaced {before['ocr_text_chars']} chars"
+            if before["has_ocr_text"]
+            else "was empty"
+        )
+        print(
+            f"set ocr_text on document #{doc['document_id']}: "
+            f"{doc['ocr_text_chars']} chars ({was})"
+        )
+        _print_document_show(doc)
         return 0
 
     return _with_document_conn(args, work)
@@ -1198,6 +1298,37 @@ def build_parser() -> argparse.ArgumentParser:
     d_list.add_argument("--person", help="owner slug; omit to list every person's")
     d_list.add_argument("--json", action="store_true", help="machine-readable output")
     d_list.set_defaults(func=_cmd_document_list)
+
+    # --- per-document detail + post-ingest text (issue #62) ---------------
+    d_show = document_sub.add_parser(
+        "show", help="one document's metadata, record counts and open conflicts"
+    )
+    d_show.add_argument("document_id", type=int, metavar="ID")
+    # Mutually exclusive: --json is the metadata view, --text is the raw transcription.
+    d_show_out = d_show.add_mutually_exclusive_group()
+    d_show_out.add_argument(
+        "--json", action="store_true", help="machine-readable output"
+    )
+    d_show_out.add_argument(
+        "--text", action="store_true",
+        help="dump the stored ocr_text to stdout and nothing else",
+    )
+    d_show.set_defaults(func=_cmd_document_show)
+
+    d_set_text = document_sub.add_parser(
+        "set-text", help="attach or replace a document's ocr_text after ingest"
+    )
+    d_set_text.add_argument("document_id", type=int, metavar="ID")
+    d_set_text.add_argument(
+        "--ocr-text-file", dest="ocr_text_file", required=True,
+        help="file of document text to store as ocr_text (same flag as `ingest`)",
+    )
+    d_set_text.add_argument(
+        "--force", action="store_true",
+        help="replace existing ocr_text (refused without this)",
+    )
+    d_set_text.add_argument("--json", action="store_true", help="machine-readable output")
+    d_set_text.set_defaults(func=_cmd_document_set_text)
 
     d_edit = document_sub.add_parser(
         "edit", help="correct a document's date/category/provider (partial)"

--- a/pemr/documents.py
+++ b/pemr/documents.py
@@ -1,4 +1,4 @@
-"""Document recovery — `pemr document list|edit|reassign|rm`.
+"""Document recovery — `pemr document list|show|edit|reassign|rm|set-text`.
 
 The escape hatch for a misfiled document (issue #54). Once `ingest` +
 `commit-extraction` have run against the wrong person (or with the wrong
@@ -6,19 +6,27 @@ doc-date/category), the rows are otherwise stuck: `person remove` correctly
 refuses once a person has records, and hand-editing SQLite means hand-fixing
 ``dedup_key`` and the FTS index too.
 
-Four operations, mirroring `persons.py` in shape:
+Six operations, mirroring `persons.py` in shape:
 
     * ``list_documents``   — what is on file, with the blast-radius record count
+    * ``get_document_view``— one document in detail: the list fields plus the
+      open-conflict ids and the ``ocr_text`` size (issue #62)
     * ``edit_document``    — correct doc_date/category/provider (no key impact)
     * ``reassign_document``— right document, wrong owner: move the document and
       every attached row, re-deriving each ``dedup_key`` (``person_id`` is part
       of every key — see :func:`dedup.dedup_key`)
     * ``remove_document``  — wrong file entirely: cascade-delete the attached
       rows, then the document
+    * ``set_document_text``— attach/replace ``ocr_text`` after ingest, the one
+      thing only `ingest` could do before (issue #62)
 
 Safety idiom (matching `pemr rekey`): ``reassign`` and ``rm`` are **dry-run by
-default**; ``apply=True`` writes. ``record_fts`` needs no explicit maintenance —
-migration 003's AFTER UPDATE/DELETE triggers on each base table keep it in sync.
+default**; ``apply=True`` writes. ``edit`` and ``set_document_text`` are not —
+a single-row, non-cascading, key-neutral write has no blast radius for a dry run
+to report, so it goes direct (``set_document_text`` guards the one surprising
+case, an overwrite, with ``force`` instead). ``record_fts`` needs no explicit
+maintenance — migration 003's AFTER UPDATE/DELETE triggers on each base table
+keep it in sync, which is exactly how a new ``ocr_text`` becomes findable.
 
 Single-provenance semantics: ``document_id`` is a row's sole owner. A fact a
 second document also attests leaves no trace in the schema (``commit_extraction``
@@ -50,6 +58,10 @@ class OpenConflictsError(ValueError):
 
 class DictionaryDriftError(ValueError):
     """Stored keys no longer match the current dictionary; `pemr rekey` comes first."""
+
+
+class OcrTextPresentError(ValueError):
+    """`set-text` refused: the document already has ``ocr_text`` and ``force`` was off."""
 
 
 # Editable via `document edit`. None of these feed a dedup_key (keys are built from
@@ -184,10 +196,84 @@ def list_documents(
     return [_document_view(conn, row) for row in rows]
 
 
+def _show_view(conn: sqlite3.Connection, row: sqlite3.Row) -> dict:
+    """The :func:`_document_view` fields plus the two `document show` extras.
+
+    Deliberately *not* folded into :func:`_document_view`: ``conflicts_open`` costs a
+    per-record-type scan, which is a cheap one-off here and an N+1 across
+    :func:`list_documents`. Keeping the split also leaves `list`'s output and JSON shape
+    byte-identical to what issue #54 shipped.
+    """
+    view = _document_view(conn, row)
+    view["ocr_text_chars"] = len(row["ocr_text"] or "")
+    # Both ends of the conflict graph — the same union `reassign` refuses on, so `show`
+    # works as its pre-flight (see :func:`_conflicts_anchored_to`).
+    view["conflicts_open"] = sorted(
+        set(_conflicts_cited_by(conn, row["document_id"]))
+        | set(_conflicts_anchored_to(conn, row["document_id"]))
+    )
+    return view
+
+
 def get_document_view(conn: sqlite3.Connection, document_id: int) -> dict:
-    """One document in the :func:`list_documents` shape."""
+    """One document in the :func:`list_documents` shape, plus ``ocr_text_chars`` and
+    ``conflicts_open``. ``ocr_text`` itself stays out — see :func:`get_document_text`."""
     db.require_migrated(conn)
-    return _document_view(conn, _require_document(conn, document_id))
+    return _show_view(conn, _require_document(conn, document_id))
+
+
+def get_document_text(conn: sqlite3.Connection, document_id: int) -> str:
+    """The stored ``ocr_text`` verbatim, ``""`` when unset.
+
+    The read half of :func:`set_document_text`: without it there is no way to see what
+    a ``force=True`` replace is about to discard.
+    """
+    db.require_migrated(conn)
+    return _require_document(conn, document_id)["ocr_text"] or ""
+
+
+def set_document_text(
+    conn: sqlite3.Connection,
+    document_id: int,
+    text: str,
+    *,
+    force: bool = False,
+) -> dict:
+    """Attach or replace a document's ``ocr_text`` after ingest (`pemr document set-text`).
+
+    Closes the gap that made an ingest without text unrecoverable: `ingest` returns early
+    on a layer-1 content-hash hit and writes nothing, so re-ingesting the same file cannot
+    supply the text a first pass missed. ``record_fts`` follows automatically — migration
+    003's ``record_fts_document_au`` trigger delete+reinserts the FTS row from
+    ``NEW.ocr_text``, so the document becomes visible to `pemr find` with no explicit
+    reindex (and a replace stops matching the old text).
+
+    The stored value is ``text.strip()``, matching :func:`ingest.ingest_document`.
+
+    Raises :class:`DocumentNotFoundError` (unknown id), :class:`OcrTextPresentError` (the
+    column is already populated and ``force`` is off — replacing a transcription is not
+    cheaply undoable, so the surprising case is refused rather than silently applied), and
+    ``ValueError`` for empty/whitespace-only text. There is deliberately no path to *clear*
+    ``ocr_text``: that only removes FTS visibility, while an empty input is far more likely
+    a wrong or truncated file.
+    """
+    db.require_migrated(conn)
+    row = _require_document(conn, document_id)
+    stored = (text or "").strip()
+    if not stored:
+        raise ValueError("text is empty - nothing to store; ocr_text unchanged")
+    existing = row["ocr_text"] or ""
+    if existing and not force:
+        raise OcrTextPresentError(
+            f"document {document_id} already has ocr_text ({len(existing)} chars) - "
+            "pass --force to replace it; nothing was written"
+        )
+    with conn:
+        conn.execute(
+            "UPDATE document SET ocr_text = ? WHERE document_id = ?",
+            (stored, document_id),
+        )
+    return _show_view(conn, _require_document(conn, document_id))
 
 
 def edit_document(

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -13,8 +13,9 @@ Design (issue #12, settled in its design comment):
   :func:`build_server` / :func:`main` (the stdio entry point) require it, imported lazily.
 * **Read/write separation** is declared via MCP ``readOnlyHint`` annotations in
   :func:`build_server`. The read-only tools here never write; the write tools
-  (``person_add``, ``ingest``, ``commit_extraction``, and ``review_conflicts`` *with* a
-  resolution) are the only ones that mutate.
+  (``person_add``, ``person_edit``, ``ingest``, ``commit_extraction``,
+  ``document_set_text``, and ``review_conflicts`` *with* a resolution) are the only ones
+  that mutate.
 
 Run it: ``python -m pemr.mcp_server`` (stdio transport). Config/db resolution is env +
 ``config.toml`` (``PEMR_DB`` / ``PEMR_CONFIG`` / ``[paths]``) — identical to the CLI with
@@ -32,6 +33,7 @@ from typing import Any
 # tool sharing a module name) can't shadow the module it delegates to.
 from . import __version__, cli, db
 from . import dedup as _dedup
+from . import documents as _documents
 from . import ingest as _ingest
 from . import persons as _persons
 from . import query as _query
@@ -219,6 +221,34 @@ def commit_extraction(
     }
 
 
+def document_set_text(
+    conn: sqlite3.Connection, *, document_id: int, text: str
+) -> dict[str, Any]:
+    """[write] Attach a document's text (``ocr_text``) after ingest. Mirrors
+    ``pemr document set-text``.
+
+    This is **ingest completion**, not misfiling recovery: ``AGENTS.md`` §3 makes a
+    populated ``ocr_text`` an obligation, and ``ingest`` returns early on a layer-1
+    content-hash hit — so an agent that missed the text on the first pass cannot fix it by
+    re-ingesting. This tool is the remediation. The document becomes visible to ``find``
+    immediately (FTS is trigger-maintained).
+
+    Deliberately narrower than the CLI: there is **no ``force``**. Filling an empty
+    ``ocr_text`` is an agent action; replacing an existing transcription is a human one at
+    the CLI (``pemr document set-text <id> --ocr-text-file <path> --force``), because it
+    discards work that is not cheaply re-derived. Refused with an explanatory error when
+    the column is already populated.
+
+    The rest of the ``document`` group (``list``/``show``/``edit``/``reassign``/``rm``) is
+    CLI-only by design — recovery is a human escape hatch.
+    """
+    try:
+        return _documents.set_document_text(conn, document_id, text)
+    # DocumentNotFoundError and OcrTextPresentError are both ValueError subclasses.
+    except (db.NotMigratedError, ValueError) as exc:
+        raise _friendly(exc) from exc
+
+
 # --- conflicts (read to list; write only with a signed-off resolution) ------
 
 def review_conflicts(
@@ -379,7 +409,8 @@ READ_ONLY_TOOLS = (
     "render_summary", "render_brief", "render_journal",
 )
 WRITE_TOOLS = (
-    "person_add", "person_edit", "ingest", "commit_extraction", "review_conflicts",
+    "person_add", "person_edit", "ingest", "commit_extraction", "document_set_text",
+    "review_conflicts",
 )
 TOOL_NAMES = READ_ONLY_TOOLS + WRITE_TOOLS
 
@@ -487,6 +518,10 @@ def build_server():  # pragma: no cover - exercised only with the mcp SDK instal
     @server.tool(name="commit_extraction", annotations=rw)
     def commit_extraction_tool(document_id: int, records: dict) -> dict:
         return _run(commit_extraction, document_id=document_id, records=records)
+
+    @server.tool(name="document_set_text", annotations=rw)
+    def document_set_text_tool(document_id: int, text: str) -> dict:
+        return _run(document_set_text, document_id=document_id, text=text)
 
     @server.tool(name="review_conflicts", annotations=rw)
     def review_conflicts_tool(resolve: int | None = None, keep: str = "existing",

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,4 +1,5 @@
-"""Misfiled-document recovery: `pemr document list|edit|reassign|rm` (issue #54).
+"""Misfiled-document recovery: `pemr document list|edit|reassign|rm` (issue #54),
+plus `document show` and `document set-text` (issue #62).
 
 Covers the module surface (pemr/documents.py) and the CLI wiring, in the shape
 test_persons.py uses for the `person` group.
@@ -109,6 +110,139 @@ def test_list_replaces_ocr_text_with_a_flag(seeded):
     view = documents.list_documents(seeded["conn"])[0]
     assert "ocr_text" not in view
     assert view["has_ocr_text"] is True
+
+
+# --- show (get_document_view / get_document_text) ---------------------------
+
+
+def test_show_unknown_document_raises(conn):
+    with pytest.raises(documents.DocumentNotFoundError):
+        documents.get_document_view(conn, 999)
+
+
+def test_show_carries_the_full_stable_record_key_set(seeded):
+    view = documents.get_document_view(seeded["conn"], seeded["doc"])
+    assert set(view["records"]) == set(dedup.KNOWN_TYPES)
+    assert view["record_count"] == 5
+    assert "ocr_text" not in view
+    assert view["has_ocr_text"] is True
+    assert view["ocr_text_chars"] == len("scan text")
+
+
+def test_show_reports_no_conflicts_by_default(seeded):
+    assert documents.get_document_view(
+        seeded["conn"], seeded["doc"]
+    )["conflicts_open"] == []
+
+
+def test_show_reports_conflicts_at_both_ends(seeded):
+    """`show` is the pre-flight for `reassign`/`rm`, so it must union the same two ends
+    those two refuse on: conflicts *raised by* the document and conflicts *anchored to*
+    a row it owns (staged by some other document)."""
+    conn = seeded["conn"]
+    other = _insert_document(conn, seeded["jane"].person_id, "ee55")
+    summary = dedup.commit_extraction(conn, other, {"lab_result": [
+        {"test_name": "HbA1c", "collected_at": "2026-01-02", "value_num": 7.4,
+         "unit": "%"},
+    ]})
+    assert summary.counts["conflict"] == 1
+    # Raised by `other`...
+    assert documents.get_document_view(conn, other)["conflicts_open"] == [1]
+    # ...and anchored to the row the seeded document owns.
+    assert documents.get_document_view(conn, seeded["doc"])["conflicts_open"] == [1]
+
+
+def test_show_view_does_not_change_the_list_view(seeded):
+    """Regression guard for the `_document_view` / `_show_view` split: `list`'s shape is
+    what issue #54 shipped and must stay byte-identical."""
+    listed = documents.list_documents(seeded["conn"])[0]
+    assert "conflicts_open" not in listed
+    assert "ocr_text_chars" not in listed
+    shown = documents.get_document_view(seeded["conn"], seeded["doc"])
+    assert {k: v for k, v in shown.items() if k in listed} == listed
+
+
+def test_get_document_text_returns_the_stored_text(seeded):
+    assert documents.get_document_text(seeded["conn"], seeded["doc"]) == "scan text"
+
+
+def test_get_document_text_is_empty_when_unset(conn):
+    person = persons.add_person(conn, "jane-doe", "Jane Doe")
+    doc = _insert_document(conn, person.person_id, "ff00", ocr_text=None)
+    assert documents.get_document_text(conn, doc) == ""
+    assert documents.get_document_view(conn, doc)["ocr_text_chars"] == 0
+
+
+# --- set-text ---------------------------------------------------------------
+
+
+def _fts_text(conn, document_id):
+    row = conn.execute(
+        "SELECT text FROM record_fts WHERE source_table = 'document' AND source_id = ?",
+        (document_id,),
+    ).fetchone()
+    return row["text"] if row is not None else None
+
+
+def test_set_text_fills_an_empty_document_and_reindexes_fts(conn):
+    """No explicit FTS maintenance: migration 003's AFTER UPDATE trigger on `document`
+    delete+reinserts the row from NEW.ocr_text, which is what makes `find` see it."""
+    person = persons.add_person(conn, "jane-doe", "Jane Doe")
+    doc = _insert_document(conn, person.person_id, "ff00", ocr_text=None)
+    view = documents.set_document_text(conn, doc, "  cholesterol panel  ")
+    assert view["has_ocr_text"] is True
+    assert view["ocr_text_chars"] == len("cholesterol panel")   # stored stripped
+    assert documents.get_document_text(conn, doc) == "cholesterol panel"
+    assert _fts_text(conn, doc) == "cholesterol panel"
+
+
+def test_set_text_refuses_a_populated_document_without_force(seeded):
+    conn = seeded["conn"]
+    with pytest.raises(documents.OcrTextPresentError) as exc:
+        documents.set_document_text(conn, seeded["doc"], "replacement")
+    assert "--force" in str(exc.value) and "nothing was written" in str(exc.value)
+    assert documents.get_document_text(conn, seeded["doc"]) == "scan text"
+
+
+def test_set_text_force_replaces_and_drops_the_old_fts_row(seeded):
+    conn = seeded["conn"]
+    documents.set_document_text(conn, seeded["doc"], "replacement text", force=True)
+    assert documents.get_document_text(conn, seeded["doc"]) == "replacement text"
+    # Exactly one FTS row for the document, carrying only the new text - proves the
+    # trigger's delete+insert rather than an accumulating insert.
+    rows = conn.execute(
+        "SELECT text FROM record_fts WHERE source_table = 'document' AND source_id = ?",
+        (seeded["doc"],),
+    ).fetchall()
+    assert [r["text"] for r in rows] == ["replacement text"]
+
+
+def test_set_text_refuses_empty_text(seeded):
+    conn = seeded["conn"]
+    for empty in ("", "   \n\t "):
+        with pytest.raises(ValueError):
+            documents.set_document_text(conn, seeded["doc"], empty, force=True)
+    assert documents.get_document_text(conn, seeded["doc"]) == "scan text"
+
+
+def test_set_text_unknown_document_raises(conn):
+    with pytest.raises(documents.DocumentNotFoundError):
+        documents.set_document_text(conn, 999, "text")
+
+
+def test_set_text_leaves_records_and_keys_untouched(seeded):
+    conn = seeded["conn"]
+    before = [
+        (r["lab_result_id"], r["dedup_key"], r["person_id"])
+        for r in conn.execute("SELECT * FROM lab_result").fetchall()
+    ]
+    documents.set_document_text(conn, seeded["doc"], "brand new text", force=True)
+    after = [
+        (r["lab_result_id"], r["dedup_key"], r["person_id"])
+        for r in conn.execute("SELECT * FROM lab_result").fetchall()
+    ]
+    assert before == after
+    assert documents.get_document_view(conn, seeded["doc"])["record_count"] == 5
 
 
 # --- edit -------------------------------------------------------------------
@@ -548,6 +682,186 @@ def test_cli_document_list_unknown_person_fails(cli_ready, capsys):
     assert "no person with slug" in capsys.readouterr().err
 
 
+def test_cli_document_show(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "show", "1") == 0
+    out = capsys.readouterr().out
+    assert "document_id    1" in out
+    assert "person         jane-doe" in out
+    # Total plus the non-zero per-type breakdown only (zeros are a --json concern).
+    assert "records        5  (" in out and "lab_result 1" in out
+    assert "procedure 0" not in out
+    assert "has_ocr_text   yes (" in out
+    assert "conflicts      none" in out
+
+
+def test_cli_document_show_json_keeps_the_stable_shape(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "show", "1", "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload["records"]) == set(dedup.KNOWN_TYPES)
+    assert payload["conflicts_open"] == []
+    assert payload["has_ocr_text"] is True
+    assert payload["ocr_text_chars"] > 0
+    assert "ocr_text" not in payload
+
+
+def test_cli_document_show_reports_open_conflicts(cli_ready, capsys):
+    scan2 = cli_ready / "scan2.txt"
+    scan2.write_bytes(b"hba1c 7.4 percent")
+    assert _run(cli_ready, "ingest", str(scan2), "--person", "jane-doe",
+                "--sources", str(cli_ready / "sources"),
+                "--ocr-text-file", str(scan2)) == 0
+    payload = cli_ready / "extract2.json"
+    payload.write_text(json.dumps({"lab_result": [
+        {"test_name": "HbA1c", "collected_at": "2026-01-02", "value_num": 7.4,
+         "unit": "%"},
+    ]}), encoding="utf-8")
+    assert _run(cli_ready, "commit-extraction", "--document", "2",
+                "--json", str(payload)) == 0
+
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "show", "1") == 0
+    out = capsys.readouterr().out
+    assert "conflicts      #1 open - resolve with `pemr review-conflicts`" in out
+    assert out.isascii(), repr(out)
+
+
+def test_cli_document_show_text_dumps_the_transcription(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "show", "1", "--text") == 0
+    captured = capsys.readouterr()
+    assert captured.out == "hba1c 5.7 percent\n"
+    assert captured.err == ""
+
+
+def test_cli_document_show_text_on_an_empty_document_notes_and_succeeds(
+    cli_ready, capsys
+):
+    scan2 = cli_ready / "scan2.txt"
+    scan2.write_bytes(b"no text supplied")
+    assert _run(cli_ready, "ingest", str(scan2), "--person", "jane-doe",
+                "--sources", str(cli_ready / "sources")) == 0
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "show", "2", "--text") == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "has no ocr_text stored" in captured.err
+
+
+def test_cli_document_show_json_and_text_are_mutually_exclusive(cli_ready):
+    with pytest.raises(SystemExit) as exc:
+        _run(cli_ready, "document", "show", "1", "--json", "--text")
+    assert exc.value.code == 2
+
+
+def test_cli_document_show_unknown_id_fails(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "show", "999") == 1
+    assert "no document with id" in capsys.readouterr().err
+
+
+def test_cli_document_set_text_fills_an_empty_document_and_find_sees_it(
+    cli_ready, capsys
+):
+    scan2 = cli_ready / "scan2.txt"
+    scan2.write_bytes(b"no text supplied at ingest")
+    assert _run(cli_ready, "ingest", str(scan2), "--person", "jane-doe",
+                "--sources", str(cli_ready / "sources")) == 0
+    capsys.readouterr()
+    assert _run(cli_ready, "find", "--person", "jane-doe", "pericarditis") == 0
+    assert "pericarditis" not in capsys.readouterr().out
+
+    text = cli_ready / "transcript.txt"
+    text.write_text("acute pericarditis noted on review", encoding="utf-8")
+    assert _run(cli_ready, "document", "set-text", "2",
+                "--ocr-text-file", str(text)) == 0
+    out = capsys.readouterr().out
+    assert "set ocr_text on document #2: 34 chars (was empty)" in out
+    assert "has_ocr_text   yes (34 chars)" in out
+
+    # No explicit reindex anywhere: the FTS trigger did it.
+    assert _run(cli_ready, "find", "--person", "jane-doe", "pericarditis") == 0
+    assert "pericarditis" in capsys.readouterr().out.lower()
+
+
+def test_cli_document_set_text_refuses_a_populated_document(cli_ready, capsys):
+    text = cli_ready / "transcript.txt"
+    text.write_text("replacement transcription", encoding="utf-8")
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "set-text", "1",
+                "--ocr-text-file", str(text)) == 1
+    err = capsys.readouterr().err
+    assert "already has ocr_text" in err and "--force" in err
+    assert _run(cli_ready, "document", "show", "1", "--text") == 0
+    assert capsys.readouterr().out == "hba1c 5.7 percent\n"
+
+
+def test_cli_document_set_text_force_replaces_and_moves_the_index(cli_ready, capsys):
+    text = cli_ready / "transcript.txt"
+    text.write_text("replacement transcription", encoding="utf-8")
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "set-text", "1", "--force",
+                "--ocr-text-file", str(text)) == 0
+    out = capsys.readouterr().out
+    assert "set ocr_text on document #1: 25 chars (replaced 17 chars)" in out
+
+    assert _run(cli_ready, "find", "--person", "jane-doe", "replacement") == 0
+    assert "replacement" in capsys.readouterr().out.lower()
+    # The old text is gone from the index, not merely shadowed by the new row.
+    assert _run(cli_ready, "find", "--person", "jane-doe", "percent") == 0
+    assert "document" not in capsys.readouterr().out.lower()
+
+
+def test_cli_document_set_text_json(cli_ready, capsys):
+    text = cli_ready / "transcript.txt"
+    text.write_text("replacement transcription", encoding="utf-8")
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "set-text", "1", "--force",
+                "--ocr-text-file", str(text), "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ocr_text_chars"] == 25
+    assert payload["has_ocr_text"] is True
+    assert "ocr_text" not in payload
+
+
+def test_cli_document_set_text_rejects_an_empty_file(cli_ready, capsys):
+    text = cli_ready / "empty.txt"
+    text.write_text("   \n", encoding="utf-8")
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "set-text", "1", "--force",
+                "--ocr-text-file", str(text)) == 1
+    assert "is empty - nothing to store" in capsys.readouterr().err
+    assert _run(cli_ready, "document", "show", "1", "--text") == 0
+    assert capsys.readouterr().out == "hba1c 5.7 percent\n"
+
+
+def test_cli_document_set_text_unreadable_path_and_unknown_id_fail(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "set-text", "1",
+                "--ocr-text-file", str(cli_ready / "nope.txt")) == 1
+    assert "cannot read" in capsys.readouterr().err
+
+    text = cli_ready / "transcript.txt"
+    text.write_text("some text", encoding="utf-8")
+    assert _run(cli_ready, "document", "set-text", "999",
+                "--ocr-text-file", str(text)) == 1
+    assert "no document with id" in capsys.readouterr().err
+
+
+def test_cli_document_set_text_leaves_records_untouched(cli_ready, capsys):
+    text = cli_ready / "transcript.txt"
+    text.write_text("replacement transcription", encoding="utf-8")
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "set-text", "1", "--force",
+                "--ocr-text-file", str(text)) == 0
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "show", "1", "--json") == 0
+    assert json.loads(capsys.readouterr().out)["record_count"] == 5
+    assert _run(cli_ready, "query", "labs", "--person", "jane-doe") == 0
+    assert "HbA1c" in capsys.readouterr().out
+
+
 def test_cli_document_edit(cli_ready, capsys):
     capsys.readouterr()
     assert _run(cli_ready, "document", "edit", "1", "--category", "imaging") == 0
@@ -668,6 +982,7 @@ def test_cli_document_output_is_console_safe(cli_ready, capsys):
     capsys.readouterr()
     for argv in (
         ("document", "list"),
+        ("document", "show", "1"),
         ("document", "reassign", "1", "--person", "john-doe"),
         ("document", "rm", "1"),
     ):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -194,6 +194,46 @@ def test_commit_extraction_via_wrapper(seeded, tmp_path, monkeypatch):
     assert out["counts"]["new"] == 1
 
 
+# --- document_set_text (ingest completion, issue #62) -----------------------
+
+
+def test_document_set_text_fills_an_empty_ocr_text(seeded):
+    doc = _doc(seeded, "jane-doe", ocr=None)
+    out = mcp_server.document_set_text(
+        seeded, document_id=doc, text="thyroid panel within range"
+    )
+    assert out["has_ocr_text"] is True
+    assert out["ocr_text_chars"] == len("thyroid panel within range")
+    assert "ocr_text" not in out
+    # FTS is trigger-maintained, so `find` sees it with no reindex.
+    assert mcp_server.find(seeded, query_text="thyroid", person="jane-doe")
+
+
+def test_document_set_text_refuses_a_populated_document(seeded):
+    doc = _doc(seeded, "jane-doe", ocr="the original transcription")
+    with pytest.raises(mcp_server.ToolError, match="already has ocr_text"):
+        mcp_server.document_set_text(seeded, document_id=doc, text="replacement")
+    assert seeded.execute(
+        "SELECT ocr_text FROM document WHERE document_id = ?", (doc,)
+    ).fetchone()["ocr_text"] == "the original transcription"
+
+
+def test_document_set_text_exposes_no_force_parameter():
+    """Replacing an existing transcription is a human-at-the-CLI action; the tool must
+    not hand an agent that lever (AGENTS.md write-tool list)."""
+    import inspect
+
+    assert "force" not in inspect.signature(mcp_server.document_set_text).parameters
+
+
+def test_document_set_text_unknown_id_and_empty_text_raise(seeded):
+    with pytest.raises(mcp_server.ToolError, match="no document with id"):
+        mcp_server.document_set_text(seeded, document_id=999, text="text")
+    doc = _doc(seeded, "jane-doe", ocr=None)
+    with pytest.raises(mcp_server.ToolError, match="empty"):
+        mcp_server.document_set_text(seeded, document_id=doc, text="   ")
+
+
 def test_review_conflicts_lists_and_requires_signoff(seeded, tmp_path, monkeypatch):
     monkeypatch.setenv("PEMR_SOURCES", str(tmp_path / "sources"))
     # Stage a conflict: same lab key (person+test+date+rounded value) with a differing unit.


### PR DESCRIPTION
## Summary
- Adds `pemr document show <id> [--json | --text]` — single-document detail view (metadata + whether extraction rows are committed); `--text` dumps stored `ocr_text` for review.
- Adds `pemr document set-text <id> --ocr-text-file <path> [--force]` — attach/replace `ocr_text` after ingest, since ingest is otherwise the only way to populate it. Refuses to overwrite a populated document unless `--force`; FTS follows via the existing trigger.
- Exposes `document_set_text` as an MCP write tool (text in, not a file path, to avoid handing an agent an arbitrary-file-read primitive); documents the remediation path in `AGENTS.md` for an ingest that left `ocr_text_populated: false`.
- Scope narrowed during intake from the original issue ask: `edit`/`reassign` were already delivered by #54/PR #68, so this issue covers only `show` + `set-text`.

Full pipeline history (design → build → verify → audit) is on the issue. Audit found no blocking issues; two deferred read-path defects (non-UTF-8 file traceback, BOM-only file defeats the emptiness guard — both pre-existing behavior shared with `ingest`) were filed as #78.

## Test plan
- [x] `python -m pytest tests/ -q` — full suite green after merging `dev` in (documents.py/mcp_server.py/cli.py all touched by both branches, merged clean, no conflicts)
- [x] `npm run check:meta-drift` — pass
- [x] Manual CLI runs during audit: round-trip `show --text` → `set-text --force`, repeat-without-force refusal, FTS before/after a `--force` replace, NULL-column rendering, invalid id handling

Closes #62