### PR TITLE
fix(dedup): qualifier-aware dedup keys so distinct assays stop colliding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,9 +72,15 @@ report's verbatim label.
   backstop, not the only defense — getting the name right at the source keeps trends, `query`, and
   dedup coherent.
 - **Unknown analyte** (no canonical match after normalization): commit the verbatim report name
-  (parentheticals stripped) and **propose the synonym to the human** in your response. Agents
-  never edit `data/dictionary.toml` directly — dictionary additions are human-approved
-  (`docs/Architecture.md` §3).
+  **including any parenthetical qualifier** and **propose the synonym to the human** in your
+  response. Agents never edit `data/dictionary.toml` directly — dictionary additions are
+  human-approved (`docs/Architecture.md` §3).
+- **Never drop a parenthetical qualifier** (issue #71). `Albumin (SPEP)` and a CMP's `Albumin`
+  are two different assays off one draw; the qualifier is what keeps their dedup keys distinct,
+  and an agent that strips it at the source destroys a distinction no later `pemr rekey` can
+  recover. Commit the label as printed. If the parenthetical really is noise for that analyte,
+  that is a dictionary entry for the human to approve (`"m-spike (spep)" = "m_spike"`), not an
+  edit for you to make in the payload.
 - MUST NOT invent abbreviations or "helpful" renames.
 
 ### 2. Observation rows — conditions, allergies, vitals, orders, screenings, immunizations

--- a/data/dictionary.example.toml
+++ b/data/dictionary.example.toml
@@ -6,12 +6,26 @@
 # to a single canonical token so `A1c`, `HbA1c`, `Hemoglobin A1c` all collapse to
 # one dedup identity. Agents propose additions; a human approves them.
 #
-# Keys are matched AFTER norm() lowercases, trims and collapses whitespace AND strips
-# parenthetical qualifiers, so write keys in that already-normalized form: lowercase,
-# single spaces, and NO parentheses — norm() removes `(HGB)`, `(SPEP)`, `(calculated)`
-# etc. before lookup, so `Hemoglobin (HGB)` matches the bare `hemoglobin` key. Seeded
-# from common lab-panel headers plus the real-corpus report vocabulary (CMP/CBC panel
-# codes, serum free light chains, SPEP); extend as new documents surface new spellings.
+# Keys are matched AFTER lowercasing, trimming and whitespace collapse, so write them
+# in that already-normalized form: lowercase, single spaces.
+#
+# PARENTHESES ARE ALLOWED IN KEYS, and that is how you declare a parenthetical to be
+# noise (issue #71). A parenthetical qualifier is treated as MEANINGFUL by default —
+# `Albumin` and `Albumin (SPEP)` are two different assays off one draw and must keep
+# distinct dedup keys — with two escapes:
+#
+#   * A redundant alias needs no entry at all: `(HGB)`, `(HCT)`, `(PLT)` already map to
+#     the same canonical token as their stem, so `Hemoglobin (HGB)` collapses to
+#     `hemoglobin` automatically.
+#   * Anything else you want collapsed gets a full parenthesized key, e.g.
+#     `"m-spike (spep)" = "m_spike"` below.
+#
+# After adding or changing a key, run `pemr rekey` (dry-run) and then `--apply` to move
+# already-stored rows onto the keys the new dictionary derives.
+#
+# Seeded from common lab-panel headers plus the real-corpus report vocabulary (CMP/CBC
+# panel codes, serum free light chains, SPEP); extend as new documents surface new
+# spellings.
 
 [synonyms]
 # --- Glycemic ---
@@ -48,6 +62,8 @@
 "creatinine" = "creatinine"
 "cr" = "creatinine"
 "crea" = "creatinine"
+# "(calculated)" is a note about how the number was produced, not a second assay.
+"creatinine (calculated)" = "creatinine"
 "egfr" = "egfr"
 "estimated gfr" = "egfr"
 "bun" = "bun"
@@ -78,14 +94,14 @@
 "mean platelet volume" = "mpv"
 
 # --- Inflammatory markers ---
-# ESR (erythrocyte sedimentation rate). Report labels vary by method. The
-# unparenthesized Quest label "sed rate by modified westergren" matches its own
-# key below; a parenthetical variant like "Sed Rate (Modified Westergren)" has
-# the method tag stripped by norm() and reduces to the bare "sed rate" key
-# instead. All spellings collapse to `esr`.
+# ESR (erythrocyte sedimentation rate). Report labels vary by method, but ESR is a
+# single assay however the lab names the technique, so every spelling collapses to
+# `esr` — including the parenthesized variant, which needs its own full-label key
+# now that a parenthetical is meaningful by default.
 "esr" = "esr"
 "sed rate" = "esr"
 "sed rate by modified westergren" = "esr"
+"sed rate (modified westergren)" = "esr"
 "erythrocyte sedimentation rate" = "esr"
 
 # --- Basic metabolic panel (CMP abbreviations) ---
@@ -120,13 +136,18 @@
 "ldh" = "ldh"
 "lactate dehydrogenase" = "ldh"
 
-# --- Serum protein: NOT mapped, on purpose ---
+# --- Serum protein: still unmapped, but no longer unsafe ---
 # A CMP and an SPEP run off the SAME draw both report total protein (`TPro` /
 # `Protein, Total`) and albumin (`ALB` / `Albumin`) — different methods, slightly
-# different numbers, same person + same collected_at. Mapping `alb`->`albumin` or
-# `tpro`->`protein_total` would give those two rows one dedup key, so the second
-# would land as a staged CONFLICT (or silently collapse when the numbers happen to
-# agree). Leave the report labels distinct; revisit only with a method-aware key.
+# different numbers, same person + same collected_at. This used to make mapping
+# `alb`->`albumin` / `tpro`->`protein_total` unsafe: it gave those two rows one dedup
+# key and the second landed as a staged CONFLICT.
+#
+# Issue #71 supplied the method-aware key that block asked for: the SPEP row's
+# `Albumin (SPEP)` label now keys as `albumin (spep)`, distinct from the CMP's bare
+# `albumin`, so the mapping is safe to add. Curating it is a separate pass — add the
+# entries deliberately, alongside whatever full-label keys your reports' SPEP fraction
+# names need, then `pemr rekey`.
 
 # --- Vitamins ---
 "vitamin d" = "vitamin_d_25oh"
@@ -138,8 +159,9 @@
 
 # --- Myeloma / paraprotein panel (SPEP, serum free light chains) ---
 # Serum free light chains, their ratio, the monoclonal spike and the immunoglobulin
-# quant / beta-2 microglobulin that track plasma-cell disease. Parenthetical method
-# tags like `(SPEP)` are stripped by norm() before this lookup.
+# quant / beta-2 microglobulin that track plasma-cell disease. `(SPEP)` is noise on
+# an M-spike (an M-spike only ever comes off an SPEP) but load-bearing on albumin —
+# hence the full-label key below rather than a global rule.
 "kappa" = "kappa_free_light_chain"
 "free kappa light chain" = "kappa_free_light_chain"
 "lambda" = "lambda_free_light_chain"
@@ -147,6 +169,7 @@
 "k/l ratio" = "kappa_lambda_ratio"
 "kappa/lambda ratio" = "kappa_lambda_ratio"
 "m-spike" = "m_spike"
+"m-spike (spep)" = "m_spike"
 "immunoglobulin g" = "igg"
 "immunoglobulin g, qn, serum" = "igg"
 "iga" = "iga"

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -197,17 +197,34 @@ Each typed/observation row computes a deterministic `dedup_key` from normalized 
 so the *same clinical fact* extracted from two different documents collapses to one row.
 
 ```
-lab_result.dedup_key   = hash(person_id | norm(test_name) | collected_at)
+lab_result.dedup_key   = hash(person_id | key_token(test_name) | collected_at)
 medication.dedup_key    = hash(person_id | norm(name) | dose | started_on)
 procedure.dedup_key     = hash(person_id | norm(name) | performed_on)
 appointment.dedup_key   = hash(person_id | provider | scheduled_for)
-observation.dedup_key   = hash(person_id | obs_type | observed_at | key)
+observation.dedup_key   = hash(person_id | obs_type | observed_at | key_token(key))
 ```
 
-`norm()` = lowercase, trim, collapse whitespace, map synonyms via an **analyte/name
-dictionary** (`data/dictionary.toml`) — e.g. `A1c`, `HbA1c`, `Hemoglobin A1c` → one
-canonical `hba1c`. The dictionary is the one place fuzzy naming gets pinned down
-deterministically; agents propose additions, you approve.
+`norm()` = lowercase, trim, collapse whitespace, drop parenthetical qualifiers, map
+synonyms via an **analyte/name dictionary** (`data/dictionary.toml`) — e.g. `A1c`,
+`HbA1c`, `Hemoglobin A1c` → one canonical `hba1c`. The dictionary is the one place fuzzy
+naming gets pinned down deterministically; agents propose additions, you approve.
+
+`key_token()` is the finer **identity** form used by the two analyte-named key parts: the
+canonical token plus a *meaningful* parenthetical qualifier, `albumin (spep)`. A
+parenthetical is meaningful unless the dictionary says otherwise (issue #71) — the
+asymmetry is deliberate, since collapsing two assays is lossy and near-silent while
+over-splitting is visible and repaired by one dictionary line plus `pemr rekey`. Two
+escapes keep the common cases quiet: a parenthetical that maps to the same canonical
+token as its stem is dropped with no entry at all (`Hemoglobin (HGB)` → `hemoglobin`),
+and anything else can be declared noise with a full parenthesized key
+(`"m-spike (spep)" = "m_spike"`). The qualifier is *folded into* the existing key part
+rather than appended as a new one, so unqualified rows keep byte-identical keys and a
+rekey moves only the rows the split affects.
+
+The `norm()`/`key_token()` split is visible in the read layer too: `pemr labs --test
+albumin` matches on `norm()` and lists the whole analyte family, while `pemr trends`
+matches on `key_token()` so a numeric series never interleaves two assays — and reports
+the rows it excluded on that basis (`other_assays`) instead of dropping them silently.
 
 **A dictionary edit is retroactive only if you make it so.** Stored keys are frozen at
 commit time, so a new synonym changes the key a *future* commit derives for a fact already
@@ -216,6 +233,17 @@ every stored key under the current dictionary (dry-run by default, `--apply` to 
 values and provenance untouched). It aborts whole if two rows would recompute to one key —
 that means the new synonym fuses two distinct facts, e.g. a CMP `ALB` and an SPEP `Albumin`
 off the same draw, and the fix belongs in the dictionary rather than the data.
+
+`rekey` is also the whole **migration for the issue-#71 key change**, and it is safe by
+construction: a qualifier can only *add* precision, so two rows can never fuse and
+`RekeyCollisionError` is unreachable from that change alone. Procedure: `pemr rekey`
+(dry-run) → read the moved labels → for any that should have stayed collapsed, add a full
+parenthesized synonym key → re-run the dry-run → `pemr rekey --apply`. Rows whose names
+carry no parenthetical do not move at all (the qualifier is folded into the existing key
+part), so a database with no qualified names reports zero changes. Note that `document
+reassign` refuses on `DictionaryDriftError` until the rekey is applied — it recomputes
+keys through the same function, so it sees the drift first. Rekeying does **not** recover
+a value already lost to a pre-fix collision: that needs the source document re-extracted.
 
 The **measured value is deliberately *not* in the key** — temporal identity carries the
 draw instead. `collected_at`/`observed_at` are used at full precision (timestamp when the
@@ -536,7 +564,11 @@ it's the best possible dedup/extraction test corpus.
   starter `data/dictionary.example.toml` now carries CMP/CBC panel codes, serum free
   light chains and SPEP naming variants; `norm()` additionally strips parenthetical
   qualifiers (`(HGB)`, `(SPEP)`, `(calculated)`) and compares units case-insensitively
-  so the dictionary only needs bare canonical spellings.
+  so the dictionary only needs bare canonical spellings. **Amended (issue #71):**
+  stripping is right for `norm()` (the analyte family) but was wrong for the *key* — it
+  collided a CMP `Albumin` with an SPEP `Albumin (SPEP)`. Keys now use `key_token()`,
+  which keeps a parenthetical unless it is a redundant alias of its stem or the
+  dictionary declares it noise via a full parenthesized key (§3).
 - **FTS**: ~~SQLite FTS5 is plenty; confirm you don't need semantic/vector search over
   notes (could add a sidecar later).~~ **Resolved (phase 3):** plain SQLite FTS5, no
   vector sidecar. `migrations/003_fts.sql` adds a standalone `record_fts` index over

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -230,9 +230,20 @@ the rows it excluded on that basis (`other_assays`) instead of dropping them sil
 commit time, so a new synonym changes the key a *future* commit derives for a fact already
 in the DB: layer-2 dedup misses it and the same fact lands twice. `pemr rekey` re-derives
 every stored key under the current dictionary (dry-run by default, `--apply` to write,
-values and provenance untouched). It aborts whole if two rows would recompute to one key —
-that means the new synonym fuses two distinct facts, e.g. a CMP `ALB` and an SPEP `Albumin`
-off the same draw, and the fix belongs in the dictionary rather than the data.
+values and provenance untouched). It aborts whole if two rows would recompute to one key,
+and the message names which of the two causes it is: *different* payloads mean the new
+synonym fuses two distinct facts (e.g. a CMP `ALB` and an SPEP `Albumin` off one draw) and
+the fix belongs in the dictionary; *identical* payloads mean one fact was filed twice, once
+under a pre-drift key, and the fix belongs in the data.
+
+**Ingesting against drifted keys is refused, not silently forked.** Until the rekey is
+applied, a stored row's frozen key is invisible to layer-2 dedup, so re-filing that same
+fact would land a *second* row reported as `new` — no duplicate, no conflict, no signal at
+all — and then wedge `rekey` on the collision it had just created. `commit-extraction`
+therefore raises `DictionaryDriftError` when a stored row recomputes onto an identity the
+submission also derives while carrying a different stored key; the message names the `pemr
+rekey --apply` to run. The check is deliberately narrow — unrelated drift elsewhere in the
+database is a maintenance chore, not a reason to refuse an ingest.
 
 `rekey` is also the whole **migration for the issue-#71 key change**, and it is safe by
 construction: a qualifier can only *add* precision, so two rows can never fuse and
@@ -240,9 +251,9 @@ construction: a qualifier can only *add* precision, so two rows can never fuse a
 (dry-run) → read the moved labels → for any that should have stayed collapsed, add a full
 parenthesized synonym key → re-run the dry-run → `pemr rekey --apply`. Rows whose names
 carry no parenthetical do not move at all (the qualifier is folded into the existing key
-part), so a database with no qualified names reports zero changes. Note that `document
-reassign` refuses on `DictionaryDriftError` until the rekey is applied — it recomputes
-keys through the same function, so it sees the drift first. Rekeying does **not** recover
+part), so a database with no qualified names reports zero changes. Both other write paths
+refuse until the rekey is applied — `document reassign` and `commit-extraction` recompute
+keys through the same function, so they see the drift first. Rekeying does **not** recover
 a value already lost to a pre-fix collision: that needs the source document re-extracted.
 
 The **measured value is deliberately *not* in the key** — temporal identity carries the

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
 import sqlite3
 import sys
 import tomllib
@@ -726,7 +727,8 @@ def _cmd_commit_extraction(args: argparse.Namespace) -> int:
         except db.NotMigratedError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 1
-        except dedup.ValidationError as exc:
+        except (dedup.ValidationError, dedup.DictionaryDriftError) as exc:
+            # Drift is a refusal, not a crash: the message names the rekey to run.
             print(f"error: {exc}", file=sys.stderr)
             return 1
     finally:
@@ -994,12 +996,17 @@ def _print_other_assays(result: dict) -> None:
 
     Without this the split is invisible: an SPEP albumin series would just be missing
     from a CMP albumin trend with no hint it exists. Each token is printed ready to
-    paste back as ``--test``."""
+    paste back as ``--test``.
+
+    Quoted with :func:`shlex.quote`, not an f-string's own ``"``: the token descends
+    from ``test_name``, i.e. untrusted document text, and this is the one place in the
+    read path that renders such text as a command the user is invited to run. A name
+    carrying a ``"`` would otherwise close the quote and leave the remainder live."""
     others = result.get("other_assays") or []
     if not others:
         return
     count = result.get("other_assay_count", 0)
-    tokens = "  ".join(f'--test "{t}"' for t in others)
+    tokens = "  ".join(f"--test {shlex.quote(t)}" for t in others)
     print(f"  note   {count} more row(s) of this analyte under another assay: {tokens}")
 
 

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -989,6 +989,20 @@ def _cmd_find(args: argparse.Namespace) -> int:
     return _with_conn_person(args, work)
 
 
+def _print_other_assays(result: dict) -> None:
+    """Disclose same-analyte rows `trends` excluded as a different assay (issue #71).
+
+    Without this the split is invisible: an SPEP albumin series would just be missing
+    from a CMP albumin trend with no hint it exists. Each token is printed ready to
+    paste back as ``--test``."""
+    others = result.get("other_assays") or []
+    if not others:
+        return
+    count = result.get("other_assay_count", 0)
+    tokens = "  ".join(f'--test "{t}"' for t in others)
+    print(f"  note   {count} more row(s) of this analyte under another assay: {tokens}")
+
+
 def _cmd_trends(args: argparse.Namespace) -> int:
     def work(conn):
         dictionary = dedup.load_dictionary(_resolve_dictionary_path(args))
@@ -998,6 +1012,7 @@ def _cmd_trends(args: argparse.Namespace) -> int:
             return 0
         if result["count"] == 0:
             print(f"no numeric results for '{result['test']}'")
+            _print_other_assays(result)
             return 0
         unit = f" {result['unit']}" if result["unit"] else ""
         print(f"{result['test']}  ({result['count']} point(s))")
@@ -1013,6 +1028,7 @@ def _cmd_trends(args: argparse.Namespace) -> int:
             print("  slope  n/a (need >=2 distinct dates)")
         else:
             print(f"  slope  {result['slope_per_day']:+.4g}{unit}/day")
+        _print_other_assays(result)
         return 0
 
     return _with_conn_person(args, work)

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -14,6 +14,12 @@ agent can't subtly get wrong:
 analyte/name dictionary (``data/dictionary.toml``) so ``A1c`` / ``HbA1c`` /
 ``Hemoglobin A1c`` collapse to one canonical token — the one place fuzzy naming
 gets pinned down deterministically.
+
+``key_token()`` is the *identity* form of that name: the canonical token plus any
+**meaningful** parenthetical qualifier (``albumin (spep)``), so two genuinely
+distinct assays of one analyte off one draw keep distinct keys (issue #71).
+``norm()`` remains the *family* form (``albumin`` for both) and is what analyte
+listings match on.
 """
 
 from __future__ import annotations
@@ -98,7 +104,9 @@ DATE_FIELDS: dict[str, frozenset[str]] = {
 }
 
 _WS = re.compile(r"\s+")
-_PAREN = re.compile(r"\([^)]*\)")
+# Capturing group so the same pattern both removes a parenthetical (`sub`, giving the
+# bare analyte stem) and yields its contents (`findall`, giving the candidate qualifier).
+_PAREN = re.compile(r"\(([^)]*)\)")
 
 # A date value is accepted at one of three precisions, each a lexically-sortable ISO
 # prefix (so `_date_only` slicing, timeline sort and every `ORDER BY <datecol>` keep
@@ -185,25 +193,90 @@ def _collapse(value: str) -> str:
 
 
 def _strip_qualifiers(value: str) -> str:
-    """Drop parenthetical qualifiers (``(SPEP)``, ``(HGB)``, ``(calculated)``) that
-    label a value's method/source without changing *which analyte it is*, then
-    re-collapse whitespace. Applied inside :func:`norm` so real-report spellings like
-    ``Hemoglobin (HGB)`` or ``M-Spike (SPEP)`` reduce to their bare analyte name and
-    the dictionary only has to carry the minimal spelling, not every parenthesized
-    variant a lab happens to print."""
+    """Drop parenthetical qualifiers (``(SPEP)``, ``(HGB)``, ``(calculated)``) to leave
+    the bare analyte *stem*, then re-collapse whitespace. The stem is what
+    :func:`identity` looks up in the dictionary, so the dictionary only has to carry
+    the minimal spelling, not every parenthesized variant a lab happens to print."""
     return _WS.sub(" ", _PAREN.sub(" ", value)).strip()
 
 
-def norm(value: object, dictionary: dict[str, str] | None = None) -> str:
-    """Normalize a free-text field: lowercase, trim, collapse whitespace (underscores
-    count as whitespace), strip parenthetical qualifiers, then map synonyms through
-    the dictionary. ``None`` -> ``""`` (deterministic key part)."""
+def _qualifier_text(value: str) -> str:
+    """The concatenated contents of ``value``'s parentheticals (``""`` when there are
+    none). ``"albumin (spep)"`` -> ``"spep"``; multiple groups join with a space."""
+    return _WS.sub(" ", " ".join(_PAREN.findall(value))).strip()
+
+
+def identity(
+    value: object, dictionary: dict[str, str] | None = None
+) -> tuple[str, str]:
+    """``(canonical, qualifier)`` — the analyte family and, when the name carries a
+    *meaningful* parenthetical, the assay that distinguishes it within that family.
+
+    A parenthetical is meaningful **unless proven otherwise**, which is the deliberate
+    inversion behind issue #71. Collapsing two distinct assays (a CMP ``Albumin`` and an
+    SPEP ``Albumin (SPEP)`` off one draw) is lossy and near-silent — one row stores, the
+    other stages as a conflict. Over-splitting is visible and non-lossy: two parallel
+    series, repaired by one dictionary line plus ``pemr rekey``. Default to the
+    recoverable failure.
+
+    Three rules on ``full = _collapse(value)`` (parentheses preserved), in order:
+
+    1. **A declared full label wins.** ``dictionary["m-spike (spep)"]`` is the human
+       saying "this exact parenthesized label *is* that analyte" -> no qualifier. This
+       needs no schema change: ``[synonyms]`` keys may simply contain parentheses.
+    2. **A redundant alias is noise, with zero curation.** When the parenthetical maps
+       to the same canonical token as the stem — ``Hemoglobin (HGB)``, ``Hematocrit
+       (HCT)``, ``Platelet Count (PLT)`` — it is just another spelling of the stem, so
+       it drops out with no dictionary entry of its own.
+    3. **Everything else is meaningful** and becomes the qualifier, mapped through the
+       dictionary so ``(SPEP)`` and ``(Serum Protein Electrophoresis)`` agree.
+    """
     if value is None:
-        return ""
-    collapsed = _strip_qualifiers(_collapse(str(value)))
-    if dictionary:
-        return dictionary.get(collapsed, collapsed)
-    return collapsed
+        return "", ""
+    full = _collapse(str(value))
+    if dictionary and full in dictionary:
+        return dictionary[full], ""
+    stem = _strip_qualifiers(full)
+    canonical = dictionary.get(stem, stem) if dictionary else stem
+    inner = _qualifier_text(full)
+    if not inner:
+        return canonical, ""
+    qualifier = dictionary.get(inner, inner) if dictionary else inner
+    if qualifier == canonical:
+        return canonical, ""
+    return canonical, qualifier
+
+
+def norm(value: object, dictionary: dict[str, str] | None = None) -> str:
+    """Normalize a free-text field to its **analyte family** token: lowercase, trim,
+    collapse whitespace (underscores count as whitespace), drop parenthetical
+    qualifiers, then map synonyms through the dictionary. ``None`` -> ``""``
+    (deterministic key part).
+
+    This is the *family* form — ``Albumin`` and ``Albumin (SPEP)`` both normalize to
+    ``albumin`` — which is what analyte listings (``pemr labs --test``) match on so a
+    listing shows the whole family. Dedup keys and numeric series use the finer
+    :func:`key_token` instead.
+    """
+    return identity(value, dictionary)[0]
+
+
+def key_token(value: object, dictionary: dict[str, str] | None = None) -> str:
+    """The **dedup identity** token for a name: :func:`norm`'s canonical token, plus a
+    meaningful qualifier in parentheses when :func:`identity` finds one.
+
+    ``"albumin"`` / ``"albumin (spep)"``. Folded into the existing key part rather than
+    appended as a new one, deliberately: a fourth hash part would change ``"a|b|c"`` to
+    ``"a|b||c"`` and move the key of *every* stored row. Folding leaves every unqualified
+    row's ``dedup_key`` bit-identical, so ``pemr rekey`` moves only the rows this bug
+    actually affects.
+    """
+    canonical, qualifier = identity(value, dictionary)
+    if not qualifier:
+        return canonical
+    if not canonical:
+        return qualifier      # degenerate "(SPEP)"-only name: the qualifier is the name
+    return f"{canonical} ({qualifier})"
 
 
 def _date_only(value: object) -> str:
@@ -242,12 +315,22 @@ def _key_parts(
 
     Kept separate from the hashing so an error message can name *why* two rows
     collide (see :func:`identity_label`) instead of quoting a bare hash.
+
+    Analyte-style names — ``lab_result.test_name`` and ``observation.key`` — key on
+    :func:`key_token`, so a meaningful assay qualifier stays part of the identity
+    (issue #71). Everything else keys on :func:`norm`: medication / procedure /
+    appointment names already carry dose / date / provider in the key, and their
+    parentheticals are usually brand or descriptive (``Insulin (Lantus)``) rather than a
+    second measurement of one thing.
     """
     def n(field_name: str) -> str:
         return norm(row.get(field_name), dictionary)
 
+    def kt(field_name: str) -> str:
+        return key_token(row.get(field_name), dictionary)
+
     if record_type == "lab_result":
-        return [person_id, n("test_name"), _norm_ts(row.get("collected_at"))]
+        return [person_id, kt("test_name"), _norm_ts(row.get("collected_at"))]
     if record_type == "medication":
         return [person_id, n("name"), _collapse(str(row.get("dose") or "")),
                 _date_only(row.get("started_on"))]
@@ -256,7 +339,7 @@ def _key_parts(
     if record_type == "appointment":
         return [person_id, n("provider"), _date_only(row.get("scheduled_for"))]
     if record_type == "observation":
-        return [person_id, n("obs_type"), _norm_ts(row.get("observed_at")), n("key")]
+        return [person_id, n("obs_type"), _norm_ts(row.get("observed_at")), kt("key")]
     raise ValidationError(f"unknown record type: {record_type}")  # guarded by validate()
 
 

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -107,6 +107,9 @@ _WS = re.compile(r"\s+")
 # Capturing group so the same pattern both removes a parenthetical (`sub`, giving the
 # bare analyte stem) and yields its contents (`findall`, giving the candidate qualifier).
 _PAREN = re.compile(r"\(([^)]*)\)")
+# Padding just inside a parenthesis, squeezed out by _collapse so `M-Spike ( SPEP )`
+# is the same label as `M-Spike (SPEP)` (and so hits the same dictionary entry).
+_PAREN_PAD = re.compile(r"\(\s+|\s+\)")
 
 # A date value is accepted at one of three precisions, each a lexically-sortable ISO
 # prefix (so `_date_only` slicing, timeline sort and every `ORDER BY <datecol>` keep
@@ -123,6 +126,15 @@ _ISO_YEAR_RE = re.compile(r"\d{4}")
 
 class ValidationError(ValueError):
     """Raised when the extraction JSON violates a record schema."""
+
+
+class DictionaryDriftError(ValueError):
+    """Stored keys no longer match the current dictionary; `pemr rekey` comes first.
+
+    Defined here rather than in :mod:`pemr.documents` because both the write paths
+    that can be corrupted by drift — `document reassign` and `commit-extraction` —
+    have to raise it, and only this module is importable from both.
+    """
 
 
 def _is_iso_date(value: str) -> bool:
@@ -187,9 +199,17 @@ def load_dictionary(path: str | Path | None) -> dict[str, str]:
 
 
 def _collapse(value: str) -> str:
-    # Underscores count as separators: machine-generated keys like
-    # "blood_pressure" must collapse to the same token as "Blood Pressure".
-    return _WS.sub(" ", value.strip().lower().replace("_", " "))
+    """Case/whitespace-normalized spelling of a free-text name.
+
+    Underscores count as separators: machine-generated keys like ``blood_pressure``
+    must collapse to the same token as ``Blood Pressure``. Trimming happens *after*
+    that substitution — a leading/trailing ``_`` becomes whitespace, and a stray edge
+    space would otherwise defeat :func:`identity`'s declared-full-label lookup
+    (``"_m-spike (spep)"`` must still find the ``"m-spike (spep)"`` entry). Padding
+    just inside a parenthesis is squeezed out for the same reason.
+    """
+    collapsed = _WS.sub(" ", value.lower().replace("_", " ")).strip()
+    return _PAREN_PAD.sub(lambda m: m.group(0).strip(), collapsed)
 
 
 def _strip_qualifiers(value: str) -> str:
@@ -506,6 +526,54 @@ def _rows_equal(
     return True
 
 
+def _assert_no_key_drift(
+    conn: sqlite3.Connection,
+    record_type: str,
+    rows: list,
+    person_id: int,
+    dictionary: dict[str, str] | None,
+) -> None:
+    """Refuse a commit that would fork a fact already stored under a **stale** key.
+
+    A ``dedup_key`` is frozen at commit time, so once the current dictionary (or the
+    key derivation itself — issue #71 gave every parenthesized analyte name a new key)
+    disagrees with what a stored row carries, layer-2 dedup silently misses: the same
+    fact lands a *second* time, reported as ``new``, with no duplicate/conflict signal
+    for anyone to notice. `pemr rekey --apply` is the fix, but nothing used to make the
+    user run it before their next ingest — this is what does.
+
+    Deliberately *narrow*: it fires only when a stored row recomputes onto an identity
+    this submission also derives, so an unrelated drifted row elsewhere in the database
+    never blocks an ingest. `document reassign` carries the equivalent guard
+    (:class:`DictionaryDriftError` there too), for the same reason.
+    """
+    bases = {dedup_key(record_type, row, person_id, dictionary) for row in rows}
+    if not bases:
+        return
+    pk = f"{record_type}_id"
+    stored = conn.execute(
+        f"SELECT * FROM {record_type} WHERE person_id = ?", (person_id,)
+    ).fetchall()
+    for row in stored:
+        payload = {name: row[name] for name in FIELD_SPECS[record_type]}
+        # An admitted repeat (`--keep both`) keys on hash(base|occurrence), so the
+        # recompute has to carry the stored occurrence or every sibling reads as drift.
+        occurrence = int(row["dedup_occurrence"] or 0)
+        base = dedup_key(record_type, payload, person_id, dictionary)
+        if base not in bases:
+            continue
+        if occurrence_key(base, occurrence) != row["dedup_key"]:
+            raise DictionaryDriftError(
+                f"{record_type}: {pk} {row[pk]} "
+                f"({_rekey_label(record_type, row)!r}) is stored under a dedup_key "
+                "that no longer matches the current dictionary, and this submission "
+                "derives that same identity - committing now would file the fact a "
+                "second time instead of deduping (or staging a conflict) against the "
+                "stored row. Run `pemr rekey --apply` first, then retry; nothing was "
+                "written"
+            )
+
+
 def commit_extraction(
     conn: sqlite3.Connection,
     document_id: int,
@@ -568,6 +636,9 @@ def commit_extraction(
                     "timestamp, commit them in separate submissions and resolve the "
                     "conflict with `--keep both`"
                 )
+        # Still pass 1 (nothing written yet): a stored row whose frozen key no longer
+        # matches its recompute would be missed by pass 2's dedup, forking the fact.
+        _assert_no_key_drift(conn, record_type, rows, person_id, dictionary)
 
     summary = CommitSummary()
     detected_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -1011,9 +1082,15 @@ def rekey(
     edit. Values, provenance and row ids are untouched — only ``dedup_key`` moves.
 
     Dry-run by default: pass ``apply=True`` to write. If two rows in a table recompute
-    to the same key the new dictionary would merge two distinct facts (typically two
-    methods for one analyte off one draw), so nothing is written and
-    :class:`RekeyCollisionError` is raised — fix the dictionary, not the data.
+    to the same key nothing is written and :class:`RekeyCollisionError` is raised, with
+    a message that names which of the two causes it is:
+
+    * the rows carry *different* payloads — the dictionary would merge two distinct
+      facts (typically two methods for one analyte off one draw): fix the dictionary;
+    * the rows carry the *same* payload — one fact was filed twice, once under a
+      pre-drift key, so it is the data that needs fixing. :func:`_assert_no_key_drift`
+      refuses the ingest that would create this state, so it should only be reachable
+      in a database that drifted before that guard existed.
     """
     db.require_migrated(conn)
     report = RekeyReport(applied=False)
@@ -1032,6 +1109,21 @@ def rekey(
             key = occurrence_key(base, occurrence)
             clash = seen.get(key)
             if clash is not None:
+                if _rows_equal(record_type, clash, payload):
+                    # Same payload, two keys: not a dictionary fault at all - one fact
+                    # was filed twice, once under a pre-drift key and once under the
+                    # current one. Say so, because "fix the dictionary" is exactly the
+                    # wrong advice here (`_assert_no_key_drift` now stops new ingests
+                    # from reaching this state).
+                    raise RekeyCollisionError(
+                        f"{record_type}: {pk} {row[pk]} and {pk} {clash[pk]} "
+                        f"({_rekey_label(record_type, row)!r}) hold the SAME fact "
+                        "under two dedup_keys - it was filed a second time by an "
+                        "ingest that ran against drifted keys before this rekey. The "
+                        "dictionary is fine; the data is doubled. Drop the duplicate "
+                        "(`pemr document rm` on the document that re-filed it, or "
+                        "resolve it by hand) and re-run; nothing was written"
+                    )
                 raise RekeyCollisionError(
                     f"{record_type}: {pk} {row[pk]} "
                     f"({_rekey_label(record_type, row)!r}) and {pk} {clash[pk]} "

--- a/pemr/documents.py
+++ b/pemr/documents.py
@@ -56,8 +56,11 @@ class OpenConflictsError(ValueError):
     """Raised when a reassign is refused because open conflicts cite the document."""
 
 
-class DictionaryDriftError(ValueError):
-    """Stored keys no longer match the current dictionary; `pemr rekey` comes first."""
+# Stored keys no longer match the current dictionary; `pemr rekey` comes first.
+# The class lives in `dedup` because `commit_extraction` raises it too (a drifted key
+# forks the fact on the next ingest, issue #71); re-exported here so
+# `documents.DictionaryDriftError` stays the name callers already catch.
+DictionaryDriftError = dedup.DictionaryDriftError
 
 
 class OcrTextPresentError(ValueError):

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -221,7 +221,11 @@ def commit_extraction(
     """
     try:
         summary = _dedup.commit_extraction(conn, document_id, records, _dictionary())
-    except (db.NotMigratedError, _dedup.ValidationError) as exc:
+    except (
+        db.NotMigratedError, _dedup.ValidationError, _dedup.DictionaryDriftError
+    ) as exc:
+        # Drift is a refusal carrying its own remedy (`pemr rekey --apply`), not an
+        # internal error - surface it as friendly as a schema violation.
         raise _friendly(exc) from exc
     return {
         "counts": summary.counts,

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -6,10 +6,16 @@ owns human-readable vs ``--json`` formatting, and phase 5's MCP wrapper reuses t
 shapes as its payload. Person is always addressed by slug and resolved to ``person_id``
 here — an unknown slug raises :class:`PersonNotFoundError` (a friendly rc=1 at the CLI).
 
-Analyte matching (``--test`` on labs/trends) runs through the same ``norm()`` +
-dictionary as dedup, so ``A1c`` finds rows stored as ``HbA1c``. Because the typed tables
-store the *original* spelling (only ``dedup_key`` is normalized), that match is done in
-Python over the candidate rows rather than in SQL.
+Analyte matching (``--test`` on labs/trends) runs through the same dictionary as dedup,
+so ``A1c`` finds rows stored as ``HbA1c``. Because the typed tables store the *original*
+spelling (only ``dedup_key`` is normalized), that match is done in Python over the
+candidate rows rather than in SQL.
+
+The two readers match at deliberately **different granularities** (issue #71):
+``query_labs`` uses ``norm()`` and shows the whole analyte family, while ``trends`` uses
+``key_token()`` so a numeric series never interleaves two different assays of one
+analyte (a CMP ``Albumin`` and an SPEP ``Albumin (SPEP)``) — and discloses the rows it
+excluded on that basis rather than dropping them silently.
 """
 
 from __future__ import annotations
@@ -20,7 +26,7 @@ import sqlite3
 from datetime import date, datetime
 
 from . import db
-from .dedup import norm
+from .dedup import key_token, norm
 
 # Word tokens for a safe FTS5 query: strips punctuation/operators so raw user input
 # can never be mis-parsed as FTS syntax (each token is quoted as a phrase, AND-ed).
@@ -125,7 +131,13 @@ def query_labs(
     dictionary: dict[str, str] | None = None,
 ) -> list[dict]:
     """Lab rows for a person, oldest first. ``test`` is dictionary-normalized and matched
-    against each row's normalized ``test_name``; ``since`` keeps rows on/after that date."""
+    against each row's normalized ``test_name``; ``since`` keeps rows on/after that date.
+
+    Matching is on ``norm()``, the **analyte family** — deliberately coarser than the
+    dedup key (issue #71). ``--test albumin`` lists the CMP albumin *and* the SPEP
+    ``Albumin (SPEP)`` fraction, because a listing should show everything filed under
+    that analyte. Only the numeric series (:func:`trends`) needs assay precision.
+    """
     person_id = resolve_person_id(conn, slug)
     sql = "SELECT * FROM lab_result WHERE person_id = ?"
     params: list[object] = [person_id]
@@ -313,24 +325,40 @@ def trends(
     test: str,
     dictionary: dict[str, str] | None = None,
 ) -> dict:
-    """Summary stats for one dictionary-normalized analyte over time.
+    """Summary stats for one **assay** of one analyte over time.
 
     Returns ``{test, count, unit, min, max, latest, latest_at, latest_tie,
-    slope_per_day}``. ``count`` is the number of numeric points; ``slope_per_day``
-    degrades to ``None`` with fewer than two distinct collection dates. ``latest`` is
-    the row with the greatest ``collected_at``, ties broken by the greatest
-    ``lab_result_id`` (most-recently-ingested wins); ``latest_tie`` counts how many
-    matched rows share that exact ``collected_at`` timestamp.
+    slope_per_day, other_assays, other_assay_count}``. ``count`` is the number of
+    numeric points; ``slope_per_day`` degrades to ``None`` with fewer than two distinct
+    collection dates. ``latest`` is the row with the greatest ``collected_at``, ties
+    broken by the greatest ``lab_result_id`` (most-recently-ingested wins);
+    ``latest_tie`` counts how many matched rows share that exact ``collected_at``
+    timestamp.
+
+    Matching is on ``key_token()``, not ``norm()`` (issue #71): a series that silently
+    interleaves a CMP albumin with an SPEP albumin is a wrong chart, the same class of
+    harm as the dedup collision this splits apart. Rows of the *same* analyte family
+    excluded by a differing qualifier are therefore **disclosed, not dropped** —
+    ``other_assays`` lists their key tokens (each usable verbatim as ``--test``) and
+    ``other_assay_count`` counts the numeric rows behind them.
     """
     person_id = resolve_person_id(conn, slug)
-    target = norm(test, dictionary)
+    target = key_token(test, dictionary)
+    family = norm(test, dictionary)
     rows = conn.execute(
         "SELECT lab_result_id, value_num, unit, collected_at, test_name FROM lab_result "
         "WHERE person_id = ? AND value_num IS NOT NULL "
         "ORDER BY collected_at, lab_result_id",
         (person_id,),
     ).fetchall()
-    matched = [r for r in rows if norm(r["test_name"], dictionary) == target]
+    matched = []
+    others: dict[str, int] = {}
+    for r in rows:
+        token = key_token(r["test_name"], dictionary)
+        if token == target:
+            matched.append(r)
+        elif norm(r["test_name"], dictionary) == family:
+            others[token] = others.get(token, 0) + 1
 
     result: dict = {
         "test": target,
@@ -342,6 +370,9 @@ def trends(
         "latest_at": None,
         "latest_tie": 0,
         "slope_per_day": None,
+        # Same analyte, different assay: reported so the excluded rows stay findable.
+        "other_assays": sorted(others),
+        "other_assay_count": sum(others.values()),
     }
     if not matched:
         return result

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -297,6 +297,22 @@ def find(conn: sqlite3.Connection, slug: str | None, query: str) -> list[dict]:
 # Trends
 # --------------------------------------------------------------------------- #
 
+def _loose(token: str) -> str:
+    """Compare-only spelling of a ``key_token``, underscore-insensitive.
+
+    A dictionary's *canonical value* may contain underscores (``vitamin_d_25oh``,
+    ``bilirubin_total``, ``m_spike``) while ``dedup._collapse`` turns ``_`` into a
+    space on the way **in** — so a token :func:`trends` prints, and offers as a
+    paste-ready ``--test``, does not survive the round trip: re-deriving it yields
+    ``vitamin d 25oh (25-oh)``, which matches nothing. Comparing both sides through
+    this makes the disclosed token actually findable.
+
+    Read-path only — no ``dedup_key`` is derived from it. The most it can do is treat
+    two spellings of one canonical name as one series, which is what they are.
+    """
+    return token.replace("_", " ")
+
+
 def _ordinal(value: object) -> int | None:
     try:
         return date.fromisoformat(_date_part(value)).toordinal()
@@ -339,12 +355,13 @@ def trends(
     interleaves a CMP albumin with an SPEP albumin is a wrong chart, the same class of
     harm as the dedup collision this splits apart. Rows of the *same* analyte family
     excluded by a differing qualifier are therefore **disclosed, not dropped** —
-    ``other_assays`` lists their key tokens (each usable verbatim as ``--test``) and
-    ``other_assay_count`` counts the numeric rows behind them.
+    ``other_assays`` lists their key tokens (each usable verbatim as ``--test``, via
+    :func:`_loose` — a canonical value may carry underscores that a re-derivation
+    cannot reproduce) and ``other_assay_count`` counts the numeric rows behind them.
     """
     person_id = resolve_person_id(conn, slug)
-    target = key_token(test, dictionary)
-    family = norm(test, dictionary)
+    target = _loose(key_token(test, dictionary))
+    family = _loose(norm(test, dictionary))
     rows = conn.execute(
         "SELECT lab_result_id, value_num, unit, collected_at, test_name FROM lab_result "
         "WHERE person_id = ? AND value_num IS NOT NULL "
@@ -353,15 +370,19 @@ def trends(
     ).fetchall()
     matched = []
     others: dict[str, int] = {}
+    matched_token = ""
     for r in rows:
         token = key_token(r["test_name"], dictionary)
-        if token == target:
+        if _loose(token) == target:
             matched.append(r)
-        elif norm(r["test_name"], dictionary) == family:
+            # Echo the stored spelling rather than whatever the caller typed, so a
+            # pasted `other_assays` token comes back labelled the way it was disclosed.
+            matched_token = matched_token or token
+        elif _loose(norm(r["test_name"], dictionary)) == family:
             others[token] = others.get(token, 0) + 1
 
     result: dict = {
-        "test": target,
+        "test": matched_token or target,
         "count": len(matched),
         "unit": None,
         "min": None,

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -39,7 +39,7 @@ import sqlite3
 from datetime import datetime
 
 from . import db, query
-from .dedup import norm
+from .dedup import key_token
 
 # Observation obs_type conventions this layer reads (see module docstring).
 OBS_CONDITION = "condition"
@@ -126,7 +126,11 @@ def _latest_vitals(
     conn: sqlite3.Connection, person_id: int, dictionary: dict[str, str] | None
 ) -> list[dict]:
     """Most recent ``obs_type='vital'`` row per normalized ``key``. Rows are ordered so
-    that, for a given key, the latest date (then highest id) wins deterministically."""
+    that, for a given key, the latest date (then highest id) wins deterministically.
+
+    Grouped by ``key_token()``, matching the dedup key (issue #71), so a meaningful
+    qualifier keeps its own row: ``Blood Pressure (sitting)`` and ``(standing)`` are two
+    readings to show, not one that overwrites the other."""
     rows = conn.execute(
         "SELECT * FROM observation WHERE person_id = ? AND obs_type = ? "
         "ORDER BY observed_at, observation_id",
@@ -134,7 +138,7 @@ def _latest_vitals(
     ).fetchall()
     latest: dict[str, dict] = {}
     for r in rows:
-        latest[norm(r["key"], dictionary)] = dict(r)  # ascending order -> last wins
+        latest[key_token(r["key"], dictionary)] = dict(r)  # ascending -> last wins
     return [latest[k] for k in sorted(latest)]
 
 

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -2,6 +2,7 @@
 human + --json output, empty-result rc=0 messages, unknown-slug rc=1."""
 
 import json
+import shlex
 import uuid
 
 import pytest
@@ -209,6 +210,45 @@ def test_trends_same_timestamp_tie_disclosed(ready, capsys):
     latest = next(line for line in out.splitlines() if "latest" in line)
     assert "5.2" in latest  # deterministic higher-id pick
     assert "(1 of 2 at this timestamp)" in latest
+
+
+def test_trends_other_assay_note_pastes_back_and_finds_the_rows(ready, capsys):
+    """Issue #71 regression: the disclosure note prints a `--test` token as a command
+    to paste, but for any analyte whose *canonical* value carries underscores
+    (`vitamin_d_25oh`) that token could not be re-derived -- pasting it returned zero
+    rows AND zero disclosure, walking the user into a silent dead end for exactly the
+    rows the note exists to keep findable.
+
+    Driven through argv (split with shlex, the way a shell would split the printed
+    command) so both halves are covered: the quoting and the re-derivation."""
+    for value, collected in ((31.0, "2025-01-01"), (28.0, "2026-01-01")):
+        _seed_lab(ready, "jane-doe", test_name="Vitamin D", value_num=value,
+                  unit="ng/mL", collected_at=collected)
+    _seed_lab(ready, "jane-doe", test_name="Vitamin D (25-OH)", value_num=44.0,
+              unit="ng/mL", collected_at="2025-01-01")
+
+    assert _run(ready, "trends", "--person", "jane-doe", "--test", "vitamin d",
+                *DICT_ARG) == 0
+    note = next(l for l in capsys.readouterr().out.splitlines() if "another assay" in l)
+    assert "1 more row(s)" in note
+    # Exactly what the user would paste, split the way their shell splits it.
+    pasted = shlex.split(note.split("another assay: ", 1)[1])
+    assert pasted[0] == "--test" and len(pasted) == 2
+
+    assert _run(ready, "trends", "--person", "jane-doe", *pasted, *DICT_ARG) == 0
+    out = capsys.readouterr().out
+    assert "(1 point(s))" in out and "44" in out
+    assert "2 more row(s)" in out          # the reciprocal disclosure still works
+
+
+def test_other_assay_note_quotes_an_injectable_token(capsys):
+    """The token descends from `test_name`, i.e. untrusted document text, and is
+    printed as a command the user is invited to run. A `\"` in it must not close the
+    quote and leave the remainder of the name live in their shell."""
+    hostile = 'albumin (spep" ; rm -rf ~ #)'
+    cli._print_other_assays({"other_assays": [hostile], "other_assay_count": 1})
+    note = capsys.readouterr().out.strip()
+    assert shlex.split(note.split("another assay: ", 1)[1]) == ["--test", hostile]
 
 
 def test_empty_results_are_clean_rc0(ready, capsys):

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -117,6 +117,16 @@ def test_key_token_honors_a_declared_full_label():
     assert dedup.key_token("Creatinine (calculated)", d) == "creatinine"
 
 
+def test_declared_full_label_tolerates_edge_underscores_and_paren_padding():
+    """Rule 1 matches the *collapsed* label, so the collapse has to be total: a
+    leading/trailing `_` (which becomes whitespace) or padding inside the parentheses
+    used to miss the declared entry and over-split a label the human already settled."""
+    d = dedup.load_dictionary(DICT_PATH)
+    for sloppy in ("_m-spike (spep)", "M-Spike ( SPEP )", "  m-spike (spep)_",
+                   "M-SPIKE  (  spep  )"):
+        assert dedup.key_token(sloppy, d) == "m_spike", sloppy
+
+
 def test_key_token_maps_the_qualifier_through_the_dictionary():
     # Two spellings of one assay tag agree, so they do not fork the series.
     d = {"albumin": "albumin", "serum protein electrophoresis": "spep"}
@@ -890,3 +900,91 @@ def test_rekey_moves_dedup_base_with_the_key(conn):
     dedup.rekey(conn, _rekey_dict(zzt="zonulin_test"), apply=True)
     row = conn.execute("SELECT * FROM lab_result").fetchone()
     assert row["dedup_base"] == row["dedup_key"]   # occurrence 0: base IS the key
+
+
+# --- ingest-before-rekey drift guard ------------------------------------------
+
+def test_commit_refuses_an_ingest_against_a_drifted_key(conn):
+    """The migration hazard behind issue #71: a stored row whose frozen key predates
+    the current dictionary is invisible to layer-2 dedup, so re-filing that same fact
+    used to land a SECOND row reported as `new` -- no duplicate, no conflict, no signal
+    at all -- and then wedged `rekey` on the collision it had just created. Refuse the
+    commit instead, naming the rekey that fixes it."""
+    doc = _make_document(conn)
+    row = {"test_name": "ZZT", "collected_at": "2026-01-02", "value_num": 108}
+    dedup.commit_extraction(conn, doc, {"lab_result": [row]}, None)
+    d_new = _rekey_dict(zzt="zonulin_test")       # the stored key is now stale
+
+    with pytest.raises(dedup.DictionaryDriftError, match="rekey --apply"):
+        dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [row]}, d_new)
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
+
+    # And the named remedy actually clears it: after the rekey the same submission
+    # dedups against the stored row instead of forking it.
+    dedup.rekey(conn, d_new, apply=True)
+    summary = dedup.commit_extraction(
+        conn, _make_document(conn), {"lab_result": [row]}, d_new
+    )
+    assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
+
+
+def test_commit_drift_guard_ignores_an_unrelated_drifted_row(conn):
+    """Deliberately narrow: drift somewhere else in the database is a `rekey` chore,
+    not a reason to refuse an unrelated ingest."""
+    doc = _make_document(conn)
+    dedup.commit_extraction(conn, doc, {"lab_result": [
+        {"test_name": "ZZT", "collected_at": "2026-01-02", "value_num": 108}]}, None)
+    d_new = _rekey_dict(zzt="zonulin_test")       # ZZT's stored key is stale
+
+    summary = dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 95}]}, d_new)
+    assert summary.counts == {"new": 1, "duplicate": 0, "conflict": 0}
+
+
+def test_commit_drift_guard_accepts_a_keep_both_sibling(conn):
+    """An admitted repeat keys on hash(base|occurrence); if the guard recomputed at
+    occurrence 0 it would read every sibling as drift and refuse every later ingest."""
+    d = dedup.load_dictionary(DICT_PATH)
+    dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2024-04-01", "value_num": 95}]}, d)
+    dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2024-04-01", "value_num": 148}]}, d)
+    dedup.resolve_conflict(conn, dedup.list_conflicts(conn)[0]["conflict_id"], keep="both")
+
+    summary = dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2024-04-01", "value_num": 148}]}, d)
+    assert summary.counts == {"new": 0, "duplicate": 1, "conflict": 0}
+
+
+def test_rekey_names_a_doubled_fact_instead_of_blaming_the_dictionary(conn):
+    """A database that drifted *before* the guard existed can still hold one fact under
+    two keys. "The dictionary maps two distinct facts onto one canonical name" is then
+    exactly the wrong diagnosis -- the dictionary is fine and the data is doubled."""
+    doc = _make_document(conn)
+    row = {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 95}
+    dedup.commit_extraction(conn, doc, {"lab_result": [row]}, None)
+    pid = conn.execute("SELECT person_id FROM person").fetchone()["person_id"]
+    # The pre-guard state, built directly: the same fact filed again under a stale key.
+    dedup._insert_record(conn, "lab_result", row, pid, doc, "stale-base-0000")
+    conn.commit()
+
+    with pytest.raises(dedup.RekeyCollisionError, match="SAME fact"):
+        dedup.rekey(conn, None)
+    # Still all-or-nothing, and the dry-run wrote nothing either.
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
+    assert conn.execute(
+        "SELECT COUNT(*) AS n FROM lab_result WHERE dedup_key = 'stale-base-0000'"
+    ).fetchone()["n"] == 1
+
+
+def test_rekey_still_blames_the_dictionary_when_it_fuses_distinct_facts(conn):
+    """The other cause keeps its own message: two *different* payloads recomputing onto
+    one key really is a dictionary that merges distinct facts."""
+    doc = _make_document(conn)
+    dedup.commit_extraction(conn, doc, {"lab_result": [
+        {"test_name": "ALB", "collected_at": "2026-01-02", "value_num": 4.2},
+        {"test_name": "Albumin", "collected_at": "2026-01-02", "value_num": 3.6},
+    ]}, dedup.load_dictionary(DICT_PATH))
+    with pytest.raises(dedup.RekeyCollisionError, match="two distinct facts"):
+        dedup.rekey(conn, _rekey_dict(alb="albumin"))

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -87,6 +87,62 @@ def test_norm_strips_parenthetical_qualifiers():
     assert dedup.norm("Creatinine (calculated)") == "creatinine"
 
 
+# --- key_token(): qualifier-aware identity (issue #71) ------------------------
+
+def test_key_token_keeps_a_meaningful_qualifier():
+    # The bug: an SPEP albumin fraction and a CMP albumin off one draw are different
+    # assays. They stay one analyte *family* under norm() but must not share a key.
+    d = dedup.load_dictionary(DICT_PATH)
+    assert dedup.norm("Albumin (SPEP)", d) == dedup.norm("Albumin", d) == "albumin"
+    assert dedup.key_token("Albumin (SPEP)", d) == "albumin (spep)"
+    assert dedup.key_token("Albumin", d) == "albumin"
+
+
+def test_key_token_drops_a_redundant_alias_qualifier():
+    # Rule 2: the parenthetical maps to the same canonical token as the stem, so it is
+    # just another spelling of it -- no dictionary entry of its own required.
+    d = dedup.load_dictionary(DICT_PATH)
+    assert dedup.key_token("Hemoglobin (HGB)", d) == dedup.key_token("HGB", d) == "hemoglobin"
+    assert dedup.key_token("Hematocrit (HCT)", d) == "hematocrit"
+    assert dedup.key_token("Platelet Count (PLT)", d) == "platelets"
+
+
+def test_key_token_honors_a_declared_full_label():
+    # Rule 1: a full parenthesized key in [synonyms] is the human declaring that
+    # parenthetical noise for this analyte.
+    d = dedup.load_dictionary(DICT_PATH)
+    assert dedup.key_token("M-Spike (SPEP)", d) == dedup.key_token("M-Spike", d) == "m_spike"
+    assert dedup.key_token("Sed Rate (Modified Westergren)", d) \
+        == dedup.key_token("Sed Rate", d) == "esr"
+    assert dedup.key_token("Creatinine (calculated)", d) == "creatinine"
+
+
+def test_key_token_maps_the_qualifier_through_the_dictionary():
+    # Two spellings of one assay tag agree, so they do not fork the series.
+    d = {"albumin": "albumin", "serum protein electrophoresis": "spep"}
+    assert dedup.key_token("Albumin (Serum Protein Electrophoresis)", d) \
+        == dedup.key_token("Albumin (SPEP)", {**d, "spep": "spep"}) == "albumin (spep)"
+
+
+def test_key_token_without_dictionary_oversplits_but_norm_does_not():
+    # No dictionary: "(calculated)" cannot be proven noise, so the key splits (the
+    # accepted, visible, non-lossy failure). norm() is unchanged -- one family.
+    assert dedup.norm("Creatinine (calculated)") == dedup.norm("Creatinine") == "creatinine"
+    assert dedup.key_token("Creatinine (calculated)") == "creatinine (calculated)"
+    bare = {"test_name": "Creatinine", "collected_at": "2026-01-02", "value_num": 1.1}
+    calc = {**bare, "test_name": "Creatinine (calculated)"}
+    assert dedup.dedup_key("lab_result", bare, 1) != dedup.dedup_key("lab_result", calc, 1)
+
+
+def test_identity_of_none_and_bare_qualifier():
+    assert dedup.identity(None) == ("", "")
+    assert dedup.key_token(None) == ""
+    # Degenerate name that is nothing but a qualifier: norm() keeps its old ""
+    # contract, key_token falls back to the qualifier rather than emitting " (spep)".
+    assert dedup.norm("(SPEP)") == ""
+    assert dedup.key_token("(SPEP)") == "spep"
+
+
 # Real-corpus naming variants (issue #11): report-side spelling <-> CSV-side spelling
 # for the same clinical fact. Every pair must collapse to a single canonical token or
 # the same analyte splits into parallel rows/series downstream.
@@ -112,6 +168,20 @@ def test_corpus_naming_variants_share_canonical_token():
     d = dedup.load_dictionary(DICT_PATH)
     for report, csv in _CORPUS_VARIANTS:
         assert dedup.norm(report, d) == dedup.norm(csv, d), (report, csv)
+
+
+def test_corpus_naming_variants_share_dedup_key():
+    # Stronger than the norm()-level check above: a shared canonical token no longer
+    # implies a shared key now that qualifiers are part of the identity (issue #71), and
+    # a shared *key* is what actually makes the two spellings dedup.
+    d = dedup.load_dictionary(DICT_PATH)
+    for report, csv in _CORPUS_VARIANTS:
+        assert dedup.key_token(report, d) == dedup.key_token(csv, d), (report, csv)
+        a = dedup.dedup_key(
+            "lab_result", {"test_name": report, "collected_at": "2026-01-02"}, 1, d)
+        b = dedup.dedup_key(
+            "lab_result", {"test_name": csv, "collected_at": "2026-01-02"}, 1, d)
+        assert a == b, (report, csv)
 
 
 # --- dedup_key determinism ----------------------------------------------------
@@ -349,6 +419,42 @@ def test_real_corpus_overlap_dedups_not_splits(conn):
     # One row per analyte, not two — the split-series / double-count damage is gone.
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] \
         == len(_CORPUS_VARIANTS)
+
+
+def test_distinct_assays_of_one_analyte_both_land_as_new(conn):
+    """Acceptance (issue #71): a CMP `Albumin` and an SPEP `Albumin (SPEP)` off ONE draw
+    are two facts. Before the fix the parenthetical was stripped, both derived one key,
+    and the second was misfiled as a conflict whose value survived only in a free-text
+    resolution note."""
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _make_document(conn)
+    rows = [
+        {"test_name": "Albumin", "collected_at": "2026-01-05", "value_num": 4.1,
+         "unit": "g/dL"},
+        {"test_name": "Albumin (SPEP)", "collected_at": "2026-01-05", "value_num": 3.8,
+         "unit": "g/dL"},
+    ]
+    # Distinct keys, so this is not even an intra-payload collision any more.
+    keys = {dedup.dedup_key("lab_result", r, 1, d) for r in rows}
+    assert len(keys) == 2
+    summary = dedup.commit_extraction(conn, doc, {"lab_result": rows}, d)
+    assert summary.counts == {"new": 2, "duplicate": 0, "conflict": 0}
+    stored = {r["test_name"]: r["value_num"] for r in
+              conn.execute("SELECT test_name, value_num FROM lab_result")}
+    assert stored == {"Albumin": 4.1, "Albumin (SPEP)": 3.8}
+
+
+def test_qualified_observation_keys_are_distinct_rows(conn):
+    # Same split for observation.key: two BP readings taken in two postures at one visit.
+    doc = _make_document(conn)
+    rows = [
+        {"obs_type": "vital", "key": "Blood Pressure (sitting)",
+         "observed_at": "2026-01-05", "value_text": "128/80"},
+        {"obs_type": "vital", "key": "Blood Pressure (standing)",
+         "observed_at": "2026-01-05", "value_text": "112/70"},
+    ]
+    summary = dedup.commit_extraction(conn, doc, {"observation": rows})
+    assert summary.counts == {"new": 2, "duplicate": 0, "conflict": 0}
 
 
 def test_corrected_value_still_conflicts_after_normalization(conn):
@@ -705,6 +811,73 @@ def test_rekey_is_a_no_op_over_a_keep_both_family(conn):
     assert report.changes == []            # no RekeyCollisionError, no key churn
     keys = [r["dedup_key"] for r in conn.execute("SELECT * FROM lab_result")]
     assert len(set(keys)) == 2
+
+
+def test_rekey_over_unqualified_names_reports_no_changes(conn):
+    """Acceptance (issue #71): the qualifier is FOLDED INTO the existing key part, not
+    appended as a fourth one. A fourth part would turn `"a|b|c"` into `"a|b||c"` and move
+    every stored key in the database; folding moves only the rows a qualifier splits.
+
+    Proven against the pre-fix formula spelled out longhand, so this fails loudly if the
+    key layout is ever changed rather than extended."""
+    import hashlib
+
+    d = dedup.load_dictionary(DICT_PATH)
+    pid = conn.execute("SELECT person_id FROM person").fetchone()["person_id"]
+    doc = _make_document(conn)
+    rows = [
+        {"test_name": "HbA1c", "collected_at": "2026-01-02T09:30", "value_num": 5.7},
+        {"test_name": "GLUC", "collected_at": "2026-01-02", "value_num": 95},
+        {"test_name": "Hemoglobin (HGB)", "collected_at": "2026-01-02", "value_num": 13.1},
+    ]
+    dedup.commit_extraction(conn, doc, {"lab_result": rows}, d)
+
+    for row in rows:
+        legacy = "|".join([
+            str(pid),
+            dedup.norm(row["test_name"], d),                    # pre-fix: norm(), not key_token()
+            row["collected_at"].replace("T", " "),
+        ])
+        assert dedup.dedup_key("lab_result", row, pid, d) \
+            == hashlib.sha256(legacy.encode("utf-8")).hexdigest(), row["test_name"]
+
+    assert dedup.rekey(conn, d).changes == []
+
+
+def test_rekey_migrates_a_row_stored_under_a_stripped_key(conn):
+    """The issue-#71 migration: a row committed *before* the fix carries the key the old
+    stripping formula derived, so `rekey` is what moves it onto its qualified key. Safe by
+    construction -- a qualifier only adds precision, so no two rows can fuse."""
+    import hashlib
+
+    d = dedup.load_dictionary(DICT_PATH)
+    pid = conn.execute("SELECT person_id FROM person").fetchone()["person_id"]
+    legacy_key = hashlib.sha256(
+        f"{pid}|albumin|2026-01-05".encode("utf-8")   # pre-fix: "(SPEP)" stripped away
+    ).hexdigest()
+    conn.execute(
+        "INSERT INTO lab_result (person_id, test_name, collected_at, value_num, "
+        "dedup_key, dedup_base, dedup_occurrence) VALUES (?, ?, ?, ?, ?, ?, 0)",
+        (pid, "Albumin (SPEP)", "2026-01-05", 3.6, legacy_key, legacy_key),
+    )
+    conn.commit()
+
+    report = dedup.rekey(conn, d)
+    assert [(c.label, c.old_key) for c in report.changes] \
+        == [("Albumin (SPEP)", legacy_key)]
+
+    dedup.rekey(conn, d, apply=True)
+    row = conn.execute("SELECT * FROM lab_result").fetchone()
+    assert row["dedup_key"] == row["dedup_base"] != legacy_key
+    assert row["value_num"] == 3.6 and row["test_name"] == "Albumin (SPEP)"
+    # The vacated key is now free for the CMP albumin that always belonged there.
+    doc = _make_document(conn)
+    summary = dedup.commit_extraction(conn, doc, {"lab_result": [
+        {"test_name": "Albumin", "collected_at": "2026-01-05", "value_num": 4.2}]}, d)
+    assert summary.counts == {"new": 1, "duplicate": 0, "conflict": 0}
+    assert conn.execute(
+        "SELECT dedup_key FROM lab_result WHERE test_name = 'Albumin'"
+    ).fetchone()["dedup_key"] == legacy_key
 
 
 def test_rekey_moves_dedup_base_with_the_key(conn):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -395,6 +395,31 @@ def test_trends_unrelated_analytes_are_not_reported_as_other_assays(albumin_assa
     assert t["count"] == 3 and t["other_assays"] == [] and t["other_assay_count"] == 0
 
 
+def test_trends_disclosed_token_round_trips_over_an_underscore_canonical(seeded):
+    """The disclosure is only worth anything if its token can be fed straight back in.
+    A canonical value may contain underscores (`vitamin_d_25oh`) that `_collapse` turns
+    back into spaces on the way in, so a strict comparison made the printed token a
+    dead end -- zero rows *and* zero disclosure. `albumin` (the fixture above) has no
+    underscore, which is why the suite could not see this."""
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _doc(seeded, "jane-doe", ocr="vitamin D panel")
+    dedup.commit_extraction(seeded, doc, {"lab_result": [
+        {"test_name": "Vitamin D", "collected_at": "2025-01-01", "value_num": 31},
+        {"test_name": "Vitamin D", "collected_at": "2026-01-01", "value_num": 28},
+        {"test_name": "Vitamin D (25-OH)", "collected_at": "2025-01-01", "value_num": 44},
+    ]}, d)
+
+    t = query.trends(seeded, "jane-doe", "vitamin d", dictionary=d)
+    assert t["count"] == 2 and t["other_assay_count"] == 1
+    token = t["other_assays"][0]
+    assert "_" in token                       # the spelling that used to be a dead end
+
+    back = query.trends(seeded, "jane-doe", token, dictionary=d)
+    assert back["count"] == 1 and back["latest"] == 44
+    assert back["test"] == token              # echoed as disclosed, not as re-derived
+    assert back["other_assays"] == [t["test"]] and back["other_assay_count"] == 2
+
+
 def _insert_lab(conn, slug, **cols):
     """Insert a lab_result row directly (bypassing dedup) to simulate the #20
     same-timestamp duplicate-row state. Returns the new lab_result_id."""

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -337,6 +337,64 @@ def test_trends_unknown_analyte_is_empty(seeded):
     assert t["count"] == 0 and t["slope_per_day"] is None
 
 
+# --- assay split: labs lists the family, trends charts one assay (issue #71) ---
+
+@pytest.fixture()
+def albumin_assays(seeded):
+    """Two albumin assays off two draws: the CMP's bare `Albumin` and the SPEP
+    electrophoresis fraction `Albumin (SPEP)`."""
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _doc(seeded, "jane-doe", ocr="CMP + SPEP")
+    dedup.commit_extraction(seeded, doc, {"lab_result": [
+        {"test_name": "Albumin", "collected_at": "2025-01-01", "value_num": 4.2,
+         "unit": "g/dL"},
+        {"test_name": "Albumin (SPEP)", "collected_at": "2025-01-01", "value_num": 3.6,
+         "unit": "g/dL"},
+        {"test_name": "Albumin", "collected_at": "2026-01-01", "value_num": 4.0,
+         "unit": "g/dL"},
+    ]}, d)
+    return seeded
+
+
+def test_labs_lists_the_whole_analyte_family(albumin_assays):
+    # A listing is coarse on purpose: `--test albumin` shows every albumin filed.
+    d = dedup.load_dictionary(DICT_PATH)
+    rows = query.query_labs(albumin_assays, "jane-doe", test="albumin", dictionary=d)
+    assert sorted(r["test_name"] for r in rows) == \
+        ["Albumin", "Albumin", "Albumin (SPEP)"]
+
+
+def test_trends_charts_one_assay_and_discloses_the_others(albumin_assays):
+    # A series that interleaved the CMP and SPEP numbers would be a wrong chart, so
+    # trends splits them -- but the excluded rows are reported, never silently dropped.
+    d = dedup.load_dictionary(DICT_PATH)
+    t = query.trends(albumin_assays, "jane-doe", "albumin", dictionary=d)
+    assert t["test"] == "albumin"
+    assert t["count"] == 2 and t["min"] == 4.0 and t["max"] == 4.2
+    assert t["other_assays"] == ["albumin (spep)"] and t["other_assay_count"] == 1
+
+    spep = query.trends(albumin_assays, "jane-doe", "Albumin (SPEP)", dictionary=d)
+    assert spep["test"] == "albumin (spep)"
+    assert spep["count"] == 1 and spep["latest"] == 3.6
+    assert spep["other_assays"] == ["albumin"] and spep["other_assay_count"] == 2
+
+
+def test_trends_discloses_other_assays_even_with_no_matching_points(albumin_assays):
+    # The empty-series path must still name the assay that does have data, or the user
+    # sees "no numeric results" for an analyte that is plainly in the record.
+    d = dedup.load_dictionary(DICT_PATH)
+    t = query.trends(albumin_assays, "jane-doe", "Albumin (Nephelometry)", dictionary=d)
+    assert t["count"] == 0
+    assert t["other_assays"] == ["albumin", "albumin (spep)"]
+    assert t["other_assay_count"] == 3
+
+
+def test_trends_unrelated_analytes_are_not_reported_as_other_assays(albumin_assays):
+    d = dedup.load_dictionary(DICT_PATH)
+    t = query.trends(albumin_assays, "jane-doe", "hba1c", dictionary=d)
+    assert t["count"] == 3 and t["other_assays"] == [] and t["other_assay_count"] == 0
+
+
 def _insert_lab(conn, slug, **cols):
     """Insert a lab_result row directly (bypassing dedup) to simulate the #20
     same-timestamp duplicate-row state. Returns the new lab_result_id."""


### PR DESCRIPTION
## Summary

`norm()`'s parenthetical stripping collapsed genuinely distinct same-day assays of one
analyte onto a single `dedup_key` — a CMP `Albumin` and an SPEP `Albumin (SPEP)` off one
draw derived the same key, so the second was misfiled as a conflict and its value
survived only in a free-text resolution note.

- Adds `dedup.identity()`/`key_token()`: a parenthetical is now treated as MEANINGFUL by
  default unless it's a redundant alias of its stem or the dictionary declares it noise
  via a full parenthesized synonym key. `norm()` (the analyte-family form used by
  `query_labs`/dictionary lookups) is unchanged; only `lab_result.test_name` and
  `observation.key` key on `key_token()`.
- `trends` matches on `key_token()` so a numeric series never interleaves two assays, and
  discloses excluded rows (`other_assays`) instead of dropping them silently.
- `commit_extraction` now raises `DictionaryDriftError` when a stored row recomputes onto
  an identity the submission also derives while carrying a different stored key (refuses
  the silent-fork-then-wedge-rekey failure mode found in audit).
- Migration is `pemr rekey`, safe by construction — a qualifier can only add precision, so
  two rows can never fuse.
- `AGENTS.md` now forbids stripping a parenthetical qualifier at extraction time.
- `docs/Architecture.md` §3 updated with the full `key_token()`/`norm()` split, the
  `DictionaryDriftError` refusal, and the issue-#71 migration procedure.

Closes #71

## Test plan
- [x] `pytest tests/test_dedup.py tests/test_cli_phase3.py tests/test_query.py tests/test_cli_phase2.py tests/test_documents.py` — all pass after merging `dev`
- [x] Audit pass (dispatch-20260803-0608-fcad-audit) found two blockers, both closed in a follow-up commit with 9 added tests
- [x] Branch merged with latest `dev` (PR #90 / issue #78 fix), auto-merge clean, no code conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)