### PR TITLE
fix(#78): read --ocr-text-file as utf-8-sig, catch UnicodeDecodeError

### DIFF
--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -174,6 +174,33 @@ def _resolve_dictionary_path(args: argparse.Namespace) -> Path | None:
     return _DEFAULT_DICTIONARY if _DEFAULT_DICTIONARY.is_file() else None
 
 
+class _OcrTextFileError(Exception):
+    """`--ocr-text-file` could not be read; the message is already user-facing."""
+
+
+def _read_ocr_text_file(path: str) -> str:
+    """Read an `--ocr-text-file` for the two commands that accept one.
+
+    One helper for `ingest` and `document set-text` so their read paths cannot
+    diverge again (issue #78); #62 deliberately mirrored `ingest`'s read
+    byte-for-byte, which duplicated both of its defects:
+
+    * `utf-8-sig`, not `utf-8`: a UTF-8 BOM survives `str.strip()`, so a BOM-only
+      "empty" file (Notepad, PowerShell 5.1 - three bytes, `EF BB BF`) sails past
+      the emptiness guard and stores one invisible character as `ocr_text`, which
+      then reports `ocr_text_populated: true` while carrying no text. A BOM on a
+      real transcription silently inflates the stored text by one character.
+    * `UnicodeDecodeError` is a `ValueError`, not an `OSError`, and `main()` has no
+      catch-all: handing in a PDF/UTF-16/latin-1 file is an ordinary user mistake
+      and must read as the friendly error, not a traceback.
+    """
+    try:
+        with open(path, encoding="utf-8-sig") as fh:
+            return fh.read()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise _OcrTextFileError(f"cannot read {path}: {exc}") from exc
+
+
 def _migration_followups(conn: sqlite3.Connection, applied: list[str]) -> list[str]:
     """Manual follow-ups the just-applied migrations leave behind.
 
@@ -473,10 +500,9 @@ def _cmd_document_show(args: argparse.Namespace) -> int:
 
 def _cmd_document_set_text(args: argparse.Namespace) -> int:
     try:
-        with open(args.ocr_text_file, encoding="utf-8") as fh:
-            text = fh.read()
-    except OSError as exc:
-        print(f"error: cannot read {args.ocr_text_file}: {exc}", file=sys.stderr)
+        text = _read_ocr_text_file(args.ocr_text_file)
+    except _OcrTextFileError as exc:
+        print(f"error: {exc}", file=sys.stderr)
         return 1
 
     def work(conn):
@@ -680,10 +706,9 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
     ocr_text = None
     if getattr(args, "ocr_text_file", None):
         try:
-            with open(args.ocr_text_file, encoding="utf-8") as fh:
-                ocr_text = fh.read()
-        except OSError as exc:
-            print(f"error: cannot read {args.ocr_text_file}: {exc}", file=sys.stderr)
+            ocr_text = _read_ocr_text_file(args.ocr_text_file)
+        except _OcrTextFileError as exc:
+            print(f"error: {exc}", file=sys.stderr)
             return 1
 
     conn = _connect_db(args)

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -266,6 +266,58 @@ def test_ingest_without_text_notes_the_owner_was_not_verified(ready, capsys):
     assert "owner not verified" in capsys.readouterr().err
 
 
+# --- --ocr-text-file reading (issue #78) --------------------------------------
+# Same helper backs `document set-text`; its half of these lives in test_documents.py.
+
+def test_ingest_non_utf8_ocr_text_file_is_a_friendly_error(ready, capsys):
+    """`UnicodeDecodeError` is a `ValueError`, not an `OSError` - a PDF or a UTF-16
+    file handed to `--ocr-text-file` used to traceback out of `main` (#78)."""
+    tmp_path = ready
+    scan = tmp_path / "scan.txt"
+    scan.write_bytes(b"some labs")
+    bad = tmp_path / "scan.pdf"
+    bad.write_bytes(b"%PDF-1.4\xff\xfe\x00binary junk")
+
+    rc = _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+              "--sources", str(tmp_path / "sources"), "--ocr-text-file", str(bad))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "error: cannot read" in err and "scan.pdf" in err
+    assert not _document_id(tmp_path)  # the read fails before anything is written
+
+
+def test_ingest_bom_only_ocr_text_file_stores_no_ocr_text(ready, capsys):
+    """Three bytes of BOM is an empty file, not one character of text (#78):
+    U+FEFF survives `str.strip()`, so a `utf-8` read would report ocr_text populated."""
+    tmp_path = ready
+    scan = tmp_path / "scan.txt"
+    scan.write_bytes(b"some labs")
+    bom = tmp_path / "bomonly.txt"
+    bom.write_bytes(b"\xef\xbb\xbf")
+
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources"), "--ocr-text-file", str(bom)) == 0
+    assert "no ocr_text stored" in capsys.readouterr().err
+    assert _run(tmp_path, "document", "show", "1", "--text") == 0
+    shown = capsys.readouterr()
+    assert shown.out == "" and "has no ocr_text stored" in shown.err
+
+
+def test_ingest_strips_a_leading_bom_from_the_ocr_text_file(ready, capsys):
+    """A BOM on a real transcription must not inflate the stored text (#78)."""
+    tmp_path = ready
+    scan = tmp_path / "hers.txt"
+    scan.write_bytes(b"her own labs")
+    ocr = tmp_path / "bommed.txt"
+    ocr.write_bytes(b"\xef\xbb\xbfPatient Name: DOE, JANE\nSodium 140 mmol/L")
+
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources"), "--ocr-text-file", str(ocr)) == 0
+    capsys.readouterr()
+    assert _run(tmp_path, "document", "show", "1", "--text") == 0
+    assert capsys.readouterr().out == "Patient Name: DOE, JANE\nSodium 140 mmol/L\n"
+
+
 def test_commit_bad_json_is_friendly(ready, capsys):
     tmp_path = ready
     bad = tmp_path / "bad.json"

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -846,6 +846,49 @@ def test_cli_document_set_text_rejects_an_empty_file(cli_ready, capsys):
     assert capsys.readouterr().out == "hba1c 5.7 percent\n"
 
 
+def test_cli_document_set_text_rejects_a_bom_only_file(cli_ready, capsys):
+    """A BOM-only "empty" file (Notepad/PowerShell 5.1) must not defeat the guard.
+
+    U+FEFF survives `str.strip()`, so a `utf-8` read would store one invisible
+    character and report `has_ocr_text: true` on a document with no text (#78).
+    """
+    text = cli_ready / "bomonly.txt"
+    text.write_bytes(b"\xef\xbb\xbf")
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "set-text", "1", "--force",
+                "--ocr-text-file", str(text)) == 1
+    assert "is empty - nothing to store" in capsys.readouterr().err
+    assert _run(cli_ready, "document", "show", "1", "--text") == 0
+    assert capsys.readouterr().out == "hba1c 5.7 percent\n"
+
+
+def test_cli_document_set_text_strips_a_leading_bom(cli_ready, capsys):
+    """A BOM on a real transcription must not inflate the stored text (#78)."""
+    text = cli_ready / "bommed.txt"
+    text.write_bytes(b"\xef\xbb\xbfreplacement transcription")
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "set-text", "1", "--force",
+                "--ocr-text-file", str(text)) == 0
+    assert "set ocr_text on document #1: 25 chars" in capsys.readouterr().out
+    assert _run(cli_ready, "document", "show", "1", "--text") == 0
+    assert capsys.readouterr().out == "replacement transcription\n"
+
+
+def test_cli_document_set_text_non_utf8_file_is_a_friendly_error(cli_ready, capsys):
+    """`UnicodeDecodeError` is a `ValueError`, not an `OSError` - handing in a PDF
+    or a UTF-16 file used to escape the `except` and traceback out of `main` (#78)."""
+    text = cli_ready / "scan.pdf"
+    text.write_bytes(b"%PDF-1.4\xff\xfe\x00binary junk")
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "set-text", "1", "--force",
+                "--ocr-text-file", str(text)) == 1
+    err = capsys.readouterr().err
+    assert "error: cannot read" in err and "scan.pdf" in err
+    # Nothing was written: the read fails before the DB is even opened.
+    assert _run(cli_ready, "document", "show", "1", "--text") == 0
+    assert capsys.readouterr().out == "hba1c 5.7 percent\n"
+
+
 def test_cli_document_set_text_unreadable_path_and_unknown_id_fail(cli_ready, capsys):
     capsys.readouterr()
     assert _run(cli_ready, "document", "set-text", "1",


### PR DESCRIPTION
## Summary
- `--ocr-text-file` (used by both `ingest` and `document set-text`) was read with a bare `open(..., encoding="utf-8")` in two call sites, inheriting two defects:
  1. A non-UTF-8 file (PDF, UTF-16, latin-1) raised `UnicodeDecodeError` (a `ValueError`, not the `OSError` each call site caught), and `main()` has no catch-all, so an ordinary user mistake tracebacked out.
  2. A UTF-8 BOM survives `str.strip()`, so a BOM-only "empty" file (Notepad, PowerShell 5.1 — `EF BB BF`) defeated the emptiness guard and stored one invisible character, leaving `ocr_text_populated: true` on a document with no text.
- Both reads now go through one `cli._read_ocr_text_file()` helper (`utf-8-sig`, catches `(OSError, UnicodeDecodeError)`) so a third call site can't reintroduce the split. User-facing error text is unchanged.

## Test plan
- [x] `pytest tests/test_cli_phase2.py tests/test_documents.py` — new coverage for non-UTF-8 file, BOM-only file, and BOM-prefixed real transcription, for both `ingest` and `document set-text`
- [x] `dev` merged into the branch cleanly (no conflicts)

Closes #78

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>