### PR TITLE
fix(#64): decode tesseract OCR output as UTF-8, not the platform codepage

### DIFF
--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -118,6 +118,14 @@ def run_ocr(path: str | Path) -> str | None:
             ["tesseract", str(path), "stdout"],
             capture_output=True,
             text=True,
+            # tesseract emits UTF-8. Without an explicit encoding, `text=True`
+            # decodes with the platform default (cp1252 on Windows), which kills
+            # the subprocess reader thread with UnicodeDecodeError on any byte
+            # invalid in that codepage — failing the whole ingest. errors=
+            # "replace" keeps a page with a stray undecodable byte usable rather
+            # than losing the OCR entirely.
+            encoding="utf-8",
+            errors="replace",
             check=True,
         )
     except (subprocess.SubprocessError, OSError) as exc:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,6 +1,7 @@
 """Document ingest: hashing, content-addressed blob store, layer-1 dedup."""
 
 import sqlite3
+import subprocess
 
 import pytest
 
@@ -113,6 +114,61 @@ def test_ocr_degrades_when_tesseract_absent(conn, tmp_path, sources, monkeypatch
     assert result.status == "new"
     assert result.document.ocr_text is None
     assert "tesseract" in capsys.readouterr().err
+
+
+# --- OCR output decoding (issue #64) ------------------------------------------
+#
+# Tesseract emits UTF-8. `subprocess.run(..., text=True)` with no explicit
+# encoding decodes the pipe with the *platform default* codepage — cp1252 on
+# Windows — inside subprocess's reader thread, so any byte invalid there
+# (0x81/0x8D/0x8F/0x90/0x9D) raised UnicodeDecodeError and failed the ingest.
+
+# 0xC3 0x8D ("Í") lands a 0x8D on the wire: undefined in cp1252, decodes fine as UTF-8.
+# Names the fixture's owner so the #61 owner check passes and the round-trip test
+# exercises decoding rather than refusal.
+OCR_UTF8 = "Patient: Jane Doe — 20 µg/dL — MARTÍNEZ CLINIC".encode("utf-8")
+
+
+def _fake_tesseract(payload: bytes, platform_default: str = "cp1252"):
+    """`subprocess.run` stand-in that decodes the way CPython actually does.
+
+    Mirrors the real contract: with `text=True` and `encoding=None` the pipe is
+    wrapped with the locale's preferred encoding under strict error handling.
+    """
+
+    def _run(argv, capture_output=False, text=False, encoding=None,
+             errors=None, check=False):
+        assert argv[0] == "tesseract"
+        if not text:
+            return subprocess.CompletedProcess(argv, 0, payload, b"")
+        decoded = payload.decode(encoding or platform_default, errors or "strict")
+        return subprocess.CompletedProcess(argv, 0, decoded, "")
+
+    return _run
+
+
+def test_run_ocr_decodes_utf8_under_a_cp1252_platform_default(tmp_path, monkeypatch):
+    monkeypatch.setattr(ingest.shutil, "which", lambda _: "/usr/bin/tesseract")
+    monkeypatch.setattr(ingest.subprocess, "run", _fake_tesseract(OCR_UTF8))
+    assert ingest.run_ocr(_make_file(tmp_path)) == OCR_UTF8.decode("utf-8")
+
+
+def test_run_ocr_survives_undecodable_bytes(tmp_path, monkeypatch):
+    """A stray non-UTF-8 byte degrades to U+FFFD, it does not lose the page."""
+    monkeypatch.setattr(ingest.shutil, "which", lambda _: "/usr/bin/tesseract")
+    monkeypatch.setattr(
+        ingest.subprocess, "run", _fake_tesseract(b"scan \xff noise")
+    )
+    assert ingest.run_ocr(_make_file(tmp_path)) == "scan � noise"
+
+
+def test_ocr_text_round_trips_through_ingest(conn, tmp_path, sources, monkeypatch):
+    monkeypatch.setattr(ingest.shutil, "which", lambda _: "/usr/bin/tesseract")
+    monkeypatch.setattr(ingest.subprocess, "run", _fake_tesseract(OCR_UTF8))
+    result = ingest.ingest_document(
+        conn, _make_file(tmp_path), "jane-doe", sources, ocr=True
+    )
+    assert result.document.ocr_text == OCR_UTF8.decode("utf-8")
 
 
 # --- owner verification (issue #61) -------------------------------------------


### PR DESCRIPTION
## Summary

Fixes `ingest --ocr tesseract` crashing on Windows when tesseract emits UTF-8 output containing a
byte undefined in the platform's default codepage (cp1252).

- `pemr/ingest.py` (`run_ocr`): the one `subprocess.run` capture in the package now passes
  `encoding="utf-8", errors="replace"` explicitly, instead of relying on `text=True` falling back
  to the locale-preferred codepage under strict error handling.
- `tests/test_ingest.py`: 3 new tests covering the undecodable-byte path, the round-trip for valid
  UTF-8, and the U+FFFD replacement behavior.

Verified against a real cp1252 host (`locale.getpreferredencoding(False) == 'cp1252'`): 491 tests
pass, including the 3 new/targeted ones.

Audited (ADVANCE): `errors="replace"` cannot weaken the #61 owner-verification gate that consumes
this text — replacement can only delete/split alphanumeric runs (never synthesize a false name
match), and every anchor token (`patient`, `name:`, `dob`, `mrn`, …) is pure ASCII so it can never
be corrupted by the substitution. Net effect is strictly more accurate than the pre-fix cp1252
mojibake, and fails closed on genuinely corrupted pages.

## Non-blocking follow-ups (not this PR)
- `subprocess.run` has no `timeout=`; a hung tesseract hangs the ingest indefinitely (pre-existing,
  orthogonal to encoding).
- No signal to the user when substitution actually fires on a page.
- `tests/test_main_module.py:17` has the same `text=True`-without-`encoding` shape on an
  ASCII-only capture (`pemr --version`) — latent, test-only.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)
