### PR TITLE
feat(#66): refuse Drive pointer stubs, extract text natively at ingest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,12 @@ to `find` (FTS5); an ingest without it is silently unsearchable.
 - **Default path: agent-supplied transcription.** You already read the document to extract from it;
   pass that text as the `ocr_text` tool param (CLI: `--ocr-text-file <path>`). A vision transcript
   beats tesseract on messy scans.
-- **Fallback:** `ocr=true` (tesseract) only when you cannot read the file type yourself.
+- **Fallback:** `ocr=true` (CLI: `--ocr auto`) only when you cannot read the file type yourself.
+  It extracts by whatever route the type allows — plaintext/`.csv`/`.json` read directly,
+  `.docx`/`.xlsx` parsed from their OOXML, images and PDFs through tesseract. `.rtf`, `.msg`,
+  `.doc` and PDF text layers have no route: transcribe those yourself.
+- **Pointer stubs are refused.** A `.gsheet`/`.gdoc` from a synced Drive folder is a ~1 KB JSON
+  link, not the document; `ingest` fails pre-write. Export it from Drive and ingest the export.
 - Self-check: the `ingest` response includes `ocr_text_populated: bool`. If it is `false`, treat
   the ingest as incomplete and supply text before moving on. (The engine only *warns* here rather
   than hard-failing, because a human at the CLI may legitimately defer — but the agent MUST not.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,8 +134,9 @@ to `find` (FTS5); an ingest without it is silently unsearchable.
   beats tesseract on messy scans.
 - **Fallback:** `ocr=true` (CLI: `--ocr auto`) only when you cannot read the file type yourself.
   It extracts by whatever route the type allows — plaintext/`.csv`/`.json` read directly,
-  `.docx`/`.xlsx` parsed from their OOXML, images and PDFs through tesseract. `.rtf`, `.msg`,
-  `.doc` and PDF text layers have no route: transcribe those yourself.
+  `.docx`/`.xlsx` parsed from their OOXML, everything else (images, PDFs, unknown suffixes)
+  through tesseract. `.rtf`, `.msg`, `.doc` and PDF text layers have no working route:
+  you get a stderr note, and must transcribe those yourself.
 - **Pointer stubs are refused.** A `.gsheet`/`.gdoc` from a synced Drive folder is a ~1 KB JSON
   link, not the document; `ingest` fails pre-write. Export it from Drive and ingest the export.
 - Self-check: the `ingest` response includes `ocr_text_populated: bool`. If it is `false`, treat

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,10 +152,13 @@ ingest-time owner check: it scans that text for the claimed person's name/DOB an
 *different* roster person), `suspect` (a patient-identity header naming nobody on the roster), or
 `unverified` (no text, no identity anchor in it, or a claimed person whose name is too short to
 carry a signal — their absence from the text is ignorance, not evidence). `mismatch`/`suspect`
-**refuse the ingest** before anything is written. `suspect` applies to prose only — your
-transcription or a tesseract pass — never to natively-extracted `.csv`/`.docx`/`.xlsx`/`.json`,
-where `Patient`/`DOB`/`MRN` are column labels rather than an identity header. `mismatch` holds
-on every route.
+**refuse the ingest** before anything is written. `suspect` is scoped by **route**: it applies to
+the text you supply and to a tesseract pass, and never to anything `--ocr auto` extracts natively
+— the whole `.txt`/`.md`/`.csv`/`.tsv`/`.json`/`.log`/`.docx`/`.xlsx` set — because in a
+structured export `Patient`/`DOB`/`MRN` are column labels rather than an identity header. The
+route is the line, not how prose-like the format is: a transcript you save as `.txt` and ingest
+with `--ocr auto` gets no identity-header check either, so pass your transcription as `ocr_text` /
+`--ocr-text-file` (the default path above) and keep the check. `mismatch` holds on every route.
 
 - On a refusal, the agent MUST surface the verdict and the `evidence` snippet to the human and get
   an **explicit go-ahead** before retrying with `force=true`. Never force on your own judgment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,9 +134,10 @@ to `find` (FTS5); an ingest without it is silently unsearchable.
   beats tesseract on messy scans.
 - **Fallback:** `ocr=true` (CLI: `--ocr auto`) only when you cannot read the file type yourself.
   It extracts by whatever route the type allows — plaintext/`.csv`/`.json` read directly,
-  `.docx`/`.xlsx` parsed from their OOXML, everything else (images, PDFs, unknown suffixes)
-  through tesseract. `.rtf`, `.msg`, `.doc` and PDF text layers have no working route:
-  you get a stderr note, and must transcribe those yourself.
+  `.docx`/`.xlsx` parsed from their OOXML, everything else (images, unknown suffixes)
+  through tesseract. **`.pdf` has no working route** — tesseract does not accept PDF input at
+  all, scanned or text-layer — and neither do `.rtf`, `.msg` or `.doc`: you get a stderr note,
+  and must transcribe those yourself. Extraction is also capped at 32 MiB per file.
 - **Pointer stubs are refused.** A `.gsheet`/`.gdoc` from a synced Drive folder is a ~1 KB JSON
   link, not the document; `ingest` fails pre-write. Export it from Drive and ingest the export.
 - Self-check: the `ingest` response includes `ocr_text_populated: bool`. If it is `false`, treat
@@ -151,7 +152,10 @@ ingest-time owner check: it scans that text for the claimed person's name/DOB an
 *different* roster person), `suspect` (a patient-identity header naming nobody on the roster), or
 `unverified` (no text, no identity anchor in it, or a claimed person whose name is too short to
 carry a signal — their absence from the text is ignorance, not evidence). `mismatch`/`suspect`
-**refuse the ingest** before anything is written.
+**refuse the ingest** before anything is written. `suspect` applies to prose only — your
+transcription or a tesseract pass — never to natively-extracted `.csv`/`.docx`/`.xlsx`/`.json`,
+where `Patient`/`DOB`/`MRN` are column labels rather than an identity header. `mismatch` holds
+on every route.
 
 - On a refusal, the agent MUST surface the verdict and the `evidence` snippet to the human and get
   an **explicit go-ahead** before retrying with `force=true`. Never force on your own judgment.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -309,8 +309,8 @@ inbox/scan.pdf
          not the document); pre-hash, so a refusal writes nothing
       1. hash bytes; if known → report duplicate, stop
       2. resolve document text (agent-supplied, or --ocr), then verify the owner:
-         text naming a different roster person, or a patient-identity header
-         naming nobody on the roster → refuse pre-write (--force overrides)
+         text naming a different roster person, or — in prose only — a patient-
+         identity header naming nobody → refuse pre-write (--force overrides)
       3. move blob → sources/<sha>/<sha>.pdf   (immutable)
       4. insert document row (category/provider left null for now)
   → AGENT step (vision): read the source, emit proposed rows as JSON
@@ -332,11 +332,22 @@ type allows, all stdlib (the engine has no runtime dependencies):
 `.txt/.md/.csv/.tsv/.json/.log` read directly, `.docx`/`.xlsx` unzipped and their OOXML
 parsed, **everything else** through `tesseract` (a soft dependency) — no image-suffix
 allowlist, so `.jfif`, `.jpe` and extension-less scans OCR like any other image. Formats
-tesseract can't read — `.rtf`, `.msg`, `.doc`, a PDF text layer — need a third-party
-parser and are deliberately out: you get a stderr note telling you to transcribe it
-yourself and pass `--ocr-text-file`. Extraction is best-effort and
-never fatal; a malformed file costs you the text, not the document. `--ocr tesseract` is
-a retained alias for `--ocr auto`.
+tesseract can't read need a third-party parser and are deliberately out: `.rtf`, `.msg`,
+`.doc`, and **`.pdf` in any form** — tesseract 5 does not accept PDF input at all, so a
+scanned PDF is no better off than a text-layer one. For those you get a stderr note
+telling you to transcribe it yourself and pass `--ocr-text-file` (or rasterize the PDF to
+an image first). Extraction is best-effort and never fatal; a malformed file costs you the
+text, not the document. It is capped at 32 MiB per file — `ocr_text` is mirrored into the
+FTS index, so an unbounded read is both a database-size problem and a decompression-bomb
+surface (a small `.docx` can declare a gigabyte of `word/document.xml`). `--ocr tesseract`
+is a retained alias for `--ocr auto`.
+
+Extraction route feeds the owner check: the identity-anchor (`suspect`) verdict is applied
+only to prose — an agent transcription or a tesseract pass. In natively-extracted
+`.csv`/`.docx`/`.xlsx`/`.json`, `Patient`/`DOB`/`MRN` are column labels and field keys, and
+counting them as an identity header refuses ordinary lab exports as belonging to a
+stranger. `mismatch` — an affirmative name/DOB match on a *different* roster person — is
+the half that actually prevents misfiling, and it blocks on every route.
 
 ---
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -305,6 +305,8 @@ point, so `trends` deltas and "latest value" stay deterministic.
 ```
 inbox/scan.pdf
   → pemr ingest inbox/scan.pdf --person jane-doe
+      0. refuse Google Drive pointer stubs (`.gsheet`/`.gdoc` — a ~1 KB JSON link,
+         not the document); pre-hash, so a refusal writes nothing
       1. hash bytes; if known → report duplicate, stop
       2. resolve document text (agent-supplied, or --ocr), then verify the owner:
          text naming a different roster person, or a patient-identity header
@@ -324,8 +326,15 @@ Division of labor: **the LLM only does the fuzzy vision-to-structure step.** Has
 validation, dedup, insertion, conflict detection are all deterministic Python the agent
 can't get subtly wrong. That's the whole point of lifting them out.
 
-Optional `--ocr tesseract` flag pre-fills `document.ocr_text` when scans are flat images,
-giving the agent text to work from instead of re-reading pixels every time.
+Optional `--ocr auto` flag pre-fills `document.ocr_text`, giving the agent text to work
+from instead of re-reading the source every time. It extracts by whatever route the file
+type allows, all stdlib (the engine has no runtime dependencies):
+`.txt/.md/.csv/.tsv/.json/.log` read directly, `.docx`/`.xlsx` unzipped and their OOXML
+parsed, images and PDFs through `tesseract` (a soft dependency). Anything else —
+`.rtf`, `.msg`, `.doc`, a PDF text layer — needs a third-party parser and is deliberately
+out: transcribe it yourself and pass `--ocr-text-file`. Extraction is best-effort and
+never fatal; a malformed file costs you the text, not the document. `--ocr tesseract` is
+a retained alias for `--ocr auto`.
 
 ---
 
@@ -335,7 +344,7 @@ giving the agent text to work from instead of re-reading pixels every time.
 
 ```
 pemr person add|list|show|edit|deactivate|reactivate|remove
-pemr ingest <file> --person <slug> [--ocr tesseract] [--force]   # --force: skip owner verification
+pemr ingest <file> --person <slug> [--ocr auto] [--force]        # --force: skip owner verification
 pemr commit-extraction --document <id> --json <file>
 pemr review-conflicts [--resolve <id> --keep existing|incoming|both [--note ...]] [--dictionary <toml>]
 pemr document list [--person <slug>]                     # newest first; omit --person for everyone

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -330,9 +330,11 @@ Optional `--ocr auto` flag pre-fills `document.ocr_text`, giving the agent text 
 from instead of re-reading the source every time. It extracts by whatever route the file
 type allows, all stdlib (the engine has no runtime dependencies):
 `.txt/.md/.csv/.tsv/.json/.log` read directly, `.docx`/`.xlsx` unzipped and their OOXML
-parsed, images and PDFs through `tesseract` (a soft dependency). Anything else —
-`.rtf`, `.msg`, `.doc`, a PDF text layer — needs a third-party parser and is deliberately
-out: transcribe it yourself and pass `--ocr-text-file`. Extraction is best-effort and
+parsed, **everything else** through `tesseract` (a soft dependency) — no image-suffix
+allowlist, so `.jfif`, `.jpe` and extension-less scans OCR like any other image. Formats
+tesseract can't read — `.rtf`, `.msg`, `.doc`, a PDF text layer — need a third-party
+parser and are deliberately out: you get a stderr note telling you to transcribe it
+yourself and pass `--ocr-text-file`. Extraction is best-effort and
 never fatal; a malformed file costs you the text, not the document. `--ocr tesseract` is
 a retained alias for `--ocr auto`.
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -343,11 +343,17 @@ surface (a small `.docx` can declare a gigabyte of `word/document.xml`). `--ocr 
 is a retained alias for `--ocr auto`.
 
 Extraction route feeds the owner check: the identity-anchor (`suspect`) verdict is applied
-only to prose — an agent transcription or a tesseract pass. In natively-extracted
-`.csv`/`.docx`/`.xlsx`/`.json`, `Patient`/`DOB`/`MRN` are column labels and field keys, and
-counting them as an identity header refuses ordinary lab exports as belonging to a
-stranger. `mismatch` — an affirmative name/DOB match on a *different* roster person — is
-the half that actually prevents misfiling, and it blocks on every route.
+only to an agent transcription or a tesseract pass, never to natively-extracted text —
+the whole `.txt/.md/.csv/.tsv/.json/.log/.docx/.xlsx` set. In a structured export
+`Patient`/`DOB`/`MRN` are column labels and field keys, and counting them as an identity
+header refuses ordinary lab exports as belonging to a stranger. The line is the *route*
+rather than how prose-like the format is, because the route is what the extractor actually
+knows; the cost is that a prose transcript saved as `.txt` and ingested with `--ocr auto`
+loses the anchor check too. That is no worse than before native extraction existed (such a
+file went to tesseract, which declined, so there was no text and no check either), and the
+`--ocr-text-file` path keeps full coverage. `mismatch` — an affirmative name/DOB match on a
+*different* roster person — is the half that actually prevents misfiling, and it blocks on
+every route.
 
 ---
 

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -670,7 +670,9 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
                 doc_date=args.doc_date,
                 category=args.category,
                 provider=args.provider,
-                ocr=(args.ocr == "tesseract"),
+                # `tesseract` is a retained alias for `auto`: both mean "extract by
+                # whatever route this file type allows" (ingest.extract_text).
+                ocr=(args.ocr is not None),
                 ocr_text=ocr_text,
                 force=args.force,
             )
@@ -698,7 +700,7 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
     if not result.ocr_text_populated:
         print(
             "note: no ocr_text stored - `find` (full-text search) will not see this "
-            "document. Supply --ocr-text-file <path> or --ocr tesseract.",
+            "document. Supply --ocr-text-file <path> or --ocr auto.",
             file=sys.stderr,
         )
     print(f"next: extract, then `pemr commit-extraction --document {doc.document_id} --json <file>`")
@@ -1410,7 +1412,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_ingest.add_argument("--category", help="labs|imaging|visit-note|rx|vaccine|...")
     p_ingest.add_argument("--provider")
     p_ingest.add_argument(
-        "--ocr", choices=["tesseract"], help="pre-fill ocr_text (soft dependency)"
+        "--ocr",
+        choices=["auto", "tesseract"],
+        help="pre-fill ocr_text: text/.docx/.xlsx read natively, images/PDF via "
+             "tesseract (soft dependency). 'tesseract' is an alias for 'auto'",
     )
     p_ingest.add_argument(
         "--ocr-text-file",

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -14,20 +14,29 @@ Issue #61 adds a pre-write **owner check**: when document text is available, it 
 scanned for the claimed person's name/DOB and the ingest is refused (pre-write, so a
 refusal is a clean no-op) when the text affirmatively points somewhere else. See
 :func:`check_owner`.
+
+Issue #66 adds two intake-format guards, both stdlib-only (the engine has no runtime
+dependencies): a pre-write refusal of Google Drive **pointer stubs** (see
+:func:`is_pointer_stub`) and a text-extraction dispatcher (:func:`extract_text`) so
+`.txt`/`.docx`/`.xlsx` and friends become findable instead of landing as opaque blobs.
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 import shutil
 import subprocess
 import sqlite3
 import sys
+import xml.etree.ElementTree as ET
+import zipfile
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Sequence
+from urllib.parse import urlsplit
 
 from . import db
 from .models import Document, Person
@@ -126,6 +135,196 @@ def run_ocr(path: str | Path) -> str | None:
         return None
     text = proc.stdout.strip()
     return text or None
+
+
+# --------------------------------------------------------------------------- #
+# Text extraction (issue #66) — `ocr=True` means "extract text by whatever route
+# this file type allows", not "shell out to tesseract". `run_ocr` keeps its name and
+# its tesseract semantics and becomes the image/PDF branch of the dispatcher below.
+#
+# Hard constraint: **zero new dependencies.** Everything here is stdlib, which is what
+# draws the scope line — `.rtf`, `.msg`, `.doc` and PDF *text-layer* extraction all
+# need a third-party parser and stay out, covered by the agent transcription path
+# (`--ocr-text-file`) that `AGENTS.md` §3 already makes the default.
+# --------------------------------------------------------------------------- #
+
+_PLAINTEXT_SUFFIXES = frozenset({".txt", ".md", ".csv", ".tsv", ".json", ".log"})
+
+# What tesseract can actually read. Everything else with no native branch below gets
+# the "no extractor" note rather than a doomed subprocess.
+_OCR_SUFFIXES = frozenset({
+    ".pdf", ".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".gif", ".webp",
+    ".jp2", ".pnm", ".ppm", ".pgm", ".pbm",
+})
+
+_WORD_NS = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
+_SHEET_NS = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+
+# Errors an OOXML/plaintext read can legitimately produce on a malformed or truncated
+# file. Extraction is best-effort: any of these degrades to "no ocr_text", never a lost
+# document — the same contract `run_ocr` already has for a missing tesseract.
+_EXTRACT_ERRORS = (
+    OSError, ValueError, KeyError, IndexError, zipfile.BadZipFile, ET.ParseError,
+)
+
+_SHEET_NUM = re.compile(r"(\d+)")
+
+
+def _xml_text(node: ET.Element, tag: str) -> str:
+    """Concatenated text of every ``tag`` descendant (OOXML splits runs arbitrarily)."""
+    return "".join(child.text or "" for child in node.iter(tag))
+
+
+def _extract_docx(path: Path) -> str:
+    """`.docx` body text: concat `w:t` runs, one line per `w:p` paragraph."""
+    with zipfile.ZipFile(path) as zf:
+        root = ET.fromstring(zf.read("word/document.xml"))
+    return "\n".join(
+        _xml_text(para, f"{_WORD_NS}t") for para in root.iter(f"{_WORD_NS}p")
+    )
+
+
+def _cell_text(cell: ET.Element, shared: list[str]) -> str:
+    """One `.xlsx` cell: shared-string lookup, inline string, or the literal value."""
+    kind = cell.get("t")
+    if kind == "s":
+        value = cell.find(f"{_SHEET_NS}v")
+        if value is None or not (value.text or "").strip():
+            return ""
+        index = int(value.text)
+        return shared[index] if 0 <= index < len(shared) else ""
+    if kind == "inlineStr":
+        return _xml_text(cell, f"{_SHEET_NS}t")
+    value = cell.find(f"{_SHEET_NS}v")
+    return (value.text or "") if value is not None else ""
+
+
+def _extract_xlsx(path: Path) -> str:
+    """`.xlsx` cell text: one line per row, tab-separated, sheets in workbook order."""
+    with zipfile.ZipFile(path) as zf:
+        names = zf.namelist()
+        shared: list[str] = []
+        if "xl/sharedStrings.xml" in names:
+            root = ET.fromstring(zf.read("xl/sharedStrings.xml"))
+            shared = [
+                _xml_text(si, f"{_SHEET_NS}t") for si in root.iter(f"{_SHEET_NS}si")
+            ]
+        sheets = sorted(
+            (n for n in names
+             if n.startswith("xl/worksheets/sheet") and n.endswith(".xml")),
+            # sheet2.xml before sheet10.xml — lexicographic order would invert them.
+            key=lambda n: [int(part) for part in _SHEET_NUM.findall(n)] or [0],
+        )
+        lines: list[str] = []
+        for name in sheets:
+            root = ET.fromstring(zf.read(name))
+            for row in root.iter(f"{_SHEET_NS}row"):
+                lines.append("\t".join(
+                    _cell_text(cell, shared) for cell in row.iter(f"{_SHEET_NS}c")
+                ))
+    return "\n".join(lines)
+
+
+def extract_text(path: str | Path) -> str | None:
+    """Best-effort document text by file type; ``None`` when there is no route.
+
+    Dispatches on suffix: plaintext-ish formats are read directly, `.docx`/`.xlsx` are
+    unzipped and their OOXML parsed with the stdlib, images and PDFs go to
+    :func:`run_ocr` (tesseract). Anything else — `.rtf`, `.msg`, `.doc` — returns
+    ``None`` with a stderr note; transcribe those yourself and pass `--ocr-text-file`.
+
+    Never raises: a malformed `.docx` must not cost you the document.
+    """
+    src = Path(path)
+    suffix = src.suffix.lower()
+    if suffix in _OCR_SUFFIXES:
+        return run_ocr(src)
+    try:
+        if suffix in _PLAINTEXT_SUFFIXES:
+            # utf-8-sig eats a BOM; errors="replace" keeps a legacy-encoded file
+            # usable rather than losing it entirely (same trade as run_ocr's decode).
+            text = src.read_text(encoding="utf-8-sig", errors="replace")
+        elif suffix == ".docx":
+            text = _extract_docx(src)
+        elif suffix == ".xlsx":
+            text = _extract_xlsx(src)
+        else:
+            print(
+                f"note: --ocr requested but there is no text extractor for "
+                f"'{suffix or src.name}'; storing document without ocr_text. "
+                f"Transcribe it and pass --ocr-text-file <path>.",
+                file=sys.stderr,
+            )
+            return None
+    except _EXTRACT_ERRORS as exc:
+        print(
+            f"note: text extraction failed for {src.name} ({exc}); "
+            "storing without ocr_text",
+            file=sys.stderr,
+        )
+        return None
+    text = text.strip()
+    return text or None
+
+
+# --------------------------------------------------------------------------- #
+# Google Drive pointer stubs (issue #66).
+#
+# A `.gsheet`/`.gdoc` in a synced Drive folder is a ~1 KB JSON link, not the document.
+# Storing it produces a permanently useless blob plus a `document` row that looks
+# legitimate. Detection is **conjunctive** so a real spreadsheet that merely got a
+# `.gsheet` name is still ingested normally.
+# --------------------------------------------------------------------------- #
+
+_POINTER_SUFFIXES = frozenset({
+    ".gdoc", ".gsheet", ".gslides", ".gdraw", ".gform", ".gsite",
+    ".gtable", ".gjam", ".glink", ".gmap", ".gscript",
+})
+_POINTER_MAX_BYTES = 16 * 1024
+_POINTER_HOSTS = frozenset({"docs.google.com", "drive.google.com"})
+
+
+def is_pointer_stub(path: str | Path) -> bool:
+    """Whether ``path`` is a Google Drive pointer stub rather than a document.
+
+    All of: a Google-native suffix, ≤16 KiB, parses as a JSON **object**, and carries
+    either a ``url`` on a Google Docs/Drive host or the older ``doc_id`` + ``email``
+    stub shape. Never raises — an unreadable/undecodable file is simply "not a stub"
+    and continues down the normal ingest path.
+    """
+    src = Path(path)
+    if src.suffix.lower() not in _POINTER_SUFFIXES:
+        return False
+    try:
+        if src.stat().st_size > _POINTER_MAX_BYTES:
+            return False
+        payload = json.loads(src.read_text(encoding="utf-8-sig"))
+    except (OSError, ValueError):  # UnicodeDecodeError/JSONDecodeError ⊂ ValueError
+        return False
+    if not isinstance(payload, dict):
+        return False
+    url = payload.get("url")
+    if isinstance(url, str):
+        try:
+            host = (urlsplit(url).hostname or "").lower()
+        except ValueError:
+            host = ""
+        if host in _POINTER_HOSTS:
+            return True
+    return isinstance(payload.get("doc_id"), str) and isinstance(
+        payload.get("email"), str
+    )
+
+
+def pointer_stub_message(path: str | Path) -> str:
+    """Refusal text naming the fix (export from Drive, ingest the export)."""
+    name = Path(path).name
+    return (
+        f"`{name}` is a Google Drive pointer stub (a ~1 KB JSON link), not the "
+        "document itself.\n"
+        "  Export it from Drive (File > Download > PDF/XLSX) and ingest the export.\n"
+        "  Nothing was ingested."
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -381,10 +580,14 @@ def ingest_document(
     status "duplicate" and nothing is written. Otherwise the blob is copied into
     the immutable content-addressed store and a new `document` row is inserted.
 
+    A Google Drive pointer stub is refused up front (issue #66) — before hashing, so
+    nothing is written and there is nothing to clean up. See :func:`is_pointer_stub`.
+
     ``ocr_text`` is caller-supplied document text (the agent's own transcription —
     the `AGENTS.md` default path, which beats tesseract on messy scans). When
-    provided it wins; otherwise ``ocr=True`` falls back to a best-effort tesseract
-    pass. An empty/whitespace-only string is treated as absent. Populating text here
+    provided it wins; otherwise ``ocr=True`` runs a best-effort :func:`extract_text`
+    pass (native for text/OOXML, tesseract for images and PDFs — issue #66).
+    An empty/whitespace-only string is treated as absent. Populating text here
     is what makes a document findable via FTS (`find`), so it is a warning-not-error
     when it ends up empty — see :attr:`IngestResult.ocr_text_populated`.
 
@@ -400,6 +603,12 @@ def ingest_document(
     if not src.is_file():
         raise IngestError(f"file not found: {src}")
 
+    # Pre-hash, pre-write: a refused pointer stub leaves no blob and no row. There is
+    # deliberately no --force escape hatch — the stub bytes are never the thing you
+    # want in the record, and renaming the file clears the (conjunctive) guard.
+    if is_pointer_stub(src):
+        raise IngestError(pointer_stub_message(src))
+
     person = _person_for_slug(conn, person_slug)
     sha = hash_file(src)
 
@@ -413,7 +622,7 @@ def ingest_document(
     # Resolve the text *before* the blob copy so the owner check is pre-write. OCR
     # runs on `src` rather than the copied blob — identical bytes, same result.
     supplied = ocr_text.strip() if ocr_text else None
-    ocr_text = supplied or (run_ocr(src) if ocr else None)
+    ocr_text = supplied or (extract_text(src) if ocr else None)
 
     roster = _roster(conn)
     owner_check = check_owner(ocr_text, person, roster)

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -35,7 +35,7 @@ import zipfile
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Sequence
+from typing import Callable, Sequence
 from urllib.parse import urlsplit
 
 from . import db
@@ -162,16 +162,49 @@ _EXTRACT_ERRORS = (
 
 _SHEET_NUM = re.compile(r"(\d+)")
 
+# Ceiling on how much text one file may contribute. `ocr_text` is stored in the row
+# *and* mirrored into the FTS index, so an unbounded read is both a DB-size problem
+# (a 106 MB log grew the database to 226 MB) and a decompression-bomb surface: a 917 KB
+# `.docx` whose `word/document.xml` inflates to ~1 GB is trivial to build, and
+# `MemoryError` is not something the best-effort handler below can honestly promise to
+# absorb. 32 MiB is far past any real medical document and far below hurting anything.
+_MAX_EXTRACT_BYTES = 32 * 1024 * 1024
+
 
 def _xml_text(node: ET.Element, tag: str) -> str:
     """Concatenated text of every ``tag`` descendant (OOXML splits runs arbitrarily)."""
     return "".join(child.text or "" for child in node.iter(tag))
 
 
+def _member_reader(zf: zipfile.ZipFile) -> Callable[[str], bytes]:
+    """Bounded member reader sharing one uncompressed-size budget across the archive.
+
+    `ZipInfo.file_size` is the *declared* uncompressed size, so the check costs no
+    read; `ZipExtFile` never yields more than that many bytes, so a lying header can
+    only under-deliver. Over budget raises `ValueError`, which the caller's
+    best-effort handler turns into the usual "no ocr_text" note.
+    """
+    remaining = _MAX_EXTRACT_BYTES
+
+    def read(name: str) -> bytes:
+        nonlocal remaining
+        size = zf.getinfo(name).file_size
+        if size > remaining:
+            raise ValueError(
+                f"{name} expands to {size} bytes, past the "
+                f"{_MAX_EXTRACT_BYTES}-byte extraction cap"
+            )
+        remaining -= size
+        return zf.read(name)
+
+    return read
+
+
 def _extract_docx(path: Path) -> str:
     """`.docx` body text: concat `w:t` runs, one line per `w:p` paragraph."""
     with zipfile.ZipFile(path) as zf:
-        root = ET.fromstring(zf.read("word/document.xml"))
+        read_member = _member_reader(zf)
+        root = ET.fromstring(read_member("word/document.xml"))
     return "\n".join(
         _xml_text(para, f"{_WORD_NS}t") for para in root.iter(f"{_WORD_NS}p")
     )
@@ -201,10 +234,11 @@ def _extract_xlsx(path: Path) -> str:
     numeric order (`sheet2.xml` before `sheet10.xml`); true workbook order lives in
     `xl/workbook.xml` and is not worth a second parse for full-text purposes."""
     with zipfile.ZipFile(path) as zf:
+        read_member = _member_reader(zf)
         names = zf.namelist()
         shared: list[str] = []
         if "xl/sharedStrings.xml" in names:
-            root = ET.fromstring(zf.read("xl/sharedStrings.xml"))
+            root = ET.fromstring(read_member("xl/sharedStrings.xml"))
             shared = [
                 _xml_text(si, f"{_SHEET_NS}t") for si in root.iter(f"{_SHEET_NS}si")
             ]
@@ -216,7 +250,7 @@ def _extract_xlsx(path: Path) -> str:
         )
         lines: list[str] = []
         for name in sheets:
-            root = ET.fromstring(zf.read(name))
+            root = ET.fromstring(read_member(name))
             for row in root.iter(f"{_SHEET_NS}row"):
                 lines.append("\t".join(
                     _cell_text(cell, shared) for cell in row.iter(f"{_SHEET_NS}c")
@@ -224,18 +258,23 @@ def _extract_xlsx(path: Path) -> str:
     return "\n".join(lines)
 
 
-def extract_text(path: str | Path) -> str | None:
-    """Best-effort document text by file type; ``None`` when nothing could be read.
+def extract_text_routed(path: str | Path) -> tuple[str | None, str]:
+    """:func:`extract_text` plus the **route** that produced the text.
 
     Dispatches on suffix: plaintext-ish formats are read directly and `.docx`/`.xlsx`
-    are unzipped and their OOXML parsed with the stdlib. **Everything else falls
-    through to :func:`run_ocr`** (tesseract) — the same thing `ocr=True` did before
-    this dispatcher existed. Deliberately not a suffix allowlist: image extensions
-    vary far too widely (`.jfif`, `.jpe`, extension-less scans) for one to be safe,
-    and silently skipping a scan that used to OCR is the worse failure — it drops the
-    document out of `find` with no signal. When tesseract declines (absent, failed, or
-    no text — e.g. `.rtf`, `.msg`, `.doc`) the caller gets ``None`` plus a stderr note
-    pointing at `--ocr-text-file`.
+    are unzipped and their OOXML parsed with the stdlib (route ``"native"``).
+    **Everything else falls through to :func:`run_ocr`** (route ``"ocr"``) — the same
+    thing `ocr=True` did before this dispatcher existed. Deliberately not a suffix
+    allowlist: image extensions vary far too widely (`.jfif`, `.jpe`, extension-less
+    scans) for one to be safe, and silently skipping a scan that used to OCR is the
+    worse failure — it drops the document out of `find` with no signal. When tesseract
+    declines (absent, failed, or no text — e.g. `.pdf`, `.rtf`, `.msg`, `.doc`) the
+    caller gets ``None`` plus a stderr note pointing at `--ocr-text-file`.
+
+    The route matters to the caller because the #61 owner check reads identity
+    *anchors* (`Patient`, `DOB`, `MRN`) as "this document names somebody". That
+    inference holds for a scanned or transcribed page and not for a spreadsheet,
+    where those words are column labels — see ``trust_anchors`` on :func:`check_owner`.
 
     Never raises: a malformed `.docx` must not cost you the document.
     """
@@ -243,6 +282,11 @@ def extract_text(path: str | Path) -> str | None:
     suffix = src.suffix.lower()
     try:
         if suffix in _PLAINTEXT_SUFFIXES:
+            size = src.stat().st_size
+            if size > _MAX_EXTRACT_BYTES:
+                raise ValueError(
+                    f"{size} bytes, past the {_MAX_EXTRACT_BYTES}-byte extraction cap"
+                )
             # utf-8-sig eats a BOM; errors="replace" keeps a legacy-encoded file
             # usable rather than losing it entirely (same trade as run_ocr's decode).
             text = src.read_text(encoding="utf-8-sig", errors="replace")
@@ -260,16 +304,25 @@ def extract_text(path: str | Path) -> str | None:
                     f"--ocr-text-file <path>.",
                     file=sys.stderr,
                 )
-            return ocr_text
+            return ocr_text, "ocr"
     except _EXTRACT_ERRORS as exc:
         print(
             f"note: text extraction failed for {src.name} ({exc}); "
             "storing without ocr_text",
             file=sys.stderr,
         )
-        return None
+        return None, "native"
     text = text.strip()
-    return text or None
+    return (text or None), "native"
+
+
+def extract_text(path: str | Path) -> str | None:
+    """Best-effort document text by file type; ``None`` when nothing could be read.
+
+    Route-blind convenience wrapper over :func:`extract_text_routed`, which is what
+    :func:`ingest_document` calls.
+    """
+    return extract_text_routed(path)[0]
 
 
 # --------------------------------------------------------------------------- #
@@ -377,7 +430,8 @@ class OwnerCheck:
     * ``mismatch`` — a *different* roster person matched and the claimed one did not.
     * ``suspect`` — the text carries a patient-identity anchor but names nobody on
       the roster. This is the case that actually happened (a legible ``Patient:`` /
-      ``DOB:`` header for someone who is not on the roster at all).
+      ``DOB:`` header for someone who is not on the roster at all). Only reachable
+      for transcribed/OCR'd text — see ``trust_anchors`` on :func:`check_owner`.
     * ``unverified`` — no text, or text with no identity anchor and no matches.
     """
 
@@ -474,9 +528,22 @@ def _evidence(raw: str) -> str | None:
 
 
 def check_owner(
-    text: str | None, claimed: Person, roster: Sequence[Person]
+    text: str | None,
+    claimed: Person,
+    roster: Sequence[Person],
+    *,
+    trust_anchors: bool = True,
 ) -> OwnerCheck:
-    """Does ``text`` look like it belongs to ``claimed``? See :class:`OwnerCheck`."""
+    """Does ``text`` look like it belongs to ``claimed``? See :class:`OwnerCheck`.
+
+    ``trust_anchors=False`` says the text is **structured**, not prose — a CSV, a
+    spreadsheet, a JSON export — where ``Patient``/``DOB``/``MRN`` are column labels
+    and field keys rather than a printed identity header. `_ANCHOR` was tuned for
+    scanned document headers and does not transfer: counting a `Patient ID,Test,Value`
+    header row as "this document names somebody" refuses an ordinary lab export as
+    belonging to a stranger. Only the ``suspect`` inference is suppressed;
+    ``match``/``mismatch`` are affirmative name/DOB evidence and hold on every route.
+    """
     if not text or not text.strip():
         return OwnerCheck(verdict="unverified")
 
@@ -505,7 +572,7 @@ def check_owner(
     # reflexively. A DOB doesn't rescue it either: most documents simply don't print
     # one, so its absence proves nothing. `mismatch` above is untouched — affirmative
     # evidence pointing at another roster person still blocks.
-    if evidence is not None and name_tokens(claimed.full_name):
+    if trust_anchors and evidence is not None and name_tokens(claimed.full_name):
         return OwnerCheck(verdict="suspect", evidence=evidence)
     return OwnerCheck(verdict="unverified")
 
@@ -590,14 +657,18 @@ def ingest_document(
 
     ``ocr_text`` is caller-supplied document text (the agent's own transcription —
     the `AGENTS.md` default path, which beats tesseract on messy scans). When
-    provided it wins; otherwise ``ocr=True`` runs a best-effort :func:`extract_text`
-    pass (native for text/OOXML, tesseract for images and PDFs — issue #66).
+    provided it wins; otherwise ``ocr=True`` runs a best-effort
+    :func:`extract_text_routed` pass (native for text/OOXML, tesseract for everything
+    else — issue #66).
     An empty/whitespace-only string is treated as absent. Populating text here
     is what makes a document findable via FTS (`find`), so it is a warning-not-error
     when it ends up empty — see :attr:`IngestResult.ocr_text_populated`.
 
-    When text is available it is also checked against the claimed owner (issue #61).
-    A blocking verdict raises :class:`OwnerMismatchError` **before** anything is
+    When text is available it is also checked against the claimed owner (issue #61),
+    with the identity-anchor (``suspect``) half of that check applied only to prose —
+    transcribed or OCR'd text, not natively-extracted CSV/OOXML/JSON, whose
+    ``Patient``/``DOB`` tokens are column labels. A blocking verdict raises
+    :class:`OwnerMismatchError` **before** anything is
     written, so a refused ingest is a clean no-op and ``force=True`` is the whole
     recovery. The verdict rides back on :attr:`IngestResult.owner_check` so callers
     report it without a second pass.
@@ -627,10 +698,21 @@ def ingest_document(
     # Resolve the text *before* the blob copy so the owner check is pre-write. OCR
     # runs on `src` rather than the copied blob — identical bytes, same result.
     supplied = ocr_text.strip() if ocr_text else None
-    ocr_text = supplied or (extract_text(src) if ocr else None)
+    if supplied:
+        # An agent transcription is prose off the page: anchors mean what they say.
+        ocr_text, route = supplied, "ocr"
+    elif ocr:
+        ocr_text, route = extract_text_routed(src)
+    else:
+        ocr_text, route = None, "ocr"  # no text at all; the route is moot
 
     roster = _roster(conn)
-    owner_check = check_owner(ocr_text, person, roster)
+    # Natively-extracted text (CSV/OOXML/JSON) is structured, so a `Patient ID` column
+    # header is not an identity claim — trusting anchors there refuses ordinary lab
+    # exports as belonging to a stranger. `mismatch` still blocks on every route.
+    owner_check = check_owner(
+        ocr_text, person, roster, trust_anchors=(route != "native")
+    )
     if owner_check.blocks and not force:
         raise OwnerMismatchError(
             refusal_message(owner_check, person, roster), owner_check

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -150,13 +150,6 @@ def run_ocr(path: str | Path) -> str | None:
 
 _PLAINTEXT_SUFFIXES = frozenset({".txt", ".md", ".csv", ".tsv", ".json", ".log"})
 
-# What tesseract can actually read. Everything else with no native branch below gets
-# the "no extractor" note rather than a doomed subprocess.
-_OCR_SUFFIXES = frozenset({
-    ".pdf", ".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".gif", ".webp",
-    ".jp2", ".pnm", ".ppm", ".pgm", ".pbm",
-})
-
 _WORD_NS = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
 _SHEET_NS = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
 
@@ -191,7 +184,11 @@ def _cell_text(cell: ET.Element, shared: list[str]) -> str:
         value = cell.find(f"{_SHEET_NS}v")
         if value is None or not (value.text or "").strip():
             return ""
-        index = int(value.text)
+        try:
+            index = int(value.text)
+        except ValueError:
+            # One malformed shared-string index must not discard the whole workbook.
+            return ""
         return shared[index] if 0 <= index < len(shared) else ""
     if kind == "inlineStr":
         return _xml_text(cell, f"{_SHEET_NS}t")
@@ -200,7 +197,9 @@ def _cell_text(cell: ET.Element, shared: list[str]) -> str:
 
 
 def _extract_xlsx(path: Path) -> str:
-    """`.xlsx` cell text: one line per row, tab-separated, sheets in workbook order."""
+    """`.xlsx` cell text: one line per row, tab-separated, sheets in sheet-file
+    numeric order (`sheet2.xml` before `sheet10.xml`); true workbook order lives in
+    `xl/workbook.xml` and is not worth a second parse for full-text purposes."""
     with zipfile.ZipFile(path) as zf:
         names = zf.namelist()
         shared: list[str] = []
@@ -226,19 +225,22 @@ def _extract_xlsx(path: Path) -> str:
 
 
 def extract_text(path: str | Path) -> str | None:
-    """Best-effort document text by file type; ``None`` when there is no route.
+    """Best-effort document text by file type; ``None`` when nothing could be read.
 
-    Dispatches on suffix: plaintext-ish formats are read directly, `.docx`/`.xlsx` are
-    unzipped and their OOXML parsed with the stdlib, images and PDFs go to
-    :func:`run_ocr` (tesseract). Anything else — `.rtf`, `.msg`, `.doc` — returns
-    ``None`` with a stderr note; transcribe those yourself and pass `--ocr-text-file`.
+    Dispatches on suffix: plaintext-ish formats are read directly and `.docx`/`.xlsx`
+    are unzipped and their OOXML parsed with the stdlib. **Everything else falls
+    through to :func:`run_ocr`** (tesseract) — the same thing `ocr=True` did before
+    this dispatcher existed. Deliberately not a suffix allowlist: image extensions
+    vary far too widely (`.jfif`, `.jpe`, extension-less scans) for one to be safe,
+    and silently skipping a scan that used to OCR is the worse failure — it drops the
+    document out of `find` with no signal. When tesseract declines (absent, failed, or
+    no text — e.g. `.rtf`, `.msg`, `.doc`) the caller gets ``None`` plus a stderr note
+    pointing at `--ocr-text-file`.
 
     Never raises: a malformed `.docx` must not cost you the document.
     """
     src = Path(path)
     suffix = src.suffix.lower()
-    if suffix in _OCR_SUFFIXES:
-        return run_ocr(src)
     try:
         if suffix in _PLAINTEXT_SUFFIXES:
             # utf-8-sig eats a BOM; errors="replace" keeps a legacy-encoded file
@@ -249,13 +251,16 @@ def extract_text(path: str | Path) -> str | None:
         elif suffix == ".xlsx":
             text = _extract_xlsx(src)
         else:
-            print(
-                f"note: --ocr requested but there is no text extractor for "
-                f"'{suffix or src.name}'; storing document without ocr_text. "
-                f"Transcribe it and pass --ocr-text-file <path>.",
-                file=sys.stderr,
-            )
-            return None
+            ocr_text = run_ocr(src)
+            if ocr_text is None:
+                # run_ocr already said *why* it declined; add what to do about it.
+                print(
+                    f"note: no text could be extracted from {src.name}; "
+                    f"storing document without ocr_text. Transcribe it and pass "
+                    f"--ocr-text-file <path>.",
+                    file=sys.stderr,
+                )
+            return ocr_text
     except _EXTRACT_ERRORS as exc:
         print(
             f"note: text extraction failed for {src.name} ({exc}); "

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -180,7 +180,9 @@ def ingest_document(
     The response's ``ocr_text_populated`` lets the agent self-check the FTS-visibility
     contract without a follow-up read. ``ocr=true`` is the fallback: it extracts by
     whatever route the file type allows (plaintext/`.docx`/`.xlsx` natively, everything
-    else via tesseract), and stores nothing when nothing could be read.
+    else via tesseract), and stores nothing when nothing could be read — `.pdf`, `.rtf`,
+    `.msg` and `.doc` have no route at all (tesseract does not accept PDF input), so
+    transcribe those yourself.
 
     A Google Drive pointer stub (``.gsheet``/``.gdoc`` — a ~1 KB JSON link, not the
     document) is refused pre-write; the fix is to export it from Drive first.
@@ -189,7 +191,10 @@ def ingest_document(
     back as ``owner_check`` (``null`` on a duplicate, which is never checked). A
     ``mismatch``/``suspect`` verdict refuses the ingest pre-write — per ``AGENTS.md``
     §3, surface the verdict and its evidence to the human and get an explicit
-    go-ahead before retrying with ``force=true``.
+    go-ahead before retrying with ``force=true``. ``suspect`` (a patient-identity
+    header naming nobody on the roster) applies to your transcription or a tesseract
+    pass only, never to natively-extracted CSV/OOXML/JSON, where those words are
+    column labels; ``mismatch`` holds on every route.
     """
     try:
         sources_dir = cli._resolve_sources_dir(_ARGS)

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -179,8 +179,8 @@ def ingest_document(
     ``ocr_text`` is the agent's own transcription — the ``AGENTS.md`` default path.
     The response's ``ocr_text_populated`` lets the agent self-check the FTS-visibility
     contract without a follow-up read. ``ocr=true`` is the fallback: it extracts by
-    whatever route the file type allows (plaintext/`.docx`/`.xlsx` natively, images and
-    PDFs via tesseract), and stores nothing when there is no route.
+    whatever route the file type allows (plaintext/`.docx`/`.xlsx` natively, everything
+    else via tesseract), and stores nothing when nothing could be read.
 
     A Google Drive pointer stub (``.gsheet``/``.gdoc`` — a ~1 KB JSON link, not the
     document) is refused pre-write; the fix is to export it from Drive first.

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -192,9 +192,11 @@ def ingest_document(
     ``mismatch``/``suspect`` verdict refuses the ingest pre-write — per ``AGENTS.md``
     §3, surface the verdict and its evidence to the human and get an explicit
     go-ahead before retrying with ``force=true``. ``suspect`` (a patient-identity
-    header naming nobody on the roster) applies to your transcription or a tesseract
-    pass only, never to natively-extracted CSV/OOXML/JSON, where those words are
-    column labels; ``mismatch`` holds on every route.
+    header naming nobody on the roster) is scoped by route: it applies to the text you
+    supply and to a tesseract pass, never to anything ``ocr=true`` extracts natively
+    (``.txt``/``.md``/``.csv``/``.tsv``/``.json``/``.log``/``.docx``/``.xlsx``), where
+    those words are column labels — so pass your transcription as ``ocr_text`` rather
+    than saving it to a ``.txt`` and re-reading that. ``mismatch`` holds on every route.
     """
     try:
         sources_dir = cli._resolve_sources_dir(_ARGS)

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -178,7 +178,12 @@ def ingest_document(
 
     ``ocr_text`` is the agent's own transcription — the ``AGENTS.md`` default path.
     The response's ``ocr_text_populated`` lets the agent self-check the FTS-visibility
-    contract without a follow-up read.
+    contract without a follow-up read. ``ocr=true`` is the fallback: it extracts by
+    whatever route the file type allows (plaintext/`.docx`/`.xlsx` natively, images and
+    PDFs via tesseract), and stores nothing when there is no route.
+
+    A Google Drive pointer stub (``.gsheet``/``.gdoc`` — a ~1 KB JSON link, not the
+    document) is refused pre-write; the fix is to export it from Drive first.
 
     When text is present it is checked against the claimed owner; the verdict comes
     back as ``owner_check`` (``null`` on a duplicate, which is never checked). A

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -412,7 +412,10 @@ def test_ocr_tesseract_is_an_alias_for_auto(ready, capsys):
     assert "#1" in capsys.readouterr().out
 
 
-def test_unextractable_format_still_ingests_with_a_note(ready, capsys):
+def test_unextractable_format_still_ingests_with_a_note(ready, capsys, monkeypatch):
+    from pemr import ingest as ingest_mod
+
+    monkeypatch.setattr(ingest_mod, "run_ocr", lambda _: None)   # tesseract declines
     tmp_path = ready
     msg = tmp_path / "thread.msg"
     msg.write_bytes(b"\xd0\xcf\x11\xe0 outlook message")
@@ -420,5 +423,22 @@ def test_unextractable_format_still_ingests_with_a_note(ready, capsys):
     assert _run(tmp_path, "ingest", str(msg), "--person", "jane-doe",
                 "--sources", str(tmp_path / "sources"), "--ocr", "auto") == 0
     err = capsys.readouterr().err
-    assert "no text extractor" in err
+    assert "no text could be extracted" in err
     assert "--ocr-text-file" in err
+    assert "no ocr_text stored" in err
+
+
+def test_ocr_auto_still_ocrs_an_unlisted_image_suffix(ready, capsys, monkeypatch):
+    """`.jfif` has no native route and must reach tesseract, not be skipped."""
+    from pemr import ingest as ingest_mod
+
+    monkeypatch.setattr(ingest_mod, "run_ocr", lambda _: "Ferritin 201 nanograms")
+    tmp_path = ready
+    img = tmp_path / "alpha.jfif"
+    img.write_bytes(b"\xff\xd8\xff\xe0 jpeg bytes")
+
+    assert _run(tmp_path, "ingest", str(img), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources"), "--ocr", "auto") == 0
+    assert "no ocr_text stored" not in capsys.readouterr().err
+    assert _run(tmp_path, "find", "--person", "jane-doe", "ferritin") == 0
+    assert "#1" in capsys.readouterr().out

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -442,3 +442,22 @@ def test_ocr_auto_still_ocrs_an_unlisted_image_suffix(ready, capsys, monkeypatch
     assert "no ocr_text stored" not in capsys.readouterr().err
     assert _run(tmp_path, "find", "--person", "jane-doe", "ferritin") == 0
     assert "#1" in capsys.readouterr().out
+
+
+def test_lab_export_with_a_patient_column_is_not_refused(ready, capsys):
+    """A `Patient ID` column header is a schema, not an identity claim: making the CSV
+    readable must not make it unfilable (issue #66 audit bounce)."""
+    tmp_path = ready
+    csv = tmp_path / "labs.csv"
+    csv.write_text(
+        "Patient ID,Test,Value,Unit\n1043,Glucose,98,mg/dL\n", encoding="utf-8"
+    )
+
+    assert _run(tmp_path, "ingest", str(csv), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources"), "--ocr", "auto") == 0
+    out = capsys.readouterr()
+    assert "ingested document #1" in out.out
+    assert "owner verification failed" not in out.err
+
+    assert _run(tmp_path, "find", "--person", "jane-doe", "glucose") == 0
+    assert "#1" in capsys.readouterr().out

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -1,6 +1,7 @@
 """End-to-end CLI wiring for phase 2: ingest -> commit-extraction -> review-conflicts."""
 
 import json
+import zipfile
 
 import pytest
 
@@ -353,3 +354,71 @@ def test_rekey_refuses_a_fusing_dictionary(ready, capsys, tmp_path):
     assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 1
     err = capsys.readouterr().err
     assert "same dedup_key" in err and "nothing was written" in err
+
+
+# --- intake formats at the CLI (issue #66) ------------------------------------
+
+def test_ingest_refuses_a_google_drive_pointer_stub(ready, capsys):
+    tmp_path = ready
+    stub = tmp_path / "budget.gsheet"
+    stub.write_text(json.dumps({
+        "url": "https://docs.google.com/spreadsheets/d/1AbC_dEf/edit?usp=drivesdk",
+        "doc_id": "1AbC_dEf",
+        "email": "someone@example.com",
+    }), encoding="utf-8")
+
+    rc = _run(tmp_path, "ingest", str(stub), "--person", "jane-doe",
+              "--sources", str(tmp_path / "sources"))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "pointer stub" in err
+    assert "Export it from Drive" in err
+    assert not _document_id(tmp_path)  # pre-write refusal: nothing landed
+
+
+def test_ocr_auto_makes_a_docx_findable(ready, capsys):
+    tmp_path = ready
+    ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+    doc = tmp_path / "visit.docx"
+    with zipfile.ZipFile(doc, "w") as zf:
+        zf.writestr("[Content_Types].xml", "<Types/>")
+        zf.writestr(
+            "word/document.xml",
+            f'<w:document xmlns:w="{ns}"><w:body>'
+            "<w:p><w:r><w:t>total cholesterol 188</w:t></w:r></w:p>"
+            "</w:body></w:document>",
+        )
+
+    assert _run(tmp_path, "ingest", str(doc), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources"), "--ocr", "auto") == 0
+    out = capsys.readouterr()
+    assert "ingested document #1" in out.out
+    assert "no ocr_text stored" not in out.err
+
+    assert _run(tmp_path, "find", "--person", "jane-doe", "cholesterol") == 0
+    assert "#1" in capsys.readouterr().out
+
+
+def test_ocr_tesseract_is_an_alias_for_auto(ready, capsys):
+    """The old spelling keeps working — it selects the same extraction dispatcher."""
+    tmp_path = ready
+    csv = tmp_path / "labs.csv"
+    csv.write_text("test,value\nferritin,68\n", encoding="utf-8")
+
+    assert _run(tmp_path, "ingest", str(csv), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources"), "--ocr", "tesseract") == 0
+    capsys.readouterr()
+    assert _run(tmp_path, "find", "--person", "jane-doe", "ferritin") == 0
+    assert "#1" in capsys.readouterr().out
+
+
+def test_unextractable_format_still_ingests_with_a_note(ready, capsys):
+    tmp_path = ready
+    msg = tmp_path / "thread.msg"
+    msg.write_bytes(b"\xd0\xcf\x11\xe0 outlook message")
+
+    assert _run(tmp_path, "ingest", str(msg), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources"), "--ocr", "auto") == 0
+    err = capsys.readouterr().err
+    assert "no text extractor" in err
+    assert "--ocr-text-file" in err

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,6 +1,8 @@
 """Document ingest: hashing, content-addressed blob store, layer-1 dedup."""
 
+import json
 import sqlite3
+import zipfile
 
 import pytest
 
@@ -107,9 +109,10 @@ def test_failed_insert_does_not_orphan_blob(conn, tmp_path, sources):
 
 def test_ocr_degrades_when_tesseract_absent(conn, tmp_path, sources, monkeypatch, capsys):
     monkeypatch.setattr(ingest.shutil, "which", lambda _: None)
-    result = ingest.ingest_document(
-        conn, _make_file(tmp_path), "jane-doe", sources, ocr=True
-    )
+    # a scan (image suffix) is the tesseract branch of ingest.extract_text; text and
+    # OOXML suffixes are read natively and never reach the binary.
+    scan = _make_file(tmp_path, "scan.png", b"\x89PNG not really")
+    result = ingest.ingest_document(conn, scan, "jane-doe", sources, ocr=True)
     assert result.status == "new"
     assert result.document.ocr_text is None
     assert "tesseract" in capsys.readouterr().err
@@ -327,3 +330,151 @@ def test_layer1_duplicate_is_unaffected_by_mismatching_text(conn, tmp_path, sour
     assert again.status == "duplicate"
     assert again.document.document_id == first.document.document_id
     assert again.owner_check is None  # nothing written -> nothing checked
+
+
+# --- intake formats (issue #66) -----------------------------------------------
+#
+# Two guards, both stdlib-only: Google Drive pointer stubs are refused pre-write, and
+# `ocr=True` extracts text natively for the formats that allow it.
+
+_STUB = {
+    "url": "https://docs.google.com/spreadsheets/d/1AbC_dEf/edit?usp=drivesdk",
+    "doc_id": "1AbC_dEf",
+    "email": "someone@example.com",
+    "resource_id": "spreadsheet:1AbC_dEf",
+}
+
+
+def _make_stub(tmp_path, name="budget.gsheet", payload=None):
+    p = tmp_path / name
+    p.write_text(json.dumps(_STUB if payload is None else payload), encoding="utf-8")
+    return p
+
+
+def _make_docx(tmp_path, name="note.docx", paragraphs=("HbA1c 5.7 percent",)):
+    body = "".join(
+        f"<w:p><w:r><w:t>{part}</w:t></w:r></w:p>" for part in paragraphs
+    )
+    document = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/'
+        f'2006/main"><w:body>{body}</w:body></w:document>'
+    )
+    p = tmp_path / name
+    with zipfile.ZipFile(p, "w") as zf:
+        zf.writestr("[Content_Types].xml", "<Types/>")
+        zf.writestr("word/document.xml", document)
+    return p
+
+
+def _make_xlsx(tmp_path, name="labs.xlsx", rows=(("test", "value"), ("sodium", "140"))):
+    strings: list[str] = []
+    for row in rows:
+        for cell in row:
+            if cell not in strings:
+                strings.append(cell)
+    ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+    shared = (
+        f'<sst xmlns="{ns}">'
+        + "".join(f"<si><t>{s}</t></si>" for s in strings)
+        + "</sst>"
+    )
+    body = "".join(
+        "<row>"
+        + "".join(f'<c t="s"><v>{strings.index(cell)}</v></c>' for cell in row)
+        + "</row>"
+        for row in rows
+    )
+    sheet = f'<worksheet xmlns="{ns}"><sheetData>{body}</sheetData></worksheet>'
+    p = tmp_path / name
+    with zipfile.ZipFile(p, "w") as zf:
+        zf.writestr("[Content_Types].xml", "<Types/>")
+        zf.writestr("xl/sharedStrings.xml", shared)
+        zf.writestr("xl/worksheets/sheet1.xml", sheet)
+    return p
+
+
+def test_pointer_stub_is_refused_pre_write(conn, tmp_path, sources):
+    stub = _make_stub(tmp_path)
+    with pytest.raises(ingest.IngestError) as excinfo:
+        ingest.ingest_document(conn, stub, "jane-doe", sources)
+    message = str(excinfo.value)
+    assert "pointer stub" in message
+    assert "Export it from Drive" in message  # names the fix
+    # pre-write: no blob and no row
+    assert not sources.exists()
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 0
+
+
+def test_pointer_guard_is_conjunctive_so_a_real_file_still_ingests(
+    conn, tmp_path, sources
+):
+    # a genuine spreadsheet that merely carries a `.gsheet` name: right suffix, but
+    # too big and not JSON -> not a stub.
+    real = _make_file(tmp_path, "real.gsheet", b"PK\x03\x04" + b"\xff" * 20_000)
+    result = ingest.ingest_document(conn, real, "jane-doe", sources)
+    assert result.status == "new"
+
+
+@pytest.mark.parametrize(
+    "name, payload",
+    [
+        ("notes.txt", _STUB),                       # wrong suffix
+        ("x.gsheet", {"url": "https://example.com/x"}),   # wrong host
+        ("x.gsheet", {"doc_id": "abc"}),            # older shape, missing `email`
+        ("x.gsheet", ["not", "an", "object"]),      # JSON, but not an object
+    ],
+)
+def test_pointer_guard_does_not_fire(conn, tmp_path, sources, name, payload):
+    src = _make_stub(tmp_path, name, payload)
+    assert not ingest.is_pointer_stub(src)
+    assert ingest.ingest_document(conn, src, "jane-doe", sources).status == "new"
+
+
+def test_pointer_guard_ignores_unparseable_files(tmp_path):
+    assert not ingest.is_pointer_stub(_make_file(tmp_path, "b.gsheet", b"\xff\xfe\x00"))
+
+
+def test_extract_text_reads_plaintext_formats(conn, tmp_path, sources):
+    src = _make_file(tmp_path, "labs.csv", "test,value\r\nsodium,140\n".encode("utf-8"))
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.ocr_text_populated
+    assert "sodium,140" in result.document.ocr_text
+
+
+def test_extract_text_reads_docx(conn, tmp_path, sources):
+    src = _make_docx(tmp_path, paragraphs=("Visit summary", "HbA1c 5.7 percent"))
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.document.ocr_text == "Visit summary\nHbA1c 5.7 percent"
+
+
+def test_extract_text_reads_xlsx(conn, tmp_path, sources):
+    src = _make_xlsx(tmp_path)
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.document.ocr_text == "test\tvalue\nsodium\t140"
+
+
+def test_extract_text_has_no_route_for_msg(conn, tmp_path, sources, capsys):
+    src = _make_file(tmp_path, "thread.msg", b"\xd0\xcf\x11\xe0 outlook")
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.status == "new"          # the document still lands
+    assert result.document.ocr_text is None
+    assert "--ocr-text-file" in capsys.readouterr().err
+
+
+def test_malformed_docx_degrades_instead_of_losing_the_document(
+    conn, tmp_path, sources, capsys
+):
+    src = _make_file(tmp_path, "broken.docx", b"not a zip at all")
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.status == "new"
+    assert result.document.ocr_text is None
+    assert "extraction failed" in capsys.readouterr().err
+
+
+def test_supplied_ocr_text_still_beats_extraction(conn, tmp_path, sources):
+    src = _make_docx(tmp_path, paragraphs=("extracted body",))
+    result = ingest.ingest_document(
+        conn, src, "jane-doe", sources, ocr=True, ocr_text="agent transcription"
+    )
+    assert result.document.ocr_text == "agent transcription"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -601,6 +601,27 @@ def test_structured_headers_do_not_refuse_the_ingest(conn, tmp_path, sources, ki
     assert result.ocr_text_populated
 
 
+@pytest.mark.parametrize("name", ["transcript.txt", "note.md", "panel.tsv", "app.log"])
+def test_plaintext_suffixes_are_route_scoped_too(conn, tmp_path, sources, name):
+    """The scope line is the *route*, not how prose-like the suffix is: a foreign
+    identity header in a natively-read `.txt`/`.md`/`.tsv`/`.log` yields `unverified`,
+    not `suspect`. Not a regression — before native extraction these went to tesseract,
+    which declined, so there was no text and no check either — but it is the behavior
+    `AGENTS.md` §3 documents, so pin it rather than let it drift silently."""
+    _seed_roster(conn)
+    src = _make_file(
+        tmp_path, name, b"MERCY LABS\nPatient: SMITH, KAREN\nDOB: 09/09/1971\n"
+    )
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.owner_check.verdict == "unverified"
+    assert result.status == "new"
+    # ...and the protective half still fires on the same route.
+    other = _make_file(tmp_path, f"other-{name}", b"Patient: ROE, ROBERT ALAN\n")
+    with pytest.raises(ingest.OwnerMismatchError) as excinfo:
+        ingest.ingest_document(conn, other, "jane-doe", sources, ocr=True)
+    assert excinfo.value.check.verdict == "mismatch"
+
+
 def test_structured_text_still_refuses_another_roster_person(conn, tmp_path, sources):
     """The half of #61 that actually protects against a misfile is untouched: an
     affirmative match on a different roster person blocks on the native route too."""
@@ -647,3 +668,30 @@ def test_oversized_extraction_degrades_instead_of_reading_it(
     assert result.status == "new"           # the document still lands
     assert result.document.ocr_text is None
     assert "extraction cap" in capsys.readouterr().err
+
+
+def test_extraction_cap_is_one_budget_shared_across_the_archive(
+    conn, tmp_path, sources, capsys, monkeypatch
+):
+    """Many members, none individually over the cap, must not add up past it — the
+    per-member check alone would let a 40-sheet workbook spend the budget 40 times."""
+    ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+    def sheet(text):
+        return (f'<worksheet xmlns="{ns}"><sheetData><row>'
+                f'<c t="inlineStr"><is><t>{text}</t></is></c>'
+                "</row></sheetData></worksheet>")
+    src = tmp_path / "many.xlsx"
+    members = ("xl/worksheets/sheet1.xml", "xl/worksheets/sheet2.xml")
+    with zipfile.ZipFile(src, "w") as zf:
+        zf.writestr(members[0], sheet("a" * 200))
+        zf.writestr(members[1], sheet("b" * 200))
+    with zipfile.ZipFile(src) as zf:
+        sizes = [zf.getinfo(name).file_size for name in members]
+    assert ingest.extract_text(src) is not None   # fine under the real cap
+
+    # A cap each member clears on its own, but the pair does not.
+    monkeypatch.setattr(ingest, "_MAX_EXTRACT_BYTES", max(sizes))
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.status == "new"
+    assert result.document.ocr_text is None
+    assert "sheet2.xml" in capsys.readouterr().err

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -454,12 +454,79 @@ def test_extract_text_reads_xlsx(conn, tmp_path, sources):
     assert result.document.ocr_text == "test\tvalue\nsodium\t140"
 
 
-def test_extract_text_has_no_route_for_msg(conn, tmp_path, sources, capsys):
+def test_extract_text_has_no_route_for_msg(conn, tmp_path, sources, capsys, monkeypatch):
+    monkeypatch.setattr(ingest, "run_ocr", lambda _: None)   # tesseract declines
     src = _make_file(tmp_path, "thread.msg", b"\xd0\xcf\x11\xe0 outlook")
     result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
     assert result.status == "new"          # the document still lands
     assert result.document.ocr_text is None
     assert "--ocr-text-file" in capsys.readouterr().err
+
+
+# --- routing boundary (issue #66 verify bounce) --------------------------------
+# `ocr=True` used to hand *every* file to tesseract. An image-suffix allowlist silently
+# dropped `.jfif`/`.jpe`/extension-less scans out of `find`, so anything without a native
+# route must still reach `run_ocr`.
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["alpha.jfif", "beta.jpe", "gamma_noext", "delta.JPG", "scan.pdf", "thread.msg"],
+)
+def test_suffixes_without_a_native_route_still_reach_tesseract(
+    conn, tmp_path, sources, monkeypatch, name
+):
+    seen: list[str] = []
+
+    def fake_run_ocr(path):
+        seen.append(str(path))
+        return "Ferritin 201 nanograms"
+
+    monkeypatch.setattr(ingest, "run_ocr", fake_run_ocr)
+    src = _make_file(tmp_path, name, b"\x89PNG pretend scan")
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert seen == [str(src)]
+    assert result.document.ocr_text == "Ferritin 201 nanograms"
+
+
+@pytest.mark.parametrize("maker", ["csv", "txt", "docx", "xlsx"])
+def test_natively_extracted_suffixes_never_shell_out(
+    conn, tmp_path, sources, monkeypatch, maker
+):
+    def boom(path):  # pragma: no cover - the assertion is that this never runs
+        raise AssertionError(f"run_ocr must not be called for {path}")
+
+    monkeypatch.setattr(ingest, "run_ocr", boom)
+    if maker == "docx":
+        src = _make_docx(tmp_path, paragraphs=("sodium 140",))
+    elif maker == "xlsx":
+        src = _make_xlsx(tmp_path)
+    else:
+        src = _make_file(tmp_path, f"labs.{maker}", b"test,value\nsodium,140\n")
+    assert ingest.ingest_document(
+        conn, src, "jane-doe", sources, ocr=True
+    ).ocr_text_populated
+
+
+def test_xlsx_bad_shared_string_index_only_loses_that_cell(conn, tmp_path, sources):
+    ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+    src = tmp_path / "badidx.xlsx"
+    with zipfile.ZipFile(src, "w") as zf:
+        zf.writestr("[Content_Types].xml", "<Types/>")
+        zf.writestr(
+            "xl/sharedStrings.xml",
+            f'<sst xmlns="{ns}"><si><t>ferritin</t></si></sst>',
+        )
+        zf.writestr(
+            "xl/worksheets/sheet1.xml",
+            f'<worksheet xmlns="{ns}"><sheetData>'
+            '<row><c t="s"><v>0</v></c><c t="s"><v>notanint</v></c>'
+            '<c t="s"><v>0</v></c></row>'
+            "</sheetData></worksheet>",
+        )
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    # bad cell blank, the rest of the workbook survives
+    assert result.document.ocr_text == "ferritin\t\tferritin"
 
 
 def test_malformed_docx_degrades_instead_of_losing_the_document(

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -545,3 +545,105 @@ def test_supplied_ocr_text_still_beats_extraction(conn, tmp_path, sources):
         conn, src, "jane-doe", sources, ocr=True, ocr_text="agent transcription"
     )
     assert result.document.ocr_text == "agent transcription"
+
+
+# --- structured text vs. the #61 identity anchor (issue #66 audit bounce) -------
+#
+# Native extraction made text available for `.csv`/`.docx`/`.xlsx`/`.json`, and that text
+# flows into the owner check. `_ANCHOR` was tuned for scanned headers where `Patient:`
+# precedes a printed name; in a lab export those same words are *column labels*, so
+# trusting them refused files that ingested fine before this issue. The anchor→`suspect`
+# inference is therefore route-scoped; `match`/`mismatch` are not.
+
+
+_HEADER_ROW = "Patient ID,Test,Value,Unit\n1043,Glucose,98,mg/dL\n"
+
+
+def test_check_owner_anchor_trust_is_route_scoped():
+    text = "Patient: SMITH, JANE A    DOB: 03/14/1900"
+    assert ingest.check_owner(text, JANE, ROSTER).verdict == "suspect"
+    assert ingest.check_owner(
+        text, JANE, ROSTER, trust_anchors=False
+    ).verdict == "unverified"
+
+
+@pytest.mark.parametrize(
+    "text, verdict, matched",
+    [
+        ("Patient: DOE, JANE   DOB: 03/14/1962", "match", "jane-doe"),
+        ("Patient: ROE, ROBERT ALAN", "mismatch", "bob-roe"),
+    ],
+)
+def test_affirmative_verdicts_survive_untrusted_anchors(text, verdict, matched):
+    """Only `suspect` is route-scoped: an actual name/DOB is evidence on any route."""
+    check = ingest.check_owner(text, JANE, ROSTER, trust_anchors=False)
+    assert check.verdict == verdict
+    assert check.matched_slug == matched
+
+
+@pytest.mark.parametrize("kind", ["csv", "docx", "xlsx", "json"])
+def test_structured_headers_do_not_refuse_the_ingest(conn, tmp_path, sources, kind):
+    """A `Patient ID` column (or a `patient` JSON key) is a schema, not an identity
+    claim — these all ingested exit-0 before native extraction existed and must still."""
+    _seed_roster(conn)
+    if kind == "docx":
+        src = _make_docx(tmp_path, paragraphs=("Patient chart summary", "Ferritin 201"))
+    elif kind == "xlsx":
+        src = _make_xlsx(tmp_path, rows=(("Patient ID", "Test"), ("1043", "Glucose")))
+    elif kind == "json":
+        src = _make_file(tmp_path, "export.json", b'{"patient": 1043, "dob": null}')
+    else:
+        src = _make_file(tmp_path, "labs.csv", _HEADER_ROW.encode("utf-8"))
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.status == "new"
+    assert result.owner_check.verdict == "unverified"
+    assert result.owner_check.blocks is False
+    assert result.ocr_text_populated
+
+
+def test_structured_text_still_refuses_another_roster_person(conn, tmp_path, sources):
+    """The half of #61 that actually protects against a misfile is untouched: an
+    affirmative match on a different roster person blocks on the native route too."""
+    _seed_roster(conn)
+    src = _make_docx(tmp_path, paragraphs=("Patient: ROE, ROBERT ALAN", "Ferritin 201"))
+    with pytest.raises(ingest.OwnerMismatchError) as excinfo:
+        ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert excinfo.value.check.verdict == "mismatch"
+    assert excinfo.value.check.matched_slug == "bob-roe"
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 0
+
+
+def test_ocr_route_still_produces_suspect(conn, tmp_path, sources, monkeypatch):
+    """Scoping the anchor to prose must not disarm #61 on the route it was built for."""
+    _seed_roster(conn)
+    monkeypatch.setattr(
+        ingest, "run_ocr", lambda _: "Patient: SMITH, KAREN    DOB: 09/09/1971"
+    )
+    src = _make_file(tmp_path, "scan.png", b"\x89PNG pretend scan")
+    with pytest.raises(ingest.OwnerMismatchError) as excinfo:
+        ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert excinfo.value.check.verdict == "suspect"
+
+
+# --- extraction size cap (issue #66 audit) -------------------------------------
+#
+# `ocr_text` lands in the row *and* the FTS index, so an unbounded read is a DB-size
+# problem and a decompression-bomb surface (a small `.docx` can declare a ~1 GB
+# `word/document.xml`). Over the cap degrades like any other extraction failure.
+
+
+@pytest.mark.parametrize("kind", ["docx", "xlsx", "txt"])
+def test_oversized_extraction_degrades_instead_of_reading_it(
+    conn, tmp_path, sources, capsys, monkeypatch, kind
+):
+    monkeypatch.setattr(ingest, "_MAX_EXTRACT_BYTES", 16)
+    if kind == "docx":
+        src = _make_docx(tmp_path, paragraphs=("a" * 500,))
+    elif kind == "xlsx":
+        src = _make_xlsx(tmp_path)
+    else:
+        src = _make_file(tmp_path, "big.txt", b"x" * 500)
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.status == "new"           # the document still lands
+    assert result.document.ocr_text is None
+    assert "extraction cap" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Handles the intake edge cases from a real Google Drive crawl (DICOM was forked to #69):

- Google-native pointer stubs (`.gdoc`/`.gsheet`/`.gslides`/`.gform`/`.gdraw`): `pemr ingest`
  now refuses these with a clear error instead of storing the useless 1 KB JSON pointer blob.
- Native text extraction at ingest for non-image office formats (`.docx`, `.xlsx`, `.csv`,
  `.json`, `.txt`/`.md`/`.tsv`/`.log`) so they're no longer invisible to `pemr find` — previously
  only tesseract-OCR'd image/PDF content populated `ocr_text`.
- Unknown suffixes route back to tesseract instead of a silent skip.
- Fixed a scope regression caught in audit: the identity-anchor owner check (`suspect`) is scoped
  by *route* (native vs. OCR), not format — `AGENTS.md` and `docs/Architecture.md` previously
  implied `.txt`/`.md`/`.tsv`/`.log` still got the check under `--ocr auto`; they don't (native
  route), and the docs + a pinned test (`b36fc40`) now say so correctly.
- Per-archive extraction budget (32 MiB) shared across all members of a zip-based format, so a
  multi-sheet workbook can't spend the cap once per sheet.

`AGENTS.md` and `docs/Architecture.md` updated for the new pointer-stub refusal, native
extraction routes, and the corrected anchor-suppression scope.

Audited (ADVANCE): pointer-stub guard is size-capped/pre-hash/pre-write and `--force`-proof;
route plumbing can't present OCR'd or agent-supplied text as `"native"`; zip reads are
declared-size bounded (no zip-slip, no over-read); no new runtime dependencies.

## Tests
`python -m pytest` — 535 passed (also 535 passed with `Tesseract-OCR` stripped from `PATH`,
confirming no new tesseract dependency). `npm run check:meta-drift` passed; `npm test` 4 passed.

## CI note
`sync:claude-config:check` is expected red — pre-existing `.claude/agents/*.md` mirror drift on
`dev` itself; `git diff --name-only origin/dev...HEAD` touches none of `.claude`/`.github`.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)
