### PR TITLE
feat(#69): study-level DICOM ingest via canonical-zip blobs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,10 @@ slice counts), so `ocr_text_populated` is already true and the study is findable
 not the contract met: if the disc or the portal carries the **radiology report**, transcribe it and
 pass it as `ocr_text` — it replaces the summary and is the only text that carries findings. The
 report often ships as a PDF beside the slices; it is not packed into the study (the engine names
-what it dropped), so ingest it as its own document too.
+what it dropped), so ingest it as its own document too. Owner verification below applies to
+studies as well, but reads the disc's own `PatientName`/`PatientBirthDate` header tags — *not*
+the derived summary, which is engine output and names nobody. Those tags are never stored, so
+they will not appear in `document_show` text or `find` hits.
 
 **Owner verification.** Because you supply the text, you are the primary consumer of the
 ingest-time owner check: it scans that text for the claimed person's name/DOB and returns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,14 @@ to `find` (FTS5); an ingest without it is silently unsearchable.
 - **Remediation:** call `document_set_text(document_id, text)`. Re-ingesting will not work — the
   layer-1 content hash matches, so `ingest` returns the existing document and writes nothing.
 
+**Study directories** (`ingest(file=<dir>, study="dicom")` — a burned imaging disc, ingested as one
+document). The engine seeds `ocr_text` with a derived summary (modality, study date, per-series
+slice counts), so `ocr_text_populated` is already true and the study is findable. That is a floor,
+not the contract met: if the disc or the portal carries the **radiology report**, transcribe it and
+pass it as `ocr_text` — it replaces the summary and is the only text that carries findings. The
+report often ships as a PDF beside the slices; it is not packed into the study (the engine names
+what it dropped), so ingest it as its own document too.
+
 **Owner verification.** Because you supply the text, you are the primary consumer of the
 ingest-time owner check: it scans that text for the claimed person's name/DOB and returns
 `owner_check: {verdict, matched_slug, evidence}` — `match`, `mismatch` (the text names a

--- a/config.example.toml
+++ b/config.example.toml
@@ -6,6 +6,9 @@
 #   * backup_dir and sources_dir ARE cloud-synced — backups are consistent single-file
 #     `VACUUM INTO` snapshots, sources are immutable content-addressed blobs. Both are
 #     safe for sync and give off-machine copies of the irreplaceable data.
+#   * EXCEPT sources_dir/.tmp/ — exclude that one subfolder from sync. `pemr ingest
+#     --study` packs a study archive there, hashes it, then moves it into place;
+#     syncing the staging area uploads gigabytes that are deleted seconds later.
 
 [paths]
 # Local-only data root: holds pemr.db (+ -wal/-shm), inbox/, exports/.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -39,6 +39,7 @@ pemr/
     db.py                      # connection, migrations runner, pragmas (WAL, foreign_keys)
     models.py                  # dataclasses / typed row shapes
     ingest.py                  # document intake, hashing, staging
+    study.py                   # study directories -> one canonical-zip blob (§4)
     dedup.py                   # content-hash + semantic-key matching
     query.py                   # canned + ad-hoc read queries
     render.py                  # generated docs (summary, journal, briefs)
@@ -49,6 +50,7 @@ pemr/
     002_...
   sources/                     # retained original documents (content-addressed)
     <sha256[:2]>/<sha256>.pdf  # dedup-friendly, immutable blob store
+    .tmp/                      # staging for study archives (§4); exclude from cloud sync
   inbox/                       # drop zone for new un-ingested scans
   exports/                     # generated docs (disposable): summaries, briefs, journal
   backups/                     # local VACUUM INTO snapshots before they sync
@@ -327,6 +329,37 @@ can't get subtly wrong. That's the whole point of lifting them out.
 Optional `--ocr tesseract` flag pre-fills `document.ocr_text` when scans are flat images,
 giving the agent text to work from instead of re-reading pixels every time.
 
+### Study directories (issue #69)
+
+A burned imaging disc is clinically *one* document but physically one folder holding
+`DICOMDIR`, thousands of extension-less slices, and a Windows viewer payload. `pemr ingest
+<dir> --person <slug> --study dicom` (module: `study.py`) folds it into the pipeline above
+rather than beside it:
+
+```
+disc/                                        (DICOMDIR + IM000001… + VIEWER.EXE + report.pdf)
+  → include every file whose bytes 128..132 are `DICM`     (content, not extension:
+      the viewer payload is excluded by construction; document-like drops are named
+      on stderr, because a radiology report is its own document)
+  → pack them into a *canonical* zip: entries sorted by POSIX relative path, ZIP_STORED,
+      timestamps/host-system/mode pinned  ⇒ same disc, any machine, same bytes
+  → sha256 of the archive IS document.sha256  ⇒ step 1 dedup and `pemr verify` work
+      unchanged; the blob lands at sources/<sha[:2]>/<sha>.dcm.zip
+```
+
+The archive is staged in `sources/.tmp/` and `os.replace`d into the store, so a crash can
+never leave a truncated blob under a valid content-hash name; the temp is unlinked on every
+path (a re-ingest repacks before it can know it is a duplicate — the accepted cost of
+hashing the bytes rather than a manifest). Studies over 4 GiB need `--allow-large`, since
+`sources_dir` is cloud-synced by default.
+
+`doc_date` (from `StudyDate`), `category` (`imaging`), and `ocr_text` (a short derived
+summary: modality, date, per-series slice counts) are **defaults only** — anything the
+caller passes wins. Header tags are read by a minimal stdlib parser for five tags,
+best-effort like `run_ocr`: the zero-runtime-dependency rule (`pyproject.toml`) rules out
+`pydicom`, and any parse failure yields no metadata rather than a failed ingest. Per-slice
+rows, pixel decoding, and thumbnails are out of scope.
+
 ---
 
 ## 5. Tool surface
@@ -336,6 +369,7 @@ giving the agent text to work from instead of re-reading pixels every time.
 ```
 pemr person add|list|show|edit|deactivate|reactivate|remove
 pemr ingest <file> --person <slug> [--ocr tesseract] [--force]   # --force: skip owner verification
+pemr ingest <dir>  --person <slug> --study dicom [--allow-large] # a study folder as ONE document (§4)
 pemr commit-extraction --document <id> --json <file>
 pemr review-conflicts [--resolve <id> --keep existing|incoming|both [--note ...]] [--dictionary <toml>]
 pemr document list [--person <slug>]                     # newest first; omit --person for everyone
@@ -375,7 +409,8 @@ under a PEP 660 editable install); see issue #22.
 
 Read-only: `person_list`, `person_show`, `query` (`kind` = `labs`/`meds`/`timeline`), `find`,
 `trends`, `render_summary`, `render_brief`, `render_journal`. Write: `person_add`, `person_edit`,
-`ingest`, `commit_extraction`, `document_set_text` (fills an empty `ocr_text` only — the `--force`
+`ingest` (`study="dicom"` + `allow_large` make `file` a study directory, §4), `commit_extraction`,
+`document_set_text` (fills an empty `ocr_text` only — the `--force`
 replace is CLI-only), `review_conflicts` (resolution gated on human sign-off). Each returns the
 same `--json`-shaped payload as the CLI; the MCP server (`pemr/mcp_server.py`) parses args and
 calls the same Python functions the CLI calls — one implementation, two front doors. `readOnlyHint`

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -355,10 +355,21 @@ hashing the bytes rather than a manifest). Studies over 4 GiB need `--allow-larg
 
 `doc_date` (from `StudyDate`), `category` (`imaging`), and `ocr_text` (a short derived
 summary: modality, date, per-series slice counts) are **defaults only** — anything the
-caller passes wins. Header tags are read by a minimal stdlib parser for five tags,
-best-effort like `run_ocr`: the zero-runtime-dependency rule (`pyproject.toml`) rules out
-`pydicom`, and any parse failure yields no metadata rather than a failed ingest. Per-slice
-rows, pixel decoding, and thumbnails are out of scope.
+caller passes wins. Header tags are read by a minimal stdlib parser, best-effort like
+`run_ocr`: the zero-runtime-dependency rule (`pyproject.toml`) rules out `pydicom`, and any
+parse failure yields no metadata rather than a failed ingest. Every length the file declares
+is bounded before it is used, since a scratched disc's corrupt length field is otherwise an
+unbounded allocation and a value spliced straight into `ocr_text`. Per-slice rows, pixel
+decoding, and thumbnails are out of scope.
+
+The step-2 owner check applies here too, and reads `PatientName`/`PatientBirthDate` from the
+header rather than the derived summary — engine output carries no patient identity, and a
+`StudyDescription` like "PATIENT POSITIONING" would trip the identity anchor into a spurious
+refusal. Caller-supplied text is checked as well; the more consequential verdict wins, and
+the refusal point is pre-pack, so a refused study costs nothing. **The identity tags are
+verification input only** — they are never written to `ocr_text`, so they never reach the
+FTS index or an agent's context. This matters most here: a 2,000-slice binary folder is the
+one document type a human cannot eyeball to catch a misfile.
 
 ---
 

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from . import (
     __version__, backup, db, dedup, documents, ingest, persons, query, render,
-    restore, verify,
+    restore, study, verify,
 )
 
 # Shipped starter analyte/name dictionary (framework, not user data — see .gitignore).
@@ -662,18 +662,42 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
     conn = _connect_db(args)
     try:
         try:
-            result = ingest.ingest_document(
-                conn,
-                args.file,
-                person_slug=args.person,
-                sources_dir=_resolve_sources_dir(args),
-                doc_date=args.doc_date,
-                category=args.category,
-                provider=args.provider,
-                ocr=(args.ocr == "tesseract"),
-                ocr_text=ocr_text,
-                force=args.force,
-            )
+            if args.study:
+                # A study *directory* is one document (issue #69): the blob is a
+                # canonical zip of its slices, hashed like any other file.
+                if args.ocr:
+                    print(
+                        f"note: --ocr is ignored for --study {args.study} (there is "
+                        "no flat image to OCR); the study's ocr_text is a derived "
+                        "summary unless you pass --ocr-text-file",
+                        file=sys.stderr,
+                    )
+                result = ingest.ingest_study_dir(
+                    conn,
+                    args.file,
+                    person_slug=args.person,
+                    sources_dir=_resolve_sources_dir(args),
+                    study=args.study,
+                    allow_large=args.allow_large,
+                    doc_date=args.doc_date,
+                    category=args.category,
+                    provider=args.provider,
+                    ocr_text=ocr_text,
+                    force=args.force,
+                )
+            else:
+                result = ingest.ingest_document(
+                    conn,
+                    args.file,
+                    person_slug=args.person,
+                    sources_dir=_resolve_sources_dir(args),
+                    doc_date=args.doc_date,
+                    category=args.category,
+                    provider=args.provider,
+                    ocr=(args.ocr == "tesseract"),
+                    ocr_text=ocr_text,
+                    force=args.force,
+                )
         except db.NotMigratedError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 1
@@ -1403,8 +1427,21 @@ def build_parser() -> argparse.ArgumentParser:
     p_ingest = sub.add_parser(
         "ingest", help="ingest a document (hash, blob store, layer-1 dedup)"
     )
-    p_ingest.add_argument("file", help="path to the document to ingest")
+    p_ingest.add_argument(
+        "file", help="path to the document, or study directory with --study"
+    )
     p_ingest.add_argument("--person", required=True, help="owner slug, e.g. jane-doe")
+    p_ingest.add_argument(
+        "--study",
+        choices=list(study.STUDY_KINDS),
+        help="treat the path as a study directory: pack it into one document",
+    )
+    p_ingest.add_argument(
+        "--allow-large",
+        dest="allow_large",
+        action="store_true",
+        help="ingest a study over the size limit (sources_dir may be cloud-synced)",
+    )
     p_ingest.add_argument("--sources", help="sources blob dir (overrides config)")
     p_ingest.add_argument("--doc-date", dest="doc_date", help="date the doc pertains to")
     p_ingest.add_argument("--category", help="labs|imaging|visit-note|rx|vaccine|...")

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -18,7 +18,8 @@ refusal is a clean no-op) when the text affirmatively points somewhere else. See
 Issue #69 adds a second entry point, :func:`ingest_study_dir`: a DICOM study
 *directory* becomes one document whose blob is a canonical zip of its slices (see
 :mod:`pemr.study`). It reuses every rail above — same person lookup, same layer-1
-dedup on the content hash, same content-addressed store, same insert.
+dedup on the content hash, same content-addressed store, same insert, and the same
+owner check, fed by the study's ``PatientName``/``PatientBirthDate`` header tags.
 """
 
 from __future__ import annotations
@@ -313,6 +314,21 @@ def check_owner(
     return OwnerCheck(verdict="unverified")
 
 
+def _strongest_check(checks: Sequence[OwnerCheck]) -> OwnerCheck:
+    """The verdict to act on when more than one identity signal was checked.
+
+    A study has two (the DICOM header tags and any caller-supplied transcription),
+    and they are independent, so the ordering is by consequence: anything blocking
+    wins — refusing on *any* evidence of a misfile is the whole point of the check —
+    then an affirmative match, then ignorance.
+    """
+    for verdict in ("mismatch", "suspect", "match"):
+        for check in checks:
+            if check.verdict == verdict:
+                return check
+    return OwnerCheck(verdict="unverified")
+
+
 def refusal_message(
     check: OwnerCheck, claimed: Person, roster: Sequence[Person]
 ) -> str:
@@ -552,10 +568,14 @@ def ingest_study_dir(
       visible to `find` instead of being an untitled row. An agent that transcribed
       the accompanying radiology report should pass that text instead.
 
-    The owner check runs only against **caller-supplied** text. Checking our own
-    derived summary would be meaningless (it carries no patient identity) and worse
-    than meaningless if a series description happened to trip an identity anchor —
-    a spurious refusal of a study nobody could fix without ``force``.
+    The issue-#61 owner check runs against two independent signals: the study's own
+    ``PatientName``/``PatientBirthDate`` header tags (:func:`pemr.study.identity_text`)
+    and any caller-supplied text, with the more consequential verdict winning. It is
+    never run against our *derived summary*, which would be meaningless (engine
+    output carries no patient identity) and worse than meaningless if a
+    ``StudyDescription`` like "PATIENT POSITIONING" tripped the identity anchor —
+    a spurious refusal of a study nobody could fix without ``force``. The refusal
+    point is pre-write **and** pre-pack, so a refused study costs nothing.
     """
     db.require_migrated(conn)
 
@@ -607,10 +627,11 @@ def ingest_study_dir(
     text = supplied or _study.summary_text(scan, metadata)
 
     roster = _roster(conn)
-    owner_check = (
-        check_owner(supplied, person, roster) if supplied
-        else OwnerCheck(verdict="unverified")
-    )
+    owner_check = _strongest_check([
+        check_owner(candidate, person, roster)
+        for candidate in (_study.identity_text(metadata), supplied)
+        if candidate
+    ])
     if owner_check.blocks and not force:
         # Pre-write *and* pre-pack: a refusal costs nothing and leaves nothing.
         raise OwnerMismatchError(

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -14,22 +14,29 @@ Issue #61 adds a pre-write **owner check**: when document text is available, it 
 scanned for the claimed person's name/DOB and the ingest is refused (pre-write, so a
 refusal is a clean no-op) when the text affirmatively points somewhere else. See
 :func:`check_owner`.
+
+Issue #69 adds a second entry point, :func:`ingest_study_dir`: a DICOM study
+*directory* becomes one document whose blob is a canonical zip of its slices (see
+:mod:`pemr.study`). It reuses every rail above — same person lookup, same layer-1
+dedup on the content hash, same content-addressed store, same insert.
 """
 
 from __future__ import annotations
 
 import hashlib
+import os
 import re
 import shutil
 import subprocess
 import sqlite3
 import sys
+import uuid
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Sequence
 
-from . import db
+from . import db, study as _study
 from .models import Document, Person
 
 
@@ -362,6 +369,46 @@ def _roster(conn: sqlite3.Connection) -> list[Person]:
     ]
 
 
+def _insert_document(
+    conn: sqlite3.Connection,
+    *,
+    sha: str,
+    ext: str,
+    person_id: int,
+    doc_date: str | None,
+    category: str | None,
+    provider: str | None,
+    ocr_text: str | None,
+) -> Document:
+    """Insert the `document` row and read it back. Shared by both ingest paths.
+
+    Blob cleanup on failure stays with the caller: the file path copies its blob in
+    and the study path renames one in, so only they know what to undo.
+    """
+    with conn:
+        cur = conn.execute(
+            """
+            INSERT INTO document
+              (sha256, person_id, doc_date, category, provider, source_path,
+               ocr_text, ingested_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                sha,
+                person_id,
+                doc_date,
+                category,
+                provider,
+                _relative_source_path(sha, ext),
+                ocr_text,
+                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            ),
+        )
+    document = get_document_by_id(conn, cur.lastrowid)
+    assert document is not None  # just inserted
+    return document
+
+
 def ingest_document(
     conn: sqlite3.Connection,
     file_path: str | Path,
@@ -397,6 +444,12 @@ def ingest_document(
     db.require_migrated(conn)
 
     src = Path(file_path)
+    if src.is_dir():
+        # Naming the flag beats the old, misleading "file not found: <dir>".
+        raise IngestError(
+            f"{src} is a directory; ingest a study folder with "
+            f"--study {_study.STUDY_KINDS[0]} (see `pemr ingest --help`)"
+        )
     if not src.is_file():
         raise IngestError(f"file not found: {src}")
 
@@ -433,29 +486,172 @@ def ingest_document(
         shutil.copy2(src, dest)
 
     try:
-        with conn:
-            cur = conn.execute(
-                """
-                INSERT INTO document
-                  (sha256, person_id, doc_date, category, provider, source_path,
-                   ocr_text, ingested_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    sha,
-                    person.person_id,
-                    doc_date,
-                    category,
-                    provider,
-                    _relative_source_path(sha, ext),
-                    ocr_text,
-                    datetime.now(timezone.utc).isoformat(timespec="seconds"),
-                ),
-            )
+        document = _insert_document(
+            conn,
+            sha=sha,
+            ext=ext,
+            person_id=person.person_id,
+            doc_date=doc_date,
+            category=category,
+            provider=provider,
+            ocr_text=ocr_text,
+        )
     except Exception:
         if blob_created:
             dest.unlink(missing_ok=True)
         raise
-    document = get_document_by_id(conn, cur.lastrowid)
-    assert document is not None  # just inserted
+    return IngestResult(status="new", document=document, owner_check=owner_check)
+
+
+# --------------------------------------------------------------------------- #
+# Study directories (issue #69)
+# --------------------------------------------------------------------------- #
+
+#: Blob extension for a packed study. `blob_dest`/`_relative_source_path` treat it as
+#: an opaque suffix, so `sources/<sha[:2]>/<sha>.dcm.zip` keeps the content-addressed
+#: invariant and `pemr verify` re-hashes it like any other blob.
+STUDY_EXT = ".dcm.zip"
+
+#: Staging area for the archive: it is packed here, hashed, then `os.replace`d into
+#: the store — a same-filesystem atomic publish, so a crash can never leave a
+#: truncated blob sitting under a valid content-hash name.
+TMP_DIRNAME = ".tmp"
+
+#: A study is imaging by construction, so it defaults there rather than to null; the
+#: caller still wins (a disc filed under a narrower `radiology` bucket, say).
+_STUDY_CATEGORY = "imaging"
+
+
+def ingest_study_dir(
+    conn: sqlite3.Connection,
+    dir_path: str | Path,
+    person_slug: str,
+    sources_dir: str | Path,
+    *,
+    study: str = "dicom",
+    allow_large: bool = False,
+    doc_date: str | None = None,
+    category: str | None = None,
+    provider: str | None = None,
+    ocr_text: str | None = None,
+    force: bool = False,
+) -> IngestResult:
+    """Ingest a study *directory* as one document (issue #69).
+
+    A burned imaging disc is clinically one document but physically ~2,000 slice
+    files plus a viewer payload. The slices are packed into a canonical zip
+    (:func:`pemr.study.pack_study`) and **that archive's** sha256 is the document
+    hash — so the blob is still the original bytes, still content-addressed, and
+    layer-1 dedup needs no special case.
+
+    Derived defaults, all of which the caller beats:
+
+    * ``doc_date`` ← the study's ``StudyDate`` tag,
+    * ``category`` ← ``"imaging"``,
+    * ``ocr_text`` ← a short derived summary (modality/date/series), so the study is
+      visible to `find` instead of being an untitled row. An agent that transcribed
+      the accompanying radiology report should pass that text instead.
+
+    The owner check runs only against **caller-supplied** text. Checking our own
+    derived summary would be meaningless (it carries no patient identity) and worse
+    than meaningless if a series description happened to trip an identity anchor —
+    a spurious refusal of a study nobody could fix without ``force``.
+    """
+    db.require_migrated(conn)
+
+    if study not in _study.STUDY_KINDS:
+        raise IngestError(
+            f"unknown study kind '{study}'; supported: "
+            + ", ".join(_study.STUDY_KINDS)
+        )
+
+    src = Path(dir_path)
+    if src.is_file():
+        raise IngestError(
+            f"--study expects a directory, but {src} is a file; "
+            "ingest it without --study"
+        )
+    if not src.is_dir():
+        raise IngestError(f"directory not found: {src}")
+
+    person = _person_for_slug(conn, person_slug)
+
+    scan = _study.scan_study_dir(src)
+    if not scan.rel_paths:
+        raise IngestError(
+            f"no DICOM files found under {src} - nothing to ingest. (Files are "
+            "recognised by the DICM magic at byte 128, not by extension.)"
+        )
+    print(
+        f"study: {scan.file_count} DICOM files, "
+        f"{_study.human_bytes(scan.total_bytes)} to pack",
+        file=sys.stderr,
+    )
+    if scan.excluded_documents:
+        print(
+            "note: not packed (a report is its own document - ingest it separately "
+            "through the normal file path): "
+            + ", ".join(scan.excluded_documents),
+            file=sys.stderr,
+        )
+    if scan.total_bytes > _study.MAX_STUDY_BYTES and not allow_large:
+        raise IngestError(
+            f"study is {_study.human_bytes(scan.total_bytes)}, over the "
+            f"{_study.human_bytes(_study.MAX_STUDY_BYTES)} limit; sources_dir is "
+            "cloud-synced by default (config.example.toml) - re-run with "
+            "--allow-large to ingest it anyway"
+        )
+
+    metadata = _study.read_metadata(scan)
+    supplied = ocr_text.strip() if ocr_text else None
+    text = supplied or _study.summary_text(scan, metadata)
+
+    roster = _roster(conn)
+    owner_check = (
+        check_owner(supplied, person, roster) if supplied
+        else OwnerCheck(verdict="unverified")
+    )
+    if owner_check.blocks and not force:
+        # Pre-write *and* pre-pack: a refusal costs nothing and leaves nothing.
+        raise OwnerMismatchError(
+            refusal_message(owner_check, person, roster), owner_check
+        )
+
+    tmp_dir = Path(sources_dir) / TMP_DIRNAME
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    tmp_blob = tmp_dir / f"{uuid.uuid4().hex}{STUDY_EXT}"
+    try:
+        sha = _study.pack_study(scan, tmp_blob)
+
+        existing = get_document(conn, sha)
+        if existing is not None:
+            # Known cost of hashing the archive rather than a manifest: an already
+            # filed disc is repacked before we can know it is a duplicate. Nothing
+            # is published and no row is inserted, so the semantics match the file
+            # path exactly - only the work is wasted.
+            return IngestResult(status="duplicate", document=existing)
+
+        dest = blob_dest(sources_dir, sha, STUDY_EXT)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        blob_created = not dest.exists()
+        if blob_created:
+            os.replace(tmp_blob, dest)
+        try:
+            document = _insert_document(
+                conn,
+                sha=sha,
+                ext=STUDY_EXT,
+                person_id=person.person_id,
+                doc_date=doc_date or metadata.study_date,
+                category=category or _STUDY_CATEGORY,
+                provider=provider,
+                ocr_text=text,
+            )
+        except Exception:
+            if blob_created:
+                dest.unlink(missing_ok=True)
+            raise
+    finally:
+        tmp_blob.unlink(missing_ok=True)
+
     return IngestResult(status="new", document=document, owner_check=owner_check)

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -173,12 +173,19 @@ def ingest_document(
     provider: str | None = None,
     ocr: bool = False,
     force: bool = False,
+    study: str | None = None,
+    allow_large: bool = False,
 ) -> dict[str, Any]:
     """[write] Ingest a document (hash, blob-store, layer-1 dedup). Mirrors ``pemr ingest``.
 
     ``ocr_text`` is the agent's own transcription — the ``AGENTS.md`` default path.
     The response's ``ocr_text_populated`` lets the agent self-check the FTS-visibility
     contract without a follow-up read.
+
+    ``study="dicom"`` makes ``file`` a study *directory* — a burned imaging disc — and
+    packs its slices into one document (issue #69). ``ocr_text`` then defaults to a
+    derived study summary; pass a transcription of the accompanying radiology report
+    when you have one. ``allow_large`` waives the study size guard.
 
     When text is present it is checked against the claimed owner; the verdict comes
     back as ``owner_check`` (``null`` on a duplicate, which is never checked). A
@@ -191,11 +198,18 @@ def ingest_document(
     except SystemExit as exc:  # CLI resolvers exit the process; a server must not
         raise ToolError(str(exc)) from exc
     try:
-        result = _ingest.ingest_document(
-            conn, file, person_slug=person, sources_dir=sources_dir,
-            doc_date=doc_date, category=category, provider=provider,
-            ocr=ocr, ocr_text=ocr_text, force=force,
-        )
+        if study:
+            result = _ingest.ingest_study_dir(
+                conn, file, person_slug=person, sources_dir=sources_dir,
+                study=study, allow_large=allow_large, doc_date=doc_date,
+                category=category, provider=provider, ocr_text=ocr_text, force=force,
+            )
+        else:
+            result = _ingest.ingest_document(
+                conn, file, person_slug=person, sources_dir=sources_dir,
+                doc_date=doc_date, category=category, provider=provider,
+                ocr=ocr, ocr_text=ocr_text, force=force,
+            )
     except (db.NotMigratedError, _ingest.IngestError) as exc:
         raise _friendly(exc) from exc
     return {
@@ -522,10 +536,11 @@ def build_server():  # pragma: no cover - exercised only with the mcp SDK instal
     def ingest_tool(file: str, person: str, ocr_text: str | None = None,
                     doc_date: str | None = None, category: str | None = None,
                     provider: str | None = None, ocr: bool = False,
-                    force: bool = False) -> dict:
+                    force: bool = False, study: str | None = None,
+                    allow_large: bool = False) -> dict:
         return _run(ingest_document, file=file, person=person, ocr_text=ocr_text,
                     doc_date=doc_date, category=category, provider=provider, ocr=ocr,
-                    force=force)
+                    force=force, study=study, allow_large=allow_large)
 
     @server.tool(name="commit_extraction", annotations=rw)
     def commit_extraction_tool(document_id: int, records: dict) -> dict:

--- a/pemr/study.py
+++ b/pemr/study.py
@@ -24,7 +24,12 @@ Two properties carry the design:
   field that would otherwise vary (entry order, compression, timestamps, host
   system, file mode) is pinned below.
 
-Metadata is read with a **minimal stdlib parser** for five tags. The project has zero
+Metadata is read with a **minimal stdlib parser** for seven tags — five descriptive
+ones that seed the derived summary, plus patient name and birth date, which are
+verification input for the issue-#61 owner check and are never stored. Every length
+the file declares is bounded before it is used: a scratched disc's corrupt length
+field is otherwise an unbounded allocation, and an untrusted element length is
+otherwise text spliced straight into `document.ocr_text`. The project has zero
 runtime dependencies (`pyproject.toml`) and `pydicom` would be the first, so it is
 refused rather than deferred; the reader is best-effort in exactly the way
 :func:`pemr.ingest.run_ocr` is — any parse failure yields no metadata and never
@@ -48,6 +53,7 @@ __all__ = [
     "StudyMetadata",
     "StudyScan",
     "human_bytes",
+    "identity_text",
     "is_dicom_file",
     "pack_study",
     "read_metadata",
@@ -224,6 +230,8 @@ _TAG_STUDY_DATE = (0x0008, 0x0020)
 _TAG_MODALITY = (0x0008, 0x0060)
 _TAG_STUDY_DESCRIPTION = (0x0008, 0x1030)
 _TAG_SERIES_DESCRIPTION = (0x0008, 0x103E)
+_TAG_PATIENT_NAME = (0x0010, 0x0010)
+_TAG_PATIENT_BIRTH_DATE = (0x0010, 0x0030)
 _TAG_STUDY_UID = (0x0020, 0x000D)
 _TAG_TRANSFER_SYNTAX = (0x0002, 0x0010)
 
@@ -232,10 +240,12 @@ _WANTED = frozenset({
     _TAG_MODALITY,
     _TAG_STUDY_DESCRIPTION,
     _TAG_SERIES_DESCRIPTION,
+    _TAG_PATIENT_NAME,
+    _TAG_PATIENT_BIRTH_DATE,
     _TAG_STUDY_UID,
 })
 
-# All five wanted tags are short-form string VRs (DA/CS/LO/UI), so no VR dictionary
+# Every wanted tag is a short-form string VR (DA/CS/LO/UI/PN), so no VR dictionary
 # is needed to read them under Implicit VR — only the length encoding differs.
 # Stop as soon as the element stream passes their groups: elements are in ascending
 # tag order, and group 0xFFFE (item delimiters) trips the same guard.
@@ -261,11 +271,23 @@ _ENCAPSULATED_PREFIX = "1.2.840.10008.1.2.4."
 #: bailing out beats reading a gigabyte per slice.
 _MAX_HEADER_SCAN = 1 << 20  # 1 MiB
 
+#: Hard cap on a single tag value. The length prefix in the file is untrusted, and
+#: every value we read has a VR maximum far below this (``DA`` 8, ``CS`` 16, ``LO``
+#: 64, ``UI`` 64, ``PN`` 64 per component) — so a longer one is corruption or hostile
+#: input, not data. Without the cap a file could declare a ~1 MiB
+#: ``StudyDescription`` and have it spliced verbatim into `document.ocr_text`, i.e.
+#: into the FTS index and into an agent's context as if it were record text.
+_MAX_TAG_CHARS = 128
+
 
 def _clean(raw: bytes) -> str | None:
-    """DICOM string value → trimmed text, or None when it carries nothing."""
+    """DICOM string value → trimmed text (capped), or None when it carries nothing.
+
+    Truncation happens *before* the decode, which latin-1 makes exact: it is a
+    1-byte-per-character codec, so a byte cap and a character cap are the same cap.
+    """
     try:
-        text = raw.decode("latin-1")
+        text = raw[:_MAX_TAG_CHARS].decode("latin-1")
     except (UnicodeDecodeError, AttributeError):  # pragma: no cover - latin-1 total
         return None
     text = text.replace("\x00", "").strip()
@@ -334,7 +356,7 @@ def _parse_elements(
 
 
 def _read_tags(path: Path) -> dict[tuple[int, int], str | None]:
-    """Read the five study tags from one DICOM file. Empty dict on any problem."""
+    """Read the wanted tags from one DICOM file. Empty dict on any problem."""
     try:
         with open(path, "rb") as fh:
             if fh.read(_DICM_OFFSET + 4)[_DICM_OFFSET:] != _DICM_MAGIC:
@@ -348,6 +370,14 @@ def _read_tags(path: Path) -> dict[tuple[int, int], str | None]:
             if (group, element) != (0x0002, 0x0000) or vr != b"UL" or short_len != 4:
                 return {}
             (meta_length,) = struct.unpack_from("<I", head, 8)
+            # Untrusted 32-bit length. `read(n)` allocates `n` up front and only
+            # then shrinks, so a corrupt group length — four wrong bytes, optical
+            # media's ordinary failure mode — would commit up to 4 GiB per slice
+            # read, and the resulting `MemoryError` is not an `OSError`, so it
+            # would escape this function and abort an ingest this module promises
+            # never to fail. Bounded by the same cap as the dataset scan.
+            if meta_length > _MAX_HEADER_SCAN:
+                return {}
             meta = fh.read(meta_length)
             syntax = _parse_elements(
                 meta, explicit=True, wanted=frozenset({_TAG_TRANSFER_SYNTAX})
@@ -358,7 +388,10 @@ def _read_tags(path: Path) -> dict[tuple[int, int], str | None]:
             return _parse_elements(
                 fh.read(_MAX_HEADER_SCAN), explicit=explicit, wanted=_WANTED
             )
-    except (OSError, struct.error):
+    except (OSError, struct.error, MemoryError):
+        # `MemoryError` is deliberate and is *not* an `OSError`: the length bound
+        # above is the fix, this is the backstop that keeps the "never fails the
+        # ingest" contract true even if some other allocation path is found.
         return {}
 
 
@@ -388,6 +421,12 @@ class StudyMetadata:
     study_description: str | None = None
     study_uid: str | None = None
     series: tuple[Series, ...] = ()
+    #: Patient identity, read purely so the issue-#61 owner check has something to
+    #: verify a study against (see :func:`identity_text`). **Verification input, not
+    #: stored text** — :func:`summary_text` never emits these, so they do not reach
+    #: `document.ocr_text`, the FTS index, or an agent's context.
+    patient_name: str | None = None   # raw DICOM PN, e.g. "DOE^JANE^"
+    patient_birth_date: str | None = None  # ISO YYYY-MM-DD
 
 
 def _metadata_sources(scan: StudyScan) -> list[str]:
@@ -435,7 +474,36 @@ def read_metadata(scan: StudyScan) -> StudyMetadata:
         study_description=head.get(_TAG_STUDY_DESCRIPTION),
         study_uid=head.get(_TAG_STUDY_UID),
         series=tuple(series),
+        patient_name=head.get(_TAG_PATIENT_NAME),
+        patient_birth_date=_iso_date(head.get(_TAG_PATIENT_BIRTH_DATE)),
     )
+
+
+def identity_text(metadata: StudyMetadata) -> str | None:
+    """Patient identity from the study header, for :func:`pemr.ingest.check_owner`.
+
+    A 2,000-slice binary folder is the one document type a human cannot eyeball, so
+    `pemr ingest D:\\DICOM --person jane-doe` on the *spouse's* disc is the realistic
+    misfile — and without this the study path would be the only ingest door in the
+    system with no owner verification at all (issue #69 audit, finding B3).
+
+    The output is shaped for the existing check rather than a new one: the
+    ``Patient:``/``DOB:`` labels are what :func:`pemr.ingest.check_owner` recognises
+    as an identity anchor, ``normalize_text`` already reduces DICOM's ``DOE^JANE^``
+    to ``doe jane``, and the DOB is emitted in the ISO form ``dob_candidates``
+    renders. Returns None when the header carries neither tag — no signal, so the
+    verdict stays ``unverified`` rather than becoming a spurious refusal.
+
+    This is *more* reliable than the file path's input, not less: a structured tag
+    beats fuzzy OCR, so the false-``suspect`` worry that shaped ``check_owner``
+    barely applies here.
+    """
+    lines = []
+    if metadata.patient_name:
+        lines.append(f"Patient: {metadata.patient_name}")
+    if metadata.patient_birth_date:
+        lines.append(f"DOB: {metadata.patient_birth_date}")
+    return "\n".join(lines) or None
 
 
 #: Cap on the per-series lines in the summary: enough to characterise a study,

--- a/pemr/study.py
+++ b/pemr/study.py
@@ -1,0 +1,478 @@
+"""Study-directory packing — a burned imaging disc as **one** document (issue #69).
+
+A DICOM study is clinically one document (one modality, one study date, one report)
+but physically a folder of ~2,000 extension-less slice files plus a Windows viewer
+payload. The engine stores one `document` row per *file*, content-addressed by the
+sha256 of its bytes (`Architecture.md` §1/§4), so a folder needs a single
+byte-stream to stand in for it.
+
+This module produces that byte-stream: a **canonical zip** of the study's DICOM
+files. `document.sha256` is the sha256 of the archive's own bytes, so
+`sources/<sha[:2]>/<sha>.dcm.zip` still means "this file's content hash is its
+name", layer-1 dedup needs no special case, and `pemr verify` re-hashes the blob
+exactly as it does for any other document.
+
+Two properties carry the design:
+
+* **Inclusion is content-based.** A file is in iff its bytes 128..132 are ``DICM``
+  (the DICOM Part 10 preamble + magic). That admits ``DICOMDIR`` and the
+  ``IMxxxxxx`` slices and excludes the viewer payload (`.exe`/`.dll`/HTML/
+  `autorun.inf`) *by construction* — no extension denylist to keep in sync, and no
+  executable retained in the archive.
+* **The archive is deterministic.** Same disc, another machine, a later crawl → the
+  same bytes → the same sha, or layer-1 dedup silently stops working. Every zip
+  field that would otherwise vary (entry order, compression, timestamps, host
+  system, file mode) is pinned below.
+
+Metadata is read with a **minimal stdlib parser** for five tags. The project has zero
+runtime dependencies (`pyproject.toml`) and `pydicom` would be the first, so it is
+refused rather than deferred; the reader is best-effort in exactly the way
+:func:`pemr.ingest.run_ocr` is — any parse failure yields no metadata and never
+fails the ingest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import struct
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+__all__ = [
+    "STUDY_KINDS",
+    "MAX_STUDY_BYTES",
+    "Series",
+    "StudyMetadata",
+    "StudyScan",
+    "human_bytes",
+    "is_dicom_file",
+    "pack_study",
+    "read_metadata",
+    "scan_study_dir",
+    "summary_text",
+]
+
+#: Study kinds this module can pack. A value (rather than a boolean flag) so a
+#: future kind is an enum entry, not a second flag.
+STUDY_KINDS = ("dicom",)
+
+#: Refuse studies larger than this without an explicit opt-in. `sources_dir` is
+#: cloud-synced (`config.example.toml`), so "is GB-per-disc acceptable?" is answered
+#: per disc, by the human, at run time — not frozen into the design.
+MAX_STUDY_BYTES = 4 * 1024**3  # 4 GiB
+
+_READ_CHUNK = 1 << 20  # 1 MiB
+
+_SIZE_UNITS = ("B", "KiB", "MiB", "GiB", "TiB")
+
+
+def human_bytes(size: float) -> str:
+    """Byte count in the largest unit that keeps it readable.
+
+    The study messages exist so a human can make a storage call at run time, and
+    "0.0 MiB" or "4831838208 bytes" both fail at that.
+    """
+    for unit in _SIZE_UNITS[:-1]:
+        if size < 1024:
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} {_SIZE_UNITS[-1]}"
+
+# --------------------------------------------------------------------------- #
+# Scanning
+# --------------------------------------------------------------------------- #
+
+_DICM_OFFSET = 128  # Part 10: 128-byte preamble, then the 4-byte "DICM" magic
+_DICM_MAGIC = b"DICM"
+
+#: Non-DICOM files worth *naming* when we drop them: a burned disc usually carries
+#: the radiology report as a PDF/RTF beside the slices, and silently losing it would
+#: be the worst outcome of this change. Reported, never packed — a report is its own
+#: document, ingested through the normal file path.
+_DOCUMENT_LIKE = frozenset({".pdf", ".rtf", ".doc", ".docx", ".txt", ".html", ".htm"})
+
+#: DICOMDIR is a directory-record file, not a slice: it carries none of the study
+#: tags below, so it is packed but never used as a metadata source.
+_DICOMDIR = "DICOMDIR"
+
+
+@dataclass(frozen=True)
+class StudyScan:
+    """What a study directory contains, after the inclusion filter."""
+
+    root: Path
+    #: Relative POSIX paths of the included DICOM files, sorted — this *is* the
+    #: canonical archive order, so it is computed once and reused.
+    rel_paths: tuple[str, ...]
+    total_bytes: int
+    #: Relative POSIX paths of dropped files that look like documents (see
+    #: :data:`_DOCUMENT_LIKE`), for the caller to report.
+    excluded_documents: tuple[str, ...]
+    #: Count of everything else that was dropped (viewer payload, autorun, …).
+    excluded_other: int
+
+    @property
+    def file_count(self) -> int:
+        return len(self.rel_paths)
+
+    def abs_path(self, rel: str) -> Path:
+        return self.root / rel
+
+
+def is_dicom_file(path: str | Path) -> bool:
+    """Whether ``path`` carries the DICOM Part 10 preamble + ``DICM`` magic.
+
+    Unreadable / too-short files are simply "not DICOM" — a scan walks whatever the
+    disc happens to hold and must not die on a locked or truncated file.
+    """
+    try:
+        with open(path, "rb") as fh:
+            fh.seek(_DICM_OFFSET)
+            return fh.read(4) == _DICM_MAGIC
+    except OSError:
+        return False
+
+
+def scan_study_dir(root: str | Path) -> StudyScan:
+    """Walk ``root`` recursively and split it into packed / dropped files."""
+    root = Path(root)
+    included: list[tuple[str, int]] = []
+    documents: list[str] = []
+    other = 0
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root).as_posix()
+        if is_dicom_file(path):
+            try:
+                size = path.stat().st_size
+            except OSError:
+                continue
+            included.append((rel, size))
+        elif path.suffix.lower() in _DOCUMENT_LIKE:
+            documents.append(rel)
+        else:
+            other += 1
+    # Bytewise on the POSIX relative path. Python's str ordering is by code point,
+    # which UTF-8 preserves, so this is the same order on every platform.
+    included.sort(key=lambda item: item[0])
+    documents.sort()
+    return StudyScan(
+        root=root,
+        rel_paths=tuple(rel for rel, _ in included),
+        total_bytes=sum(size for _, size in included),
+        excluded_documents=tuple(documents),
+        excluded_other=other,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Canonical archive
+# --------------------------------------------------------------------------- #
+
+# Every zip field that varies by host, clock, or library version, pinned. Deflate is
+# excluded too: its output depends on the zlib version and level, and it buys almost
+# nothing on already-compressed pixel data.
+_ZIP_DATE_TIME = (1980, 1, 1, 0, 0, 0)  # the zip epoch; the lowest legal value
+_ZIP_CREATE_SYSTEM = 0  # zipfile defaults this to 0 on Windows, 3 elsewhere
+_ZIP_CREATE_VERSION = 20
+_ZIP_EXTRACT_VERSION = 20
+# Pinned to what `ZipFile.open(..., "w")` substitutes for a zero value (`0o600 << 16`),
+# so the archive does not silently depend on that fallback staying put — and never to
+# the *source* file's mode, which varies with how the disc was copied.
+_ZIP_EXTERNAL_ATTR = 0o600 << 16
+
+
+def pack_study(scan: StudyScan, out_path: str | Path) -> str:
+    """Write ``scan``'s files to ``out_path`` as a canonical zip; return its sha256.
+
+    Entries are written through :meth:`zipfile.ZipFile.open` from a hand-built
+    :class:`zipfile.ZipInfo` — deliberately *not* :meth:`ZipFile.write`, which reads
+    the source file's mtime and mode into the archive and would make the hash depend
+    on how the disc happened to be copied.
+    """
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(out_path, "w", allowZip64=True) as zf:
+        for rel in scan.rel_paths:
+            info = zipfile.ZipInfo(filename=rel, date_time=_ZIP_DATE_TIME)
+            info.compress_type = zipfile.ZIP_STORED
+            info.create_system = _ZIP_CREATE_SYSTEM
+            info.create_version = _ZIP_CREATE_VERSION
+            info.extract_version = _ZIP_EXTRACT_VERSION
+            info.external_attr = _ZIP_EXTERNAL_ATTR
+            info.internal_attr = 0
+            info.comment = b""
+            info.extra = b""
+            with open(scan.abs_path(rel), "rb") as src, zf.open(info, "w") as dst:
+                shutil.copyfileobj(src, dst, _READ_CHUNK)
+    digest = hashlib.sha256()
+    with out_path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(_READ_CHUNK), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+# --------------------------------------------------------------------------- #
+# Minimal DICOM header reader (stdlib only — see the module docstring)
+# --------------------------------------------------------------------------- #
+
+_TAG_STUDY_DATE = (0x0008, 0x0020)
+_TAG_MODALITY = (0x0008, 0x0060)
+_TAG_STUDY_DESCRIPTION = (0x0008, 0x1030)
+_TAG_SERIES_DESCRIPTION = (0x0008, 0x103E)
+_TAG_STUDY_UID = (0x0020, 0x000D)
+_TAG_TRANSFER_SYNTAX = (0x0002, 0x0010)
+
+_WANTED = frozenset({
+    _TAG_STUDY_DATE,
+    _TAG_MODALITY,
+    _TAG_STUDY_DESCRIPTION,
+    _TAG_SERIES_DESCRIPTION,
+    _TAG_STUDY_UID,
+})
+
+# All five wanted tags are short-form string VRs (DA/CS/LO/UI), so no VR dictionary
+# is needed to read them under Implicit VR — only the length encoding differs.
+# Stop as soon as the element stream passes their groups: elements are in ascending
+# tag order, and group 0xFFFE (item delimiters) trips the same guard.
+_STOP_GROUP = 0x0021
+
+# Explicit VR: these carry 2 reserved bytes then a 4-byte length; everything else
+# uses a 2-byte length.
+_LONG_FORM_VR = frozenset({
+    b"OB", b"OD", b"OF", b"OL", b"OV", b"OW", b"SQ", b"SV",
+    b"UC", b"UN", b"UR", b"UT", b"UV",
+})
+
+_IMPLICIT_VR_LE = "1.2.840.10008.1.2"
+_EXPLICIT_VR_LE = "1.2.840.10008.1.2.1"
+# The encapsulated-pixel-data syntaxes (JPEG, JPEG2000, RLE, …) all encode the
+# *dataset* as Explicit VR LE — only the pixel data is compressed, and we never read
+# it. Deflated (…1.2.1.99) and Explicit VR Big Endian (…1.2.2) are not supported and
+# fall through to "no metadata", which is a soft failure by design.
+_ENCAPSULATED_PREFIX = "1.2.840.10008.1.2.4."
+
+#: How much of the dataset to read looking for the five tags. They live in groups
+#: 0008/0020, long before pixel data; a header this large means something exotic, and
+#: bailing out beats reading a gigabyte per slice.
+_MAX_HEADER_SCAN = 1 << 20  # 1 MiB
+
+
+def _clean(raw: bytes) -> str | None:
+    """DICOM string value → trimmed text, or None when it carries nothing."""
+    try:
+        text = raw.decode("latin-1")
+    except (UnicodeDecodeError, AttributeError):  # pragma: no cover - latin-1 total
+        return None
+    text = text.replace("\x00", "").strip()
+    return text or None
+
+
+def _explicit_vr_le(transfer_syntax: str | None) -> bool | None:
+    """True → Explicit VR LE, False → Implicit VR LE, None → unsupported/unknown."""
+    if transfer_syntax is None:
+        return None
+    if transfer_syntax == _IMPLICIT_VR_LE:
+        return False
+    if transfer_syntax == _EXPLICIT_VR_LE:
+        return True
+    if transfer_syntax.startswith(_ENCAPSULATED_PREFIX):
+        return True
+    return None
+
+
+def _parse_elements(
+    buf: bytes, *, explicit: bool, wanted: frozenset[tuple[int, int]]
+) -> dict[tuple[int, int], str | None]:
+    """Best-effort scan of a little-endian DICOM element stream for ``wanted`` tags.
+
+    Never raises: any structure this parser does not understand (an undefined-length
+    sequence, a truncated element, a value running past the buffer) ends the scan and
+    yields whatever was found so far.
+    """
+    found: dict[tuple[int, int], str | None] = {}
+    pos = 0
+    end = len(buf)
+    while pos + 8 <= end:
+        group, element = struct.unpack_from("<HH", buf, pos)
+        if group >= _STOP_GROUP:
+            break
+        pos += 4
+        if explicit:
+            vr = buf[pos:pos + 2]
+            pos += 2
+            if vr in _LONG_FORM_VR:
+                if pos + 6 > end:
+                    break
+                (length,) = struct.unpack_from("<I", buf, pos + 2)
+                pos += 6
+            else:
+                if pos + 2 > end:
+                    break
+                (length,) = struct.unpack_from("<H", buf, pos)
+                pos += 2
+        else:
+            if pos + 4 > end:
+                break
+            (length,) = struct.unpack_from("<I", buf, pos)
+            pos += 4
+        if length == 0xFFFFFFFF:  # undefined-length sequence: stop rather than guess
+            break
+        if pos + length > end:
+            break
+        tag = (group, element)
+        if tag in wanted:
+            found[tag] = _clean(buf[pos:pos + length])
+            if len(found) == len(wanted):
+                break
+        pos += length
+    return found
+
+
+def _read_tags(path: Path) -> dict[tuple[int, int], str | None]:
+    """Read the five study tags from one DICOM file. Empty dict on any problem."""
+    try:
+        with open(path, "rb") as fh:
+            if fh.read(_DICM_OFFSET + 4)[_DICM_OFFSET:] != _DICM_MAGIC:
+                return {}
+            # File-meta group (0002) is always Explicit VR LE and always opens with
+            # (0002,0000) UL group-length, which tells us where the dataset starts.
+            head = fh.read(12)
+            if len(head) < 12:
+                return {}
+            group, element, vr, short_len = struct.unpack_from("<HH2sH", head, 0)
+            if (group, element) != (0x0002, 0x0000) or vr != b"UL" or short_len != 4:
+                return {}
+            (meta_length,) = struct.unpack_from("<I", head, 8)
+            meta = fh.read(meta_length)
+            syntax = _parse_elements(
+                meta, explicit=True, wanted=frozenset({_TAG_TRANSFER_SYNTAX})
+            ).get(_TAG_TRANSFER_SYNTAX)
+            explicit = _explicit_vr_le(syntax)
+            if explicit is None:
+                return {}
+            return _parse_elements(
+                fh.read(_MAX_HEADER_SCAN), explicit=explicit, wanted=_WANTED
+            )
+    except (OSError, struct.error):
+        return {}
+
+
+def _iso_date(da: str | None) -> str | None:
+    """DICOM ``DA`` (``YYYYMMDD``) → ISO ``YYYY-MM-DD``, or None if unparseable."""
+    if not da or len(da) < 8:
+        return None
+    try:
+        return datetime.strptime(da[:8], "%Y%m%d").date().isoformat()
+    except ValueError:
+        return None
+
+
+@dataclass(frozen=True)
+class Series:
+    """One series of the study — in practice, one subdirectory of slices."""
+
+    directory: str  # relative POSIX dir, "" for the study root
+    description: str | None
+    slice_count: int
+
+
+@dataclass(frozen=True)
+class StudyMetadata:
+    modality: str | None = None
+    study_date: str | None = None  # ISO YYYY-MM-DD
+    study_description: str | None = None
+    study_uid: str | None = None
+    series: tuple[Series, ...] = ()
+
+
+def _metadata_sources(scan: StudyScan) -> list[str]:
+    """Included files usable as a metadata source, i.e. slices (not ``DICOMDIR``)."""
+    return [
+        rel for rel in scan.rel_paths
+        if Path(rel).name.upper() != _DICOMDIR
+    ]
+
+
+def read_metadata(scan: StudyScan) -> StudyMetadata:
+    """Study-level tags from the first slice + a per-series description pass.
+
+    Best-effort throughout: an unreadable, truncated, or unsupported-transfer-syntax
+    slice contributes nothing and never fails the ingest.
+    """
+    sources = _metadata_sources(scan)
+    if not sources:
+        return StudyMetadata()
+
+    head = _read_tags(scan.abs_path(sources[0]))
+
+    # A "series" is a slice directory. Flat discs land in one series keyed "".
+    counts: dict[str, int] = {}
+    first_slice: dict[str, str] = {}
+    for rel in sources:
+        directory = Path(rel).parent.as_posix()
+        directory = "" if directory == "." else directory
+        counts[directory] = counts.get(directory, 0) + 1
+        first_slice.setdefault(directory, rel)
+
+    series = []
+    for directory in sorted(counts):
+        rel = first_slice[directory]
+        tags = head if rel == sources[0] else _read_tags(scan.abs_path(rel))
+        series.append(Series(
+            directory=directory,
+            description=tags.get(_TAG_SERIES_DESCRIPTION),
+            slice_count=counts[directory],
+        ))
+
+    return StudyMetadata(
+        modality=head.get(_TAG_MODALITY),
+        study_date=_iso_date(head.get(_TAG_STUDY_DATE)),
+        study_description=head.get(_TAG_STUDY_DESCRIPTION),
+        study_uid=head.get(_TAG_STUDY_UID),
+        series=tuple(series),
+    )
+
+
+#: Cap on the per-series lines in the summary: enough to characterise a study,
+#: short of turning `ocr_text` into a file listing that pollutes FTS.
+_MAX_SERIES_LINES = 20
+
+
+def summary_text(scan: StudyScan, metadata: StudyMetadata) -> str:
+    """A short derived description of the study, for ``document.ocr_text``.
+
+    Deliberately *not* the 2,000-line file list: the point is that the study shows up
+    in `find` as something recognisable instead of an untitled row. A caller-supplied
+    transcription of the accompanying radiology report always wins over this.
+    """
+    lines = [f"DICOM study: {scan.root.name or scan.root.as_posix()}"]
+    if metadata.modality:
+        lines.append(f"modality: {metadata.modality}")
+    if metadata.study_date:
+        lines.append(f"study date: {metadata.study_date}")
+    if metadata.study_description:
+        lines.append(f"study description: {metadata.study_description}")
+    slices = sum(s.slice_count for s in metadata.series)
+    if slices:
+        suffix = (
+            f" in {len(metadata.series)} series" if len(metadata.series) > 1 else ""
+        )
+        lines.append(f"slices: {slices}{suffix}")
+    # One unnamed series (a flat disc) is fully described by the slice count above.
+    if len(metadata.series) > 1 or any(s.description for s in metadata.series):
+        lines.append("series:")
+        for item in metadata.series[:_MAX_SERIES_LINES]:
+            label = item.description or item.directory or "(unnamed)"
+            lines.append(f"  - {label} - {item.slice_count} slices")
+        remaining = len(metadata.series) - _MAX_SERIES_LINES
+        if remaining > 0:
+            lines.append(f"  - ... and {remaining} more series")
+    if metadata.study_uid:
+        lines.append(f"study UID: {metadata.study_uid}")
+    lines.append(f"files packed: {scan.file_count}")
+    return "\n".join(lines)

--- a/tests/test_cli_ascii.py
+++ b/tests/test_cli_ascii.py
@@ -49,6 +49,23 @@ def test_ingest_no_ocr_note_is_console_safe(ready, capsys):
     _assert_console_safe(captured.err)
 
 
+def test_study_ingest_output_is_console_safe(ready, capsys):
+    """Issue #69's new surface: the pack/exclusion notes and the derived summary."""
+    from test_study import make_study
+
+    capsys.readouterr()
+    assert _run(ready, "ingest", str(make_study(ready / "disc")), "--person",
+                "jane-doe", "--study", "dicom", "--sources", str(ready / "sources")) == 0
+    captured = capsys.readouterr()
+    assert "DICOM files" in captured.err
+    _assert_console_safe(captured.out)
+    _assert_console_safe(captured.err)
+
+    capsys.readouterr()
+    assert _run(ready, "document", "show", "1", "--text") == 0
+    _assert_console_safe(capsys.readouterr().out)
+
+
 def test_duplicate_output_is_console_safe(ready, capsys):
     """The exact reproduction from the issue: '... - nothing ingested'."""
     scan = ready / "s.txt"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -206,6 +206,30 @@ def test_ingest_refuses_a_mismatched_owner(seeded, tmp_path, monkeypatch):
     assert "SMITH, KAREN A" in out["owner_check"]["evidence"]
 
 
+def test_ingest_study_directory(seeded, tmp_path, monkeypatch):
+    """Issue #69 through MCP: `study` makes `file` a directory, packed as one document."""
+    from test_study import make_study  # same synthesized fixtures, one definition
+
+    monkeypatch.setenv("PEMR_SOURCES", str(tmp_path / "sources"))
+    out = mcp_server.ingest_document(
+        seeded, file=str(make_study(tmp_path / "disc")), person="jane-doe",
+        study="dicom",
+    )
+    assert out["status"] == "new"
+    assert out["ocr_text_populated"] is True
+    assert out["document"]["source_path"].endswith(".dcm.zip")
+    assert out["document"]["category"] == "imaging"
+    assert out["document"]["doc_date"] == "2019-04-12"
+
+
+def test_ingest_study_unknown_kind_is_a_tool_error(seeded, tmp_path, monkeypatch):
+    monkeypatch.setenv("PEMR_SOURCES", str(tmp_path / "sources"))
+    (tmp_path / "disc").mkdir()
+    with pytest.raises(mcp_server.ToolError, match="unknown study kind"):
+        mcp_server.ingest_document(seeded, file=str(tmp_path / "disc"),
+                                   person="jane-doe", study="ct-raw")
+
+
 def test_commit_extraction_via_wrapper(seeded, tmp_path, monkeypatch):
     monkeypatch.setenv("PEMR_SOURCES", str(tmp_path / "sources"))
     scan = tmp_path / "s2.txt"

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -7,6 +7,7 @@ neither reviewable nor greppable.
 
 import json
 import struct
+import tracemalloc
 import zipfile
 
 import pytest
@@ -44,9 +45,17 @@ def dicom_bytes(
     modality: str | None = "CT",
     study_description: str | None = "CT ABDOMEN PELVIS",
     series_description: str | None = "AXIAL 2.0",
+    patient_name: str | None = None,
+    patient_birth_date: str | None = None,
     study_uid: str | None = "1.2.840.113619.2.55.3.1",
+    meta_length: int | None = None,
 ) -> bytes:
-    """A minimal valid Part 10 file carrying (only) the tags this engine reads."""
+    """A minimal valid Part 10 file carrying (only) the tags this engine reads.
+
+    ``meta_length`` overrides the ``(0002,0000)`` group-length element with a value
+    that does not describe the file — the corruption the reader must survive without
+    allocating on it (issue #69 audit B1).
+    """
     meta = _explicit(0x0002, 0x0010, b"UI", _pad(transfer_syntax, "\x00"))
     explicit = transfer_syntax != IMPLICIT_VR_LE
 
@@ -61,30 +70,33 @@ def dicom_bytes(
         element(0x0008, 0x0060, b"CS", modality),
         element(0x0008, 0x1030, b"LO", study_description),
         element(0x0008, 0x103E, b"LO", series_description),
+        element(0x0010, 0x0010, b"PN", patient_name),
+        element(0x0010, 0x0030, b"DA", patient_birth_date),
         element(0x0020, 0x000D, b"UI", study_uid, "\x00"),
         # A blob of pixel data, so the "stop before the payload" path is exercised.
         (_explicit(0x7FE0, 0x0010, b"OW", b"\x00" * 16) if explicit
          else _implicit(0x7FE0, 0x0010, b"\x00" * 16)),
     ])
+    declared = len(meta) if meta_length is None else meta_length
     return (
         b"\x00" * 128
         + b"DICM"
-        + _explicit(0x0002, 0x0000, b"UL", struct.pack("<I", len(meta)))
+        + _explicit(0x0002, 0x0000, b"UL", struct.pack("<I", declared))
         + meta
         + dataset
     )
 
 
-def make_study(root, *, series=("SER1",), slices=2, viewer=True, report=True):
+def make_study(root, *, series=("SER1",), slices=2, viewer=True, report=True, **tags):
     """A burned-disc-shaped tree: DICOMDIR + slice dirs + a Windows viewer payload."""
     root.mkdir(parents=True, exist_ok=True)
-    (root / "DICOMDIR").write_bytes(dicom_bytes(series_description=None))
+    (root / "DICOMDIR").write_bytes(dicom_bytes(series_description=None, **tags))
     for name in series:
         directory = root / name
         directory.mkdir(exist_ok=True)
         for slice_no in range(slices):
             (directory / f"IM{slice_no:06d}").write_bytes(
-                dicom_bytes(series_description=f"{name} SERIES")
+                dicom_bytes(series_description=f"{name} SERIES", **tags)
             )
     if viewer:
         (root / "VIEWER.EXE").write_bytes(b"MZ" + b"\x90" * 64)
@@ -229,6 +241,77 @@ def test_read_metadata_never_raises_on_bad_input(tmp_path, content):
     assert meta.study_date is None  # junk/unsupported => no metadata, no exception
 
 
+def test_read_metadata_ignores_a_bogus_meta_group_length(tmp_path):
+    """Issue #69 audit B1: the file's declared meta length must not size a read.
+
+    `BufferedReader.read(n)` allocates `n` up front, so an unbounded 32-bit length —
+    four corrupt bytes, which is exactly how optical media fails — would commit up to
+    4 GiB per slice, and the `MemoryError` that follows on a machine that cannot
+    satisfy it is *not* an `OSError`, so it would escape the reader's "never fails
+    the ingest" contract.
+    """
+    root = tmp_path / "disc"
+    root.mkdir()
+    (root / "IM000001").write_bytes(dicom_bytes(meta_length=0xFFFFFFFF))
+
+    tracemalloc.start()
+    try:
+        meta = study.read_metadata(study.scan_study_dir(root))
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert meta == study.StudyMetadata(series=(study.Series("", None, 1),))
+    # Without the bound this is ~4 GiB; the bound makes it a few KiB.
+    assert peak < 8 * 1024**2
+
+
+def test_read_metadata_caps_an_overlong_tag_value(tmp_path):
+    """Issue #69 audit B2: an untrusted element length must not reach `ocr_text`.
+
+    `StudyDescription` is VR `LO` (64 chars); a file declaring 60,000 would otherwise
+    be spliced verbatim into the FTS index and into an agent's context as if it were
+    clinical record text.
+    """
+    root = tmp_path / "disc"
+    root.mkdir()
+    (root / "IM000001").write_bytes(dicom_bytes(study_description="X" * 60_000))
+    scan = study.scan_study_dir(root)
+    meta = study.read_metadata(scan)
+
+    assert meta.study_description is not None
+    assert len(meta.study_description) == 128
+    assert len(study.summary_text(scan, meta)) < 512
+    # Truncation is of the stored *value* only — the element stream still advances by
+    # the declared length, so later tags are read as usual.
+    assert [s.description for s in meta.series] == ["AXIAL 2.0"]
+
+
+def test_identity_text_is_shaped_for_the_owner_check(tmp_path):
+    root = tmp_path / "disc"
+    root.mkdir()
+    (root / "IM000001").write_bytes(
+        dicom_bytes(patient_name="DOE^JANE^", patient_birth_date="19780504")
+    )
+    meta = study.read_metadata(study.scan_study_dir(root))
+
+    assert meta.patient_name == "DOE^JANE^"
+    assert meta.patient_birth_date == "1978-05-04"  # ISO, as `dob_candidates` renders
+    text = study.identity_text(meta)
+    # The labels are what `check_owner`'s identity anchor recognises, and
+    # `normalize_text` reduces the DICOM caret form to plain name tokens.
+    assert text == "Patient: DOE^JANE^\nDOB: 1978-05-04"
+    assert " doe jane " in ingest.normalize_text(text)
+
+
+def test_identity_text_is_none_without_the_tags(tmp_path):
+    """No signal must stay `unverified`, not become a spurious refusal."""
+    root = tmp_path / "disc"
+    root.mkdir()
+    (root / "IM000001").write_bytes(dicom_bytes())
+    assert study.identity_text(study.read_metadata(study.scan_study_dir(root))) is None
+
+
 def test_metadata_ignores_dicomdir_as_the_tag_source(tmp_path):
     """DICOMDIR is packed but carries directory records, not study tags."""
     root = tmp_path / "disc"
@@ -370,8 +453,7 @@ def test_ingest_document_points_a_directory_at_the_study_flag(conn, tmp_path, so
     assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 0
 
 
-def test_ingest_study_dir_owner_check_runs_on_supplied_text_only(conn, tmp_path,
-                                                                 sources):
+def test_ingest_study_dir_owner_check_runs_on_supplied_text(conn, tmp_path, sources):
     persons.add_person(conn, "john-roe", "John Roe")
     root = make_study(tmp_path / "disc")
 
@@ -387,6 +469,75 @@ def test_ingest_study_dir_owner_check_runs_on_supplied_text_only(conn, tmp_path,
     # The derived summary is engine output, not document text: it is never checked.
     result = ingest.ingest_study_dir(conn, root, "jane-doe", sources)
     assert result.owner_check.verdict == "unverified"
+
+
+def test_ingest_study_dir_owner_check_reads_the_dicom_header(conn, tmp_path, sources):
+    """Issue #69 audit B3: the study path must not opt out of the #61 misfile rail.
+
+    A 2,000-slice binary folder is the one document type a human cannot eyeball, so
+    pointing `--person jane-doe` at the spouse's disc is the realistic slip — and the
+    identity is sitting in the header.
+    """
+    persons.add_person(conn, "john-roe", "John Roe")
+    root = make_study(tmp_path / "disc", patient_name="ROE^JOHN^")
+
+    with pytest.raises(ingest.OwnerMismatchError) as excinfo:
+        ingest.ingest_study_dir(conn, root, "jane-doe", sources)
+    assert excinfo.value.check.verdict == "mismatch"
+    assert excinfo.value.check.matched_slug == "john-roe"
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 0
+    assert not sources.exists()  # refused pre-write *and* pre-pack
+
+    # ...and `--force` is still the whole recovery.
+    result = ingest.ingest_study_dir(conn, root, "jane-doe", sources, force=True)
+    assert result.status == "new"
+    assert result.owner_check.verdict == "mismatch"
+
+
+def test_ingest_study_dir_header_identity_verifies_and_is_never_stored(
+    conn, tmp_path, sources
+):
+    root = make_study(tmp_path / "disc", patient_name="DOE^JANE^")
+    result = ingest.ingest_study_dir(conn, root, "jane-doe", sources)
+
+    assert result.owner_check.verdict == "match"
+    assert result.owner_check.matched_slug == "jane-doe"
+    # Verification input, not stored text: the identity tags never reach `ocr_text`,
+    # so they never reach the FTS index or an agent's context.
+    assert "JANE" not in result.document.ocr_text
+    assert "DOE" not in result.document.ocr_text
+
+
+def test_ingest_study_dir_header_dob_alone_verifies(conn, tmp_path, sources):
+    persons.add_person(conn, "ann-poe", "Ann Poe", dob="1978-05-04")
+    root = make_study(tmp_path / "disc", patient_birth_date="19780504")
+
+    result = ingest.ingest_study_dir(conn, root, "ann-poe", sources)
+    assert result.owner_check.verdict == "match"
+
+
+def test_ingest_study_dir_unknown_patient_is_suspect(conn, tmp_path, sources):
+    """Nobody on the roster: the header names *someone*, and it isn't the claimant."""
+    root = make_study(tmp_path / "disc", patient_name="STRANGER^SAM^")
+
+    with pytest.raises(ingest.OwnerMismatchError) as excinfo:
+        ingest.ingest_study_dir(conn, root, "jane-doe", sources)
+    assert excinfo.value.check.verdict == "suspect"
+
+
+@pytest.mark.parametrize(
+    "verdicts, expected",
+    [
+        (("match", "mismatch"), "mismatch"),   # blocking beats affirmative
+        (("suspect", "match"), "suspect"),
+        (("unverified", "match"), "match"),    # affirmative beats ignorance
+        (("unverified", "unverified"), "unverified"),
+        ((), "unverified"),
+    ],
+)
+def test_strongest_check_orders_by_consequence(verdicts, expected):
+    checks = [ingest.OwnerCheck(verdict=v) for v in verdicts]
+    assert ingest._strongest_check(checks).verdict == expected
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1,0 +1,468 @@
+"""Study-directory packing (issue #69): canonical zip, DICM filter, header reader.
+
+Fixtures are synthesized here rather than checked in — a minimal but *real* DICOM
+Part 10 byte stream is a few lines of `struct`, and binary blobs in the repo are
+neither reviewable nor greppable.
+"""
+
+import json
+import struct
+import zipfile
+
+import pytest
+
+from pemr import cli, db, ingest, persons, study
+
+
+# --------------------------------------------------------------------------- #
+# Fixture synthesis: minimal DICOM Part 10 files
+# --------------------------------------------------------------------------- #
+
+IMPLICIT_VR_LE = "1.2.840.10008.1.2"
+EXPLICIT_VR_LE = "1.2.840.10008.1.2.1"
+EXPLICIT_VR_BE = "1.2.840.10008.1.2.2"  # unsupported on purpose
+
+
+def _pad(value: str, pad: str = " ") -> bytes:
+    """DICOM values are even-length; text VRs pad with a space, UI with NUL."""
+    raw = value.encode("ascii")
+    return raw + pad.encode("ascii") if len(raw) % 2 else raw
+
+
+def _explicit(group, element, vr, value: bytes) -> bytes:
+    return struct.pack("<HH2sH", group, element, vr, len(value)) + value
+
+
+def _implicit(group, element, value: bytes) -> bytes:
+    return struct.pack("<HHI", group, element, len(value)) + value
+
+
+def dicom_bytes(
+    *,
+    transfer_syntax: str = EXPLICIT_VR_LE,
+    study_date: str | None = "20190412",
+    modality: str | None = "CT",
+    study_description: str | None = "CT ABDOMEN PELVIS",
+    series_description: str | None = "AXIAL 2.0",
+    study_uid: str | None = "1.2.840.113619.2.55.3.1",
+) -> bytes:
+    """A minimal valid Part 10 file carrying (only) the tags this engine reads."""
+    meta = _explicit(0x0002, 0x0010, b"UI", _pad(transfer_syntax, "\x00"))
+    explicit = transfer_syntax != IMPLICIT_VR_LE
+
+    def element(group, elem, vr, value, pad=" "):
+        if value is None:
+            return b""
+        raw = _pad(value, pad)
+        return _explicit(group, elem, vr, raw) if explicit else _implicit(group, elem, raw)
+
+    dataset = b"".join([
+        element(0x0008, 0x0020, b"DA", study_date),
+        element(0x0008, 0x0060, b"CS", modality),
+        element(0x0008, 0x1030, b"LO", study_description),
+        element(0x0008, 0x103E, b"LO", series_description),
+        element(0x0020, 0x000D, b"UI", study_uid, "\x00"),
+        # A blob of pixel data, so the "stop before the payload" path is exercised.
+        (_explicit(0x7FE0, 0x0010, b"OW", b"\x00" * 16) if explicit
+         else _implicit(0x7FE0, 0x0010, b"\x00" * 16)),
+    ])
+    return (
+        b"\x00" * 128
+        + b"DICM"
+        + _explicit(0x0002, 0x0000, b"UL", struct.pack("<I", len(meta)))
+        + meta
+        + dataset
+    )
+
+
+def make_study(root, *, series=("SER1",), slices=2, viewer=True, report=True):
+    """A burned-disc-shaped tree: DICOMDIR + slice dirs + a Windows viewer payload."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "DICOMDIR").write_bytes(dicom_bytes(series_description=None))
+    for name in series:
+        directory = root / name
+        directory.mkdir(exist_ok=True)
+        for slice_no in range(slices):
+            (directory / f"IM{slice_no:06d}").write_bytes(
+                dicom_bytes(series_description=f"{name} SERIES")
+            )
+    if viewer:
+        (root / "VIEWER.EXE").write_bytes(b"MZ" + b"\x90" * 64)
+        (root / "viewer.dll").write_bytes(b"MZ" + b"\x00" * 64)
+        (root / "autorun.inf").write_bytes(b"[autorun]\r\n")
+        (root / "index.html").write_text("<html>viewer</html>")
+    if report:
+        (root / "report.pdf").write_bytes(b"%PDF-1.4 radiology report")
+    return root
+
+
+# --------------------------------------------------------------------------- #
+# Scanning / inclusion filter
+# --------------------------------------------------------------------------- #
+
+def test_scan_includes_dicom_by_magic_and_drops_viewer_payload(tmp_path):
+    scan = study.scan_study_dir(make_study(tmp_path / "disc"))
+
+    assert scan.rel_paths == ("DICOMDIR", "SER1/IM000000", "SER1/IM000001")
+    # index.html is dropped as a viewer file, but it *is* document-like, so it is
+    # named rather than counted; the executables are only counted.
+    assert scan.excluded_documents == ("index.html", "report.pdf")
+    assert scan.excluded_other == 3  # VIEWER.EXE, viewer.dll, autorun.inf
+    assert scan.total_bytes == sum(
+        (tmp_path / "disc" / rel).stat().st_size for rel in scan.rel_paths
+    )
+
+
+def test_is_dicom_file_tolerates_short_and_missing_files(tmp_path):
+    short = tmp_path / "short.bin"
+    short.write_bytes(b"\x00" * 40)
+    assert study.is_dicom_file(short) is False
+    assert study.is_dicom_file(tmp_path / "nope.bin") is False
+    assert study.is_dicom_file(tmp_path) is False
+
+
+@pytest.mark.parametrize("size,expected", [
+    (0, "0 B"), (999, "999 B"), (1536, "1.5 KiB"), (5 * 1024**2, "5.0 MiB"),
+    (4 * 1024**3, "4.0 GiB"), (3 * 1024**4, "3.0 TiB"),
+])
+def test_human_bytes(size, expected):
+    assert study.human_bytes(size) == expected
+
+
+def test_scan_empty_dir_yields_no_files(tmp_path):
+    (tmp_path / "empty").mkdir()
+    assert study.scan_study_dir(tmp_path / "empty").rel_paths == ()
+
+
+# --------------------------------------------------------------------------- #
+# Canonical archive — the determinism the content hash rests on
+# --------------------------------------------------------------------------- #
+
+def test_pack_is_deterministic_across_trees_and_creation_order(tmp_path):
+    first = make_study(tmp_path / "a", series=("S1", "S2"))
+    # Same content, created in the opposite order, at a different path, later.
+    second = tmp_path / "b"
+    second.mkdir()
+    (second / "S2").mkdir()
+    (second / "S1").mkdir()
+    for rel in reversed(study.scan_study_dir(first).rel_paths):
+        (second / rel).write_bytes((first / rel).read_bytes())
+    make_study(second, series=(), viewer=True, report=True)
+
+    sha_a = study.pack_study(study.scan_study_dir(first), tmp_path / "a.zip")
+    sha_b = study.pack_study(study.scan_study_dir(second), tmp_path / "b.zip")
+    assert sha_a == sha_b
+    # ...and stable across repeated packs of the same tree.
+    assert sha_a == study.pack_study(study.scan_study_dir(first), tmp_path / "a2.zip")
+
+
+def test_pack_golden_hash(tmp_path):
+    """A pinned hash over a fixed fixture: catches cross-version `zipfile` drift.
+
+    If this fails after a Python upgrade, every previously ingested study would
+    re-ingest as a *new* document instead of deduping — that is exactly the
+    regression worth failing loudly on.
+    """
+    root = tmp_path / "golden"
+    root.mkdir()
+    (root / "IM000001").write_bytes(b"\x00" * 128 + b"DICM" + b"payload-a")
+    (root / "IM000002").write_bytes(b"\x00" * 128 + b"DICM" + b"payload-b")
+    sha = study.pack_study(study.scan_study_dir(root), tmp_path / "golden.zip")
+    assert sha == "07368b18d1294cc67eafa48e25c6a7798281db45ac0dd77acea8a336c4d6b2b9"
+
+
+def test_pack_pins_every_varying_zip_field(tmp_path):
+    scan = study.scan_study_dir(make_study(tmp_path / "disc"))
+    out = tmp_path / "study.zip"
+    study.pack_study(scan, out)
+
+    with zipfile.ZipFile(out) as zf:
+        assert [i.filename for i in zf.infolist()] == list(scan.rel_paths)
+        for info in zf.infolist():
+            assert info.date_time == (1980, 1, 1, 0, 0, 0)
+            assert info.compress_type == zipfile.ZIP_STORED
+            assert info.create_system == 0
+            # never the source file's mode — see `_ZIP_EXTERNAL_ATTR`
+            assert info.external_attr == 0o600 << 16
+            assert info.internal_attr == 0
+            assert info.comment == b""
+            assert info.extra == b""
+        # ...and the archive still round-trips the original bytes.
+        assert zf.read("SER1/IM000000") == (
+            scan.abs_path("SER1/IM000000").read_bytes()
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Header reader
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("syntax", [EXPLICIT_VR_LE, IMPLICIT_VR_LE])
+def test_read_metadata_both_transfer_syntaxes(tmp_path, syntax):
+    root = tmp_path / "disc"
+    root.mkdir()
+    (root / "IM000001").write_bytes(dicom_bytes(transfer_syntax=syntax))
+    meta = study.read_metadata(study.scan_study_dir(root))
+
+    assert meta.modality == "CT"
+    assert meta.study_date == "2019-04-12"
+    assert meta.study_description == "CT ABDOMEN PELVIS"
+    assert meta.study_uid == "1.2.840.113619.2.55.3.1"
+    assert [s.description for s in meta.series] == ["AXIAL 2.0"]
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        b"\x00" * 128 + b"DICM",                       # truncated after the magic
+        b"\x00" * 128 + b"DICM" + b"\x02\x00\x00\x00", # truncated meta element
+        dicom_bytes(transfer_syntax=EXPLICIT_VR_BE),   # unsupported syntax
+        dicom_bytes(study_date="not-a-date", modality=None),
+    ],
+    ids=["truncated", "truncated-meta", "big-endian", "junk-date"],
+)
+def test_read_metadata_never_raises_on_bad_input(tmp_path, content):
+    root = tmp_path / "disc"
+    root.mkdir()
+    (root / "IM000001").write_bytes(content)
+    meta = study.read_metadata(study.scan_study_dir(root))
+    assert meta.study_date is None  # junk/unsupported => no metadata, no exception
+
+
+def test_metadata_ignores_dicomdir_as_the_tag_source(tmp_path):
+    """DICOMDIR is packed but carries directory records, not study tags."""
+    root = tmp_path / "disc"
+    root.mkdir()
+    (root / "DICOMDIR").write_bytes(dicom_bytes(modality=None, study_date=None))
+    (root / "IM000001").write_bytes(dicom_bytes())
+    meta = study.read_metadata(study.scan_study_dir(root))
+    assert meta.modality == "CT"
+
+
+def test_summary_text_is_a_digest_not_a_file_listing(tmp_path):
+    scan = study.scan_study_dir(make_study(tmp_path / "disc", series=("S1", "S2")))
+    text = study.summary_text(scan, study.read_metadata(scan))
+
+    assert "DICOM study: disc" in text
+    assert "modality: CT" in text
+    assert "study date: 2019-04-12" in text
+    assert "slices: 4 in 2 series" in text
+    assert "S1 SERIES - 2 slices" in text
+    assert "IM000000" not in text  # never the per-slice listing
+
+
+# --------------------------------------------------------------------------- #
+# Ingest integration
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture()
+def conn(tmp_path):
+    conn = db.connect(tmp_path / "test.db")
+    db.migrate(conn)
+    persons.add_person(conn, "jane-doe", "Jane Doe")
+    yield conn
+    conn.close()
+
+
+@pytest.fixture()
+def sources(tmp_path):
+    return tmp_path / "sources"
+
+
+def test_ingest_study_dir_stores_one_document(conn, tmp_path, sources):
+    root = make_study(tmp_path / "disc")
+    result = ingest.ingest_study_dir(conn, root, "jane-doe", sources)
+
+    assert result.status == "new"
+    doc = result.document
+    sha = doc.sha256
+    assert doc.source_path == f"{sha[:2]}/{sha}.dcm.zip"
+    assert (sources / sha[:2] / f"{sha}.dcm.zip").is_file()
+    # derived defaults
+    assert doc.doc_date == "2019-04-12"
+    assert doc.category == "imaging"
+    assert result.ocr_text_populated
+    assert "DICOM study: disc" in doc.ocr_text
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 1
+    # the stored blob's bytes really are the content hash (what `pemr verify` checks)
+    assert ingest.hash_file(sources / doc.source_path) == sha
+
+
+def test_ingest_study_dir_reingest_is_a_duplicate_no_op(conn, tmp_path, sources):
+    root = make_study(tmp_path / "disc")
+    first = ingest.ingest_study_dir(conn, root, "jane-doe", sources)
+    second = ingest.ingest_study_dir(conn, root, "jane-doe", sources)
+
+    assert second.status == "duplicate"
+    assert second.document.document_id == first.document.document_id
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 1
+    assert len(list((sources / first.document.sha256[:2]).iterdir())) == 1
+    # the staging copy is unlinked on every path, duplicate included
+    assert list((sources / ingest.TMP_DIRNAME).iterdir()) == []
+
+
+def test_ingest_study_dir_caller_values_win(conn, tmp_path, sources):
+    root = make_study(tmp_path / "disc")
+    result = ingest.ingest_study_dir(
+        conn, root, "jane-doe", sources,
+        doc_date="2020-02-02", category="radiology", provider="Mercy Imaging",
+        ocr_text="  IMPRESSION: no acute findings.  ",
+    )
+    doc = result.document
+    assert doc.doc_date == "2020-02-02"
+    assert doc.category == "radiology"
+    assert doc.provider == "Mercy Imaging"
+    assert doc.ocr_text == "IMPRESSION: no acute findings."
+
+
+def test_ingest_study_dir_reports_excluded_documents(conn, tmp_path, sources, capsys):
+    ingest.ingest_study_dir(conn, make_study(tmp_path / "disc"), "jane-doe", sources)
+    err = capsys.readouterr().err
+    assert "3 DICOM files" in err
+    assert "report.pdf" in err
+
+
+def test_ingest_study_dir_size_guard(conn, tmp_path, sources, monkeypatch):
+    root = make_study(tmp_path / "disc")
+    monkeypatch.setattr(study, "MAX_STUDY_BYTES", 10)
+
+    with pytest.raises(ingest.IngestError, match="over the 10 B limit.*--allow-large"):
+        ingest.ingest_study_dir(conn, root, "jane-doe", sources)
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 0
+    assert not sources.exists()  # refused pre-write: nothing staged, nothing stored
+
+    result = ingest.ingest_study_dir(conn, root, "jane-doe", sources, allow_large=True)
+    assert result.status == "new"
+
+
+def test_ingest_study_dir_rejects_a_file(conn, tmp_path, sources):
+    path = tmp_path / "scan.pdf"
+    path.write_bytes(b"%PDF-1.4")
+    with pytest.raises(ingest.IngestError, match="is a file"):
+        ingest.ingest_study_dir(conn, path, "jane-doe", sources)
+
+
+def test_ingest_study_dir_unknown_kind(conn, tmp_path, sources):
+    with pytest.raises(ingest.IngestError, match="unknown study kind"):
+        ingest.ingest_study_dir(
+            conn, make_study(tmp_path / "disc"), "jane-doe", sources, study="mri-raw"
+        )
+
+
+def test_ingest_study_dir_missing_dir(conn, tmp_path, sources):
+    with pytest.raises(ingest.IngestError, match="directory not found"):
+        ingest.ingest_study_dir(conn, tmp_path / "nope", "jane-doe", sources)
+
+
+def test_ingest_study_dir_with_no_dicom_files(conn, tmp_path, sources):
+    root = tmp_path / "disc"
+    root.mkdir()
+    (root / "readme.txt").write_text("nothing here")
+    with pytest.raises(ingest.IngestError, match="no DICOM files"):
+        ingest.ingest_study_dir(conn, root, "jane-doe", sources)
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 0
+
+
+def test_ingest_document_points_a_directory_at_the_study_flag(conn, tmp_path, sources):
+    root = make_study(tmp_path / "disc")
+    with pytest.raises(ingest.IngestError, match="--study dicom"):
+        ingest.ingest_document(conn, root, "jane-doe", sources)
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 0
+
+
+def test_ingest_study_dir_owner_check_runs_on_supplied_text_only(conn, tmp_path,
+                                                                 sources):
+    persons.add_person(conn, "john-roe", "John Roe")
+    root = make_study(tmp_path / "disc")
+
+    with pytest.raises(ingest.OwnerMismatchError) as excinfo:
+        ingest.ingest_study_dir(
+            conn, root, "jane-doe", sources,
+            ocr_text="Patient: John Roe\nIMPRESSION: normal study.",
+        )
+    assert excinfo.value.check.verdict == "mismatch"
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 0
+    assert not sources.exists()  # pre-write *and* pre-pack
+
+    # The derived summary is engine output, not document text: it is never checked.
+    result = ingest.ingest_study_dir(conn, root, "jane-doe", sources)
+    assert result.owner_check.verdict == "unverified"
+
+
+# --------------------------------------------------------------------------- #
+# CLI + MCP wiring
+# --------------------------------------------------------------------------- #
+
+def _cli(tmp_path, *argv):
+    return cli.main(["--db", str(tmp_path / "cli.db"), *argv])
+
+
+@pytest.fixture()
+def cli_ready(tmp_path):
+    assert _cli(tmp_path, "migrate", "--create") == 0
+    assert _cli(tmp_path, "person", "add", "--slug", "jane-doe",
+                "--name", "Jane Doe") == 0
+    return tmp_path
+
+
+def test_cli_ingest_study_roundtrip(cli_ready, capsys):
+    tmp_path = cli_ready
+    root = make_study(tmp_path / "disc")
+    sources = tmp_path / "sources"
+
+    assert _cli(tmp_path, "ingest", str(root), "--person", "jane-doe",
+                "--study", "dicom", "--sources", str(sources)) == 0
+    captured = capsys.readouterr()
+    assert "ingested document #1" in captured.out
+    assert ".dcm.zip" in captured.out
+    # a study is searchable off the derived summary, so no "no ocr_text" warning
+    assert "no ocr_text stored" not in captured.err
+
+    assert _cli(tmp_path, "document", "show", "1", "--text") == 0
+    assert "DICOM study: disc" in capsys.readouterr().out
+
+    # re-run is a no-op duplicate, per layer-1 dedup on the archive's hash
+    assert _cli(tmp_path, "ingest", str(root), "--person", "jane-doe",
+                "--study", "dicom", "--sources", str(sources)) == 0
+    assert "duplicate: already filed as document #1" in capsys.readouterr().out
+
+
+def test_cli_ingest_study_says_it_ignores_ocr(cli_ready, capsys):
+    tmp_path = cli_ready
+    assert _cli(tmp_path, "ingest", str(make_study(tmp_path / "disc")),
+                "--person", "jane-doe", "--study", "dicom", "--ocr", "tesseract",
+                "--sources", str(tmp_path / "sources")) == 0
+    assert "--ocr is ignored for --study dicom" in capsys.readouterr().err
+
+
+def test_cli_ingest_directory_without_study_flag_errors(cli_ready, capsys):
+    tmp_path = cli_ready
+    root = make_study(tmp_path / "disc")
+    assert _cli(tmp_path, "ingest", str(root), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources")) == 1
+    assert "--study dicom" in capsys.readouterr().err
+
+
+def test_cli_ingest_study_flag_with_a_file_errors(cli_ready, capsys):
+    tmp_path = cli_ready
+    scan = tmp_path / "scan.txt"
+    scan.write_bytes(b"a flat scan")
+    assert _cli(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--study", "dicom", "--sources", str(tmp_path / "sources")) == 1
+    assert "is a file" in capsys.readouterr().err
+
+
+def test_cli_study_verify_resolves_the_packed_blob(cli_ready, capsys):
+    """`pemr verify` re-hashes `sources/<source_path>` — the archive must satisfy it."""
+    tmp_path = cli_ready
+    sources = tmp_path / "sources"
+    assert _cli(tmp_path, "ingest", str(make_study(tmp_path / "disc")),
+                "--person", "jane-doe", "--study", "dicom",
+                "--sources", str(sources)) == 0
+    capsys.readouterr()
+    assert _cli(tmp_path, "verify", "--sources", str(sources), "--json") == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is True
+    assert report["blobs"] == {
+        "checked": 1, "ok": 1, "missing": 0, "mismatched": 0, "skipped": None
+    }


### PR DESCRIPTION
## Summary

Adds study-level ingest for burned imaging discs (DICOM study directories), forked out of #66's
design pass because it raises a storage-invariant question the other intake edge cases don't.

- `pemr/study.py`: packs a DICOM study directory into a canonical, deterministic zip (sorted
  entries, fixed timestamps, viewer payload excluded by rule) and ingests it through the existing
  single-blob `sources/<sha[:2]>/<sha><ext>` path unchanged — preserving both the content-address
  and layer-1-dedup invariants from `docs/Architecture.md` §1/§4.
- Bounded DICOM header parsing (`_MAX_HEADER_SCAN`, per-tag length cap) — a crafted
  `meta_length`/tag-length header can no longer exhaust memory (measured multi-GB `tracemalloc`
  peak pre-fix vs. ~9 KB post-fix).
- Study-level owner check (`_strongest_check`, order-independent, `mismatch > suspect > match >
  unverified`) so a study disc gets the same identity-anchor guard as single-file ingest; the
  verdict is never persisted (rides on `IngestResult` only), so it never reaches `ocr_text`/FTS.
- Atomic publish (`.tmp` → `os.replace`) with cleanup on every path; per-series description length
  bounds to keep a forged DICOM tag from writing unbounded text into the derived summary.
- `AGENTS.md`, `docs/Architecture.md` updated for the new study-ingest path and its owner-check
  scope.

Audited (ADVANCE): all three build-time blockers (unbounded meta length, uncapped tag value,
missing owner check) verified fixed with mutation evidence that the bounds are load-bearing; the
one item audit deferred (control characters in tag text forging summary lines) is confirmed
cosmetic — it reaches the FTS-indexed summary only, never the owner-check signal, and is deferred
to a text-hygiene follow-up rather than blocking ship.

## Tests
`python -m pytest` — 540 passed. `npm run check:meta-drift` passes; `npm test` 4 passed.

## Non-blocking follow-ups (not this PR)
- Collapse DICOM tag control characters in `_clean` (text hygiene for the derived summary; does
  not close any identity-check gap — tested and confirmed).
- Four realistic header shapes (surname-only, de-identification label, initials, MRN-in-PN-field)
  now `suspect`-refuse a person's own disc and need `--force` — same trade #61 already made for
  single-file ingest.
- `--allow-large` without `--study`; unset `ZipInfo.file_size`; no `sources/.tmp/` sweeper;
  owner-check/dedup ordering divergence (safe direction) — carried from build/verify/audit, none
  blocking.

## CI note
`sync:claude-config:check` may show drift from pre-existing `.claude/` mirror state unrelated to
this branch — confirmed empty via `git diff --name-only origin/dev...HEAD -- .claude .github`.

Closes #69