### PR TITLE
feat(#63): promote allergy + condition to typed tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,16 +73,14 @@ report's verbatim label.
   (`docs/Architecture.md` §3).
 - MUST NOT invent abbreviations or "helpful" renames.
 
-### 2. Observation rows — conditions, allergies, vitals, orders, screenings, immunizations
+### 2. Observation rows — vitals, orders, screenings, immunizations
 
-`render_summary` populates its **Conditions**, **Allergies**, **Orders & Referrals**, and **Latest
-Vitals** sections purely from `observation` rows, keyed by `obs_type`. An extraction that omits them
-leaves those sections permanently `_none recorded_`, so a visit note carrying a diagnosis, allergy,
-vital reading, or non-medication order MUST commit the matching `observation` rows in
-`commit_extraction`:
+`render_summary` populates its **Orders & Referrals** and **Latest Vitals** sections purely from
+`observation` rows, keyed by `obs_type`. An extraction that omits them leaves those sections
+permanently `_none recorded_`, so a visit note carrying a vital reading or a non-medication order
+MUST commit the matching `observation` rows in `commit_extraction`. (Conditions and allergies are
+**no longer observations** — they are typed rows, see §3.)
 
-- **Condition** → `obs_type='condition'`, `key=<condition name>`, optional `value_text=<detail>`.
-- **Allergy** → `obs_type='allergy'`, `key=<allergen>`, optional `value_text=<reaction>`.
 - **Vital** → `obs_type='vital'`, `key=<canonical vital token>` (below), the reading in `value_num`
   (+ `unit`) or `value_text`. "Latest vitals" is the most recent `vital` row per normalized `key`.
 - **Order** → `obs_type='order'`, `key=<item/order name>`, optional `value_text=<instructions
@@ -120,7 +118,36 @@ the sole evidence of last-done** (no administration record to capture). Don't do
 event as both. Canonical screening/vaccine vocabulary is owned by the care-gap phase — for now emit
 sensible `snake_case` tokens (same discipline as vitals) and let `dedup.norm()` handle case/spacing.
 
-### 3. OCR text at ingest
+### 3. Allergy and condition rows (typed, not observations)
+
+`allergy` and `condition` are **first-class record types** (migration 006), not `obs_type` values —
+the generic `observation` shape has one date and no criticality, so it could not hold a resolved
+problem or a machine-readable allergy severity. `render_summary` feeds its **Active Problems**,
+**Past Medical History**, **Family History** and **Allergies** sections from them, so a visit note
+carrying a diagnosis or an allergy MUST commit these rows:
+
+- **Allergy** → `allergy` with `substance=<allergen>` (required), optional `reaction`,
+  `criticality` ∈ {`high`, `low`, `unable-to-assess`}, and `noted_on` (ISO date). Emit
+  `criticality` whenever the source states one — it is what sorts a dangerous allergen to the top
+  of the list, and free-text severity buried in `reaction` cannot do that.
+- **Condition** → `condition` with `name=<condition name>` and `status` (both required), optional
+  `onset_on` / `resolved_on` (ISO dates), `relation`, and `note=<free-text detail>`.
+  `status` is a closed vocabulary — a value outside it is rejected:
+  - `active` — a current problem-list entry;
+  - `resolved` — a past problem with an end (set `resolved_on` when the source gives one);
+  - `history` — a past-medical-history line with no stated resolution date;
+  - `family-history` — a **relative's** diagnosis.
+- A family-history item MUST carry `status='family-history'` and the relative in `relation`
+  (`mother`, `father`, `sibling`, ... free text) — **never** an `active` condition row. The subject
+  is part of the dedup key, so this is what keeps a mother's diabetes out of the patient's own
+  problem list; miscommitting it there is a clinical-safety error, not a cosmetic one.
+- Both are **standing facts**: their dedup keys are date-free, so restating the same allergen or
+  problem across documents collapses to one row. A stated disagreement (`penicillin: rash` vs
+  `penicillin: anaphylaxis`, or `active` -> `resolved`) stages a **conflict** for human
+  adjudication (§5); a field the new document simply doesn't mention is silence, not a change, and
+  never conflicts. Do not "helpfully" restate a value the source omitted.
+
+### 4. OCR text at ingest
 
 Every `ingest` MUST end with `document.ocr_text` populated. This is what makes a document visible
 to `find` (FTS5); an ingest without it is silently unsearchable.
@@ -143,11 +170,11 @@ carry a signal — their absence from the text is ignorance, not evidence). `mis
 
 - On a refusal, the agent MUST surface the verdict and the `evidence` snippet to the human and get
   an **explicit go-ahead** before retrying with `force=true`. Never force on your own judgment.
-- Unlike §4 conflict resolution, this is not mechanically gated on a `signoff` param. The
+- Unlike §5 conflict resolution, this is not mechanically gated on a `signoff` param. The
   asymmetry is deliberate: a wrongly-forced ingest is recoverable (`pemr document reassign`),
   whereas a wrongly-resolved conflict destroys the losing value.
 
-### 4. Conflict discipline
+### 5. Conflict discipline
 
 Agents never resolve staged conflicts silently.
 
@@ -160,7 +187,7 @@ Agents never resolve staged conflicts silently.
   text with the resolution.
 - `keep both` is the odd one out: it **admits a row** rather than choosing between two. Use it only
   for a genuine repeat the source cannot distinguish — two same-day draws on a report that prints
-  no collection times (see §6). It inserts the incoming row alongside the stored one as the next
+  no collection times (see §7). It inserts the incoming row alongside the stored one as the next
   *occurrence* of that identity; a later re-commit of that same payload then dedups against it. If
   the source *did* give distinct times and the extraction dropped them, the fix is a corrected
   extraction, not `keep both`.
@@ -175,7 +202,7 @@ Agents never resolve staged conflicts silently.
   that is an extraction error, not a conflict. Re-read the source for collection times; if there
   genuinely are none, submit them separately and ask the human about `keep both`.
 
-### 5. Medication-interaction section
+### 6. Medication-interaction section
 
 `render_brief` emits a placeholder **"Medication Interaction Review"** section for the agent layer
 to fill. The engine deliberately does not compute this: an external drug-interaction API would send
@@ -192,16 +219,16 @@ The agent fills it **from its own general knowledge**, under fixed framing it MU
 The agent MUST NEVER: claim safety or the absence of interactions, give dosing advice, or recommend
 starting, stopping, or changing a medication.
 
-### 6. Date precision
+### 7. Date precision
 
 Every date field (`collected_at`, `started_on`, `ended_on`, `performed_on`, `scheduled_for`,
-`observed_at`) accepts an ISO prefix at **three precisions**: full `YYYY-MM-DD` (optionally + a
+`observed_at`, `noted_on`, `onset_on`, `resolved_on`) accepts an ISO prefix at **three precisions**: full `YYYY-MM-DD` (optionally + a
 `T`/space time), month `YYYY-MM`, or year `YYYY`. Emit the **most precise prefix the source
 supports** — a full date when the document gives one, else `YYYY-MM`, else `YYYY` — never invent a
 day or month the source didn't state, and never fall back to stashing an imprecise date elsewhere.
 
 - e.g. a prior surgery cited only as "03/2019" commits as `procedure.performed_on = "2019-03"`,
-  not stashed in a condition observation's `value_text`.
+  not stashed in a `condition.note`.
 - A time component is only valid with a full date (`2026-03T09:00` is rejected).
 - Non-ISO forms (`06/15/2026`, `2026-13`, `2026-3`, `Jan 2026`) are still rejected — reformat to an
   ISO prefix first.
@@ -209,7 +236,7 @@ day or month the source didn't state, and never fall back to stashing an impreci
   guesses that one refines the other); reconciling them is a human conflict-review action.
 - Date-only precision is also why two genuine same-day results collide: they derive one key, so the
   second stages a conflict. Emitting a time you invented is never the fix — the recovery path is
-  `keep both` under human sign-off (§4).
+  `keep both` under human sign-off (§5).
 
 ## Privacy posture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,11 @@ carrying a diagnosis or an allergy MUST commit these rows:
   `penicillin: anaphylaxis`, or `active` -> `resolved`) stages a **conflict** for human
   adjudication (§5); a field the new document simply doesn't mention is silence, not a change, and
   never conflicts. Do not "helpfully" restate a value the source omitted.
+- Silence only reads that way in one direction. A field the new document **does** state over a
+  stored NULL is new information with nothing to adjudicate: it fills the stored row in place and
+  the commit reports it as `enriched` rather than `duplicate`. So emit every field the source
+  states even for an allergen or problem you know is already on file — a terse first document
+  followed by a detailed one is the normal case, and this is what makes the detail land.
 
 ### 4. OCR text at ingest
 
@@ -204,6 +209,11 @@ Agents never resolve staged conflicts silently.
   identity was removed in the meantime (the source document was deleted or reassigned), it is
   **refused** — never silently applied to nothing. Report the refusal to the human; `keep both`
   admits the staged row as a fresh record if they want the value kept.
+- On the standing-fact types (§3) `keep incoming` overwrites only the fields the incoming row
+  actually states — an unstated field there means "this document didn't say", so adjudicating one
+  disagreement (`criticality: high` vs `low`) does not also erase a `reaction` the incoming
+  document simply didn't repeat. On the dated types an unstated field IS a clearing and is written
+  as one.
 - `commit_extraction` **rejects** two rows of one submission that derive the same key and disagree;
   that is an extraction error, not a conflict. Re-read the source for collection times; if there
   genuinely are none, submit them separately and ask the human about `keep both`.

--- a/data/dictionary.example.toml
+++ b/data/dictionary.example.toml
@@ -160,15 +160,17 @@
 "beta-2 microglobulin" = "beta2_microglobulin"
 
 # --- observation obs_type conventions ---
-# Six obs_type families out of the generic `observation` table. Extraction
+# Four obs_type families out of the generic `observation` table. Extraction
 # agents should emit:
 #   * obs_type='vital'        key=<canonical vital token below>  (blood_pressure ...)
-#   * obs_type='condition'    key=<condition name>     value_text=<optional detail>
-#   * obs_type='allergy'      key=<allergen>           value_text=<optional reaction>
 #   * obs_type='order'        key=<item/order name>    value_text=<instructions/prescriber>
 #   * obs_type='screening'    key=<snake_case screen>  observed_at=<last-done date>  value_text=<freq/next-due>
 #   * obs_type='immunization' key=<snake_case vaccine> observed_at=<date given>      value_text=<optional detail>
-# vital/condition/allergy/order drive the phase-4 render layer (master summary /
+# Conditions and allergies used to live here too; migration 006 promoted them to the
+# typed `condition` / `allergy` tables (record types of their own in commit-extraction,
+# with status/criticality/two-date fields the generic shape could not hold) - see
+# AGENTS.md MUST rule 3. Nothing in this dictionary applies to them beyond norm().
+# vital/order drive the phase-4 render layer (master summary /
 # appointment brief); "Latest vitals" is the most recent `vital` row per normalized key.
 # The `order` family captures non-medication orders mined from the med-list section
 # (DME, outpatient PT, referrals, pre-op consults); `key` is free-text (verbatim item

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -247,6 +247,16 @@ duplicate-vs-conflict comparison differs by record type (`dedup._SPARSE_TYPES`).
 `subject` discriminator is a correctness fix, not a nicety: without it a patient's
 diabetes and her mother's derive one key and silently merge.
 
+That reading is asymmetric by design. Treating a *stored* NULL as silence too would make the
+common terse-then-detailed document sequence lossy: the second document's `criticality` would
+count as a duplicate and be dropped, with no conflict to catch it. So a field the incoming row
+states over a stored NULL is a **gain** — no competing value, nothing to adjudicate — and fills
+the stored row in place, reported as `enriched` (a fourth commit bucket beside
+new/duplicate/conflict). A stated value never overwrites a stored one on that path, so
+enrichment cannot launder a disagreement into a silent overwrite. The same reading governs
+`keep incoming` on these types: it writes the fields the incoming row states and leaves the
+rest as stored, so a one-field adjudication doesn't erase the row's other payload.
+
 `norm()` = lowercase, trim, collapse whitespace, map synonyms via an **analyte/name
 dictionary** (`data/dictionary.toml`) — e.g. `A1c`, `HbA1c`, `Hemoglobin A1c` → one
 canonical `hba1c`. The dictionary is the one place fuzzy naming gets pinned down
@@ -358,7 +368,7 @@ inbox/scan.pdf
       matching the record schemas (lab_result[], medication[], observation[]...)
   → pemr commit-extraction --document <id> --json extracted.json
       5. validate JSON against schema (types, required fields)
-      6. compute dedup_keys; split into {new, duplicate, conflict}
+      6. compute dedup_keys; split into {new, duplicate, enriched, conflict}
       7. insert new; report the rest
   → pemr review-conflicts   (if any)
 ```

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -157,6 +157,31 @@ CREATE TABLE appointment (
   dedup_key      TEXT NOT NULL,
   UNIQUE(dedup_key)
 );
+CREATE TABLE allergy (                     -- migration 006 (promoted from observation)
+  allergy_id    INTEGER PRIMARY KEY,
+  person_id     INTEGER NOT NULL REFERENCES person(person_id),
+  document_id   INTEGER REFERENCES document(document_id),
+  substance     TEXT NOT NULL,
+  reaction      TEXT,
+  criticality   TEXT,                      -- high|low|unable-to-assess
+  noted_on      TEXT,
+  dedup_key     TEXT NOT NULL,
+  UNIQUE(dedup_key)
+);
+
+CREATE TABLE condition (                   -- migration 006 (promoted from observation)
+  condition_id  INTEGER PRIMARY KEY,
+  person_id     INTEGER NOT NULL REFERENCES person(person_id),
+  document_id   INTEGER REFERENCES document(document_id),
+  name          TEXT NOT NULL,
+  status        TEXT NOT NULL,             -- active|resolved|history|family-history
+  onset_on      TEXT,
+  resolved_on   TEXT,
+  relation      TEXT,                      -- family-history only: mother|father|...
+  note          TEXT,
+  dedup_key     TEXT NOT NULL,
+  UNIQUE(dedup_key)
+);
 ```
 
 Generic catch-all (new record types with zero migration):
@@ -167,8 +192,9 @@ CREATE TABLE observation (
   person_id      INTEGER NOT NULL REFERENCES person(person_id),
   document_id    INTEGER REFERENCES document(document_id),
   obs_type       TEXT NOT NULL,           -- 'vital' (key = canonical vital token, e.g.
-                                           -- 'blood_pressure'/'weight'), 'condition',
-                                           -- 'allergy' (phase 4 render.py convention)
+                                           -- 'blood_pressure'/'weight'), 'order',
+                                           -- 'screening', 'immunization'
+                                           -- (condition/allergy graduated in 006)
   observed_at    TEXT,
   key            TEXT,
   value_num      REAL,
@@ -181,7 +207,11 @@ CREATE TABLE observation (
 
 Promotion path: an `obs_type` that grows important graduates from `observation`
 into its own typed table via a migration. The generic table absorbs the long tail so
-you're never blocked waiting on schema work.
+you're never blocked waiting on schema work. `condition` and `allergy` are the worked
+example (migration 006, issue #63): both graduated on *fields with no legal home* in the
+generic shape — a resolved problem needs two dates where `observation` has one, and an
+allergy's `criticality` had nowhere to live but free text — not on row volume. Volume
+alone is not a reason to promote.
 
 ---
 
@@ -202,7 +232,20 @@ medication.dedup_key    = hash(person_id | norm(name) | dose | started_on)
 procedure.dedup_key     = hash(person_id | norm(name) | performed_on)
 appointment.dedup_key   = hash(person_id | provider | scheduled_for)
 observation.dedup_key   = hash(person_id | obs_type | observed_at | key)
+allergy.dedup_key       = hash(person_id | norm(substance))
+condition.dedup_key     = hash(person_id | norm(name) | subject)
+    subject = 'family:' + norm(relation)  when status = 'family-history'
+            = 'self'                      otherwise
 ```
+
+The last two are deliberately **date-free**: allergies and problem lists are *standing
+facts* restated on every document with inconsistent or absent dates, so a date in the key
+would fork one allergy into one row per document. Their dates are payload, and a stated
+disagreement (in a date or anywhere else) stages a conflict. A field the incoming document
+simply omits is silence, not a change, and never conflicts — the one place the
+duplicate-vs-conflict comparison differs by record type (`dedup._SPARSE_TYPES`). The
+`subject` discriminator is a correctness fix, not a nicety: without it a patient's
+diabetes and her mother's derive one key and silently merge.
 
 `norm()` = lowercase, trim, collapse whitespace, map synonyms via an **analyte/name
 dictionary** (`data/dictionary.toml`) — e.g. `A1c`, `HbA1c`, `Hemoglobin A1c` → one

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -16,8 +16,8 @@ is `pemr person add`, nothing else.
   (connection/pragmas/migrations), `models.py` typed rows; later `ingest.py`, `dedup.py`,
   `query.py`, `render.py`, `backup.py`, `mcp_server.py`.
 - **Schema** (`migrations/*.sql`) — hybrid: typed tables (`person`, `document`,
-  `lab_result`, `medication`, `procedure`, `appointment`) plus a generic `observation`
-  catch-all. See [Architecture.md §2](Architecture.md#2-schema-hybrid).
+  `lab_result`, `medication`, `procedure`, `appointment`, `condition`, `allergy`) plus a
+  generic `observation` catch-all. See [Architecture.md §2](Architecture.md#2-schema-hybrid).
 - **Dedup** — two layers: content-hash on documents, deterministic semantic keys on
   extracted rows. The core determinism win: [Architecture.md §3](Architecture.md#3-dedup-algorithm-the-core-determinism-win).
 - **Data layout** — the live `pemr.db` stays on a local-only (non-synced) path; only

--- a/migrations/003_fts.sql
+++ b/migrations/003_fts.sql
@@ -9,6 +9,7 @@
 
 CREATE VIRTUAL TABLE record_fts USING fts5(
   source_table UNINDEXED,   -- 'document'|'lab_result'|'medication'|'procedure'|'appointment'|'observation'
+                           -- (migration 006 added 'allergy'|'condition')
   source_id    UNINDEXED,   -- primary key of the row in source_table
   person_id    UNINDEXED,   -- owner, for the `pemr find --person` filter
   document_id  UNINDEXED,   -- provenance (self for 'document' rows)

--- a/migrations/006_condition_allergy.sql
+++ b/migrations/006_condition_allergy.sql
@@ -1,0 +1,139 @@
+-- 006_condition_allergy: promote `condition` and `allergy` out of `observation` into
+-- typed tables (issue #63).
+--
+-- Both cleared the Architecture.md §2 promotion bar on *fields with no legal home* in the
+-- generic shape, not on volume:
+--
+--   * a resolved problem needs TWO dates (onset + resolved); `observation` has exactly one
+--     (`observed_at`), and AGENTS.md §MUST-7 forbids stashing the other in `value_text` —
+--     so a resolved condition was simply unrepresentable;
+--   * `observation.dedup_key = hash(person_id | obs_type | observed_at | key)` gave an
+--     ACTIVE problem and a FAMILY-HISTORY entry naming the same disease ("diabetes" in the
+--     patient, "diabetes" in the mother) the same key: they silently deduped into one row
+--     and the summary then presented a relative's diagnosis as the patient's own. The
+--     `status`/`relation` discriminator is what fixes that, and it has to be in the key;
+--   * an allergy's `criticality` had nowhere to go but free text, where nothing can flag
+--     or sort on it.
+--
+-- `immunization` and `screening` are deliberately NOT promoted — the #43 `obs_type`
+-- convention holds them losslessly and their shared consumer is the future `pemr due`.
+--
+-- Table/PK names match the record-type names (`condition`/`condition_id`,
+-- `allergy`/`allergy_id`) because `dedup._insert_record`, `_overwrite_record` and
+-- `documents.reassign` interpolate `record_type` as the table name and
+-- `f"{record_type}_id"` as the primary key. Neither name is an SQLite keyword.
+--
+-- Dedup keys (see pemr/dedup.py `_key_parts`) are deliberately DATE-FREE:
+--
+--   allergy.dedup_key   = hash(person_id | norm(substance))
+--   condition.dedup_key = hash(person_id | norm(name) | subject)
+--       subject = 'family:' + norm(relation)  when status = 'family-history'
+--               = 'self'                      otherwise
+--
+-- Allergies and problem lists are *standing facts* restated on every document with
+-- inconsistent or absent dates; a date in the key would fork one allergy into one row per
+-- document. Dates are payload, and a disagreement in them stages a conflict.
+
+CREATE TABLE allergy (
+  allergy_id       INTEGER PRIMARY KEY,
+  person_id        INTEGER NOT NULL REFERENCES person(person_id),
+  document_id      INTEGER REFERENCES document(document_id),
+  substance        TEXT NOT NULL,
+  reaction         TEXT,
+  criticality      TEXT,                    -- high|low|unable-to-assess
+  noted_on         TEXT,                    -- ISO date
+  dedup_key        TEXT NOT NULL,
+  dedup_base       TEXT,
+  dedup_occurrence INTEGER NOT NULL DEFAULT 0,
+  UNIQUE(dedup_key)
+);
+CREATE INDEX idx_allergy_dedup_base ON allergy(dedup_base);
+
+CREATE TABLE condition (
+  condition_id     INTEGER PRIMARY KEY,
+  person_id        INTEGER NOT NULL REFERENCES person(person_id),
+  document_id      INTEGER REFERENCES document(document_id),
+  name             TEXT NOT NULL,
+  status           TEXT NOT NULL,           -- active|resolved|history|family-history
+  onset_on         TEXT,                    -- ISO date
+  resolved_on      TEXT,                    -- ISO date
+  relation         TEXT,                    -- family-history only: mother|father|sibling...
+  note             TEXT,                    -- free-text detail (was observation.value_text)
+  dedup_key        TEXT NOT NULL,
+  dedup_base       TEXT,
+  dedup_occurrence INTEGER NOT NULL DEFAULT 0,
+  UNIQUE(dedup_key)
+);
+CREATE INDEX idx_condition_dedup_base ON condition(dedup_base);
+
+-- --- FTS triggers (mirror 003_fts.sql) --------------------------------------
+-- Created BEFORE the row move below, so the index maintains itself on the INSERT ...
+-- SELECT and no explicit backfill is needed.
+
+CREATE TRIGGER record_fts_allergy_ai AFTER INSERT ON allergy BEGIN
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('allergy', NEW.allergy_id, NEW.person_id, NEW.document_id,
+          TRIM(COALESCE(NEW.substance, '') || ' ' || COALESCE(NEW.reaction, '')));
+END;
+CREATE TRIGGER record_fts_allergy_ad AFTER DELETE ON allergy BEGIN
+  DELETE FROM record_fts WHERE source_table='allergy' AND source_id=OLD.allergy_id;
+END;
+CREATE TRIGGER record_fts_allergy_au AFTER UPDATE ON allergy BEGIN
+  DELETE FROM record_fts WHERE source_table='allergy' AND source_id=OLD.allergy_id;
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('allergy', NEW.allergy_id, NEW.person_id, NEW.document_id,
+          TRIM(COALESCE(NEW.substance, '') || ' ' || COALESCE(NEW.reaction, '')));
+END;
+
+CREATE TRIGGER record_fts_condition_ai AFTER INSERT ON condition BEGIN
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('condition', NEW.condition_id, NEW.person_id, NEW.document_id,
+          TRIM(COALESCE(NEW.name, '') || ' ' || COALESCE(NEW.note, '')));
+END;
+CREATE TRIGGER record_fts_condition_ad AFTER DELETE ON condition BEGIN
+  DELETE FROM record_fts WHERE source_table='condition' AND source_id=OLD.condition_id;
+END;
+CREATE TRIGGER record_fts_condition_au AFTER UPDATE ON condition BEGIN
+  DELETE FROM record_fts WHERE source_table='condition' AND source_id=OLD.condition_id;
+  INSERT INTO record_fts (source_table, source_id, person_id, document_id, text)
+  VALUES ('condition', NEW.condition_id, NEW.person_id, NEW.document_id,
+          TRIM(COALESCE(NEW.name, '') || ' ' || COALESCE(NEW.note, '')));
+END;
+
+-- --- move the existing observation rows --------------------------------------
+-- `status='active'` for every migrated condition is the honest reading: the pre-existing
+-- convention had no status field, and those rows were exactly what `render_summary`
+-- printed under its (single) Conditions section.
+--
+-- THE dedup_key CAVEAT. The new keys are sha256 over dictionary-normalized parts, which
+-- SQL cannot compute, so the old `observation` key/base/occurrence are carried forward
+-- verbatim (guaranteed unique, so UNIQUE(dedup_key) holds and nothing is lost) and the
+-- correct key is re-derived by `pemr rekey --apply`. Until that runs, a re-commit of an
+-- already-stored allergy/condition inserts a second row instead of deduping —
+-- `pemr migrate` prints a one-line reminder when this migration is among those applied.
+--
+-- One known rough edge: an OPEN conflict staged against one of these rows still carries
+-- `record_type='observation'` and a key no observation row holds any more. It still
+-- lists, and `keep existing` still closes it; `keep incoming` refuses with the friendly
+-- "no stored row left to overwrite" message. Re-extract from the source document if the
+-- staged value matters.
+
+INSERT INTO allergy
+  (person_id, document_id, substance, reaction, noted_on,
+   dedup_key, dedup_base, dedup_occurrence)
+SELECT person_id, document_id, key, value_text, observed_at,
+       dedup_key, COALESCE(dedup_base, dedup_key), dedup_occurrence
+  FROM observation WHERE obs_type = 'allergy' AND key IS NOT NULL;
+
+INSERT INTO condition
+  (person_id, document_id, name, status, onset_on, note,
+   dedup_key, dedup_base, dedup_occurrence)
+SELECT person_id, document_id, key, 'active', observed_at, value_text,
+       dedup_key, COALESCE(dedup_base, dedup_key), dedup_occurrence
+  FROM observation WHERE obs_type = 'condition' AND key IS NOT NULL;
+
+-- `key IS NULL` rows could not be moved (substance/name are NOT NULL) and are left in
+-- `observation` rather than dropped: they carry no identifiable allergen/problem, so a
+-- human has to re-extract them from the source document.
+DELETE FROM observation
+ WHERE obs_type IN ('allergy', 'condition') AND key IS NOT NULL;

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -174,6 +174,30 @@ def _resolve_dictionary_path(args: argparse.Namespace) -> Path | None:
     return _DEFAULT_DICTIONARY if _DEFAULT_DICTIONARY.is_file() else None
 
 
+def _migration_followups(conn: sqlite3.Connection, applied: list[str]) -> list[str]:
+    """Manual follow-ups the just-applied migrations leave behind.
+
+    006 moves allergy/condition rows out of `observation` carrying their OLD dedup keys
+    (the new ones are sha256 over dictionary-normalized fields, which SQL cannot compute),
+    so until `rekey` re-derives them a re-commit of an already-stored allergy/condition
+    inserts a second row instead of deduping. Saying so here makes it impossible to miss
+    (issue #63) -- but only when rows actually moved: on a fresh `--create` there is
+    nothing to rekey, and a note nobody has to act on trains people to skip notes.
+    """
+    notes: list[str] = []
+    if "006_condition_allergy.sql" in applied:
+        moved = conn.execute(
+            "SELECT (SELECT COUNT(*) FROM allergy) + (SELECT COUNT(*) FROM condition) "
+            "AS n"
+        ).fetchone()["n"]
+        if moved:
+            notes.append(
+                f"run `pemr rekey --apply` to re-derive dedup keys for the {moved} "
+                "allergy/condition row(s) migrated out of `observation`"
+            )
+    return notes
+
+
 def _cmd_migrate(args: argparse.Namespace) -> int:
     # The one command allowed to create a database - and only with --create. Without it
     # `migrate` applies migrations to an existing database and nothing else (issue #55).
@@ -183,11 +207,14 @@ def _cmd_migrate(args: argparse.Namespace) -> int:
     conn = db.connect(db_path)
     try:
         applied = db.migrate(conn, args.migrations_dir or db.DEFAULT_MIGRATIONS_DIR)
+        followups = _migration_followups(conn, applied)
     finally:
         conn.close()
     if applied:
         for name in applied:
             print(f"applied {name}")
+        for note in followups:
+            print(f"note: {note}")
     else:
         print("up to date")
     return 0

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -762,7 +762,7 @@ def _cmd_commit_extraction(args: argparse.Namespace) -> int:
     c = summary.counts
     print(
         f"committed: {c['new']} new, {c['duplicate']} duplicate, "
-        f"{c['conflict']} conflict"
+        f"{c['enriched']} enriched, {c['conflict']} conflict"
     )
     if summary.conflict:
         print(

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -877,13 +877,23 @@ def _cmd_review_conflicts(args: argparse.Namespace) -> int:
 
 
 def _resolved_as(result: dedup.ResolveResult) -> str:
-    """How a resolution reports itself on the success line."""
+    """How a resolution reports itself on the success line.
+
+    A keep-both no-op on a sparse type is only a no-op about the *row count*: it still
+    fills the matched sibling's NULL columns from the staged payload (issue #63). Naming
+    those fields keeps the operator's line honest about the write, matching what
+    `dedup._resolution_text` persists on the conflict. Field names only, never values --
+    the resolution text is an audit trail, not a place to echo clinical data.
+    """
     if result.kept != "both":
         return f"keep-{result.kept}"
     if result.no_op:
+        filled = (
+            f", filled {', '.join(sorted(result.gains))}" if result.gains else ""
+        )
         return (
             f"keep-both, no-op: already stored as {result.record_type} "
-            f"#{result.row_id}"
+            f"#{result.row_id}{filled}"
         )
     return (
         f"keep-both -> {result.record_type} #{result.row_id}, "

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -430,6 +430,7 @@ def _type_names(types: object) -> str:
 class CommitSummary:
     new: list[tuple[str, int]] = field(default_factory=list)          # (type, row_id)
     duplicate: list[tuple[str, str]] = field(default_factory=list)    # (type, dedup_key)
+    enriched: list[tuple[str, int]] = field(default_factory=list)     # (type, row_id)
     conflict: list[tuple[str, int]] = field(default_factory=list)     # (type, conflict_id)
 
     @property
@@ -437,6 +438,7 @@ class CommitSummary:
         return {
             "new": len(self.new),
             "duplicate": len(self.duplicate),
+            "enriched": len(self.enriched),
             "conflict": len(self.conflict),
         }
 
@@ -459,14 +461,23 @@ _COMPARE_FIELDS: dict[str, list[str]] = {
     "condition": ["status", "onset_on", "resolved_on", "relation", "note"],
 }
 
-# Types whose rows are standing facts restated across documents: a missing incoming
-# field means "this document didn't say", not "the value was cleared", so a one-sided
-# None is NOT a disagreement (issue #63). Without this, re-ingesting next year's health
-# summary — which reprints the same 8 allergies but omits criticality — would stage 8
-# conflicts that mean nothing. Present-and-different still always conflicts, and
-# `condition.status` is required so a lifecycle change (active -> resolved) is never
-# skipped. For the date-keyed types (labs, meds ...) a cleared field IS news, so they
-# keep the strict comparison.
+# Types whose rows are standing facts restated across documents. For these, an absent
+# field means "this document didn't say" — never "the value was cleared" (issue #63).
+# That reading is asymmetric, and both halves matter:
+#
+#   incoming None over a stored value -> silence. Re-ingesting next year's health
+#       summary, which reprints the same 8 allergies but omits criticality, must not
+#       stage 8 conflicts that mean nothing.
+#   stored None under a stated incoming value -> a GAIN, not silence. The document is
+#       supplying a fact the record simply lacked; there is no competing value to
+#       adjudicate, so it is neither a conflict nor a duplicate to drop. The stored
+#       row's NULL columns are filled in place (:func:`_sparse_gains`) and the commit
+#       reports it as `enriched`.
+#
+# Present-and-different still always conflicts, and `condition.status` is required so a
+# lifecycle change (active -> resolved) is never skipped. For the date-keyed types
+# (labs, meds ...) a cleared field IS news, so they keep the strict comparison and can
+# never produce a gain.
 _SPARSE_TYPES = frozenset({"allergy", "condition"})
 
 
@@ -489,7 +500,11 @@ def _rows_equal(
     rather than a conflicting one — i.e. their payload fields all agree.
 
     ``existing`` is a stored row (or, in the pass-1 intra-payload check, an earlier
-    row of the same submission)."""
+    row of the same submission).
+
+    For a :data:`_SPARSE_TYPES` row this answers "is there anything to *adjudicate*",
+    which is not the same as "is there nothing to write": a field the incoming row
+    states over a stored NULL agrees here but is reported by :func:`_sparse_gains`."""
     existing_map = dict(existing)
     sparse = record_type in _SPARSE_TYPES
     for name in _COMPARE_FIELDS[record_type]:
@@ -513,6 +528,44 @@ def _rows_equal(
         elif ev != iv:
             return False
     return True
+
+
+def _sparse_gains(
+    record_type: str, existing: sqlite3.Row | dict, incoming: dict
+) -> dict:
+    """Payload fields the incoming row states that the stored row is missing.
+
+    Only :data:`_SPARSE_TYPES` can gain: for every other type a stored NULL under a
+    stated incoming value is a disagreement, so it conflicts and never reaches here.
+    Empty dict = the incoming row adds nothing (a plain duplicate).
+
+    Only NULL columns are filled — a stated value never overwrites a stored one, so
+    enrichment can't launder a disagreement into a silent overwrite (that path still
+    stages a conflict via :func:`_rows_equal`)."""
+    if record_type not in _SPARSE_TYPES:
+        return {}
+    existing_map = dict(existing)
+    return {
+        name: incoming[name]
+        for name in _COMPARE_FIELDS[record_type]
+        if existing_map.get(name) is None and incoming.get(name) is not None
+    }
+
+
+def _enrich_record(
+    conn: sqlite3.Connection, record_type: str, row_id: int, gains: dict
+) -> None:
+    """Fill a stored row's NULL payload columns from a later document's statement.
+
+    ``document_id`` is deliberately left alone: it records which document the row
+    (and its identity) came from, and the identity fields are unchanged here. A row
+    attested by several documents already has this limitation for plain duplicates —
+    enrichment doesn't deepen it."""
+    assignments = ", ".join(f"{name} = ?" for name in gains)
+    conn.execute(
+        f"UPDATE {record_type} SET {assignments} WHERE {record_type}_id = ?",
+        [*gains.values(), row_id],
+    )
 
 
 def commit_extraction(
@@ -600,7 +653,17 @@ def commit_extraction(
                     (f for f in family if _rows_equal(record_type, f, row)), None
                 )
                 if twin is not None:
-                    summary.duplicate.append((record_type, twin["dedup_key"]))
+                    # A standing fact whose stored row lacks a field this document
+                    # states is not a duplicate to drop — fill the NULL in place
+                    # (issue #63). Nothing to adjudicate, so no conflict is staged,
+                    # but the write is reported rather than being invisible.
+                    gains = _sparse_gains(record_type, twin, row)
+                    twin_id = int(twin[f"{record_type}_id"])
+                    if gains:
+                        _enrich_record(conn, record_type, twin_id, gains)
+                        summary.enriched.append((record_type, twin_id))
+                    else:
+                        summary.duplicate.append((record_type, twin["dedup_key"]))
                 else:
                     # Stage against occurrence 0: it is the row the conflict's
                     # dedup_key anchors to, and the reviewer sees the family size.
@@ -736,6 +799,9 @@ class ResolveResult:
     dedup_key: str | None = None
     dedup_base: str | None = None
     no_op: bool = False          # keep-both that matched an existing sibling
+    # Sparse-type fields the matched sibling was missing and the staged payload
+    # supplies; filled in place so a no-op still can't drop stated data (issue #63).
+    gains: dict = field(default_factory=dict)
 
 
 KEEP_CHOICES = ("existing", "incoming", "both")
@@ -806,7 +872,12 @@ def resolve_conflict(
             _overwrite_record(
                 conn, record_type, int(result.row_id), row["document_id"], incoming
             )
-        elif keep == "both" and not result.no_op:
+        elif keep == "both" and result.no_op:
+            if result.gains:
+                _enrich_record(
+                    conn, record_type, int(result.row_id), result.gains
+                )
+        elif keep == "both":
             result.row_id = _insert_record(
                 conn, record_type, json.loads(row["incoming_json"]),
                 row["person_id"], row["document_id"],
@@ -827,7 +898,10 @@ def _resolution_text(result: ResolveResult) -> str:
     if result.kept != "both":
         return f"keep-{result.kept}"
     if result.no_op:
-        return f"keep-both (no-op: matches {result.record_type} #{result.row_id})"
+        matched = f"keep-both (no-op: matches {result.record_type} #{result.row_id}"
+        if result.gains:
+            matched += f"; filled {', '.join(sorted(result.gains))}"
+        return matched + ")"
     return (
         f"keep-both -> {result.record_type} #{result.row_id} "
         f"occurrence={result.occurrence} key={(result.dedup_key or '')[:12]}..."
@@ -957,11 +1031,15 @@ def _plan_keep_both(
     twin = next((f for f in family if _rows_equal(record_type, f, incoming)), None)
     if twin is not None:
         # Two conflicts staged from one payload, both resolved 'both': the second
-        # must not produce a twin row.
+        # must not produce a twin row. On a sparse type the matched sibling may be
+        # strictly thinner than the staged payload (it "matches" because an absent
+        # field is silence); absorbing it would drop the fields the payload adds, so
+        # the no-op still fills those NULLs (issue #63).
         return ResolveResult(
             kept="both", record_type=record_type, row_id=int(twin[pk]),
             occurrence=int(twin["dedup_occurrence"]),
             dedup_key=twin["dedup_key"], dedup_base=twin["dedup_base"], no_op=True,
+            gains=_sparse_gains(record_type, twin, incoming),
         )
 
     # Occurrence numbers are monotonic over the family and never reused, so a removed
@@ -1095,10 +1173,19 @@ def _overwrite_record(
     error, never a silent success - it would discard the incoming row while the
     conflict is marked resolved. The guard only catches *no* row, not the *wrong*
     row; picking the right one is :func:`_conflict_family`'s job.
+
+    On a :data:`_SPARSE_TYPES` row, fields the incoming row does not state are left as
+    stored rather than nulled: for a standing fact an absent field is "this document
+    didn't say", so a single-field adjudication ("criticality: low, not high") must not
+    also erase the reaction and noted_on the incoming document simply didn't repeat
+    (issue #63). Fields it *does* state win, which is what keep-incoming means.
     """
+    sparse = record_type in _SPARSE_TYPES
     assignments = ["document_id = ?"]
     values: list[object] = [document_id]
     for name in _COMPARE_FIELDS[record_type]:
+        if sparse and incoming.get(name) is None:
+            continue
         assignments.append(f"{name} = ?")
         values.append(incoming.get(name))
     values.append(row_id)

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -77,6 +77,24 @@ FIELD_SPECS: dict[str, dict[str, tuple[object, bool]]] = {
         "value_text": (str, False),
         "unit": (str, False),
     },
+    # Promoted out of `observation` by migration 006 (issue #63): both carry fields the
+    # generic shape has no legal home for (two dates on a resolved problem; an allergy's
+    # machine-readable criticality) and both need a subject discriminator in the key so a
+    # relative's diagnosis never dedups into the patient's own problem list.
+    "allergy": {
+        "substance": (str, True),
+        "reaction": (str, False),
+        "criticality": (str, False),
+        "noted_on": (str, False),
+    },
+    "condition": {
+        "name": (str, True),
+        "status": (str, True),
+        "onset_on": (str, False),
+        "resolved_on": (str, False),
+        "relation": (str, False),
+        "note": (str, False),
+    },
 }
 
 KNOWN_TYPES = tuple(FIELD_SPECS)
@@ -95,6 +113,22 @@ DATE_FIELDS: dict[str, frozenset[str]] = {
     "procedure": frozenset({"performed_on"}),
     "appointment": frozenset({"scheduled_for"}),
     "observation": frozenset({"observed_at"}),
+    "allergy": frozenset({"noted_on"}),
+    "condition": frozenset({"onset_on", "resolved_on"}),
+}
+
+# Closed vocabularies per record type, enforced by validate_row right after the
+# DATE_FIELDS check. Only fields the read layer *branches on* belong here: a typo'd
+# `condition.status='inactive'` would vanish from every rendered section rather than
+# show up wrong, which is the failure mode worth a hard reject. Membership is tested on
+# :func:`enum_token` (case/space/underscore/hyphen-insensitive) but the **verbatim**
+# value is stored, mirroring how `_norm_unit` compares case-insensitively while display
+# casing survives.
+ENUM_FIELDS: dict[str, dict[str, frozenset[str]]] = {
+    "allergy": {"criticality": frozenset({"high", "low", "unable-to-assess"})},
+    "condition": {
+        "status": frozenset({"active", "resolved", "history", "family-history"})
+    },
 }
 
 _WS = re.compile(r"\s+")
@@ -206,6 +240,21 @@ def norm(value: object, dictionary: dict[str, str] | None = None) -> str:
     return collapsed
 
 
+def enum_token(value: object) -> str:
+    """Canonical comparison form of an :data:`ENUM_FIELDS` value.
+
+    Case-, space-, underscore- and hyphen-insensitive: ``"Unable to Assess"``,
+    ``"unable_to_assess"`` and ``"unable-to-assess"`` all reduce to
+    ``unable-to-assess``, so a source's own casing/punctuation validates while the
+    verbatim value is what gets stored. Also the comparison the read layer uses when it
+    branches on a stored ``status`` (render sections, timeline) — reading the raw column
+    would miss a row stored as ``"Family History"``.
+    """
+    if value is None:
+        return ""
+    return _collapse(str(value)).replace(" ", "-")
+
+
 def _date_only(value: object) -> str:
     """Date portion of an ISO datetime/date string ('2026-01-02T09:00' -> '2026-01-02')."""
     if value is None:
@@ -257,7 +306,28 @@ def _key_parts(
         return [person_id, n("provider"), _date_only(row.get("scheduled_for"))]
     if record_type == "observation":
         return [person_id, n("obs_type"), _norm_ts(row.get("observed_at")), n("key")]
+    # allergy/condition are DATE-FREE by design: they are standing facts restated on
+    # every document with inconsistent or absent dates, so a date in the key would fork
+    # one allergy into one row per document. The dates are payload, and a disagreement
+    # in them stages a conflict (issue #63 design).
+    if record_type == "allergy":
+        return [person_id, n("substance")]
+    if record_type == "condition":
+        return [person_id, n("name"), _condition_subject(row, dictionary)]
     raise ValidationError(f"unknown record type: {record_type}")  # guarded by validate()
+
+
+def _condition_subject(row: dict, dictionary: dict[str, str] | None = None) -> str:
+    """Whose condition this is — the discriminator that keeps a relative's diagnosis out
+    of the patient's own problem list.
+
+    ``self`` for every status but ``family-history``, which keys on the relative instead
+    (``family:mother``). Two relatives with the same disease therefore stay distinct rows,
+    and neither collides with the patient's.
+    """
+    if enum_token(row.get("status")) != "family-history":
+        return "self"
+    return "family:" + norm(row.get("relation"), dictionary)
 
 
 def identity_label(
@@ -338,6 +408,12 @@ def validate_row(record_type: str, row: object) -> None:
                 f"(YYYY-MM) or full (YYYY-MM-DD) precision, or a full-date ISO "
                 f"timestamp, got {value!r}"
             )
+        allowed = ENUM_FIELDS.get(record_type, {}).get(name)
+        if allowed is not None and enum_token(value) not in allowed:
+            raise ValidationError(
+                f"{record_type}.{name}: expected one of "
+                f"{', '.join(sorted(allowed))}, got {value!r}"
+            )
 
 
 def _type_names(types: object) -> str:
@@ -379,7 +455,19 @@ _COMPARE_FIELDS: dict[str, list[str]] = {
     "procedure": ["provider", "outcome"],
     "appointment": ["specialty", "reason", "summary"],
     "observation": ["value_num", "value_text", "unit"],
+    "allergy": ["reaction", "criticality", "noted_on"],
+    "condition": ["status", "onset_on", "resolved_on", "relation", "note"],
 }
+
+# Types whose rows are standing facts restated across documents: a missing incoming
+# field means "this document didn't say", not "the value was cleared", so a one-sided
+# None is NOT a disagreement (issue #63). Without this, re-ingesting next year's health
+# summary — which reprints the same 8 allergies but omits criticality — would stage 8
+# conflicts that mean nothing. Present-and-different still always conflicts, and
+# `condition.status` is required so a lifecycle change (active -> resolved) is never
+# skipped. For the date-keyed types (labs, meds ...) a cleared field IS news, so they
+# keep the strict comparison.
+_SPARSE_TYPES = frozenset({"allergy", "condition"})
 
 
 def _stored_fields(record_type: str, row_map: dict) -> dict:
@@ -403,10 +491,14 @@ def _rows_equal(
     ``existing`` is a stored row (or, in the pass-1 intra-payload check, an earlier
     row of the same submission)."""
     existing_map = dict(existing)
+    sparse = record_type in _SPARSE_TYPES
     for name in _COMPARE_FIELDS[record_type]:
         ev = existing_map.get(name)
         iv = incoming.get(name)
         if ev is None and iv is None:
+            continue
+        # Standing facts: one side simply not stating a field is silence, not a change.
+        if sparse and (ev is None or iv is None):
             continue
         # Unit strings are compared case-insensitively so casing variants across
         # documents don't stage a spurious conflict.
@@ -885,8 +977,10 @@ def _rekey_label(record_type: str, row: sqlite3.Row) -> str:
     """Short human identifier for a row in `pemr rekey` output ("CL", "Metformin")."""
     if record_type == "lab_result":
         return row["test_name"] or ""
-    if record_type in ("medication", "procedure"):
+    if record_type in ("medication", "procedure", "condition"):
         return row["name"] or ""
+    if record_type == "allergy":
+        return row["substance"] or ""
     if record_type == "appointment":
         return " ".join(p for p in (row["provider"], row["scheduled_for"]) if p)
     return " ".join(p for p in (row["obs_type"], row["key"]) if p)  # observation

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -227,6 +227,7 @@ def commit_extraction(
         "counts": summary.counts,
         "new": summary.new,
         "duplicate": summary.duplicate,
+        "enriched": summary.enriched,
         "conflict": summary.conflict,
     }
 

--- a/pemr/persons.py
+++ b/pemr/persons.py
@@ -31,7 +31,7 @@ _EDITABLE_FIELDS = ("full_name", "dob", "sex", "blood_type", "notes")
 # otherwise fail with an IntegrityError, and destroying medical history is irreversible.
 _CHILD_TABLES = (
     "document", "lab_result", "medication", "procedure",
-    "appointment", "observation", "conflict",
+    "appointment", "observation", "condition", "allergy", "conflict",
 )
 
 

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -20,7 +20,7 @@ import sqlite3
 from datetime import date, datetime
 
 from . import db
-from .dedup import norm
+from .dedup import enum_token, norm
 
 # Word tokens for a safe FTS5 query: strips punctuation/operators so raw user input
 # can never be mis-parsed as FTS syntax (each token is quoted as a phrase, AND-ed).
@@ -171,7 +171,9 @@ def query_timeline(
     """Merged chronological event stream across the typed tables + observations.
 
     Each event carries ``date``, ``type``, a one-line ``summary`` and ``document_id``
-    provenance. Medications contribute up to two events (start and, if ended, stop).
+    provenance. Medications contribute up to two events (start and, if ended, stop), and
+    so do conditions (``onset_on`` -> ``condition``, ``resolved_on`` ->
+    ``condition-resolved``); family-history rows contribute none.
     Events without a usable date are omitted (they cannot be placed on a timeline).
     ``since`` (a date) drops events strictly before it. Ordered oldest first.
     """
@@ -227,6 +229,22 @@ def query_timeline(
         detail = " ".join(parts)
         val = "" if value is None else f" = {value}{unit}"
         add(r["observed_at"], "observation", f"{detail}{val}".strip(), r["document_id"])
+
+    for r in conn.execute(
+        "SELECT * FROM condition WHERE person_id = ?", (person_id,)
+    ).fetchall():
+        # A relative's onset date is not an event in *this* patient's chronology, so
+        # family history is deliberately absent from the timeline (issue #63).
+        if enum_token(r["status"]) == "family-history":
+            continue
+        add(r["onset_on"], "condition", f"{r['name']} ({r['status']})", r["document_id"])
+        add(r["resolved_on"], "condition-resolved", f"resolved {r['name']}",
+            r["document_id"])
+
+    for r in conn.execute(
+        "SELECT * FROM allergy WHERE person_id = ?", (person_id,)
+    ).fetchall():
+        add(r["noted_on"], "allergy", f"{r['substance']} allergy", r["document_id"])
 
     if since:
         cutoff = _date_part(since)

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -8,13 +8,15 @@ optional synonym ``dictionary`` and a ``now`` for a deterministic generated-at s
 phase 5's MCP wrapper stays thin. The CLI owns argument parsing and the §5
 stdout/redirect contract; nothing here writes to the DB, ever.
 
+**Conditions and allergies are typed tables**, not observations, since migration 006
+(issue #63): ``condition`` (``name`` + a ``status`` of active/resolved/history/
+family-history, ``onset_on``/``resolved_on``, ``relation`` for a family entry) feeds the
+Active Problems / Past Medical History / Family History sections, and ``allergy``
+(``substance``, ``reaction``, ``criticality``, ``noted_on``) feeds Allergies.
+
 Observation conventions (decided for this phase, documented alongside the dictionary's
 canonical *vital* vocabulary in ``data/dictionary.example.toml``):
 
-  * **conditions** -> ``observation`` rows with ``obs_type='condition'`` (the condition
-    name in ``key``, optional detail in ``value_text``).
-  * **allergies**  -> ``observation`` rows with ``obs_type='allergy'`` (the allergen in
-    ``key``, optional reaction in ``value_text``).
   * **vitals**     -> ``observation`` rows with ``obs_type='vital'`` whose ``key`` is one
     of the dictionary's canonical vital tokens (``blood_pressure``, ``weight`` ...).
     "Latest vitals" is the most recent row per normalized ``key``.
@@ -39,13 +41,17 @@ import sqlite3
 from datetime import datetime
 
 from . import db, query
-from .dedup import norm
+from .dedup import enum_token, norm
 
 # Observation obs_type conventions this layer reads (see module docstring).
-OBS_CONDITION = "condition"
-OBS_ALLERGY = "allergy"
 OBS_VITAL = "vital"
 OBS_ORDER = "order"
+
+# `condition.status` buckets, one rendered section each (family history last: it is
+# context about relatives, not the patient's own record).
+CONDITION_ACTIVE = ("active",)
+CONDITION_PAST = ("resolved", "history")
+CONDITION_FAMILY = "family-history"
 
 # Default window for "recent labs" in an appointment brief (last N most recent).
 _BRIEF_RECENT_LABS = 10
@@ -122,6 +128,51 @@ def _observations(conn: sqlite3.Connection, person_id: int, obs_type: str) -> li
     return [dict(r) for r in rows]
 
 
+def _conditions(
+    conn: sqlite3.Connection, person_id: int, statuses: tuple[str, ...] | str
+) -> list[dict]:
+    """Condition rows in one status bucket, ordered by name.
+
+    Filtering happens in Python on :func:`enum_token` rather than in SQL: the column
+    stores the source's verbatim casing (``"Family History"`` validates and is stored as
+    written), so a literal ``WHERE status = 'family-history'`` would silently drop rows.
+    """
+    wanted = {statuses} if isinstance(statuses, str) else set(statuses)
+    rows = conn.execute(
+        "SELECT * FROM condition WHERE person_id = ? ORDER BY name, condition_id",
+        (person_id,),
+    ).fetchall()
+    return [dict(r) for r in rows if enum_token(r["status"]) in wanted]
+
+
+def _allergies(conn: sqlite3.Connection, person_id: int) -> list[dict]:
+    """Allergy rows, ``criticality='high'`` first then alphabetical -- the dangerous ones
+    have to survive a skim of the list."""
+    rows = conn.execute(
+        "SELECT * FROM allergy WHERE person_id = ? ORDER BY substance, allergy_id",
+        (person_id,),
+    ).fetchall()
+    return sorted(
+        (dict(r) for r in rows), key=lambda r: enum_token(r["criticality"]) != "high"
+    )
+
+
+def _condition_line(row: dict, *, past: bool = False) -> str:
+    since = f"  (since {row['onset_on']})" if row["onset_on"] else ""
+    resolved = (
+        f"  (resolved {row['resolved_on']})" if past and row["resolved_on"] else ""
+    )
+    note = f" - {row['note']}" if row["note"] else ""
+    return f"- {row['name']}{since}{resolved}{note}"
+
+
+def _allergy_line(row: dict) -> str:
+    crit = f" [{str(row['criticality']).upper()}]" if row["criticality"] else ""
+    reaction = f" - {row['reaction']}" if row["reaction"] else ""
+    noted = f"  (noted {row['noted_on']})" if row["noted_on"] else ""
+    return f"- {row['substance']}{crit}{reaction}{noted}"
+
+
 def _latest_vitals(
     conn: sqlite3.Connection, person_id: int, dictionary: dict[str, str] | None
 ) -> list[dict]:
@@ -171,7 +222,8 @@ def _open_appointments(
 
 def _row_counts(conn: sqlite3.Connection, person_id: int) -> dict[str, int]:
     counts = {}
-    for table in ("lab_result", "medication", "procedure", "appointment", "observation"):
+    for table in ("lab_result", "medication", "procedure", "appointment",
+                  "observation", "condition", "allergy"):
         counts[table] = conn.execute(
             f"SELECT COUNT(*) AS n FROM {table} WHERE person_id = ?", (person_id,)
         ).fetchone()["n"]
@@ -230,8 +282,9 @@ def render_summary(
     dictionary: dict[str, str] | None = None,
     now: datetime | None = None,
 ) -> str:
-    """Markdown master summary for a person: active meds, conditions, allergies, latest
-    vitals, recent abnormal labs, upcoming/open appointments, and any open conflicts --
+    """Markdown master summary for a person: active meds, active problems, past medical
+    history, family history, allergies, orders, latest vitals, recent abnormal labs,
+    upcoming/open appointments, and any open conflicts --
     with a self-identifying header (name, DOB, generated-at, source row counts).
     Read-only.
 
@@ -255,7 +308,8 @@ def render_summary(
         f"- Source rows: labs={counts['lab_result']}, "
         f"medications={counts['medication']}, procedures={counts['procedure']}, "
         f"appointments={counts['appointment']}, "
-        f"observations={counts['observation']}\n"
+        f"observations={counts['observation']}, "
+        f"conditions={counts['condition']}, allergies={counts['allergy']}\n"
     )
 
     meds = query.query_meds(conn, slug, active=True, now=now)
@@ -266,16 +320,18 @@ def render_summary(
         since = f" (since {m['started_on']})" if m["started_on"] else ""
         med_lines.append(f"- {m['name']}{dose}{freq}{since}")
 
-    cond_lines = [
-        f"- {c['key'] or c['value_text'] or '(unspecified)'}"
-        + (f" - {c['value_text']}" if c["key"] and c["value_text"] else "")
-        for c in _observations(conn, person_id, OBS_CONDITION)
+    active_lines = [
+        _condition_line(c) for c in _conditions(conn, person_id, CONDITION_ACTIVE)
     ]
-    allergy_lines = [
-        f"- {a['key'] or a['value_text'] or '(unspecified)'}"
-        + (f" - {a['value_text']}" if a["key"] and a["value_text"] else "")
-        for a in _observations(conn, person_id, OBS_ALLERGY)
+    past_lines = [
+        _condition_line(c, past=True)
+        for c in _conditions(conn, person_id, CONDITION_PAST)
     ]
+    family_lines = [
+        f"- {c['relation'] or 'family'}: {c['name']}"
+        for c in _conditions(conn, person_id, CONDITION_FAMILY)
+    ]
+    allergy_lines = [_allergy_line(a) for a in _allergies(conn, person_id)]
     order_lines = [
         f"- {o['key'] or o['value_text'] or '(unspecified)'}"
         + (f" - {o['value_text']}" if o["key"] and o["value_text"] else "")
@@ -304,7 +360,9 @@ def render_summary(
     parts = [
         header,
         _section("Active Medications", med_lines),
-        _section("Conditions", cond_lines),
+        _section("Active Problems", active_lines),
+        _section("Past Medical History", past_lines),
+        _section("Family History", family_lines),
         _section("Allergies", allergy_lines),
         _section("Orders & Referrals", order_lines),
         _section("Latest Vitals", vital_lines),
@@ -331,8 +389,12 @@ def render_brief(
 ) -> str:
     """Markdown walk-in brief for one appointment: the appointment header, current meds,
     recent labs (last N, newest draw first and abnormal-before-normal inside each draw),
-    procedures + observations, and an open-conflicts warning if any
-    staged rows touch this person. Read-only.
+    allergies, active problems, procedures + observations, and an open-conflicts warning
+    if any staged rows touch this person. Read-only.
+
+    Allergies and active problems are their own sections here (issue #63): a brief handed
+    to a clinician that omits allergies is a safety gap, and since migration 006 moved
+    them out of ``observation`` the generic observation loop no longer surfaces them.
 
     Med-interaction flags and suggested questions require external drug knowledge and are
     NOT deterministic engine work (Architecture.md §Open questions); a placeholder section
@@ -422,6 +484,11 @@ def render_brief(
             f"- {_date_part(o['observed_at']) or '(undated)'}  {detail}{val}"
         )
 
+    brief_allergy_lines = [_allergy_line(a) for a in _allergies(conn, person_id)]
+    brief_problem_lines = [
+        _condition_line(c) for c in _conditions(conn, person_id, CONDITION_ACTIVE)
+    ]
+
     conflict_lines = _open_conflict_lines(conn, person_id)
 
     interaction = _section(
@@ -439,6 +506,8 @@ def render_brief(
         appt_block,
         _section("Current Medications", med_lines),
         _section(f"Recent Labs (last {recent_labs}, abnormal first)", lab_lines),
+        _section("Allergies", brief_allergy_lines),
+        _section("Active Problems", brief_problem_lines),
         _section("Procedures & Observations", ctx_lines),
         _section("Open Conflicts", conflict_lines, empty="_none_"),
         interaction,

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -33,6 +33,8 @@ COUNTED_TABLES = (
     "procedure",
     "appointment",
     "observation",
+    "condition",
+    "allergy",
     "conflict",
     "record_fts",
 )

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -353,3 +353,49 @@ def test_rekey_refuses_a_fusing_dictionary(ready, capsys, tmp_path):
     assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 1
     err = capsys.readouterr().err
     assert "same dedup_key" in err and "nothing was written" in err
+
+
+def _stage_pre_006(tmp_path):
+    """Copy every migration below 006 into a staging dir (leaving 006 pending)."""
+    import shutil
+
+    staged = tmp_path / "pre006"
+    staged.mkdir()
+    for path in sorted(db.DEFAULT_MIGRATIONS_DIR.glob("*.sql")):
+        if path.name < "006":
+            shutil.copy(path, staged / path.name)
+    return staged
+
+
+def test_migrate_prints_the_rekey_followup_when_006_moves_rows(tmp_path, capsys):
+    """Migration 006 carries the old observation dedup keys forward (SQL cannot compute
+    the new sha256 ones), so `migrate` has to name the follow-up or a re-commit of an
+    already-stored allergy/condition silently forks a second row (issue #63)."""
+    staged = _stage_pre_006(tmp_path)
+    assert _run(tmp_path, "migrate", "--create", "--migrations-dir", str(staged)) == 0
+    conn = db.connect(tmp_path / "cli.db")
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane-doe', 'Jane')")
+    conn.execute(
+        "INSERT INTO observation (person_id, obs_type, key, dedup_key, dedup_base) "
+        "VALUES (1, 'allergy', 'Penicillin', 'k1', 'k1')"
+    )
+    conn.commit()
+    conn.close()
+    capsys.readouterr()
+
+    assert _run(tmp_path, "migrate") == 0
+    out = capsys.readouterr().out
+    assert "applied 006_condition_allergy.sql" in out
+    assert "note: run `pemr rekey --apply`" in out and "1 allergy/condition row" in out
+    # ... and it is not repeated on a no-op re-run.
+    assert _run(tmp_path, "migrate") == 0
+    assert capsys.readouterr().out.strip() == "up to date"
+
+
+def test_migrate_of_a_fresh_database_has_no_rekey_followup(tmp_path, capsys):
+    """Nothing moved, nothing to rekey - a note nobody must act on trains people to
+    skip notes."""
+    assert _run(tmp_path, "migrate", "--create") == 0
+    out = capsys.readouterr().out
+    assert "applied 006_condition_allergy.sql" in out
+    assert "note:" not in out

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -399,3 +399,43 @@ def test_migrate_of_a_fresh_database_has_no_rekey_followup(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "applied 006_condition_allergy.sql" in out
     assert "note:" not in out
+
+
+def test_keep_both_no_op_line_names_the_fields_it_filled(ready, capsys):
+    """A keep-both no-op on a sparse type still writes: it fills the matched sibling's
+    NULL columns. The operator's line must say so - reporting a clinical write as a bare
+    "no-op" is the invisible-write failure the `enriched` bucket exists to prevent
+    (issue #63). The persisted resolution already names the fields; the CLI line did not.
+    """
+    tmp_path = ready
+    scan = tmp_path / "a.txt"
+    scan.write_bytes(b"allergy list")
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources")) == 0
+    for name, rows in (
+        ("a1", [{"substance": "Latex", "reaction": "hives"}]),
+        ("a2", [{"substance": "Latex", "reaction": "rash", "criticality": "high"}]),
+        ("a3", [{"substance": "Latex", "reaction": "rash"}]),
+    ):
+        payload = _write_json(tmp_path, f"{name}.json", {"allergy": rows})
+        assert _run(tmp_path, "commit-extraction", "--document", "1",
+                    "--json", str(payload)) == 0
+    capsys.readouterr()
+
+    # Admit the thin "rash" row first, so the rich one then matches a sibling missing
+    # exactly the field the promotion was about.
+    assert _run(tmp_path, "review-conflicts", "--resolve", "2", "--keep", "both") == 0
+    capsys.readouterr()
+    assert _run(tmp_path, "review-conflicts", "--resolve", "1", "--keep", "both") == 0
+    out = capsys.readouterr().out
+    assert "no-op" in out and "filled criticality" in out
+    assert out.isascii()
+
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        stored = conn.execute(
+            "SELECT reaction, criticality FROM allergy WHERE reaction = 'rash'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert (stored["reaction"], stored["criticality"]) == ("rash", "high")

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -114,7 +114,7 @@ def repeat_draw(conn):
         conn, _doc(conn, "draw-2"),
         {"lab_result": [_glucose(148, "2-hour post-prandial draw")]},
     )
-    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
     return dedup.list_conflicts(conn)[0]["conflict_id"]
 
 
@@ -169,7 +169,7 @@ def test_recommit_of_an_admitted_draw_dedups_instead_of_forking(conn, repeat_dra
         conn, _doc(conn, "draw-3"),
         {"lab_result": [_glucose(148, "2-hour post-prandial draw")]},
     )
-    assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
     # It deduped against the sibling, not against occurrence 0.
     sibling_key = conn.execute(
@@ -186,7 +186,7 @@ def test_a_changed_value_on_an_admitted_identity_restages_a_conflict(conn, repea
         conn, _doc(conn, "draw-4"),
         {"lab_result": [_glucose(210, "third draw")]},
     )
-    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
 
 
@@ -277,7 +277,7 @@ def orphaned_family(conn, repeat_draw):
     summary = dedup.commit_extraction(
         conn, _doc(conn, "draw-5"), {"lab_result": [_glucose(210, "third draw")]}
     )
-    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
     conflict = dedup.list_conflicts(conn)[0]
     survivor = conn.execute("SELECT * FROM lab_result").fetchone()
     # The premise of the regression: key-targeted writes cannot find this row.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -14,6 +14,8 @@ EXPECTED_TABLES = {
     "procedure",
     "appointment",
     "observation",
+    "condition",
+    "allergy",
     "conflict",
     "schema_migrations",
 }
@@ -37,10 +39,15 @@ ALL_MIGRATIONS = [
     "003_fts.sql",
     "004_person_deactivate.sql",
     "005_dedup_occurrence.sql",
+    "006_condition_allergy.sql",
 ]
 
-# Every record table carries the occurrence-family columns (migration 005).
-RECORD_TABLES = ("lab_result", "medication", "procedure", "appointment", "observation")
+# Every record table carries the occurrence-family columns (migration 005; 006's two
+# new tables were born with them).
+RECORD_TABLES = (
+    "lab_result", "medication", "procedure", "appointment", "observation",
+    "condition", "allergy",
+)
 
 
 def test_migrate_creates_all_tables(conn):
@@ -88,6 +95,77 @@ def test_occurrence_defaults_to_zero_for_a_bare_insert(conn):
     )
     row = conn.execute("SELECT dedup_occurrence FROM lab_result").fetchone()
     assert row["dedup_occurrence"] == 0
+
+
+def _migrate_through_005(conn, tmp_path):
+    """Apply every migration up to 005 into a staging dir, leaving 006 pending."""
+    import shutil
+
+    staged = tmp_path / "pre006"
+    staged.mkdir()
+    for path in sorted(db.DEFAULT_MIGRATIONS_DIR.glob("*.sql")):
+        if path.name < "006":
+            shutil.copy(path, staged / path.name)
+    db.migrate(conn, staged)
+    return staged
+
+
+def test_migration_006_moves_condition_and_allergy_observations(conn, tmp_path):
+    """The upgrade path (issue #63): rows committed under the old `obs_type` convention
+    land in the typed tables, keep their keys and provenance, and leave `observation`."""
+    _migrate_through_005(conn, tmp_path)
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane', 'Jane')")
+    conn.executemany(
+        "INSERT INTO observation (person_id, obs_type, observed_at, key, value_text, "
+        "dedup_key, dedup_base) VALUES (1, ?, ?, ?, ?, ?, ?)",
+        [
+            ("allergy", "2010-01-01", "Penicillin", "rash", "k-allergy", "k-allergy"),
+            ("condition", "2024-01-01", "Type 2 Diabetes", "dx by PCP", "k-cond", "k-cond"),
+            ("vital", "2026-01-01", "weight", None, "k-vital", "k-vital"),
+        ],
+    )
+    conn.commit()
+
+    assert db.migrate(conn) == ["006_condition_allergy.sql"]
+
+    a = conn.execute("SELECT * FROM allergy").fetchone()
+    assert (a["substance"], a["reaction"], a["noted_on"]) == (
+        "Penicillin", "rash", "2010-01-01")
+    assert a["dedup_key"] == "k-allergy" and a["dedup_base"] == "k-allergy"
+    c = conn.execute("SELECT * FROM condition").fetchone()
+    assert (c["name"], c["note"], c["onset_on"]) == (
+        "Type 2 Diabetes", "dx by PCP", "2024-01-01")
+    assert c["status"] == "active"       # the honest reading: the old convention had none
+    assert c["dedup_key"] == "k-cond"
+
+    # The vital stays behind; the two moved rows are gone from `observation`.
+    left = [r["obs_type"] for r in conn.execute("SELECT * FROM observation")]
+    assert left == ["vital"]
+
+    # FTS follows them (the triggers are created before the move, so no backfill).
+    hits = {
+        (r["source_table"], r["source_id"])
+        for r in conn.execute(
+            "SELECT source_table, source_id FROM record_fts WHERE record_fts MATCH ?",
+            ("Penicillin OR Diabetes",),
+        )
+    }
+    assert hits == {("allergy", 1), ("condition", 1)}
+
+
+def test_migration_006_keeps_keyless_rows_in_observation(conn, tmp_path):
+    """A legacy row with no `key` has no allergen/problem name, and `substance`/`name`
+    are NOT NULL - it stays put for a human rather than being dropped."""
+    _migrate_through_005(conn, tmp_path)
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane', 'Jane')")
+    conn.execute(
+        "INSERT INTO observation (person_id, obs_type, value_text, dedup_key, dedup_base) "
+        "VALUES (1, 'allergy', 'unspecified reaction', 'k1', 'k1')"
+    )
+    conn.commit()
+    db.migrate(conn)
+    assert conn.execute("SELECT COUNT(*) AS n FROM allergy").fetchone()["n"] == 0
+    assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 1
 
 
 def test_multi_statement_migration_rolls_back_partial_ddl(conn, tmp_path):

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -269,7 +269,7 @@ def test_commit_inserts_new_rows(conn):
     doc = _make_document(conn)
     d = dedup.load_dictionary(DICT_PATH)
     summary = dedup.commit_extraction(conn, doc, {"lab_result": [_lab(5.7)]}, d)
-    assert summary.counts == {"new": 1, "duplicate": 0, "conflict": 0}
+    assert summary.counts == {"new": 1, "duplicate": 0, "enriched": 0, "conflict": 0}
     row = conn.execute("SELECT * FROM lab_result").fetchone()
     assert row["test_name"] == "HbA1c" and row["value_num"] == 5.7
 
@@ -298,7 +298,7 @@ def test_differing_value_stages_conflict(conn):
     # same person/analyte/date (the dedup key) but a corrected value -> conflict.
     # The value is no longer in the key, so this fires regardless of magnitude.
     summary = dedup.commit_extraction(conn, doc2, {"lab_result": [_lab(6.2)]}, d)
-    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
     # original row untouched, no second lab row inserted
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
     assert conn.execute("SELECT value_num FROM lab_result").fetchone()["value_num"] == 5.7
@@ -317,7 +317,7 @@ def test_unit_casing_difference_is_duplicate_not_conflict(conn):
           "unit": "mg/dL"}
     dedup.commit_extraction(conn, doc1, {"lab_result": [r1]}, d)
     summary = dedup.commit_extraction(conn, doc2, {"lab_result": [r2]}, d)
-    assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
 
 
@@ -343,9 +343,11 @@ def test_real_corpus_overlap_dedups_not_splits(conn):
         for i, (_report, csv) in enumerate(_CORPUS_VARIANTS)
     ]
     s1 = dedup.commit_extraction(conn, doc_report, {"lab_result": report_rows}, d)
-    assert s1.counts == {"new": len(_CORPUS_VARIANTS), "duplicate": 0, "conflict": 0}
+    assert s1.counts == {
+        "new": len(_CORPUS_VARIANTS), "duplicate": 0, "enriched": 0, "conflict": 0}
     s2 = dedup.commit_extraction(conn, doc_csv, {"lab_result": csv_rows}, d)
-    assert s2.counts == {"new": 0, "duplicate": len(_CORPUS_VARIANTS), "conflict": 0}
+    assert s2.counts == {
+        "new": 0, "duplicate": len(_CORPUS_VARIANTS), "enriched": 0, "conflict": 0}
     # One row per analyte, not two — the split-series / double-count damage is gone.
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] \
         == len(_CORPUS_VARIANTS)
@@ -362,7 +364,7 @@ def test_corrected_value_still_conflicts_after_normalization(conn):
           "value_num": 13.4, "unit": "G/DL"}  # same draw, corrected value
     dedup.commit_extraction(conn, doc1, {"lab_result": [r1]}, d)
     summary = dedup.commit_extraction(conn, doc2, {"lab_result": [r2]}, d)
-    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
 
 
 def test_far_apart_correction_conflicts_not_duplicates(conn):
@@ -378,7 +380,7 @@ def test_far_apart_correction_conflicts_not_duplicates(conn):
           "unit": "mg/dL"}  # OCR re-read of the *same* draw, wildly different value
     dedup.commit_extraction(conn, doc1, {"lab_result": [r1]}, d)
     summary = dedup.commit_extraction(conn, doc2, {"lab_result": [r2]}, d)
-    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
 
 
@@ -394,7 +396,7 @@ def test_serial_same_day_draws_are_distinct_rows(conn):
          "unit": "mg/dL"},
     ]
     summary = dedup.commit_extraction(conn, doc, {"lab_result": rows}, d)
-    assert summary.counts == {"new": 2, "duplicate": 0, "conflict": 0}
+    assert summary.counts == {"new": 2, "duplicate": 0, "enriched": 0, "conflict": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
 
 
@@ -410,7 +412,7 @@ def test_observation_correction_conflicts_not_duplicates(conn):
           "value_num": 155}  # re-read of the same measurement, corrected value
     dedup.commit_extraction(conn, doc1, {"observation": [o1]}, d)
     summary = dedup.commit_extraction(conn, doc2, {"observation": [o2]}, d)
-    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
     assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 1
 
 
@@ -425,7 +427,7 @@ def test_serial_same_day_observations_are_distinct_rows(conn):
          "value_num": 138},
     ]
     summary = dedup.commit_extraction(conn, doc, {"observation": rows}, d)
-    assert summary.counts == {"new": 2, "duplicate": 0, "conflict": 0}
+    assert summary.counts == {"new": 2, "duplicate": 0, "enriched": 0, "conflict": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 2
 
 
@@ -457,7 +459,7 @@ def test_intra_payload_identical_rows_still_report_duplicate(conn):
     doc = _make_document(conn)
     row = {"test_name": "Glucose", "collected_at": "2024-04-01", "value_num": 95}
     summary = dedup.commit_extraction(conn, doc, {"lab_result": [dict(row), dict(row)]})
-    assert summary.counts == {"new": 1, "duplicate": 1, "conflict": 0}
+    assert summary.counts == {"new": 1, "duplicate": 1, "enriched": 0, "conflict": 0}
 
 
 def test_intra_payload_collision_checked_per_record_type(conn):
@@ -526,7 +528,7 @@ def test_migration_005_preserves_pre_existing_keys(tmp_path):
         # And the pre-005 row still dedups against a fresh commit of the same fact.
         doc = _make_document(conn)
         summary = dedup.commit_extraction(conn, doc, {"lab_result": [row]})
-        assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
+        assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
     finally:
         conn.close()
 
@@ -623,7 +625,7 @@ def test_rekey_apply_restores_dedup_for_a_renamed_analyte(conn):
 
     doc2 = _make_document(conn)
     summary = dedup.commit_extraction(conn, doc2, {"lab_result": [row]}, d_new)
-    assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
 
 
@@ -738,7 +740,7 @@ def test_allergy_key_is_date_free(conn):
         {"substance": "Penicillin", "reaction": "rash", "noted_on": "2010-01-01"}]})
     summary = _commit(conn, {"allergy": [
         {"substance": "penicillin", "reaction": "rash", "noted_on": "2021-06-01"}]})
-    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
     assert conn.execute("SELECT COUNT(*) AS n FROM allergy").fetchone()["n"] == 1
 
 
@@ -750,7 +752,7 @@ def test_condition_family_history_does_not_collide_with_the_patients_own(conn):
         {"name": "Type 2 Diabetes", "status": "family-history", "relation": "mother"},
         {"name": "Type 2 Diabetes", "status": "family-history", "relation": "father"},
     ]})
-    assert summary.counts == {"new": 3, "duplicate": 0, "conflict": 0}
+    assert summary.counts == {"new": 3, "duplicate": 0, "enriched": 0, "conflict": 0}
 
 
 def test_condition_lifecycle_change_stages_a_conflict(conn):
@@ -759,7 +761,7 @@ def test_condition_lifecycle_change_stages_a_conflict(conn):
     _commit(conn, {"condition": [{"name": "Anemia", "status": "active"}]})
     summary = _commit(conn, {"condition": [
         {"name": "Anemia", "status": "resolved", "resolved_on": "2025-09-01"}]})
-    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
 
     conflict_id = dedup.list_conflicts(conn)[0]["conflict_id"]
     dedup.resolve_conflict(conn, conflict_id, keep="incoming")
@@ -773,11 +775,115 @@ def test_sparse_types_do_not_conflict_on_an_omitted_field(conn):
     _commit(conn, {"allergy": [
         {"substance": "Sulfa", "reaction": "hives", "criticality": "high"}]})
     summary = _commit(conn, {"allergy": [{"substance": "Sulfa"}]})
-    assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
     # ... but a stated disagreement still conflicts.
     summary = _commit(conn, {"allergy": [
         {"substance": "Sulfa", "reaction": "anaphylaxis"}]})
-    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
+
+
+def test_a_stated_field_over_a_stored_null_enriches_rather_than_dedups(conn):
+    """The other half of the sparse rule: silence is only silence in the *incoming*
+    direction. A later document supplying criticality/reaction the record lacks is new
+    information with nothing to adjudicate - fill the NULLs, don't drop the row."""
+    _commit(conn, {"allergy": [{"substance": "Bee sting"}]})
+    summary = _commit(conn, {"allergy": [
+        {"substance": "Bee sting", "criticality": "high", "reaction": "anaphylaxis",
+         "noted_on": "2024-07-07"}]})
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 1, "conflict": 0}
+    row = conn.execute("SELECT * FROM allergy").fetchone()
+    assert (row["criticality"], row["reaction"], row["noted_on"]) == (
+        "high", "anaphylaxis", "2024-07-07")
+    assert summary.enriched == [("allergy", row["allergy_id"])]
+    # Re-stating exactly what is now stored is a plain duplicate again.
+    summary = _commit(conn, {"allergy": [
+        {"substance": "Bee sting", "criticality": "high", "reaction": "anaphylaxis",
+         "noted_on": "2024-07-07"}]})
+    assert summary.counts["duplicate"] == 1 and summary.counts["enriched"] == 0
+
+
+def test_enrichment_fills_only_nulls_and_never_launders_a_disagreement(conn):
+    """A stated value must never overwrite a stored one on the quiet path - that is
+    still a conflict, even when the same row also has a NULL the document could fill."""
+    _commit(conn, {"condition": [{"name": "Chickenpox", "status": "history"}]})
+    summary = _commit(conn, {"condition": [
+        {"name": "Chickenpox", "status": "active", "onset_on": "1988-03-01"}]})
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
+    row = conn.execute("SELECT * FROM condition").fetchone()
+    assert (row["status"], row["onset_on"]) == ("history", None)
+
+
+def test_a_terser_row_later_in_one_submission_does_not_undo_an_enrichment(conn):
+    """Both directions inside a single batch: the detailed row enriches the terse one,
+    and a third terse row after it is still just a duplicate."""
+    summary = _commit(conn, {"condition": [
+        {"name": "Anemia", "status": "active"},
+        {"name": "Anemia", "status": "active", "note": "iron deficiency",
+         "onset_on": "2019-02-01"},
+        {"name": "Anemia", "status": "active"},
+    ]})
+    assert summary.counts == {"new": 1, "duplicate": 1, "enriched": 1, "conflict": 0}
+    row = conn.execute("SELECT * FROM condition").fetchone()
+    assert (row["note"], row["onset_on"]) == ("iron deficiency", "2019-02-01")
+
+
+def test_keep_incoming_on_a_sparse_type_keeps_fields_the_document_did_not_state(conn):
+    """Adjudicating one field must not erase the rest of a standing fact's payload:
+    the incoming document not repeating `reaction` means "didn't say", here too."""
+    _commit(conn, {"allergy": [
+        {"substance": "Penicillin", "reaction": "anaphylaxis", "criticality": "high",
+         "noted_on": "2010-05-05"}]})
+    summary = _commit(conn, {"allergy": [
+        {"substance": "Penicillin", "criticality": "low"}]})
+    assert summary.counts["conflict"] == 1
+    dedup.resolve_conflict(conn, dedup.list_conflicts(conn)[0]["conflict_id"],
+                           keep="incoming")
+    row = conn.execute("SELECT * FROM allergy").fetchone()
+    assert (row["criticality"], row["reaction"], row["noted_on"]) == (
+        "low", "anaphylaxis", "2010-05-05")
+
+
+def test_keep_incoming_still_clears_an_unstated_field_on_a_dated_type(conn):
+    """Scoped to sparse types: for a lab draw an unstated field IS a clearing, and
+    keep-incoming keeps its documented overwrite-the-row semantics."""
+    _commit(conn, {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 95,
+         "unit": "mg/dL", "flag": "H"}]})
+    _commit(conn, {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 101}]})
+    dedup.resolve_conflict(conn, dedup.list_conflicts(conn)[0]["conflict_id"],
+                           keep="incoming")
+    row = conn.execute("SELECT * FROM lab_result").fetchone()
+    assert (row["value_num"], row["unit"], row["flag"]) == (101, None, None)
+
+
+def test_keep_both_no_op_fills_what_the_sibling_was_missing(conn):
+    """A strictly-thinner sibling "matches" the staged payload under the sparse
+    comparison, so keep-both is still a no-op - but it must not swallow the fields the
+    payload adds on its way to that no-op."""
+    # occ0 is Latex/hives; two later documents both stage a "rash" conflict against it,
+    # one of them also stating criticality.
+    _commit(conn, {"allergy": [{"substance": "Latex", "reaction": "hives"}]})
+    _commit(conn, {"allergy": [
+        {"substance": "Latex", "reaction": "rash", "criticality": "high"}]})
+    _commit(conn, {"allergy": [{"substance": "Latex", "reaction": "rash"}]})
+    staged = {
+        ("criticality" in c["incoming_json"]): c["conflict_id"]
+        for c in dedup.list_conflicts(conn)
+    }
+    rich, thin = staged[True], staged[False]
+    # The thin one is admitted first, so the rich one now matches a sibling missing
+    # criticality.
+    dedup.resolve_conflict(conn, thin, keep="both")
+    result = dedup.resolve_conflict(conn, rich, keep="both")
+    assert result.no_op is True and result.gains == {"criticality": "high"}
+    assert conn.execute("SELECT COUNT(*) AS n FROM allergy").fetchone()["n"] == 2
+    admitted = conn.execute(
+        "SELECT * FROM allergy WHERE allergy_id = ?", (result.row_id,)
+    ).fetchone()
+    assert (admitted["reaction"], admitted["criticality"]) == ("rash", "high")
+    assert "filled criticality" in dedup.list_conflicts(
+        conn, status="resolved")[0]["resolution"]
 
 
 def test_labs_keep_the_strict_comparison(conn):
@@ -846,4 +952,4 @@ def test_rekey_rederives_a_carried_forward_migration_key(conn):
     assert row["dedup_key"] == change.new_key and row["dedup_base"] == change.new_key
     # ... and now a fresh commit of the same allergy dedups instead of forking.
     summary = _commit(conn, {"allergy": [{"substance": "Penicillin", "reaction": "rash"}]})
-    assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -494,7 +494,9 @@ def test_migration_005_preserves_pre_existing_keys(tmp_path):
     staged = tmp_path / "migrations"
     staged.mkdir()
     all_migrations = sorted(db.DEFAULT_MIGRATIONS_DIR.glob("*.sql"))
-    pre_005 = [p for p in all_migrations if not p.name.startswith("005_")]
+    # Everything numbered below 005 - later migrations build ON the occurrence columns,
+    # so they cannot stand in for the pre-005 shape.
+    pre_005 = [p for p in all_migrations if p.name < "005"]
     for path in pre_005:
         shutil.copy(path, staged / path.name)
 
@@ -514,7 +516,7 @@ def test_migration_005_preserves_pre_existing_keys(tmp_path):
 
         for path in all_migrations:
             shutil.copy(path, staged / path.name)
-        assert db.migrate(conn, staged) == ["005_dedup_occurrence.sql"]
+        assert "005_dedup_occurrence.sql" in db.migrate(conn, staged)
 
         stored = conn.execute("SELECT * FROM lab_result").fetchone()
         assert stored["dedup_key"] == legacy_key      # no key churn
@@ -682,6 +684,8 @@ def test_rekey_covers_every_record_type(conn):
         "procedure": [{"name": "Colonoscopy", "performed_on": "2025-06-01"}],
         "appointment": [{"scheduled_for": "2026-03-01", "provider": "Dr. Smith"}],
         "observation": [{"obs_type": "vital", "key": "bp", "observed_at": "2026-01-02"}],
+        "allergy": [{"substance": "Penicillin", "reaction": "rash"}],
+        "condition": [{"name": "Type 2 Diabetes", "status": "active"}],
     })
     report = dedup.rekey(conn, None)
     assert report.scanned == {t: 1 for t in dedup.KNOWN_TYPES}
@@ -717,3 +721,129 @@ def test_rekey_moves_dedup_base_with_the_key(conn):
     dedup.rekey(conn, _rekey_dict(zzt="zonulin_test"), apply=True)
     row = conn.execute("SELECT * FROM lab_result").fetchone()
     assert row["dedup_base"] == row["dedup_key"]   # occurrence 0: base IS the key
+
+
+# --- allergy / condition typed rows (issue #63) -------------------------------
+
+def _commit(conn, records, doc=None, dictionary=None):
+    return dedup.commit_extraction(
+        conn, doc if doc is not None else _make_document(conn), records, dictionary
+    )
+
+
+def test_allergy_key_is_date_free(conn):
+    """Allergies are standing facts restated on every document with inconsistent dates,
+    so the same allergen collapses to ONE row however the dates differ."""
+    _commit(conn, {"allergy": [
+        {"substance": "Penicillin", "reaction": "rash", "noted_on": "2010-01-01"}]})
+    summary = _commit(conn, {"allergy": [
+        {"substance": "penicillin", "reaction": "rash", "noted_on": "2021-06-01"}]})
+    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+    assert conn.execute("SELECT COUNT(*) AS n FROM allergy").fetchone()["n"] == 1
+
+
+def test_condition_family_history_does_not_collide_with_the_patients_own(conn):
+    """The clinical-safety defect the typed table exists to fix: under the old
+    observation key, the patient's diabetes and her mother's deduped into one row."""
+    summary = _commit(conn, {"condition": [
+        {"name": "Type 2 Diabetes", "status": "active"},
+        {"name": "Type 2 Diabetes", "status": "family-history", "relation": "mother"},
+        {"name": "Type 2 Diabetes", "status": "family-history", "relation": "father"},
+    ]})
+    assert summary.counts == {"new": 3, "duplicate": 0, "conflict": 0}
+
+
+def test_condition_lifecycle_change_stages_a_conflict(conn):
+    """active -> resolved keeps the same key (the date is payload), so the change is a
+    conflict for a human rather than a silent second problem-list entry."""
+    _commit(conn, {"condition": [{"name": "Anemia", "status": "active"}]})
+    summary = _commit(conn, {"condition": [
+        {"name": "Anemia", "status": "resolved", "resolved_on": "2025-09-01"}]})
+    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+
+    conflict_id = dedup.list_conflicts(conn)[0]["conflict_id"]
+    dedup.resolve_conflict(conn, conflict_id, keep="incoming")
+    row = conn.execute("SELECT * FROM condition").fetchone()
+    assert (row["status"], row["resolved_on"]) == ("resolved", "2025-09-01")
+
+
+def test_sparse_types_do_not_conflict_on_an_omitted_field(conn):
+    """A document that simply doesn't restate criticality means "didn't say", not
+    "cleared" - otherwise re-ingesting next year's summary stages a conflict per allergy."""
+    _commit(conn, {"allergy": [
+        {"substance": "Sulfa", "reaction": "hives", "criticality": "high"}]})
+    summary = _commit(conn, {"allergy": [{"substance": "Sulfa"}]})
+    assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
+    # ... but a stated disagreement still conflicts.
+    summary = _commit(conn, {"allergy": [
+        {"substance": "Sulfa", "reaction": "anaphylaxis"}]})
+    assert summary.counts == {"new": 0, "duplicate": 0, "conflict": 1}
+
+
+def test_labs_keep_the_strict_comparison(conn):
+    """The sparse rule is scoped to standing facts: for a dated lab draw a cleared unit
+    is still news, so a one-sided None must stay a conflict."""
+    _commit(conn, {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 95,
+         "unit": "mg/dL"}]})
+    summary = _commit(conn, {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 95}]})
+    assert summary.counts["conflict"] == 1
+
+
+def test_condition_status_is_required_and_enum_checked(conn):
+    with pytest.raises(dedup.ValidationError, match="missing required field 'status'"):
+        dedup.validate_row("condition", {"name": "Anemia"})
+    with pytest.raises(dedup.ValidationError, match="active, family-history"):
+        dedup.validate_row("condition", {"name": "Anemia", "status": "inactive"})
+
+
+def test_enum_values_are_matched_leniently_but_stored_verbatim(conn):
+    """A source's own casing/punctuation validates; the column keeps what it wrote."""
+    dedup.validate_row(
+        "allergy", {"substance": "Latex", "criticality": "Unable to Assess"})
+    _commit(conn, {"condition": [{"name": "Asthma", "status": "Family_History",
+                                  "relation": "Mother"}]})
+    row = conn.execute("SELECT * FROM condition").fetchone()
+    assert row["status"] == "Family_History"        # verbatim
+    # ... and it still keys as family history, so it never joins the patient's own list.
+    summary = _commit(conn, {"condition": [{"name": "Asthma", "status": "active"}]})
+    assert summary.counts["new"] == 1
+
+
+def test_allergy_criticality_is_optional_but_checked(conn):
+    dedup.validate_row("allergy", {"substance": "Latex"})              # no raise
+    with pytest.raises(dedup.ValidationError, match="high, low"):
+        dedup.validate_row("allergy", {"substance": "Latex", "criticality": "severe"})
+
+
+def test_new_types_have_date_validation(conn):
+    with pytest.raises(dedup.ValidationError, match="expected ISO date"):
+        dedup.validate_row("allergy", {"substance": "Latex", "noted_on": "06/15/2026"})
+    with pytest.raises(dedup.ValidationError, match="expected ISO date"):
+        dedup.validate_row(
+            "condition", {"name": "Anemia", "status": "active", "resolved_on": "soon"})
+
+
+def test_rekey_rederives_a_carried_forward_migration_key(conn):
+    """Migration 006 moves rows carrying their OLD observation key (SQL can't compute
+    sha256 over normalized fields); `pemr rekey --apply` is what re-derives them, and it
+    must name the row by substance/name rather than blowing up on `obs_type`."""
+    pid = conn.execute("SELECT person_id FROM person").fetchone()["person_id"]
+    conn.execute(
+        "INSERT INTO allergy (person_id, substance, reaction, dedup_key, dedup_base) "
+        "VALUES (?, 'Penicillin', 'rash', 'legacy-obs-key', 'legacy-obs-key')", (pid,))
+    conn.commit()
+
+    report = dedup.rekey(conn, None)
+    change = next(c for c in report.changes if c.record_type == "allergy")
+    assert change.old_key == "legacy-obs-key"
+    assert change.label == "Penicillin"
+    assert change.new_key == dedup.dedup_key("allergy", {"substance": "Penicillin"}, pid)
+
+    dedup.rekey(conn, None, apply=True)
+    row = conn.execute("SELECT * FROM allergy").fetchone()
+    assert row["dedup_key"] == change.new_key and row["dedup_base"] == change.new_key
+    # ... and now a fresh commit of the same allergy dedups instead of forking.
+    summary = _commit(conn, {"allergy": [{"substance": "Penicillin", "reaction": "rash"}]})
+    assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -28,7 +28,17 @@ RECORDS = {
         {"obs_type": "blood_pressure", "observed_at": "2026-01-02",
          "key": "systolic", "value_num": 120},
     ],
+    "allergy": [
+        {"substance": "Penicillin", "reaction": "rash", "criticality": "high"},
+    ],
+    "condition": [
+        {"name": "Type 2 Diabetes", "status": "active", "onset_on": "2024-01-01"},
+    ],
 }
+
+# One row of every known record type -- the fixture's whole point, so counts assert on
+# this rather than on a literal that goes stale the next time a type is added.
+_SEEDED_ROWS = sum(len(rows) for rows in RECORDS.values())
 
 
 @pytest.fixture()
@@ -85,7 +95,7 @@ def test_list_newest_first_with_counts(seeded):
     second = _insert_document(conn, jane.person_id, "bb99")
     views = documents.list_documents(conn)
     assert [v["document_id"] for v in views] == [second, seeded["doc"]]
-    assert views[1]["record_count"] == 5
+    assert views[1]["record_count"] == _SEEDED_ROWS
     assert views[1]["records"]["lab_result"] == 1
     assert views[0]["record_count"] == 0
     assert views[1]["person"] == "jane-doe"
@@ -161,7 +171,7 @@ def test_reassign_moves_document_and_every_record_type(seeded):
     )
     assert report.applied is True
     assert sorted(report.counts) == sorted(dedup.KNOWN_TYPES)
-    assert len(report.changes) == 5
+    assert len(report.changes) == len(dedup.KNOWN_TYPES)  # one row seeded per type
 
     assert conn.execute(
         "SELECT person_id FROM document WHERE document_id = ?", (seeded["doc"],)
@@ -194,7 +204,7 @@ def test_reassign_rederives_dedup_keys(seeded):
 def test_reassign_dry_run_writes_nothing(seeded):
     conn, jane = seeded["conn"], seeded["jane"]
     report = documents.reassign_document(conn, seeded["doc"], "john-doe")
-    assert report.applied is False and len(report.changes) == 5
+    assert report.applied is False and len(report.changes) == _SEEDED_ROWS
     assert conn.execute(
         "SELECT person_id FROM document WHERE document_id = ?", (seeded["doc"],)
     ).fetchone()["person_id"] == jane.person_id
@@ -353,7 +363,7 @@ def test_reassign_unknown_document_and_slug(seeded):
 def test_rm_dry_run_reports_but_deletes_nothing(seeded):
     conn = seeded["conn"]
     report = documents.remove_document(conn, seeded["doc"])
-    assert report.applied is False and report.record_count == 5
+    assert report.applied is False and report.record_count == _SEEDED_ROWS
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
     assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 1
 
@@ -361,7 +371,7 @@ def test_rm_dry_run_reports_but_deletes_nothing(seeded):
 def test_rm_apply_cascades_records_and_fts(seeded):
     conn = seeded["conn"]
     report = documents.remove_document(conn, seeded["doc"], apply=True)
-    assert report.applied is True and report.record_count == 5
+    assert report.applied is True and report.record_count == _SEEDED_ROWS
     for record_type in dedup.KNOWN_TYPES:
         assert conn.execute(
             f"SELECT COUNT(*) AS n FROM {record_type}"
@@ -533,11 +543,11 @@ def test_cli_document_list_and_json(cli_ready, capsys):
     capsys.readouterr()
     assert _run(cli_ready, "document", "list") == 0
     out = capsys.readouterr().out
-    assert "#1" in out and "jane-doe" in out and "5 rec" in out
+    assert "#1" in out and "jane-doe" in out and f"{_SEEDED_ROWS} rec" in out
 
     assert _run(cli_ready, "document", "list", "--json") == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload[0]["record_count"] == 5
+    assert payload[0]["record_count"] == _SEEDED_ROWS
     assert payload[0]["has_ocr_text"] is True
     assert "ocr_text" not in payload[0]
 
@@ -563,11 +573,11 @@ def test_cli_document_reassign_dry_run_then_apply(cli_ready, capsys):
     assert _run(cli_ready, "document", "reassign", "1", "--person", "john-doe") == 0
     out = capsys.readouterr().out
     assert "jane-doe -> john-doe" in out
-    assert "dry run: 5 record(s) would move" in out and "--apply" in out
+    assert f"dry run: {_SEEDED_ROWS} record(s) would move" in out and "--apply" in out
 
     assert _run(cli_ready, "document", "reassign", "1", "--person", "john-doe",
                 "--apply") == 0
-    assert "reassigned 5 record(s)" in capsys.readouterr().out
+    assert f"reassigned {_SEEDED_ROWS} record(s)" in capsys.readouterr().out
 
     # The move is visible to the person-scoped reads.
     assert _run(cli_ready, "query", "labs", "--person", "john-doe") == 0
@@ -585,7 +595,7 @@ def test_cli_document_reassign_json(cli_ready, capsys):
                 "--json") == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["applied"] is False and payload["to"] == "john-doe"
-    assert len(payload["moved"]) == 5
+    assert len(payload["moved"]) == _SEEDED_ROWS
 
 
 def test_cli_document_reassign_unknown_person_fails(cli_ready, capsys):
@@ -598,7 +608,7 @@ def test_cli_document_rm_dry_run_then_apply(cli_ready, capsys):
     capsys.readouterr()
     assert _run(cli_ready, "document", "rm", "1") == 0
     out = capsys.readouterr().out
-    assert "records: 5 total" in out and "blob kept" in out
+    assert f"records: {_SEEDED_ROWS} total" in out and "blob kept" in out
     assert "dry run: nothing was deleted" in out
 
     assert _run(cli_ready, "document", "rm", "1", "--apply") == 0

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -133,7 +133,7 @@ def test_show_unknown_document_raises(conn):
 def test_show_carries_the_full_stable_record_key_set(seeded):
     view = documents.get_document_view(seeded["conn"], seeded["doc"])
     assert set(view["records"]) == set(dedup.KNOWN_TYPES)
-    assert view["record_count"] == 5
+    assert view["record_count"] == _SEEDED_ROWS
     assert "ocr_text" not in view
     assert view["has_ocr_text"] is True
     assert view["ocr_text_chars"] == len("scan text")
@@ -252,7 +252,7 @@ def test_set_text_leaves_records_and_keys_untouched(seeded):
         for r in conn.execute("SELECT * FROM lab_result").fetchall()
     ]
     assert before == after
-    assert documents.get_document_view(conn, seeded["doc"])["record_count"] == 5
+    assert documents.get_document_view(conn, seeded["doc"])["record_count"] == _SEEDED_ROWS
 
 
 # --- edit -------------------------------------------------------------------
@@ -468,7 +468,7 @@ def test_reassign_moves_a_keep_both_family_intact(seeded):
     summary = dedup.commit_extraction(
         conn, seeded["doc"], {"lab_result": [draw | {"value_num": 148}]}
     )
-    assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
 
 
 def test_reassign_refused_on_dictionary_drift(seeded):
@@ -699,7 +699,7 @@ def test_cli_document_show(cli_ready, capsys):
     assert "document_id    1" in out
     assert "person         jane-doe" in out
     # Total plus the non-zero per-type breakdown only (zeros are a --json concern).
-    assert "records        5  (" in out and "lab_result 1" in out
+    assert f"records        {_SEEDED_ROWS}  (" in out and "lab_result 1" in out
     assert "procedure 0" not in out
     assert "has_ocr_text   yes (" in out
     assert "conflicts      none" in out
@@ -867,7 +867,7 @@ def test_cli_document_set_text_leaves_records_untouched(cli_ready, capsys):
                 "--ocr-text-file", str(text)) == 0
     capsys.readouterr()
     assert _run(cli_ready, "document", "show", "1", "--json") == 0
-    assert json.loads(capsys.readouterr().out)["record_count"] == 5
+    assert json.loads(capsys.readouterr().out)["record_count"] == _SEEDED_ROWS
     assert _run(cli_ready, "query", "labs", "--person", "jane-doe") == 0
     assert "HbA1c" in capsys.readouterr().out
 

--- a/tests/test_persons.py
+++ b/tests/test_persons.py
@@ -147,6 +147,26 @@ def test_remove_with_dependents_refused(conn):
     assert persons.get_person(conn, "jane-doe") is not None  # not deleted
 
 
+def test_remove_refuses_on_condition_and_allergy_rows(conn):
+    """The typed tables from migration 006 are child tables too (issue #63): without
+    them in the guard, `remove` reaches a raw IntegrityError instead of the friendly
+    refusal, and the message never names what is actually blocking."""
+    for table, columns, values in (
+        ("condition", "name, status", "'Anemia', 'active'"),
+        ("allergy", "substance", "'Penicillin'"),
+    ):
+        person = persons.add_person(conn, f"jane-{table}", "Jane Doe")
+        conn.execute(
+            f"INSERT INTO {table} (person_id, {columns}, dedup_key, dedup_base) "
+            f"VALUES (?, {values}, ?, ?)",
+            (person.person_id, f"k-{table}", f"k-{table}"),
+        )
+        conn.commit()
+        with pytest.raises(persons.PersonHasDependentsError, match=table):
+            persons.remove_person(conn, f"jane-{table}")
+        assert persons.get_person(conn, f"jane-{table}") is not None
+
+
 def test_remove_unknown_slug_raises(conn):
     with pytest.raises(persons.PersonNotFoundError):
         persons.remove_person(conn, "nobody")

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -61,6 +61,15 @@ def seeded(tmp_path):
             {"obs_type": "blood_pressure", "observed_at": "2025-07-01",
              "key": "systolic", "value_num": 128, "unit": "mmHg"},
         ],
+        "condition": [
+            {"name": "Anemia", "status": "resolved", "onset_on": "2022-05-01",
+             "resolved_on": "2023-08-01"},
+            {"name": "Breast Cancer", "status": "family-history", "relation": "mother",
+             "onset_on": "2001-01-01"},
+        ],
+        "allergy": [
+            {"substance": "Penicillin", "reaction": "rash", "noted_on": "2010-01-01"},
+        ],
     }, d)
 
     doc2 = _doc(conn, "john-doe", ocr="unrelated note")
@@ -202,6 +211,25 @@ def test_timeline_merge_ordering_and_since(seeded):
     since = query.query_timeline(seeded, "jane-doe", since="2026-01-01")
     assert all(e["date"] >= "2026-01-01" for e in since)
     assert len(since) < len(events)
+
+
+def test_timeline_includes_conditions_and_allergies(seeded):
+    """Conditions contribute up to two events (onset + resolution) and allergies one,
+    so the journal keeps them after they left `observation` (issue #63)."""
+    events = query.query_timeline(seeded, "jane-doe")
+    by_type = {e["type"]: e for e in events}
+    assert by_type["condition"]["date"] == "2022-05-01"
+    assert by_type["condition"]["summary"] == "Anemia (resolved)"
+    assert by_type["condition-resolved"]["date"] == "2023-08-01"
+    assert by_type["condition-resolved"]["summary"] == "resolved Anemia"
+    assert by_type["allergy"]["summary"] == "Penicillin allergy"
+
+
+def test_timeline_excludes_family_history(seeded):
+    """A relative's onset date is not an event in this patient's chronology."""
+    events = query.query_timeline(seeded, "jane-doe")
+    assert not any("Breast Cancer" in e["summary"] for e in events)
+    assert not any(e["date"] == "2001-01-01" for e in events)
 
 
 def test_timeline_carries_provenance(seeded):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -16,7 +16,7 @@ DICT_PATH = Path(__file__).resolve().parent.parent / "data" / "dictionary.exampl
 
 _TABLES = (
     "person", "document", "lab_result", "medication", "procedure",
-    "appointment", "observation", "conflict",
+    "appointment", "observation", "condition", "allergy", "conflict",
 )
 
 
@@ -98,12 +98,22 @@ def seeded(tmp_path):
              "value_num": 118, "unit": "mmHg"},                                   # latest wins
             {"obs_type": "vital", "key": "weight", "observed_at": "2026-01-01",
              "value_num": 80, "unit": "kg"},
-            {"obs_type": "condition", "key": "Type 2 Diabetes", "observed_at": "2024-01-01"},
-            {"obs_type": "allergy", "key": "Penicillin", "value_text": "rash",
-             "observed_at": "2010-01-01"},
             {"obs_type": "order", "key": "cervical collar", "value_text": "Dr. Smith, ortho",
              "observed_at": "2026-02-01"},                                        # DME order
             {"obs_type": "order", "key": "outpatient physical therapy"},          # bare item, no detail
+        ],
+        "condition": [
+            {"name": "Type 2 Diabetes", "status": "active", "onset_on": "2024-01-01",
+             "note": "diet-controlled"},
+            {"name": "Appendicitis", "status": "resolved", "onset_on": "2015-03-01",
+             "resolved_on": "2015-03-08"},
+            {"name": "Chickenpox", "status": "history"},
+            {"name": "Type 2 Diabetes", "status": "family-history",
+             "relation": "mother"},        # same disease as the active row: distinct subject
+        ],
+        "allergy": [
+            {"substance": "Penicillin", "reaction": "rash", "noted_on": "2010-01-01"},
+            {"substance": "Sulfa", "reaction": "anaphylaxis", "criticality": "high"},
         ],
     }, d)
 
@@ -132,7 +142,8 @@ def test_summary_header_is_self_identifying(seeded):
     assert "DOB: 1980-01-01" in md
     assert "Generated:" in md
     # source row counts so a stale export identifies itself
-    assert "labs=4" in md and "medications=2" in md and "observations=7" in md
+    assert "labs=4" in md and "medications=2" in md and "observations=5" in md
+    assert "conditions=4" in md and "allergies=2" in md
 
 
 def test_summary_active_meds_only(seeded):
@@ -170,10 +181,28 @@ def test_brief_excludes_expired_course_labelled_active(seeded):
     assert "Metformin" in md
 
 
-def test_summary_conditions_and_allergies(seeded):
+def test_summary_splits_conditions_by_status(seeded):
+    """The single Conditions section became three, one per `condition.status` bucket
+    (issue #63) -- an active problem, a past one and a relative's must never read alike."""
     md = render.render_summary(seeded, "jane-doe")
-    assert "## Conditions" in md and "Type 2 Diabetes" in md
-    assert "## Allergies" in md and "Penicillin - rash" in md
+    active = md.split("## Active Problems")[1].split("\n## ")[0]
+    past = md.split("## Past Medical History")[1].split("\n## ")[0]
+    family = md.split("## Family History")[1].split("\n## ")[0]
+
+    assert "- Type 2 Diabetes  (since 2024-01-01) - diet-controlled" in active
+    assert "Appendicitis" not in active and "mother" not in active
+    assert "- Appendicitis  (since 2015-03-01)  (resolved 2015-03-08)" in past
+    assert "- Chickenpox" in past                 # history: no dates given
+    assert "- mother: Type 2 Diabetes" in family  # the relative's, never the patient's
+
+
+def test_summary_allergies_are_typed_rows_high_criticality_first(seeded):
+    md = render.render_summary(seeded, "jane-doe")
+    section = md.split("## Allergies")[1].split("\n## ")[0]
+    assert "- Sulfa [HIGH] - anaphylaxis" in section
+    assert "- Penicillin - rash  (noted 2010-01-01)" in section
+    # criticality='high' outranks alphabetical order: it must survive a skim
+    assert section.index("Sulfa") < section.index("Penicillin")
 
 
 def test_summary_orders_and_referrals(seeded):
@@ -264,7 +293,10 @@ def test_summary_empty_sections_are_explicit(seeded):
     empty-state note (an absent section must not read as an overlooked one)."""
     md = render.render_summary(seeded, "john-doe")
     assert "## Active Medications" in md and "_none recorded_" in md
-    assert "## Conditions" in md
+    for section in ("## Active Problems", "## Past Medical History",
+                    "## Family History", "## Allergies"):
+        assert section in md
+        assert "_none recorded_" in md.split(section)[1].split("\n## ")[0]
     assert "## Orders & Referrals" in md
     order_section = md.split("## Orders & Referrals")[1].split("##")[0]
     assert "_none recorded_" in order_section  # no orders -> explicit empty state
@@ -344,6 +376,34 @@ def test_brief_open_conflict_warning(seeded):
 def test_brief_unknown_appointment_raises(seeded):
     with pytest.raises(render.AppointmentNotFoundError):
         render.render_brief(seeded, 99999)
+
+
+def test_brief_surfaces_allergies_and_active_problems(seeded):
+    """A brief handed to a clinician that omits allergies is a safety gap - and after
+    migration 006 the generic observation loop no longer carries them (issue #63)."""
+    md = render.render_brief(seeded, _upcoming_appt_id(seeded))
+    allergies = md.split("## Allergies")[1].split("\n## ")[0]
+    problems = md.split("## Active Problems")[1].split("\n## ")[0]
+    assert "- Sulfa [HIGH] - anaphylaxis" in allergies
+    assert "- Penicillin - rash" in allergies
+    assert "Type 2 Diabetes" in problems
+    assert "Appendicitis" not in problems      # resolved: not an active problem
+    assert "mother" not in problems            # a relative's dx is never the patient's
+    # placement: before the generic context section, above the fold for a walk-in
+    assert md.index("## Allergies") < md.index("## Procedures & Observations")
+
+
+def test_brief_empty_allergy_section_is_explicit(seeded):
+    """John has no allergies: the section must still render with an empty-state note
+    rather than vanish (an absent Allergies section reads as 'none checked')."""
+    aid = seeded.execute(
+        "INSERT INTO appointment (person_id, scheduled_for, provider, dedup_key, "
+        "dedup_base) SELECT person_id, '2099-05-01', 'Dr. Nobody', 'k-appt-j', "
+        "'k-appt-j' FROM person WHERE slug='john-doe'"
+    ).lastrowid
+    seeded.commit()
+    md = render.render_brief(seeded, aid)
+    assert "_none recorded_" in md.split("## Allergies")[1].split("\n## ")[0]
 
 
 # --- journal ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds typed row support for allergies and problem-list/history conditions so `commit-extraction`
no longer drops them when ingesting a real patient health summary.

- New migration `006_condition_allergy.sql` adding `allergy` (substance req; reaction, criticality,
  noted_on) and `condition` (name req; onset_on, resolved_on, status: active|resolved|history|
  family-history) row types, with dedup keys.
- `dedup.py` (FIELD_SPECS, DATE_FIELDS, _COMPARE_FIELDS, _key_parts, _rekey_label), `persons.py`
  (_CHILD_TABLES), `verify.py` (COUNTED_TABLES), `render.py` (_row_counts + new summary sections),
  `query.py`, `cli.py`, and `mcp_server.py` all extended to cover the two new types.
- Enrichment fix (`b69cccb`, `3cb8e06`): a stated field over a stored NULL enriches the row instead
  of being silently dropped, and the operator-facing resolution line now names the fields it filled
  instead of reporting a plain no-op.
- `AGENTS.md`, `docs/Architecture.md`, `docs/Overview.md` updated for the new record types.
- Tests: 515 passed (`tests/test_dedup.py`, `tests/test_db.py`, `tests/test_render.py`,
  `tests/test_cli_phase2.py`, `tests/test_query.py`, `tests/test_persons.py`, `tests/test_conflict.py`,
  `tests/test_documents.py`).

Audited (ADVANCE): enrichment cannot overwrite a stored value or corrupt a dedup key, identifier
interpolation is injection-safe, and the enum vocabulary matches the render partition.

## Non-blocking follow-ups (not this PR)
- Render-layer markdown injection via unescaped free-text fields (pre-existing, repo-wide) — the
  new Allergies section in the walk-in brief raises the stakes; worth its own issue.
- `_enrich_record` has no structural guard that written columns are key-independent.
- Enrichment provenance stays with the first document; `document rm <first-doc>` can remove fields
  only a second document attested.
- Doc nit: `migrations/002_conflict.sql:8`'s `record_type` comment lists only the five original types.

## CI note
The `meta` job is expected red on this PR for pre-existing `.claude/` mirror drift unrelated to
this branch — `git diff --name-only origin/dev...HEAD -- .claude .github` is empty.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)