### PR TITLE
feat(#80): document_tombstone - opt-in memory of an intentional removal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,8 @@ Write tools (mutate the DB; the only tools that do):
 - `person_add` — add a person to the roster.
 - `person_edit` — update a person's fields (partial; `slug` is not editable, pass `""` to
   clear a nullable field).
-- `ingest` — hash + blob-store + layer-1 dedup a document.
+- `ingest` — hash + blob-store + layer-1 dedup a document. Returns `status: "tombstoned"` for
+  content a human deliberately excluded, and `force` cannot override that (see §3).
 - `commit_extraction` — validate + dedup + commit extracted rows for a document.
 - `document_set_text` — attach a document's text (`ocr_text`) after ingest, when the ingest itself
   didn't carry it (see §3). Fills an empty `ocr_text` only; **replacing** an existing transcription
@@ -210,6 +211,17 @@ with `--ocr auto` gets no identity-header check either, so pass your transcripti
 - Unlike §5 conflict resolution, this is not mechanically gated on a `signoff` param. The
   asymmetry is deliberate: a wrongly-forced ingest is recoverable (`pemr document reassign`),
   whereas a wrongly-resolved conflict destroys the losing value.
+
+**Tombstones — never force past one.** Content whose hash carries a `document_tombstone` row
+comes back as `status: "tombstoned"` with `document: null` and the `tombstone` row (reason,
+removal date, note). That is not an error and not a failure of your call: a human recorded that
+this content is deliberately kept out of the store, and nothing was written. Report the skip and
+its reason to the human and **stop**. `force=true` does *not* override a tombstone — the tool
+refuses it. That is deliberately stricter than owner verification above: the owner check is a
+heuristic a human may reasonably ask you to override, whereas a tombstone *is* the human's
+already-recorded decision, so overriding it is never an agent judgment call. If they want the
+document filed after all, they lift it themselves at the CLI
+(`pemr document tombstone rm <sha256>`). No MCP tool writes or lifts tombstones.
 
 ### 5. Conflict discipline
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -95,6 +95,18 @@ CREATE TABLE document (
   ocr_text      TEXT,                     -- extracted full text (agent or tesseract)
   ingested_at   TEXT NOT NULL
 );
+
+-- Opt-in memory of an intentional removal (issue #80). Layer-1 identity is scoped to
+-- the live `document` table above, so without this a removed document silently
+-- re-ingests on the next sweep. Checked by `ingest`; written by
+-- `document rm --tombstone` and `document tombstone add`.
+CREATE TABLE document_tombstone (
+  sha256      TEXT PRIMARY KEY NOT NULL,  -- content hash; the value document.sha256 holds
+  removed_at  TEXT NOT NULL,              -- ISO8601 UTC
+  reason      TEXT,                       -- free-text slug, e.g. 'identifiers'; no taxonomy
+  note        TEXT,                       -- free text: the only human-recognisable label
+  document_id INTEGER                     -- the id it had; forensics only, not a FK
+);
 ```
 
 High-value typed tables (each carries `document_id` provenance + a `dedup_key`; migration
@@ -223,6 +235,17 @@ alone is not a reason to promote.
 On ingest, `sha256` the raw file bytes. If the hash already exists in `document`,
 it's a re-scan of a document already filed → skip (or attach as an alternate path).
 Catches "I scanned the same lab report twice."
+
+That identity is scoped to the **live** `document` table, so `document rm` erases every
+trace that a hash was ever seen and the next sweep over the same source folder re-ingests
+the file as new. `document_tombstone` (migration 007, issue #80) is the opt-in memory of an
+*intentional* removal: `document rm --tombstone` records the hash in the same transaction
+as the delete, and `ingest` checks the table right after the `document` lookup, returning
+status `tombstoned` (rc=0, nothing written) instead of re-filing. Opt-in on purpose — most
+removals are corrections (wrong owner, bad scan, superseded version) and must stay
+re-ingestable, so tombstoning every removed hash would turn an ordinary correction into a
+permanent silent block. `ingest --force` overrides one run without lifting the row; the MCP
+`ingest` tool cannot (a tombstone is the human's recorded decision, not a heuristic).
 
 **Layer 2 — record identity (semantic key).**
 Each typed/observation row computes a deterministic `dedup_key` from normalized fields,
@@ -478,7 +501,13 @@ pemr document list [--person <slug>]                     # newest first; omit --
 pemr document show <id> [--json | --text]                # one document's detail; --text dumps stored ocr_text
 pemr document edit <id> [--doc-date|--category|--provider ...]   # partial update; "" clears a field
 pemr document reassign <id> --person <slug> [--apply]    # move a misfiled document + records; dry run by default
-pemr document rm <id> [--apply] [--purge-blob]           # delete a document + records; dry run by default
+pemr document rm <id> [--apply] [--purge-blob] [--tombstone [--reason ...] [--note ...]]
+                                                         # delete a document + records; dry run by default
+                                                         # --tombstone: also refuse to re-ingest this content (§3)
+pemr document tombstone list [--json]                    # recorded intentional removals, newest first
+pemr document tombstone add (--file <path> | --sha256 <hex>) [--reason ...] [--note ...]
+                                                         # pre-emptive exclusion; ingests and copies nothing
+pemr document tombstone rm <sha256>                      # lift one (full hash only)
 pemr document set-text <id> --ocr-text-file <path> [--force]     # attach/replace ocr_text after ingest; FTS follows via trigger
 pemr query labs --person jane --test hba1c --since 2023-01-01
 pemr query meds --person jane --active
@@ -600,6 +629,16 @@ and a command is testable (§5, "the tested engine"):
    counts, and blob resolution.
 
 Every abort path up to and including step 4 leaves the live database exactly as it was.
+
+Between steps 3 and 4 a read-only diff names any **`document_tombstone` rows** (§3, issue
+#80) the live database holds and the snapshot does not. A whole-database replace drops
+them — correct, since it equally drops every document and person edit made since, and
+merging them would break both the atomic single-file install and the "every abort leaves
+the live database as it was" property. But the *consequence* is issue #80's own bug
+resurrected (the next sweep silently re-ingests an excluded document), so the loss is
+reported before the replace, naming each hash, the rescue copy that still holds them, and
+`pemr document tombstone add --sha256 <hash>` to re-apply. Reported, never merged, never
+blocking.
 
 `pemr verify` runs step 7 on its own, any time. Blob checking is exact rather than
 heuristic — `document` stores both `sha256` and a relative content-addressed

--- a/migrations/007_document_tombstone.sql
+++ b/migrations/007_document_tombstone.sql
@@ -1,0 +1,22 @@
+-- 007_document_tombstone: removal memory for layer-1 dedup (issue #80).
+--
+-- Layer-1 identity is a lookup against the *live* `document` table, so `document rm`
+-- erases all memory that a hash was ever seen and the next bulk-intake sweep over the
+-- same source folder re-ingests it as brand new. This table is the opt-in record of
+-- "a human decided against this content", checked by `ingest` alongside the `document`
+-- lookup. Opt-in on purpose: most removals are corrections (wrong owner, bad scan,
+-- superseded version) and must stay re-ingestable, so suppressing every removed hash
+-- would turn an ordinary correction into a permanent, silent block.
+--
+-- No CHECK on the hash shape (no migration here uses one) - validation lives in
+-- pemr/tombstones.py, which produces a better message than a constraint violation.
+-- No FK on document_id: the row it names is gone by construction. No index beyond the
+-- PK: the table is small and every access is a PK lookup or a full list.
+
+CREATE TABLE document_tombstone (
+  sha256      TEXT PRIMARY KEY NOT NULL,  -- content hash; the value `document.sha256` holds
+  removed_at  TEXT NOT NULL,              -- ISO8601 UTC, timespec=seconds (as document.ingested_at)
+  reason      TEXT,                       -- free-text slug, e.g. 'identifiers'; no taxonomy
+  note        TEXT,                       -- free text: the only human-recognisable label
+  document_id INTEGER                     -- the id it had, forensics only; deliberately not a FK
+);

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from . import (
     __version__, backup, db, dedup, documents, ingest, persons, query, render,
-    restore, study, verify,
+    restore, study, tombstones, verify,
 )
 
 # Shipped starter analyte/name dictionary (framework, not user data — see .gitignore).
@@ -613,15 +613,61 @@ def _cmd_document_reassign(args: argparse.Namespace) -> int:
     return _with_document_conn(args, work)
 
 
+def _warn_purge_without_tombstone(
+    report: "documents.RemoveReport", args: argparse.Namespace
+) -> None:
+    """`--purge-blob` over-promises without a tombstone (issue #80) — say so.
+
+    Purging deletes the stored scan, which reads final, but layer-1 identity is scoped
+    to the live `document` table: the next sweep over the unchanged source folder
+    re-ingests the file as new. The two flags stay **orthogonal** rather than
+    `--purge-blob` implying `--tombstone` — purging is disk hygiene ("this 400 MB scan
+    is junk"), tombstoning is content policy ("never file this again"), and conflating
+    them would make every space-reclaiming purge a permanent silent block, which is the
+    blanket ignore-list failure the design rejects. So: a warning, not a behaviour change.
+
+    Emitted on the **dry run too**: a warning that only appears after the irreversible
+    run is useless. Suppressed when a tombstone was asked for or already exists (no
+    nagging on a re-run). The git-history caveat is unconditional on `--tombstone` — the
+    blob may still be in a data repo's history, which no flag here can fix.
+    """
+    if not args.purge_blob:
+        return
+    if not (report.tombstoned or report.tombstone_existed):
+        print(
+            "warning: --purge-blob deletes the stored scan but does not prevent "
+            "re-ingest. The next\n"
+            "  sweep over the source folder will re-ingest this file as new. Add "
+            "--tombstone to\n"
+            "  record that the removal was intentional.",
+            file=sys.stderr,
+        )
+    if report.blob_purged:
+        print(
+            "note: if this blob was ever committed to a data repo, purging it here "
+            "does not\n  remove it from that repo's git history.",
+            file=sys.stderr,
+        )
+
+
 def _cmd_document_rm(args: argparse.Namespace) -> int:
     # The sources dir is only needed to delete the blob; keeping it (the default)
     # must not require configured paths.
     sources_dir = _resolve_sources_dir(args) if args.purge_blob else None
+    if (args.reason is not None or args.note is not None) and not args.tombstone:
+        # An argparse error (usage + rc=2), not a silent ignore: `--reason identifiers`
+        # without `--tombstone` reads as "I recorded why", and it would record nothing.
+        # The owning subparser is carried on the namespace so the usage line names
+        # `pemr document rm` rather than the top-level parser.
+        args.parser.error(
+            "--reason/--note only apply with --tombstone; nothing was written"
+        )
 
     def work(conn):
         report = documents.remove_document(
             conn, args.document_id, sources_dir=sources_dir,
-            purge_blob=args.purge_blob, apply=args.apply,
+            purge_blob=args.purge_blob, tombstone=args.tombstone,
+            reason=args.reason, note=args.note, apply=args.apply,
         )
         if args.json:
             _print_json({
@@ -636,7 +682,12 @@ def _cmd_document_rm(args: argparse.Namespace) -> int:
                 "conflicts_detached": report.conflicts_detached,
                 "blob_path": report.blob_path,
                 "blob_purged": report.blob_purged,
+                "tombstoned": report.tombstoned,
+                "tombstone_reason": report.tombstone_reason,
+                "tombstone_note": report.tombstone_note,
+                "tombstone_existed": report.tombstone_existed,
             })
+            _warn_purge_without_tombstone(report, args)
             return 0
         print(
             f"document #{report.document_id}  {_fmt(report.person_slug)}  "
@@ -663,6 +714,15 @@ def _cmd_document_rm(args: argparse.Namespace) -> int:
             print(f"  blob already gone: {report.blob_path}")
         else:
             print(f"  blob would be deleted: {report.blob_path}")
+        if report.tombstoned:
+            verb = "tombstone updated" if report.tombstone_existed else "tombstone recorded"
+            if not report.applied:
+                verb = (
+                    "would update tombstone" if report.tombstone_existed
+                    else "would record tombstone"
+                )
+            detail = f" (reason: {report.tombstone_reason})" if report.tombstone_reason else ""
+            print(f"  {verb}{detail}")
         if report.applied:
             print(f"removed document #{report.document_id}")
         else:
@@ -670,6 +730,97 @@ def _cmd_document_rm(args: argparse.Namespace) -> int:
                 "dry run: nothing was deleted - re-run with --apply "
                 "(back up first: `pemr backup`)"
             )
+        _warn_purge_without_tombstone(report, args)
+        return 0
+
+    return _with_document_conn(args, work)
+
+
+# --- tombstones (intentional-removal memory, issue #80) ---------------------
+
+def _tombstone_row_line(row: dict) -> str:
+    """One `tombstone list` line. Truncated hash (full one is a `--json` concern)."""
+    live = row.get("live_document_id")
+    note = row["note"] or ""
+    if live:
+        marker = f"(live as document #{live})"
+        note = f"{note} {marker}".strip() if note else marker
+    return (
+        f"{row['sha256'][:12]}  {(row['removed_at'] or '')[:10]:10}  "
+        f"{('#' + str(row['document_id'])) if row['document_id'] else '-':5} "
+        f"{_fmt(row['reason']):12} {note}"
+    ).rstrip()
+
+
+def _cmd_document_tombstone_list(args: argparse.Namespace) -> int:
+    def work(conn):
+        rows = tombstones.list_tombstones(conn)
+        if args.json:
+            _print_json(rows)
+            return 0
+        if not rows:
+            print("no tombstones recorded")
+            return 0
+        print(f"{'sha256':12}  {'removed':10}  {'doc':5} {'reason':12} note")
+        for row in rows:
+            print(_tombstone_row_line(row))
+        return 0
+
+    return _with_document_conn(args, work)
+
+
+def _cmd_document_tombstone_add(args: argparse.Namespace) -> int:
+    """Pre-emptive exclusion: record a hash without ingesting the content first.
+
+    Without this verb the only way to exclude a never-ingested file would be to ingest
+    it and then `rm --tombstone` — which copies the blob into `sources/` and inserts a
+    row, i.e. puts precisely the content the operator wants kept out of the store *into*
+    the store first. ``--file`` is the primary form and hashes the bytes here rather
+    than asking anyone to transcribe 64 hex characters (a typo'd hash is a tombstone
+    that silently matches nothing); it reads the file and does nothing else — no blob
+    copy, no `document` row, no owner check. ``--sha256`` is the forensic escape hatch
+    for when the file itself is gone.
+    """
+    if args.file is not None:
+        try:
+            sha = ingest.hash_file(args.file)
+        except OSError as exc:
+            print(f"error: cannot read {args.file}: {exc}", file=sys.stderr)
+            return 1
+    else:
+        try:
+            sha = tombstones.normalize_sha256(args.sha256)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+
+    def work(conn):
+        row = tombstones.add_tombstone(
+            conn, sha, reason=args.reason, note=args.note
+        )
+        if args.json:
+            _print_json(row)
+            return 0
+        print(
+            f"tombstoned {row['sha256'][:12]} - {tombstones.describe(row)}. "
+            f"`pemr ingest` will refuse this content; lift it with "
+            f"`pemr document tombstone rm {row['sha256']}`"
+        )
+        return 0
+
+    return _with_document_conn(args, work)
+
+
+def _cmd_document_tombstone_rm(args: argparse.Namespace) -> int:
+    try:
+        sha = tombstones.normalize_sha256(args.sha256)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    def work(conn):
+        row = tombstones.remove_tombstone(conn, sha)
+        print(f"lifted tombstone {row['sha256'][:12]} - {tombstones.describe(row)}")
         return 0
 
     return _with_document_conn(args, work)
@@ -761,6 +912,23 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
     finally:
         conn.close()
 
+    if result.is_tombstoned:
+        # rc=0 and no `next:` line: an expected, benign skip with the same shape as
+        # `duplicate` (issue #80). Deliberately worded so a sweep log tells the two
+        # apart at a glance - that reporting gap is what the issue is about.
+        ts = result.tombstone or {}
+        print(
+            f"skipped: tombstoned {tombstones.describe(ts)} - nothing ingested"
+        )
+        if ts.get("note"):
+            print(f"  note: {ts['note']}")
+        print(
+            f"  sha256 {ts.get('sha256', '')[:12]}...  Lift with "
+            f"`pemr document tombstone rm {ts.get('sha256', '')}`,\n"
+            "  or ingest anyway with --force."
+        )
+        return 0
+
     doc = result.document
     if result.is_duplicate:
         print(
@@ -768,6 +936,15 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
             f"(sha256 {doc.sha256[:12]}...) - nothing ingested"
         )
         return 0
+    if result.tombstone is not None:
+        print(
+            "warning: this content is tombstoned "
+            f"({tombstones.describe(result.tombstone)}) and was ingested anyway with "
+            "--force.\n  The tombstone was NOT lifted, so the next sweep will skip "
+            f"this file again. Undo with\n  `pemr document rm {result.document.document_id}"
+            " --apply`.",
+            file=sys.stderr,
+        )
     print(
         f"ingested document #{doc.document_id} (sha256 {doc.sha256[:12]}...) "
         f"-> sources/{doc.source_path}"
@@ -1263,6 +1440,35 @@ def _cmd_backup(args: argparse.Namespace) -> int:
 # Issue #55: restore (the other direction) + verify (DB + blob health)
 # --------------------------------------------------------------------------- #
 
+def _report_lost_tombstones(result: "restore.RestoreResult") -> None:
+    """Name the tombstones this restore drops (issue #80), and how to put them back.
+
+    A snapshot older than a tombstone loses it along with everything else recorded
+    since — correct, but the *consequence* is issue #80's bug resurrected: the next
+    sweep silently re-ingests a document a human deliberately excluded. Reported on
+    stderr because it is a caveat about a restore that otherwise succeeded, and capped
+    like every other problem list (`verify.PROBLEM_DISPLAY_LIMIT`).
+    """
+    lost = result.lost_tombstones
+    if not lost:
+        return
+    lines = [
+        f"note: {len(lost)} tombstone(s) in the current database are not in this "
+        "snapshot and will be lost:"
+    ]
+    for row in lost[:verify.PROBLEM_DISPLAY_LIMIT]:
+        lines.append(f"  {row['sha256'][:12]}... {tombstones.describe(row)}")
+    hidden = len(lost) - verify.PROBLEM_DISPLAY_LIMIT
+    if hidden > 0:
+        lines.append(f"  ... and {hidden} more (use --json for the full list)")
+    if result.rescue is not None:
+        lines.append(f"  They are preserved in the rescue copy {result.rescue.name}.")
+    lines.append(
+        "  Re-apply with `pemr document tombstone add --sha256 <hash> --reason <slug>`."
+    )
+    print("\n".join(lines), file=sys.stderr)
+
+
 def _cmd_restore(args: argparse.Namespace) -> int:
     db_path = _resolve_db_path(args)
     try:
@@ -1286,12 +1492,14 @@ def _cmd_restore(args: argparse.Namespace) -> int:
             "rescue": str(result.rescue) if result.rescue else None,
             "cleared_sidecars": [str(p) for p in result.cleared_sidecars],
             "applied_migrations": result.applied_migrations,
+            "lost_tombstones": result.lost_tombstones,
             "report": report.as_dict() if report else None,
         })
         return 0
 
     if result.rescue:
         print(f"rescue copy of the previous database: {result.rescue}")
+    _report_lost_tombstones(result)
     for sidecar in result.cleared_sidecars:
         print(f"cleared stale sidecar {sidecar.name}")
     print(f"restored {result.db_path} from {result.snapshot}")
@@ -1485,8 +1693,62 @@ def build_parser() -> argparse.ArgumentParser:
         help="also delete the stored scan (irreversible; kept by default)",
     )
     d_rm.add_argument("--sources", help="sources blob dir (overrides config)")
+    d_rm.add_argument(
+        "--tombstone", action="store_true",
+        help="record that this removal is permanent, so a later sweep refuses to "
+             "re-ingest the file (off by default: most removals are corrections)",
+    )
+    d_rm.add_argument(
+        "--reason",
+        help="short free-text slug for the tombstone, e.g. identifiers, not-medical, "
+             "wrong-household (needs --tombstone; not validated - no taxonomy)",
+    )
+    d_rm.add_argument(
+        "--note",
+        help="free text for the human, e.g. \"dad's 2019 insurance card\" - the only "
+             "recognisable label a tombstone carries (needs --tombstone)",
+    )
     d_rm.add_argument("--json", action="store_true", help="machine-readable output")
-    d_rm.set_defaults(func=_cmd_document_rm)
+    # `parser` rides along so the flag-combination check in the handler can raise a
+    # real argparse error against *this* subparser (usage line included).
+    d_rm.set_defaults(func=_cmd_document_rm, parser=d_rm)
+
+    # --- intentional-removal memory (issue #80) ---------------------------
+    d_tombstone = document_sub.add_parser(
+        "tombstone",
+        help="inspect, record and lift intentional-removal memory (layer-1 dedup)",
+    )
+    tombstone_sub = d_tombstone.add_subparsers(
+        dest="tombstone_command", required=True
+    )
+
+    t_list = tombstone_sub.add_parser(
+        "list", help="recorded tombstones, newest first"
+    )
+    t_list.add_argument("--json", action="store_true", help="machine-readable output")
+    t_list.set_defaults(func=_cmd_document_tombstone_list)
+
+    t_add = tombstone_sub.add_parser(
+        "add",
+        help="tombstone content without ingesting it (pre-emptive exclusion)",
+    )
+    # Exactly one: --file hashes the bytes here (no transcription, no typo'd hash);
+    # --sha256 is the forensic path for when the file itself is gone.
+    t_add_what = t_add.add_mutually_exclusive_group(required=True)
+    t_add_what.add_argument(
+        "--file", help="hash this file and tombstone it (nothing is ingested or copied)"
+    )
+    t_add_what.add_argument(
+        "--sha256", help="tombstone a bare content hash (64 hex characters)"
+    )
+    t_add.add_argument("--reason", help="short free-text slug, e.g. identifiers")
+    t_add.add_argument("--note", help="free text for the human")
+    t_add.add_argument("--json", action="store_true", help="machine-readable output")
+    t_add.set_defaults(func=_cmd_document_tombstone_add)
+
+    t_rm = tombstone_sub.add_parser("rm", help="lift a tombstone (full hash only)")
+    t_rm.add_argument("sha256", metavar="SHA256")
+    t_rm.set_defaults(func=_cmd_document_tombstone_rm)
 
     p_ingest = sub.add_parser(
         "ingest", help="ingest a document (hash, blob store, layer-1 dedup)"

--- a/pemr/documents.py
+++ b/pemr/documents.py
@@ -16,7 +16,8 @@ Six operations, mirroring `persons.py` in shape:
       every attached row, re-deriving each ``dedup_key`` (``person_id`` is part
       of every key — see :func:`dedup.dedup_key`)
     * ``remove_document``  — wrong file entirely: cascade-delete the attached
-      rows, then the document
+      rows, then the document (optionally recording a `document_tombstone` so a
+      later sweep does not silently re-ingest it — issue #80, :mod:`pemr.tombstones`)
     * ``set_document_text``— attach/replace ``ocr_text`` after ingest, the one
       thing only `ingest` could do before (issue #62)
 
@@ -40,7 +41,7 @@ import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from . import db, dedup
+from . import db, dedup, tombstones
 from .persons import PersonNotFoundError, get_person
 
 
@@ -493,6 +494,13 @@ class RemoveReport:
     blob_path: str = ""
     blob_purged: bool = False
     applied: bool = False
+    # Issue #80 — opt-in removal memory. `tombstoned` is what was asked for (so a dry
+    # run can report "would record"); `tombstone_existed` distinguishes recorded from
+    # updated, and suppresses the --purge-blob nag on a re-run.
+    tombstoned: bool = False
+    tombstone_reason: str | None = None
+    tombstone_note: str | None = None
+    tombstone_existed: bool = False
 
     @property
     def record_count(self) -> int:
@@ -505,6 +513,9 @@ def remove_document(
     *,
     sources_dir: str | Path | None = None,
     purge_blob: bool = False,
+    tombstone: bool = False,
+    reason: str | None = None,
+    note: str | None = None,
     apply: bool = False,
 ) -> RemoveReport:
     """Delete a document and cascade to every row it produced.
@@ -530,6 +541,15 @@ def remove_document(
     (content-addressed; a later re-ingest of the same file reuses it). Deleting the
     blob happens after the transaction commits, so a failed unlink leaves an orphan
     file rather than a document row pointing at a file that no longer exists.
+
+    ``tombstone=True`` additionally records this hash in `document_tombstone` (issue
+    #80), so a later sweep over the same source folder refuses it instead of silently
+    re-ingesting. Opt-in on purpose — most removals are corrections that must stay
+    re-ingestable. The insert happens **inside the same transaction** as the deletes: a
+    delete that commits without its tombstone is the exact failure being fixed. Under a
+    dry run nothing is written and the report merely says what would be recorded.
+    ``reason``/``note`` are free text (:mod:`pemr.tombstones` — no taxonomy) and are
+    ignored unless ``tombstone`` is set; the CLI rejects that combination up front.
     """
     db.require_migrated(conn)
     doc = _require_document(conn, document_id)
@@ -561,6 +581,14 @@ def remove_document(
         "SELECT COUNT(*) AS n FROM conflict WHERE document_id = ? AND status != 'open'",
         (document_id,),
     ).fetchone()["n"])
+    report.tombstoned = tombstone
+    report.tombstone_reason = reason
+    report.tombstone_note = note
+    # Reported either way: a dry run says "would update" rather than "would record", and
+    # the CLI uses it to skip the --purge-blob nag when the memory already exists.
+    report.tombstone_existed = (
+        tombstones.get_tombstone(conn, doc["sha256"]) is not None
+    )
 
     if apply:
         # Children first: foreign_keys=ON with NO ACTION means the document DELETE
@@ -584,6 +612,18 @@ def remove_document(
             conn.execute(
                 "DELETE FROM document WHERE document_id = ?", (document_id,)
             )
+            if tombstone:
+                # Same transaction as the deletes, and `allow_live` because the row it
+                # would object to is being deleted right here.
+                tombstones.add_tombstone(
+                    conn,
+                    doc["sha256"],
+                    reason=reason,
+                    note=note,
+                    document_id=document_id,
+                    allow_live=True,
+                    conn_managed=True,
+                )
         if purge_blob and blob is not None:
             existed = blob.exists()     # don't claim a delete that never happened
             blob.unlink(missing_ok=True)

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -2,7 +2,8 @@
 
 The deterministic first half of the ingestion pipeline (Architecture.md §4):
 
-    1. sha256 the raw bytes; if the hash is already in `document` -> duplicate, stop
+    1. sha256 the raw bytes; if the hash is already in `document` -> duplicate, stop;
+       if it carries a `document_tombstone` row -> tombstoned, stop (issue #80)
     2. copy the blob into sources/<sha[:2]>/<sha>.<ext> (immutable, content-addressed)
     3. insert a `document` row (category/provider left null for now)
 
@@ -52,7 +53,7 @@ from pathlib import Path
 from typing import Callable, Sequence
 from urllib.parse import urlsplit
 
-from . import db, study as _study
+from . import db, study as _study, tombstones as _tombstones
 from .models import Document, Person
 
 
@@ -76,15 +77,30 @@ class OwnerMismatchError(IngestError):
 
 @dataclass(frozen=True)
 class IngestResult:
-    status: str  # "new" | "duplicate"
-    document: Document
+    status: str  # "new" | "duplicate" | "tombstoned"
+    # None on the tombstoned path: nothing was written, and there is no document to
+    # point at (the whole point of a tombstone is that the content is not on file).
+    document: Document | None = None
     # None on the duplicate path: a layer-1 duplicate returns before any check runs
-    # (nothing is written, so there is nothing to misfile).
+    # (nothing is written, so there is nothing to misfile). Also None when tombstoned.
     owner_check: "OwnerCheck | None" = None
+    # The `document_tombstone` row, on the tombstoned path only (issue #80).
+    tombstone: dict | None = None
 
     @property
     def is_duplicate(self) -> bool:
         return self.status == "duplicate"
+
+    @property
+    def is_tombstoned(self) -> bool:
+        """Whether the content was refused by an intentional-removal record (issue #80).
+
+        A benign, expected no-op with the same shape as ``duplicate`` — *not* an error.
+        The bulk sweep is the common case this exists to serve, and a sweep that starts
+        exiting non-zero on expected skips trains operators into `|| true`, re-burying
+        the signal.
+        """
+        return self.status == "tombstoned"
 
     @property
     def ocr_text_populated(self) -> bool:
@@ -93,7 +109,7 @@ class IngestResult:
         The `AGENTS.md` contract asks agents to populate `ocr_text` on every ingest
         (empty FTS otherwise); this lets a caller self-check without a follow-up read.
         """
-        return bool(self.document.ocr_text)
+        return bool(self.document and self.document.ocr_text)
 
 
 _READ_CHUNK = 1 << 20  # 1 MiB
@@ -905,12 +921,23 @@ def ingest_document(
     ocr: bool = False,
     ocr_text: str | None = None,
     force: bool = False,
+    tombstone_force: bool = True,
 ) -> IngestResult:
     """Ingest one document: hash, layer-1 dedup, owner check, blob store, insert row.
 
     On a content-hash hit (layer 1), the existing document is returned with
     status "duplicate" and nothing is written. Otherwise the blob is copied into
     the immutable content-addressed store and a new `document` row is inserted.
+
+    A hash carrying a `document_tombstone` row — a removal a human deliberately recorded
+    as permanent (issue #80) — returns status ``"tombstoned"`` with the row attached and
+    writes nothing. That is a benign expected skip, not an error: the bulk sweep is the
+    common case, and failing it would train operators to ignore the output. ``force=True``
+    ingests anyway and **does not lift the tombstone** — it is a one-shot override, so the
+    next sweep skips again; the row rides back on the ``"new"`` result so callers can warn.
+    ``tombstone_force=False`` withholds that override from ``force`` (the MCP surface
+    passes it: a tombstone *is* the human's already-recorded decision, so overriding it
+    is never an agent judgment call — unlike the owner check, which is a heuristic).
 
     A Google Drive pointer stub is refused up front (issue #66) — before hashing, so
     nothing is written and there is nothing to clean up. See :func:`is_pointer_stub`.
@@ -962,6 +989,13 @@ def ingest_document(
         # job, not a reason to fail a no-op.
         return IngestResult(status="duplicate", document=existing)
 
+    # Removal memory (issue #80). Strictly *after* the `document` lookup: a live
+    # document means the content is filed, which is a different answer than "excluded",
+    # and `tombstone add` refuses the both-at-once state except via `--force` below.
+    tombstone = _tombstones.get_tombstone(conn, sha)
+    if tombstone is not None and not (force and tombstone_force):
+        return IngestResult(status="tombstoned", tombstone=tombstone)
+
     # Resolve the text *before* the blob copy so the owner check is pre-write. OCR
     # runs on `src` rather than the copied blob — identical bytes, same result.
     supplied = ocr_text.strip() if ocr_text else None
@@ -1010,7 +1044,11 @@ def ingest_document(
         if blob_created:
             dest.unlink(missing_ok=True)
         raise
-    return IngestResult(status="new", document=document, owner_check=owner_check)
+    # `tombstone` is non-None here only on the `--force` override path: the row is
+    # deliberately *not* lifted (see the docstring), so callers warn and name the undo.
+    return IngestResult(
+        status="new", document=document, owner_check=owner_check, tombstone=tombstone
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -1045,6 +1083,7 @@ def ingest_study_dir(
     provider: str | None = None,
     ocr_text: str | None = None,
     force: bool = False,
+    tombstone_force: bool = True,
 ) -> IngestResult:
     """Ingest a study *directory* as one document (issue #69).
 
@@ -1146,6 +1185,13 @@ def ingest_study_dir(
             # path exactly - only the work is wasted.
             return IngestResult(status="duplicate", document=existing)
 
+        # Same removal-memory check as the file path (issue #80) — a study's blob is a
+        # content-addressed archive like any other, so a tombstoned disc must not
+        # silently re-ingest either.
+        tombstone = _tombstones.get_tombstone(conn, sha)
+        if tombstone is not None and not (force and tombstone_force):
+            return IngestResult(status="tombstoned", tombstone=tombstone)
+
         dest = blob_dest(sources_dir, sha, STUDY_EXT)
         dest.parent.mkdir(parents=True, exist_ok=True)
         blob_created = not dest.exists()
@@ -1169,4 +1215,6 @@ def ingest_study_dir(
     finally:
         tmp_blob.unlink(missing_ok=True)
 
-    return IngestResult(status="new", document=document, owner_check=owner_check)
+    return IngestResult(
+        status="new", document=document, owner_check=owner_check, tombstone=tombstone
+    )

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -38,6 +38,7 @@ from . import ingest as _ingest
 from . import persons as _persons
 from . import query as _query
 from . import render as _render
+from . import tombstones as _tombstones
 
 
 class ToolError(RuntimeError):
@@ -204,6 +205,13 @@ def ingest_document(
     (``.txt``/``.md``/``.csv``/``.tsv``/``.json``/``.log``/``.docx``/``.xlsx``), where
     those words are column labels — so pass your transcription as ``ocr_text`` rather
     than saving it to a ``.txt`` and re-reading that. ``mismatch`` holds on every route.
+
+    Content whose hash carries a **tombstone** — a removal a human recorded as permanent
+    (issue #80) — comes back as ``status="tombstoned"`` with ``document: null`` and the
+    ``tombstone`` row: a structured, non-exceptional "not filed, on purpose". ``force``
+    does **not** override it (unlike the owner check, which is a heuristic): a tombstone
+    is the human's already-recorded decision, so forcing one is never an agent judgment
+    call. Report the skip and its reason and stop; lifting it is a CLI action.
     """
     try:
         sources_dir = cli._resolve_sources_dir(_ARGS)
@@ -215,23 +223,39 @@ def ingest_document(
                 conn, file, person_slug=person, sources_dir=sources_dir,
                 study=study, allow_large=allow_large, doc_date=doc_date,
                 category=category, provider=provider, ocr_text=ocr_text, force=force,
+                tombstone_force=False,
             )
         else:
             result = _ingest.ingest_document(
                 conn, file, person_slug=person, sources_dir=sources_dir,
                 doc_date=doc_date, category=category, provider=provider,
-                ocr=ocr, ocr_text=ocr_text, force=force,
+                ocr=ocr, ocr_text=ocr_text, force=force, tombstone_force=False,
             )
     except (db.NotMigratedError, _ingest.IngestError) as exc:
         raise _friendly(exc) from exc
+    if result.is_tombstoned and force:
+        # `force` overrides the owner check, which is a *heuristic* a human may
+        # reasonably ask an agent to override. A tombstone is the opposite: it is the
+        # human's already-recorded decision that this content stays out, so overriding
+        # it is never an agent judgment call (AGENTS.md §3). Lifting it is a CLI action.
+        sha = (result.tombstone or {}).get("sha256", "")
+        raise ToolError(
+            "this content is tombstoned - a human recorded its removal as intentional "
+            f"({_tombstones.describe(result.tombstone or {})}). `force` does not "
+            "override a tombstone. Report the skip and its reason to the human; if "
+            f"they want it filed, they lift it at the CLI with "
+            f"`pemr document tombstone rm {sha}`."
+        )
     return {
         "status": result.status,
         "is_duplicate": result.is_duplicate,
+        "is_tombstoned": result.is_tombstoned,
         "ocr_text_populated": result.ocr_text_populated,
         "owner_check": (
             asdict(result.owner_check) if result.owner_check is not None else None
         ),
-        "document": asdict(result.document),
+        "tombstone": result.tombstone,
+        "document": asdict(result.document) if result.document is not None else None,
     }
 
 

--- a/pemr/restore.py
+++ b/pemr/restore.py
@@ -13,6 +13,12 @@ the operator-error protection the drill exposed, in a form that is testable:
 * restoring over an existing database requires ``--force`` *and* first banks a rescue
   copy of that database, which makes restore non-destructive by construction.
 
+A whole-database replace also drops any `document_tombstone` rows (issue #80) the live
+database holds and the snapshot does not. That is correct — it equally drops every
+document and person edit made since — but the *consequence* is issue #80's own bug
+resurrected, so the loss is reported before the replace, naming each hash and the rescue
+copy that still holds it. Reported, never merged: see :func:`_lost_tombstones`.
+
 **The rescue copy's off-pattern name is load-bearing.** :data:`pemr.backup._SNAPSHOT_RE`
 matches only ``pemr-<8 digits>-<4|6 digits>.sqlite``, and the backup module's contract
 guarantees anything else is never parsed and never pruned. So
@@ -29,7 +35,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
-from . import backup, db, verify
+from . import backup, db, tombstones, verify
 
 # Rescue-copy filename: deliberately outside backup._SNAPSHOT_RE, so rotation is
 # structurally incapable of pruning it (see the module docstring).
@@ -57,6 +63,11 @@ class RestoreResult:
     applied_migrations: list[str] = field(default_factory=list)
     cleared_sidecars: list[Path] = field(default_factory=list)
     report: verify.VerifyReport | None = None
+    # Tombstones (issue #80) the live database holds and the snapshot does not: a
+    # whole-database replace drops them, and the consequence is the bug #80 fixed
+    # coming back (the next sweep silently re-ingests an excluded document). Reported,
+    # never merged - see :func:`_lost_tombstones`.
+    lost_tombstones: list[dict] = field(default_factory=list)
 
 
 def latest_snapshot(backup_dir: str | Path) -> Path | None:
@@ -135,6 +146,53 @@ def _live_row_total(db_path: Path) -> int | None:
         conn.close()
 
 
+def _read_tombstones(path: Path) -> list[dict]:
+    """Every tombstone in the database at ``path``; ``[]`` when there is no such table.
+
+    Guarded on both sides of the diff for the table's absence — a snapshot predating
+    migration 007 simply has none, exactly as :func:`verify.row_counts` omits tables
+    missing from an older schema. Read-only and non-fatal: a database this cannot open
+    contributes nothing rather than failing a restore.
+    """
+    try:
+        conn = sqlite3.connect(path)
+    except sqlite3.Error:
+        return []
+    try:
+        conn.row_factory = sqlite3.Row
+        if not tombstones.has_table(conn):
+            return []
+        return [
+            dict(row) for row in conn.execute(
+                "SELECT sha256, removed_at, reason, note FROM document_tombstone"
+            ).fetchall()
+        ]
+    except sqlite3.Error:
+        return []
+    finally:
+        conn.close()
+
+
+def _lost_tombstones(db_path: Path, snapshot: Path) -> list[dict]:
+    """Live tombstones absent from ``snapshot``, newest first.
+
+    A snapshot predating a tombstone loses it — but it equally loses every document and
+    person edit made since, so the tombstone is not special and merging it across the
+    replace would break the two properties this module is built around (the atomic
+    single-file install, and "every abort path leaves the live database exactly as it
+    was"). What *is* special is the consequence: a silently lost tombstone means the
+    next bulk sweep re-ingests a document a human deliberately excluded. So the loss is
+    reported loudly and actionably, and never blocks.
+    """
+    snapshot_shas = {row["sha256"] for row in _read_tombstones(snapshot)}
+    lost = [
+        row for row in _read_tombstones(db_path)
+        if row["sha256"] not in snapshot_shas
+    ]
+    lost.sort(key=lambda row: (row["removed_at"] or "", row["sha256"]), reverse=True)
+    return lost
+
+
 def _sidecars(db_path: Path) -> list[Path]:
     return [db_path.with_name(db_path.name + suffix) for suffix in _SIDECAR_SUFFIXES]
 
@@ -208,6 +266,9 @@ def restore(
                 "--force)."
             ) from exc
         result.rescue = rescue
+        # Read-only diff, taken *after* the rescue copy is banked (so the data it names
+        # is already safe) and before anything is staged. Issue #80.
+        result.lost_tombstones = _lost_tombstones(db_path, snapshot)
 
     # 4. Stage the copy first: a failed copy then destroys nothing (under the reverse
     # order a copy failure would leave the operator with no live database at all).

--- a/pemr/tombstones.py
+++ b/pemr/tombstones.py
@@ -1,0 +1,214 @@
+"""Removal memory for layer-1 dedup — `pemr document tombstone list|add|rm` (issue #80).
+
+Layer-1 document identity is a single lookup against the **live** `document` table
+(:func:`ingest.get_document`), so `document rm` erases every trace that a hash was ever
+seen. The next bulk-intake sweep over the same source folder re-ingests the file as
+brand new, silently, and `--purge-blob` reads far more final than it is.
+
+A blanket ignore-list of removed hashes would be the wrong fix: most removals are
+*corrections* (wrong owner, bad scan, superseded version) and there the file should be
+re-ingestable later. So removal has two intents that want opposite behaviour, and only
+the second wants a tombstone:
+
+    correction          -> re-ingest normally    (the default; unchanged)
+    permanent exclusion -> refuse on re-ingest   (opt-in: `--tombstone`)
+
+Hence one small table and four functions. The module imports :mod:`db` only — `ingest`
+imports *it* for the hot-path lookup, and the CLI resolves a file path to a hex digest
+(``ingest.hash_file``) before calling :func:`add_tombstone`, so the engine never takes a
+path and the import graph stays acyclic.
+
+A tombstone is never a one-way door: :func:`remove_tombstone` lifts one, and
+``ingest --force`` overrides a single run without lifting it (see
+:func:`ingest.ingest_document`).
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from datetime import datetime, timezone
+
+from . import db
+
+#: A sha256 hex digest, post-``strip().lower()``. Validated in Python rather than as a
+#: schema CHECK: a typo'd hash is a tombstone that silently matches nothing — exactly
+#: the class of silent failure this feature exists to remove — so it earns a real
+#: message naming the expected format.
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class TombstoneNotFoundError(ValueError):
+    """Raised when a sha256 has no tombstone (friendly rc=1 at the CLI)."""
+
+
+class DocumentLiveError(ValueError):
+    """`tombstone add` refused: that hash is a live `document`, so `rm --tombstone` is
+    the coherent path (delete + record, one transaction)."""
+
+
+def _now(now: str | None = None) -> str:
+    """ISO8601 UTC to the second — the same stamp `document.ingested_at` carries."""
+    return now or datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def normalize_sha256(sha256: str) -> str:
+    """``strip().lower()`` a hex digest, or raise ``ValueError`` naming the format."""
+    candidate = (sha256 or "").strip().lower()
+    if not _SHA256_RE.match(candidate):
+        raise ValueError(
+            f"not a sha256 content hash: {sha256!r} - expected 64 hex characters "
+            "(see `pemr document list --json` or an old `document rm --json` report)"
+        )
+    return candidate
+
+
+def _row_view(row: sqlite3.Row) -> dict:
+    return {
+        "sha256": row["sha256"],
+        "removed_at": row["removed_at"],
+        "reason": row["reason"],
+        "note": row["note"],
+        "document_id": row["document_id"],
+    }
+
+
+def _clean(value: str | None) -> str | None:
+    """Free text in, NULL out for empty/whitespace-only (no taxonomy, no validation)."""
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def live_document_id(conn: sqlite3.Connection, sha256: str) -> int | None:
+    """The `document_id` currently filed under ``sha256``, or None."""
+    row = conn.execute(
+        "SELECT document_id FROM document WHERE sha256 = ?", (sha256,)
+    ).fetchone()
+    return int(row["document_id"]) if row is not None else None
+
+
+def get_tombstone(conn: sqlite3.Connection, sha256: str) -> dict | None:
+    """The tombstone for ``sha256``, or None. The hot path `ingest` calls.
+
+    Deliberately does **not** normalize: `ingest` passes a digest it just computed.
+    Callers taking human input go through :func:`normalize_sha256` first.
+    """
+    row = conn.execute(
+        "SELECT * FROM document_tombstone WHERE sha256 = ?", (sha256,)
+    ).fetchone()
+    return _row_view(row) if row is not None else None
+
+
+def add_tombstone(
+    conn: sqlite3.Connection,
+    sha256: str,
+    *,
+    reason: str | None = None,
+    note: str | None = None,
+    document_id: int | None = None,
+    now: str | None = None,
+    allow_live: bool = False,
+    conn_managed: bool = False,
+) -> dict:
+    """Record (or refresh) the tombstone for ``sha256``; returns the stored row.
+
+    ``UPSERT`` rather than a plain insert: a `--force`d ingest past a tombstone leaves
+    the hash both live and tombstoned, and the later `document rm --tombstone` must
+    refresh ``removed_at``/``reason``/``note``/``document_id`` rather than raising. That
+    also makes a re-run of the same command a safe no-op-shaped write.
+
+    Raises :class:`DocumentLiveError` when the hash is a live document and ``allow_live``
+    is off — creating a tombstone *beside* a live document through a command whose whole
+    purpose is exclusion would be incoherent. ``remove_document`` passes ``allow_live``
+    because it is deleting that document in the same transaction.
+
+    ``conn_managed=True`` skips the ``with conn:`` block, for callers that already own
+    an open transaction (``documents.remove_document`` — a delete that commits without
+    its tombstone is the exact failure being fixed, so they cannot separate).
+    """
+    db.require_migrated(conn)
+    if not allow_live:
+        live = live_document_id(conn, sha256)
+        if live is not None:
+            raise DocumentLiveError(
+                f"sha256 {sha256[:12]}... is live as document #{live} - a tombstone "
+                "beside a filed document would be incoherent. Remove and record it in "
+                f"one step: `pemr document rm {live} --tombstone --apply`; "
+                "nothing was written"
+            )
+    params = (sha256, _now(now), _clean(reason), _clean(note), document_id)
+    sql = """
+        INSERT INTO document_tombstone
+          (sha256, removed_at, reason, note, document_id)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(sha256) DO UPDATE SET
+          removed_at = excluded.removed_at,
+          reason     = excluded.reason,
+          note       = excluded.note,
+          document_id = excluded.document_id
+    """
+    if conn_managed:
+        conn.execute(sql, params)
+    else:
+        with conn:
+            conn.execute(sql, params)
+    stored = get_tombstone(conn, sha256)
+    assert stored is not None  # just written
+    return stored
+
+
+def list_tombstones(conn: sqlite3.Connection) -> list[dict]:
+    """Every tombstone, newest first, each with ``live_document_id``.
+
+    ``live_document_id`` is normally None. It is not None exactly when somebody ran
+    `ingest --force` past the tombstone: the row stays (force is a one-shot override,
+    not a lift), so the hash is both filed and excluded. That state is deliberate and
+    reachable, so `list` labels it rather than hiding it.
+    """
+    db.require_migrated(conn)
+    rows = conn.execute(
+        "SELECT * FROM document_tombstone ORDER BY removed_at DESC, sha256"
+    ).fetchall()
+    out: list[dict] = []
+    for row in rows:
+        view = _row_view(row)
+        view["live_document_id"] = live_document_id(conn, row["sha256"])
+        out.append(view)
+    return out
+
+
+def remove_tombstone(conn: sqlite3.Connection, sha256: str) -> dict:
+    """Lift the tombstone for ``sha256``; returns the row that was removed.
+
+    Raises :class:`TombstoneNotFoundError` for an unknown hash — a typo must not read as
+    success. Full 64-character hashes only (no prefix matching: a prefix matching two
+    tombstones has no safe answer, and `list --json` supplies the full value).
+    """
+    db.require_migrated(conn)
+    existing = get_tombstone(conn, sha256)
+    if existing is None:
+        raise TombstoneNotFoundError(
+            f"no tombstone for {sha256} - see `pemr document tombstone list`"
+        )
+    with conn:
+        conn.execute("DELETE FROM document_tombstone WHERE sha256 = ?", (sha256,))
+    return existing
+
+
+def has_table(conn: sqlite3.Connection) -> bool:
+    """Whether `document_tombstone` exists — false for a snapshot predating migration
+    007. `restore` needs this on both sides of its pre-replace diff, the same way
+    :func:`verify.row_counts` omits tables missing from an older schema."""
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='document_tombstone'"
+    ).fetchone()
+    return row is not None
+
+
+def describe(tombstone: dict) -> str:
+    """One-line ``<date> (reason: x)`` summary shared by the CLI and restore printers."""
+    day = (tombstone.get("removed_at") or "")[:10]
+    reason = tombstone.get("reason")
+    return f"{day} (reason: {reason})" if reason else f"{day} (no reason recorded)"

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -28,6 +28,7 @@ from . import db, ingest
 COUNTED_TABLES = (
     "person",
     "document",
+    "document_tombstone",
     "lab_result",
     "medication",
     "procedure",

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -17,6 +17,7 @@ EXPECTED_TABLES = {
     "condition",
     "allergy",
     "conflict",
+    "document_tombstone",
     "schema_migrations",
 }
 
@@ -40,6 +41,7 @@ ALL_MIGRATIONS = [
     "004_person_deactivate.sql",
     "005_dedup_occurrence.sql",
     "006_condition_allergy.sql",
+    "007_document_tombstone.sql",
 ]
 
 # Every record table carries the occurrence-family columns (migration 005; 006's two
@@ -126,7 +128,9 @@ def test_migration_006_moves_condition_and_allergy_observations(conn, tmp_path):
     )
     conn.commit()
 
-    assert db.migrate(conn) == ["006_condition_allergy.sql"]
+    assert db.migrate(conn) == [
+        "006_condition_allergy.sql", "007_document_tombstone.sql"
+    ]
 
     a = conn.execute("SELECT * FROM allergy").fetchone()
     assert (a["substance"], a["reaction"], a["noted_on"]) == (

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 
-from pemr import __version__, db, dedup, mcp_server, persons
+from pemr import __version__, db, dedup, ingest, mcp_server, persons, tombstones
 
 REPO = Path(__file__).resolve().parent.parent
 DICT_PATH = REPO / "data" / "dictionary.example.toml"
@@ -204,6 +204,42 @@ def test_ingest_refuses_a_mismatched_owner(seeded, tmp_path, monkeypatch):
     assert out["status"] == "new"
     assert out["owner_check"]["verdict"] == "suspect"
     assert "SMITH, KAREN A" in out["owner_check"]["evidence"]
+
+
+def test_ingest_of_tombstoned_content_is_structured_not_an_error(
+    seeded, tmp_path, monkeypatch
+):
+    """Issue #80 via MCP: a tombstone hit is a structured, non-exceptional answer."""
+    monkeypatch.setenv("PEMR_SOURCES", str(tmp_path / "sources"))
+    scan = tmp_path / "excluded.txt"
+    scan.write_bytes(b"a document carrying identifiers")
+    tombstones.add_tombstone(
+        seeded, ingest.hash_file(scan), reason="identifiers", note="insurance card"
+    )
+
+    out = mcp_server.ingest_document(seeded, file=str(scan), person="jane-doe")
+    assert out["status"] == "tombstoned"
+    assert out["is_tombstoned"] is True
+    assert out["document"] is None
+    assert out["ocr_text_populated"] is False
+    assert out["tombstone"]["reason"] == "identifiers"
+
+
+def test_agent_cannot_force_past_a_tombstone(seeded, tmp_path, monkeypatch):
+    """Deliberately stricter than the owner check: that verdict is a heuristic a human
+    may reasonably ask an agent to override, a tombstone *is* the human's decision."""
+    monkeypatch.setenv("PEMR_SOURCES", str(tmp_path / "sources"))
+    scan = tmp_path / "excluded2.txt"
+    scan.write_bytes(b"still excluded")
+    sha = ingest.hash_file(scan)
+    tombstones.add_tombstone(seeded, sha, reason="identifiers")
+
+    with pytest.raises(mcp_server.ToolError, match="does not override a tombstone"):
+        mcp_server.ingest_document(seeded, file=str(scan), person="jane-doe",
+                                   force=True)
+    assert seeded.execute(
+        "SELECT COUNT(*) FROM document WHERE sha256 = ?", (sha,)
+    ).fetchone()[0] == 0
 
 
 def test_ingest_study_directory(seeded, tmp_path, monkeypatch):

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 import pytest
 
-from pemr import backup, cli, db, restore, verify
+from pemr import backup, cli, db, restore, tombstones, verify
 
 
 # --------------------------------------------------------------------------- #
@@ -612,3 +612,88 @@ def test_snapshot_name_override_is_verbatim_and_never_overwrites(tmp_path):
     with pytest.raises(backup.BackupError):
         backup.snapshot(db_path, out, name=snap.name)
     assert snap.exists(), "the refused second write must not clobber the first"
+
+
+# --------------------------------------------------------------------------- #
+# tombstones lost across a restore (issue #80)
+# --------------------------------------------------------------------------- #
+
+def test_restore_reports_tombstones_the_snapshot_does_not_have(tmp_path, capsys):
+    """A snapshot predating a tombstone loses it - correct, but the *consequence* is
+    issue #80's bug resurrected, so the loss is named before the replace."""
+    db_path, sources = _populated(tmp_path)
+    backups = tmp_path / "backups"
+    assert _run(db_path, "backup", "--backup-dir", str(backups)) == 0
+
+    # Recorded *after* the snapshot, so the restore drops it.
+    assert _run(db_path, "document", "rm", "1", "--tombstone", "--reason",
+                "identifiers", "--apply") == 0
+
+    capsys.readouterr()
+    assert _run(db_path, "restore", "latest", "--backup-dir", str(backups),
+                "--sources", str(sources), "--force") == 0
+    err = capsys.readouterr().err
+    assert "1 tombstone(s) in the current database are not in this snapshot" in err
+    assert "identifiers" in err
+    assert restore.RESCUE_PREFIX in err          # where they are still recoverable
+    assert "tombstone add --sha256" in err       # and how to put them back
+    assert err.isascii()
+
+    # Reported, never merged: the restored database is the snapshot's, tombstone-free.
+    conn = db.connect(db_path)
+    try:
+        assert verify.row_counts(conn)["document_tombstone"] == 0
+    finally:
+        conn.close()
+
+
+def test_restore_says_nothing_when_no_tombstone_is_lost(tmp_path, capsys):
+    db_path, sources = _populated(tmp_path)
+    backups = tmp_path / "backups"
+    assert _run(db_path, "document", "rm", "1", "--tombstone", "--apply") == 0
+    assert _run(db_path, "backup", "--backup-dir", str(backups)) == 0
+
+    capsys.readouterr()
+    assert _run(db_path, "restore", "latest", "--backup-dir", str(backups),
+                "--sources", str(sources), "--force") == 0
+    assert "will be lost" not in capsys.readouterr().err
+
+
+def test_restore_from_a_pre_migration_snapshot_does_not_crash(tmp_path, capsys):
+    """The snapshot has no `document_tombstone` table at all - guarded on both sides,
+    exactly as `verify.row_counts` omits tables missing from an older schema."""
+    import shutil
+
+    db_path = tmp_path / "pemr.db"
+    backups = tmp_path / "backups"
+    staged = tmp_path / "pre007"
+    staged.mkdir()
+    for path in sorted(db.DEFAULT_MIGRATIONS_DIR.glob("*.sql")):
+        if path.name < "007":
+            shutil.copy(path, staged / path.name)
+    old = db.connect(db_path)
+    try:
+        db.migrate(old, staged)
+    finally:
+        old.close()
+    assert _run(db_path, "backup", "--backup-dir", str(backups)) == 0
+
+    # Bring the live database forward and record a tombstone the snapshot cannot hold.
+    assert _run(db_path, "migrate") == 0
+    conn = db.connect(db_path)
+    try:
+        tombstones.add_tombstone(conn, "c" * 64, reason="identifiers")
+    finally:
+        conn.close()
+
+    capsys.readouterr()
+    assert _run(db_path, "restore", "latest", "--backup-dir", str(backups),
+                "--force") == 0
+    err = capsys.readouterr().err
+    assert "1 tombstone(s)" in err
+    # migrate ran forward again, so the table is back (empty).
+    conn = db.connect(db_path)
+    try:
+        assert verify.row_counts(conn)["document_tombstone"] == 0
+    finally:
+        conn.close()

--- a/tests/test_tombstones.py
+++ b/tests/test_tombstones.py
@@ -1,0 +1,504 @@
+"""Intentional-removal memory for layer-1 dedup (issue #80).
+
+The bug: layer-1 identity is a lookup against the *live* `document` table, so
+`document rm` erases every trace that a hash was ever seen and the next bulk sweep
+re-ingests the file silently. These cover the opt-in fix end to end — the engine
+(`pemr/tombstones.py`), the ingest check, `document rm --tombstone`, the
+`document tombstone list|add|rm` verbs, and the `--purge-blob` over-promise warning.
+
+`restore`'s pre-replace loss note lives in test_restore.py, next to the rest of the
+restore mechanics.
+"""
+
+import json
+
+import pytest
+
+from pemr import cli, db, documents, ingest, persons, tombstones, verify
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    conn = db.connect(tmp_path / "test.db")
+    db.migrate(conn)
+    persons.add_person(conn, "jane-doe", "Jane Doe")
+    yield conn
+    conn.close()
+
+
+@pytest.fixture()
+def sources(tmp_path):
+    return tmp_path / "sources"
+
+
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+
+
+def _make_file(tmp_path, name="scan.txt", content=b"lab report bytes"):
+    p = tmp_path / name
+    p.write_bytes(content)
+    return p
+
+
+# --- engine -----------------------------------------------------------------
+
+
+def test_add_and_get_round_trip(conn):
+    row = tombstones.add_tombstone(
+        conn, SHA_A, reason="identifiers", note="dad's 2019 insurance card"
+    )
+    assert row["sha256"] == SHA_A
+    assert row["reason"] == "identifiers"
+    assert tombstones.get_tombstone(conn, SHA_A) == row
+    assert tombstones.get_tombstone(conn, SHA_B) is None
+
+
+def test_blank_reason_and_note_store_as_null(conn):
+    row = tombstones.add_tombstone(conn, SHA_A, reason="   ", note="")
+    assert row["reason"] is None and row["note"] is None
+
+
+def test_add_is_an_upsert_not_an_error(conn):
+    first = tombstones.add_tombstone(conn, SHA_A, reason="typo", now="2026-01-01T00:00:00+00:00")
+    second = tombstones.add_tombstone(
+        conn, SHA_A, reason="identifiers", now="2026-02-02T00:00:00+00:00"
+    )
+    assert first["reason"] == "typo" and second["reason"] == "identifiers"
+    assert second["removed_at"].startswith("2026-02-02")
+    assert len(tombstones.list_tombstones(conn)) == 1
+
+
+def test_add_refuses_a_live_document(conn, tmp_path, sources):
+    result = ingest.ingest_document(conn, _make_file(tmp_path), "jane-doe", sources)
+    with pytest.raises(tombstones.DocumentLiveError) as exc:
+        tombstones.add_tombstone(conn, result.document.sha256)
+    assert f"#{result.document.document_id}" in str(exc.value)
+    assert tombstones.get_tombstone(conn, result.document.sha256) is None
+
+
+def test_list_is_newest_first_and_marks_live_hashes(conn, tmp_path, sources):
+    tombstones.add_tombstone(conn, SHA_A, now="2026-01-01T00:00:00+00:00")
+    tombstones.add_tombstone(conn, SHA_B, now="2026-03-03T00:00:00+00:00")
+    rows = tombstones.list_tombstones(conn)
+    assert [r["sha256"] for r in rows] == [SHA_B, SHA_A]
+    assert all(r["live_document_id"] is None for r in rows)
+
+    # `ingest --force` leaves a hash both filed and excluded - deliberate, so it is
+    # labelled rather than hidden.
+    src = _make_file(tmp_path)
+    tombstones.add_tombstone(conn, ingest.hash_file(src))
+    forced = ingest.ingest_document(conn, src, "jane-doe", sources, force=True)
+    live = [r for r in tombstones.list_tombstones(conn) if r["live_document_id"]]
+    assert [r["live_document_id"] for r in live] == [forced.document.document_id]
+
+
+def test_remove_lifts_and_unknown_hash_raises(conn):
+    tombstones.add_tombstone(conn, SHA_A, reason="identifiers")
+    lifted = tombstones.remove_tombstone(conn, SHA_A)
+    assert lifted["reason"] == "identifiers"
+    assert tombstones.get_tombstone(conn, SHA_A) is None
+    with pytest.raises(tombstones.TombstoneNotFoundError):
+        tombstones.remove_tombstone(conn, SHA_A)
+
+
+@pytest.mark.parametrize(
+    "bad", ["", "   ", "abc", SHA_A[:63], SHA_A + "a", "z" * 64, "not a hash"]
+)
+def test_normalize_sha256_rejects_malformed_input(bad):
+    with pytest.raises(ValueError):
+        tombstones.normalize_sha256(bad)
+
+
+def test_normalize_sha256_strips_and_lowercases():
+    assert tombstones.normalize_sha256(f"  {SHA_A.upper()}\n") == SHA_A
+
+
+# --- ingest check -----------------------------------------------------------
+
+
+def test_ingest_of_a_tombstoned_hash_writes_nothing(conn, tmp_path, sources):
+    src = _make_file(tmp_path)
+    sha = ingest.hash_file(src)
+    tombstones.add_tombstone(conn, sha, reason="identifiers", note="insurance card")
+
+    result = ingest.ingest_document(conn, src, "jane-doe", sources)
+    assert result.status == "tombstoned" and result.is_tombstoned
+    assert result.document is None
+    assert result.tombstone["reason"] == "identifiers"
+    assert result.ocr_text_populated is False       # must not dereference a None document
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 0
+    assert not sources.exists()                     # no blob copied either
+
+
+def test_a_live_document_still_wins_over_a_tombstone(conn, tmp_path, sources):
+    """`document` is checked first: filed is a different answer than excluded."""
+    src = _make_file(tmp_path)
+    first = ingest.ingest_document(conn, src, "jane-doe", sources)
+    tombstones.add_tombstone(
+        conn, first.document.sha256, allow_live=True  # only reachable deliberately
+    )
+    again = ingest.ingest_document(conn, src, "jane-doe", sources)
+    assert again.status == "duplicate"
+
+
+def test_force_ingests_but_does_not_lift_the_tombstone(conn, tmp_path, sources):
+    src = _make_file(tmp_path)
+    sha = ingest.hash_file(src)
+    tombstones.add_tombstone(conn, sha, reason="identifiers")
+
+    forced = ingest.ingest_document(conn, src, "jane-doe", sources, force=True)
+    assert forced.status == "new"
+    # The row rides back so the caller can warn, and is still there afterwards: force
+    # is a one-shot override, not a lift.
+    assert forced.tombstone is not None
+    assert tombstones.get_tombstone(conn, sha) is not None
+
+
+def test_tombstone_force_false_withholds_the_override(conn, tmp_path, sources):
+    """The MCP stance: a tombstone is the human's recorded decision, not a heuristic."""
+    src = _make_file(tmp_path)
+    tombstones.add_tombstone(conn, ingest.hash_file(src))
+    result = ingest.ingest_document(
+        conn, src, "jane-doe", sources, force=True, tombstone_force=False
+    )
+    assert result.status == "tombstoned"
+
+
+def test_study_ingest_honours_a_tombstone(conn, tmp_path, sources):
+    from test_study import make_study
+
+    study_dir = make_study(tmp_path / "disc")
+    first = ingest.ingest_study_dir(conn, study_dir, "jane-doe", sources)
+    report = documents.remove_document(
+        conn, first.document.document_id, tombstone=True, reason="wrong-household",
+        apply=True,
+    )
+    assert report.tombstoned
+    again = ingest.ingest_study_dir(conn, study_dir, "jane-doe", sources)
+    assert again.status == "tombstoned"
+    assert again.tombstone["reason"] == "wrong-household"
+
+
+# --- document rm --tombstone ------------------------------------------------
+
+
+def _ingested(conn, tmp_path, sources, content=b"lab report bytes"):
+    src = _make_file(tmp_path, "scan.txt", content)
+    return src, ingest.ingest_document(conn, src, "jane-doe", sources)
+
+
+def test_rm_without_tombstone_leaves_no_memory(conn, tmp_path, sources):
+    src, result = _ingested(conn, tmp_path, sources)
+    documents.remove_document(conn, result.document.document_id, apply=True)
+    assert tombstones.list_tombstones(conn) == []
+    # The bug as filed: a re-sweep re-ingests it as brand new.
+    assert ingest.ingest_document(conn, src, "jane-doe", sources).status == "new"
+
+
+def test_rm_dry_run_reports_the_tombstone_but_writes_nothing(conn, tmp_path, sources):
+    src, result = _ingested(conn, tmp_path, sources)
+    report = documents.remove_document(
+        conn, result.document.document_id, tombstone=True, reason="identifiers"
+    )
+    assert report.tombstoned is True and report.tombstone_reason == "identifiers"
+    assert report.applied is False
+    assert tombstones.list_tombstones(conn) == []
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 1
+
+
+def test_rm_apply_records_the_tombstone_and_blocks_re_ingest(conn, tmp_path, sources):
+    src, result = _ingested(conn, tmp_path, sources)
+    doc_id, sha = result.document.document_id, result.document.sha256
+    report = documents.remove_document(
+        conn, doc_id, tombstone=True, reason="identifiers", note="insurance card",
+        apply=True,
+    )
+    assert report.tombstoned and report.tombstone_existed is False
+    stored = tombstones.get_tombstone(conn, sha)
+    assert stored["document_id"] == doc_id     # forensics: the id it had
+    assert stored["note"] == "insurance card"
+    assert ingest.ingest_document(conn, src, "jane-doe", sources).status == "tombstoned"
+
+
+def test_rm_tombstone_is_one_transaction_with_the_delete(
+    conn, tmp_path, sources, monkeypatch
+):
+    """A delete that commits without its tombstone is the exact failure being fixed."""
+    src, result = _ingested(conn, tmp_path, sources)
+    sha = result.document.sha256
+
+    def exploding(*args, **kwargs):
+        raise RuntimeError("write failed mid-transaction")
+
+    monkeypatch.setattr(documents.tombstones, "add_tombstone", exploding)
+    with pytest.raises(RuntimeError):
+        documents.remove_document(
+            conn, result.document.document_id, tombstone=True, apply=True
+        )
+    # The delete rolled back with it: the document and its rows are still there.
+    assert conn.execute(
+        "SELECT COUNT(*) AS n FROM document WHERE sha256 = ?", (sha,)
+    ).fetchone()["n"] == 1
+
+
+def test_rm_tombstone_after_a_forced_ingest_updates_in_place(conn, tmp_path, sources):
+    src = _make_file(tmp_path)
+    sha = ingest.hash_file(src)
+    tombstones.add_tombstone(conn, sha, reason="typo")
+    forced = ingest.ingest_document(conn, src, "jane-doe", sources, force=True)
+
+    report = documents.remove_document(
+        conn, forced.document.document_id, tombstone=True, reason="identifiers",
+        apply=True,
+    )
+    assert report.tombstone_existed is True
+    assert tombstones.get_tombstone(conn, sha)["reason"] == "identifiers"
+    assert len(tombstones.list_tombstones(conn)) == 1
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def _run(tmp_path, *argv):
+    return cli.main([
+        "--db", str(tmp_path / "cli.db"),
+        "--config", str(tmp_path / "absent.toml"), *argv,
+    ])
+
+
+@pytest.fixture()
+def cli_ready(tmp_path):
+    """Migrated DB, one person, one ingested document owned by jane."""
+    assert _run(tmp_path, "migrate", "--create") == 0
+    assert _run(tmp_path, "person", "add", "--slug", "jane-doe", "--name", "Jane") == 0
+    scan = tmp_path / "scan.txt"
+    scan.write_bytes(b"hba1c 5.7 percent")
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources")) == 0
+    return tmp_path
+
+
+def _assert_console_safe(text: str) -> None:
+    assert text.isascii(), f"non-ASCII CLI output would garble on cp437: {text!r}"
+    text.encode("cp437")
+
+
+def test_cli_rm_tombstone_then_ingest_is_skipped(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "rm", "1", "--tombstone", "--reason",
+                "identifiers", "--note", "dad's card", "--apply") == 0
+    out = capsys.readouterr().out
+    assert "tombstone recorded (reason: identifiers)" in out
+
+    capsys.readouterr()
+    assert _run(cli_ready, "ingest", str(cli_ready / "scan.txt"), "--person",
+                "jane-doe", "--sources", str(cli_ready / "sources")) == 0
+    captured = capsys.readouterr()
+    assert "skipped: tombstoned" in captured.out
+    assert "reason: identifiers" in captured.out
+    assert "dad's card" in captured.out
+    assert "next:" not in captured.out          # nothing to extract
+    _assert_console_safe(captured.out)
+    _assert_console_safe(captured.err)
+
+
+def test_cli_rm_dry_run_says_would_record(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "rm", "1", "--tombstone") == 0
+    assert "would record tombstone" in capsys.readouterr().out
+    assert _run(cli_ready, "document", "tombstone", "list") == 0
+    assert "no tombstones recorded" in capsys.readouterr().out
+
+
+def test_cli_reason_without_tombstone_is_an_argparse_error(cli_ready, capsys):
+    with pytest.raises(SystemExit):
+        _run(cli_ready, "document", "rm", "1", "--reason", "identifiers")
+    assert "--reason/--note only apply with --tombstone" in capsys.readouterr().err
+
+
+def test_cli_ingest_force_past_a_tombstone_warns_and_keeps_it(cli_ready, capsys):
+    assert _run(cli_ready, "document", "rm", "1", "--tombstone", "--apply") == 0
+    capsys.readouterr()
+    assert _run(cli_ready, "ingest", str(cli_ready / "scan.txt"), "--person",
+                "jane-doe", "--sources", str(cli_ready / "sources"), "--force") == 0
+    captured = capsys.readouterr()
+    assert "ingested document" in captured.out
+    assert "tombstone was NOT lifted" in captured.err
+    _assert_console_safe(captured.err)
+
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "tombstone", "list") == 0
+    assert "(live as document #" in capsys.readouterr().out
+
+
+def test_cli_purge_blob_warns_without_a_tombstone(cli_ready, capsys):
+    # Dry run too: a warning that only appears after the irreversible run is useless.
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "rm", "1", "--purge-blob",
+                "--sources", str(cli_ready / "sources")) == 0
+    err = capsys.readouterr().err
+    assert "does not prevent re-ingest" in err
+    _assert_console_safe(err)
+
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "rm", "1", "--purge-blob", "--apply",
+                "--sources", str(cli_ready / "sources")) == 0
+    err = capsys.readouterr().err
+    assert "does not prevent re-ingest" in err
+    assert "git history" in err          # the unconditional purge caveat
+
+
+def test_cli_purge_blob_with_a_tombstone_does_not_warn(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "rm", "1", "--purge-blob", "--tombstone",
+                "--apply", "--sources", str(cli_ready / "sources")) == 0
+    err = capsys.readouterr().err
+    assert "does not prevent re-ingest" not in err
+
+
+def test_cli_purge_blob_does_not_nag_when_a_tombstone_already_exists(
+    cli_ready, capsys
+):
+    assert _run(cli_ready, "document", "rm", "1", "--tombstone", "--apply") == 0
+    scan = cli_ready / "scan.txt"
+    assert _run(cli_ready, "ingest", str(scan), "--person", "jane-doe", "--sources",
+                str(cli_ready / "sources"), "--force") == 0
+    # SQLite reuses the rowid of the only deleted row, so the re-ingest is #1 again.
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "rm", "1", "--purge-blob", "--apply",
+                "--sources", str(cli_ready / "sources")) == 0
+    err = capsys.readouterr().err
+    # The tombstone from the first rm still exists, so the nag is suppressed.
+    assert "does not prevent re-ingest" not in err
+
+
+def _sha_of(tmp_path, document_id: int) -> str:
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        return conn.execute(
+            "SELECT sha256 FROM document WHERE document_id = ?", (document_id,)
+        ).fetchone()["sha256"]
+    finally:
+        conn.close()
+
+
+def test_cli_tombstone_add_by_file_ingests_nothing(cli_ready, capsys):
+    excluded = cli_ready / "never-file-this.txt"
+    excluded.write_bytes(b"a document carrying identifiers")
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "tombstone", "add", "--file", str(excluded),
+                "--reason", "identifiers") == 0
+    out = capsys.readouterr().out
+    assert "tombstoned" in out
+    _assert_console_safe(out)
+
+    # No blob copied, no document row added (the document from cli_ready is #1).
+    assert _run(cli_ready, "document", "list", "--json") == 0
+    assert len(json.loads(capsys.readouterr().out)) == 1
+    sha = ingest.hash_file(excluded)
+    assert not (cli_ready / "sources" / sha[:2] / f"{sha}.txt").exists()
+
+    capsys.readouterr()
+    assert _run(cli_ready, "ingest", str(excluded), "--person", "jane-doe",
+                "--sources", str(cli_ready / "sources")) == 0
+    assert "skipped: tombstoned" in capsys.readouterr().out
+
+
+def test_cli_tombstone_add_by_sha256_and_bad_hash(cli_ready, capsys):
+    assert _run(cli_ready, "document", "tombstone", "add", "--sha256", SHA_A) == 0
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "tombstone", "add", "--sha256", "nope") == 1
+    assert "not a sha256 content hash" in capsys.readouterr().err
+
+
+def test_cli_tombstone_add_needs_exactly_one_source(cli_ready):
+    with pytest.raises(SystemExit):
+        _run(cli_ready, "document", "tombstone", "add")
+    with pytest.raises(SystemExit):
+        _run(cli_ready, "document", "tombstone", "add", "--sha256", SHA_A,
+             "--file", str(cli_ready / "scan.txt"))
+
+
+def test_cli_tombstone_add_for_a_live_document_is_refused(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "tombstone", "add", "--file",
+                str(cli_ready / "scan.txt")) == 1
+    err = capsys.readouterr().err
+    assert "live as document #1" in err
+    assert "--tombstone --apply" in err
+
+
+def test_cli_tombstone_add_unreadable_file_is_friendly(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "tombstone", "add", "--file",
+                str(cli_ready / "absent.txt")) == 1
+    assert "cannot read" in capsys.readouterr().err
+
+
+def test_cli_tombstone_list_empty_and_populated(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "tombstone", "list") == 0
+    assert capsys.readouterr().out.strip() == "no tombstones recorded"
+
+    assert _run(cli_ready, "document", "rm", "1", "--tombstone", "--reason",
+                "identifiers", "--note", "insurance card", "--apply") == 0
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "tombstone", "list") == 0
+    out = capsys.readouterr().out
+    assert "identifiers" in out and "insurance card" in out and "#1" in out
+    _assert_console_safe(out)
+
+    assert _run(cli_ready, "document", "tombstone", "list", "--json") == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert len(rows[0]["sha256"]) == 64          # full hash in --json
+    assert rows[0]["live_document_id"] is None
+
+
+def test_cli_tombstone_rm_lifts_and_re_ingest_succeeds(cli_ready, capsys):
+    sha = _sha_of(cli_ready, 1)
+    assert _run(cli_ready, "document", "rm", "1", "--tombstone", "--apply") == 0
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "tombstone", "rm", sha) == 0
+    assert "lifted tombstone" in capsys.readouterr().out
+
+    assert _run(cli_ready, "ingest", str(cli_ready / "scan.txt"), "--person",
+                "jane-doe", "--sources", str(cli_ready / "sources")) == 0
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "list", "--json") == 0
+    assert len(json.loads(capsys.readouterr().out)) == 1
+
+
+def test_cli_tombstone_rm_unknown_hash_is_rc1(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "tombstone", "rm", SHA_B) == 1
+    assert "no tombstone for" in capsys.readouterr().err
+    # A truncated hash is a format error, not a silent miss.
+    assert _run(cli_ready, "document", "tombstone", "rm", SHA_B[:12]) == 1
+    assert "not a sha256 content hash" in capsys.readouterr().err
+
+
+# --- verify -----------------------------------------------------------------
+
+
+def test_verify_counts_tombstones(conn):
+    tombstones.add_tombstone(conn, SHA_A)
+    assert verify.row_counts(conn)["document_tombstone"] == 1
+
+
+def test_verify_omits_the_table_on_a_pre_007_schema(tmp_path):
+    """The existing "omit tables missing from the schema" rule covers old snapshots."""
+    import shutil
+
+    staged = tmp_path / "pre007"
+    staged.mkdir()
+    for path in sorted(db.DEFAULT_MIGRATIONS_DIR.glob("*.sql")):
+        if path.name < "007":
+            shutil.copy(path, staged / path.name)
+    old = db.connect(tmp_path / "old.db")
+    try:
+        db.migrate(old, staged)
+        assert "document_tombstone" not in verify.row_counts(old)
+        assert tombstones.has_table(old) is False
+    finally:
+        old.close()


### PR DESCRIPTION
## Summary

Adds a `document_tombstone` table as opt-in memory that a document was **intentionally**
removed, so a later bulk-intake sweep over an unchanged source folder no longer silently
re-ingests content a human already excluded. Correction-style removals (misfiled, bad
scan, superseded version) are unaffected — the tombstone is only written when
`document rm` is given `--tombstone` explicitly.

- `migrations/007_document_tombstone.sql` — `sha256` PK, `removed_at`, `reason`, `note`,
  forensic `document_id` (no FK, no CHECK).
- New `pemr/tombstones.py` engine module (`add_tombstone` / `get_tombstone` /
  `list_tombstones` / `remove_tombstone`).
- `pemr document rm <id> --tombstone [--reason SLUG] [--note TEXT] [--apply]` — writes the
  tombstone atomically with the delete; UPSERT on re-run.
- `ingest` (`ingest_document` and `ingest_study_dir`) checks the tombstone table after the
  live `document` lookup; a hit is a new `IngestResult.status == "tombstoned"` (rc=0, not
  an exception) with a skip line distinct from `duplicate: ...`. `--force` still ingests
  but does not lift the tombstone, and warns on stderr.
- `pemr document tombstone add (--file | --sha256) [--reason] [--note]` for pre-emptive
  tombstoning without ingesting the content first; `list` / `rm`.
- `--purge-blob` warns when used without `--tombstone` (and no tombstone already exists)
  that the file will simply be re-ingested on the next sweep; unconditional git-history
  caveat after a successful purge.
- `restore` reports (read-only, never blocks) tombstones present in the live DB but absent
  from the snapshot being restored, naming the rescue copy and the re-apply command.
  `document_tombstone` added to `verify.COUNTED_TABLES`.
- MCP surface: `ingest` returns the structured `tombstoned` payload and refuses
  `force=True` past a tombstone (a human policy decision, not an agent override) — no MCP
  write tool for tombstones. `AGENTS.md` §3 documents the never-force rule.
- `docs/Architecture.md` updated: layer-1 dedup is scoped to the *live* `document` table;
  `document_tombstone` added to the schema listing and CLI surface sections.

Full design rationale (schema, module layout, the four originally-unsettled questions, and
build/verify/audit notes) is on the issue thread.

Ship-lane merge: `dev` merged into this branch cleanly (auto-merge, no conflicts) to pick
up `feat/71-qualifier-aware-dedup` (#95) and other `dev` advances since this branch cut;
full suite re-run green after the merge.

Closes #80

## Test plan

- [x] `python -m pytest` — full suite green post-merge (Windows/py3.12)
- [x] `npm run check:meta-drift` passes
- [x] Design §13 done-criteria (1–9) covered by `tests/test_tombstones.py` (41 tests),
      `tests/test_restore.py`, `tests/test_mcp_server.py`, `tests/test_db.py` — see
      verify/audit comments on #80 for the manual walkthrough (skip path, `--force`,
      dry-run/apply, `--purge-blob` warning matrix, `tombstone add/rm/list`, restore loss
      note incl. pre-migration snapshot, `verify` output)
- [x] Audit pass: no blocking findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
