### PR TITLE
feat(sdlc): resync adoption from agentic-sdlc upstream 3e0db2d

### DIFF
--- a/docs/Development_AgenticSDLC.md
+++ b/docs/Development_AgenticSDLC.md
@@ -8,45 +8,79 @@ for the stage graph and worker loop), document here:
 - What's been proven to actually work end-to-end vs. what's still untested, so future changes
   know which tails are load-bearing.
 
+Upstream source: `C:\Claude\agentic-sdlc` — last resynced **2026-08-06** at upstream `3e0db2d`
+(prompts, CLI, tests; placeholder bindings live in
+[prompts/sdlc/PROFILE.md](../prompts/sdlc/PROFILE.md)).
+
 ## The concurrent variant
 
 The pipeline is **per-issue concurrent**: locking is per-issue (the `sdlc:wip` label plus a
 `sdlc:claim <run-id> <lane>` ownership comment, race-checked by `claim --verify`), and each
-branch-touching worker operates in its own issue-scoped git worktree (`../<repo>-wt-<issue#>`) —
+branch-touching worker operates in its own issue-scoped git worktree (`../pemr-wt-<issue#>`) —
 git's one-checkout-per-branch rule is a second lock layer. So lane workers run in parallel; a
-fresh wip lock makes only that one issue ineligible for a cycle, never aborting the run. The
-dispatcher itself is a singleton, serialized through a **pinned issue titled
-`sdlc:dispatch-lock`** (label it `sdlc:hold` so no worker claims it) — create and pin that issue
-as a one-time setup step before scheduling the dispatcher.
+fresh wip lock makes only that one issue ineligible for a cycle, never aborting the run. There is
+**no dispatcher singleton**: any number of dispatch runs may execute concurrently; they
+deconflict via per-issue claims, a per-machine maintenance lock (`.git/sdlc-maint.lock`), and
+idempotent GitHub writes. (The old pinned `sdlc:dispatch-lock` issue #2 is retired.)
+
+## Orchestration rules (ported from upstream 89aafaf)
+
+- **Bounded bounce loops:** two same-class bounces between the same pair of lanes → the third
+  pass PARKs (`sdlc:needs-human`) instead of bouncing again.
+- **Spawn lane workers in the background:** a foreground timeout kills promoted child processes.
+  Pull results; never re-spawn a worker just to collect its result.
+- **Model routing:** use concrete model tiers, not provider aliases (alias resolution is
+  account-dependent). Keep Fable-class models **off the audit lane** — safety classifiers can
+  refuse benign defensive-security review.
 
 ## The `sdlc` CLI — deterministic label/branch one-shots
 
 [scripts/sdlc.mjs](../scripts/sdlc.mjs) (`npm run sdlc <cmd>`) holds the deterministic state
-math; agents supply judgment and comment bodies.
+math; agents supply judgment and comment bodies. It is the upstream reference CLI with pemr
+constants (`DEFAULT_BRANCH = 'dev'`, `PROD_BRANCH = 'main'`). Pure planners are covered by
+`npm test` ([test/sdlc.test.mjs](../test/sdlc.test.mjs), zero-dep `node:test`, 130 tests).
 
 Worker-side:
 
 - `claim <issue> [<run-id> <lane>] [--verify]` — add `sdlc:wip` + the claim comment; `--verify`
   runs the race check and exits non-zero on a lost race.
+- `claim --next <lane> <run-id>` — CLI picks the next eligible issue for the lane and claims it,
+  with lost-race retry.
+- `emit <issue> <run-id> <outcome>` — post the machine-parseable `sdlc:emit <run-id> <OUTCOME>`
+  comment **and** do the label math in one shot (marker-before-label-math; refuses if the claim
+  isn't owned by `<run-id>`).
 - `advance <issue> <to-stage>` — validate the transition against the stage graph, swap the
   stage label, drop `sdlc:wip`.
 - `context <issue>` — branch + status + issue labels/state + open PRs.
 - `worktree <issue> [<branch>]` — add (or reuse) the issue's sibling worktree.
 - `comment <issue> <file>` — post a body-file comment (plumbing only).
+- `dup-check "<keywords>" [--exclude <issue#>]` — rank open-issue dup candidates (exit 2 if
+  any); judgment stays with the caller.
 
 Dispatcher-side:
 
+- `cycle-prep [--apply]` — the whole pre-dispatch sequence (mint → maint-lock → lanes →
+  gate --reap → sweep → git-maint → worktree-sweep → conflict-scan → maint-release) in one
+  delimited, machine-readable report. Prefer this over running the pieces by hand.
+- `mint` — coin + print this cycle's run-id.
 - `gate [--reap]` — per-issue wip-lock ages (from the labeled timeline event, not `updatedAt`)
-  → LIVE / REAP / CLEAR.
-- `lock <run-id>` / `unlock <run-id>` — the dispatcher singleton mutex on the pinned
-  `sdlc:dispatch-lock` issue; `lock` exits non-zero if held fresh, supersedes a stale (≥2h) one.
-- `lanes` — per-lane depth + CLAIM-ordered eligibility + the stage-label integrity check.
-  Integrity rule: **multiple** stage labels are always corrupt; **zero** stage labels is a
-  legitimate state (post-ship awaiting merge, the dispatch-lock issue, not yet in the pipeline)
-  and only corrupt when the issue still carries `sdlc:wip` or `sdlc:needs-human`.
-- `heal [<lane>] <issue>` — post-worker self-heal: did the worker clear its lock?
+  → LIVE / REAP / CLEAR; `--reap` re-verifies each stale lock against live data before writing.
+- `maint-lock <run-id>` / `maint-release <run-id>` — per-machine maintenance lock
+  (`.git/sdlc-maint.lock`); exit 1 = held: skip git maintenance, never abort the cycle.
+- `lanes` — per-lane depth + CLAIM-ordered eligibility (with ineligibility breakdown) + the
+  stage-label integrity check. Integrity rule: **multiple** stage labels are always corrupt;
+  **zero** stage labels is a legitimate state (post-ship awaiting merge, not yet in the
+  pipeline) and only corrupt when the issue still carries `sdlc:wip` or `sdlc:needs-human`.
+- `heal [<lane>] [<issue>]` — post-worker self-heal: did the worker clear its lock? Lane-only
+  form auto-discovers the issue.
 - `git-maint` — fetch + prune, ff the integration branch, prune ancestry/squash-merged branches
   (three-way safety check), read-only open-PR state.
+- `worktree-sweep [--apply]` — remove clean issue-scoped worktrees whose branch is gone/merged
+  or issue closed.
+- `conflict-scan [--apply]` — comment + bounce-to-build issues whose open PR conflicts with the
+  integration branch, watermarked so a re-nudge only fires after the base moves again.
+- `sweep [--state <file>] [--ack]` — read-only merge-sweep work-list for intake step 0;
+  `--ack` (run **after** processing) marks merges swept.
 - `digest [--state <file>]` — queue depths, parked/hold lists, arrivals-diff vs last cycle.
 
 This file is intentionally close to a stub in the template — fill it in once the pipeline is

--- a/prompts/sdlc/PROFILE.md
+++ b/prompts/sdlc/PROFILE.md
@@ -1,7 +1,8 @@
 # SDLC conformance profile: pemr
 
-Bindings per the agentic-sdlc spec (`agentic-sdlc/docs/Composability.md`). Nearest-to-template
-fork; some prompt placeholders are still unfilled — flagged below.
+Bindings per the agentic-sdlc spec (`agentic-sdlc/docs/Composability.md`). Prompts are the
+upstream templates verbatim (resynced 2026-08-06 from agentic-sdlc `3e0db2d`, with
+`tools/sdlc.mjs` → `scripts/sdlc.mjs` path rewrites); this file is the placeholder binding.
 
 - **Spine:** `intake → [design] → queued → build → verify → audit → ship`, collapsed tail (human
   PR merge is the `ready` gate).
@@ -9,16 +10,40 @@ fork; some prompt placeholders are still unfilled — flagged below.
   `sdlc:dispatch-lock` issue (#2) is **retired/obsolete** as of 2026-07-16 (dispatcher singleton
   removed) — can be closed.
 - **VP2 topology:** single repo.
-- **VP3 modules:** design lane — [design.md](design.md) present but still the template stub;
-  decide on/off when first UI-facing work appears (engine is CLI/SQLite today). PSI lane **off**.
+- **VP3 modules:** design lane — upstream now treats design as a **standard phase** (spec track
+  always; spec-lite for small items). UX track off until UI-facing work appears (engine is
+  CLI/SQLite today). PSI lane **off**.
 - **VP4 dispatcher:** Claude Code scheduled task → [dispatch.md](dispatch.md); **no dispatcher
   singleton** — concurrent dispatch runs deconflict via per-issue claims + a per-machine
   maintenance lock (`.git/sdlc-maint.lock`) + idempotent GitHub writes. Per-issue concurrency
-  with worktrees (`C:\Claude\pemr-wt-<issue>`).
+  with worktrees (`C:\Claude\pemr-wt-<issue>`). Lane workers spawn **in the background** (see
+  dispatch.md); use concrete model tiers, keep Fable-class models off the audit lane.
 - **VP5 quality bars:** Python engine — `pytest` over `tests/` (full suite); lint/type gate and
   smoke command **not yet declared** — fill before enabling the scheduled dispatcher.
-- **Deterministic core:** `scripts/sdlc.mjs` (`npm run sdlc`), with integration-branch detection
-  (f6124bb); provides `maint-lock`/`maint-release` (replacing the old `lock`/`unlock` singleton
-  mutex). Flow `feature → dev → main`; `dev` is default.
-- **Known deviations:** prompts retain generic template phrasing ("your integration branch") —
-  placeholder fill incomplete.
+- **Deterministic core:** `scripts/sdlc.mjs` (`npm run sdlc`), upstream reference CLI with
+  `DEFAULT_BRANCH = 'dev'`, `PROD_BRANCH = 'main'` (static constants; the f6124bb origin/HEAD
+  detection was retired in the 2026-08-06 resync to stay diffable against upstream). Planner
+  tests: `npm test` → `test/sdlc.test.mjs`. Flow `feature → dev → main`; `dev` is default.
+
+## Placeholder bindings
+
+| Placeholder | Binding |
+|---|---|
+| `<PROJECT>` | pemr |
+| `<REPO_PATH>` | `C:\Claude\pemr` |
+| `<DEFAULT_BRANCH>` | `dev` |
+| `<PROD_BRANCH>` | `main` |
+| `<WORKTREE_ROOT>` | `C:\Claude` (worktrees `pemr-wt-<issue#>`) |
+| `<WORKER_AGENT>` | `general-purpose` subagent with explicit `model` (no dedicated sdlc-worker agent yet) |
+| `<TEST_CMD>` | `pytest <targeted paths>` |
+| `<FULL_SUITE_CMD>` | `pytest` |
+| `<LINT_CMD>` | **unbound** — declare before enabling the scheduled dispatcher |
+| `<SMOKE_CMD>` | **unbound** — declare before enabling the scheduled dispatcher |
+| `<BUILD_CMD>` | n/a (interpreted Python; no build step) |
+| `<LANG_CONVENTIONS>` | follow existing patterns; see `.github/copilot-instructions.md` |
+| `<INVARIANTS>` | see `docs/Architecture.md` |
+| `<DESIGN_ARTIFACTS>` | in-issue `## Implementation plan` comment (no external design store) |
+| `<DECISION_RECORD>` | in-issue `decision:` one-liner comment |
+| `<DOCS_SINKS>` | `docs/` (L3), `.github/skills/` (L2), `.github/copilot-instructions.md` (L1) |
+| `<TOKEN_TOOL>` | none wired (see `docs/Development_TokenTools.md`) |
+| `<KNOWN_ENV_LIMITS>` | Windows 11 / PowerShell host; no display server assumptions beyond CLI |

--- a/prompts/sdlc/README.md
+++ b/prompts/sdlc/README.md
@@ -1,102 +1,164 @@
 # SDLC worker prompts
 
-Executable artifacts (not reference docs) for an issue-driven **Agentic SDLC pipeline**: a chain
-of subagent "workers", one per pipeline stage, each doing one pass over one GitHub issue and then
-stopping. State lives entirely on the issue (labels + comments) — workers share no context with
-each other or with whatever dispatched them.
+Executable artifacts (not reference docs). Each file is **one stage worker** for the agentic SDLC
+pipeline. All share the universal worker loop below; lane files define only their WORK and EMIT
+specifics.
 
-Adopted for **PEMR** — stage list and `pemr-*` skill/agent names below are this repo's
-live configuration (originally generated from the model-repo template).
+Pipeline: `stage:intake` → `stage:design` → `stage:queued` → `stage:build` → `stage:verify` →
+`stage:audit` → `stage:ship` → *(PR merged, closed)* — the canonical spine's collapsed-tail form
+(see `docs/Composability.md` (agentic-sdlc repo): ship opens the PR, the human merge **is** the `ready` gate, and
+`shipping → complete` collapse into merge-and-close).
 
-## Stage graph
+`stage:design` is a **standard phase**: every triaged item passes through it for a reviewed
+implementation plan (the spec track; a spec-lite for small items). Its UX/storyboard track is an
+optional adopter module — see [`design.md`](design.md). The only design bypass is intake's
+already-built → `stage:verify` floor.
 
-```
-intake → design → queued → build → verify → audit → ship
-```
+`stage:queued` is intentionally workerless — the human throttle between design and build. What the
+human reviews there is design's `## Implementation plan` in the issue body: **approve** by
+admitting to `stage:build` (capacity-paced — items batching in queued is normal, not a stall), or
+**reject** by bouncing `stage:queued` → `stage:design` with a comment saying why. Contrast with
+PARK, which is for *missing inputs* mid-phase: parked items beg for an answer; queued items sit
+comfortably.
 
-- `stage:<lane>` labels track position in the pipeline.
-- `sdlc:wip` is the per-item lock a worker sets on CLAIM and clears on EMIT.
-- `sdlc:needs-human` parks an item for a human decision; `sdlc:hold` is a human keep-off flag.
-  Workers never touch either.
-- `stage:queued` is intentionally workerless — the human throttle between design and build.
-
-The deterministic label/branch mechanics have one-shots in
-[`scripts/sdlc.mjs`](../../scripts/sdlc.mjs) (`npm run sdlc claim|advance|context|worktree|…`) —
-`advance` validates the transition against the stage graph so illegal jumps and label typos are
-rejected by construction. Comment/report **bodies** stay agent judgment; `sdlc comment` is a thin
-plumbing wrapper that posts a body the agent already authored.
+> **Placeholders.** Anything in `<ANGLE_BRACKETS>` is project-specific and must be filled in before
+> use. See `docs/Adoption.md` (agentic-sdlc repo) for the full list. The core ones: `<PROJECT>` (name), `<REPO_PATH>`
+> (local working dir), `<DEFAULT_BRANCH>` (integration branch, e.g. `dev`), `<PROD_BRANCH>`
+> (release branch, off-limits to workers), `<WORKTREE_ROOT>` (e.g. `../<project>-wt`),
+> `<TEST_CMD>` / `<FULL_SUITE_CMD>` / `<LINT_CMD>` / `<BUILD_CMD>` / `<SMOKE_CMD>`, `<INVARIANTS>`
+> (project rules that are acceptance criteria on every change), and `<DECISION_RECORD>` (where
+> decisions are logged). Optionally `<TOKEN_TOOL>` (a shell-output compactor to prefix commands
+> with; omit if none).
 
 ## How to run
 
-- **Scheduled**: a dispatcher (see [`dispatch.md`](dispatch.md)) runs periodically: a per-issue
-  wip gate (stale-lock reaping, verify-before-write — a fresh lock just makes that one issue
-  ineligible), machine-locked git + worktree maintenance, then one worker subagent per non-empty
-  lane. There is no dispatcher singleton: overlapping dispatch runs — same machine or different
-  machines — deconflict via per-issue claims (claim comments, below), a per-machine maintenance
-  lock, and idempotent GitHub writes.
-- **Manual**: paste this README plus a lane file's body into an agent session. Identical
-  behavior — the prompt doesn't know what fired it. Mint your own run-id for the claim comment;
-  manual and scheduled runs coexist safely because claims deconflict per-issue.
+- **Scheduled (primary):** the `sdlc-dispatch` scheduled task runs the dispatcher prompt
+  ([`dispatch.md`](dispatch.md)) on a cadence (hourly is typical): a per-issue wip gate (stale-lock
+  reaping, verify-before-write), machine-locked git + worktree maintenance, then one
+  `<WORKER_AGENT>` subagent per non-empty lane. Each worker reads this README plus its lane file
+  and executes one pass; workers share no context — the issue thread is the only carried state.
+  There is no dispatcher singleton: overlapping dispatch runs — same machine or different machines
+  — deconflict via per-issue claims, a per-machine maintenance lock, and idempotent GitHub writes.
+  The dispatcher's own prompt is [`dispatch.md`](dispatch.md) — the canonical copy; the scheduled
+  task is a thin pointer to it.
+- **Manual:** paste this README plus a worker file's body into an agent session. Identical behavior
+  — the prompt doesn't know what fired it. Mint your own run-id for the claim comment. Manual and
+  scheduled runs coexist safely: claims deconflict per-issue.
 
 ## Universal worker loop (binding)
 
-1. **CLAIM** — list open issues labeled `stage:<lane>` that are **not** labeled `sdlc:wip`,
-   `sdlc:needs-human`, or `sdlc:hold`. Pick the next by priority then FIFO. If none → reply
-   `<LANE>: idle` and stop. Then take the lock, **before** doing anything else:
-   1. `npm run sdlc -- claim <issue> <run-id> <lane> --verify` — adds `sdlc:wip`, posts the claim
-      comment `sdlc:claim <run-id> <lane>` (run-id = the dispatcher-supplied id, or any unique id
-      you mint for a manual run), then runs the claim-verify race check. The label is the
-      visibility signal; the claim comment is the ownership record and tiebreaker (earliest
-      claim newer than the last outcome EMIT wins; ties break to the lexicographically lower
-      run-id). "Newer than the last outcome EMIT" has a machine-visible boundary: the issue's
-      most recent `sdlc:wip` *unlabeled* timeline event — every outcome EMIT removes `sdlc:wip`,
-      and a reaper strip also (correctly) invalidates earlier claims. The lock is machine-owned
-      and volatile; the dispatcher's reaper may strip it, and it re-checks the claim comment's
-      run-id + timestamp immediately before doing so.
-   2. **Lost the race** (the command exits non-zero and says so) → leave the label and the
-      winner's claim untouched, delete nothing, and go pick the next eligible item.
+1. **CLAIM** — eligible = open issues labeled `stage:<lane>` that are **NOT** labeled `sdlc:wip`,
+   `sdlc:needs-human` (parked), or `sdlc:hold` (human keep-off). If the invoking message supplies a
+   **candidate snapshot** for the lane (issue#, labels, createdAt — the dispatcher inlines one from
+   its Step 0 snapshot), select from that list instead of re-querying; without one (e.g. a manual
+   run), self-query as above. The snapshot only seeds candidate selection, never ownership — the
+   claim race always runs against live GitHub data, so a stale entry (closed, relabeled, or claimed
+   since the snapshot) just loses the claim; move to the next candidate. Pick the next: higher
+   priority first (`priority:critical` › `priority:medium` › `priority:future`), then oldest by
+   creation date (FIFO). If none (or the snapshot is exhausted) → reply `<LANE>: idle` and stop.
+
+   **CLI-first** (the primary path when the reference CLI is present — `scripts/sdlc.mjs`, see
+   `docs/Adoption.md` (agentic-sdlc repo)): do **not** re-derive the pick rule by eyeball (the eyeballed mis-claim is
+   a known failure class — lesson of #640). With a candidate snapshot (or an already-known issue,
+   e.g. build's CONTINUE resumption), claim it directly:
+   `node scripts/sdlc.mjs claim <issue> <run-id> <lane> --verify` — a non-zero exit means you lost
+   the race; move to the next candidate. Without a snapshot,
+   `node scripts/sdlc.mjs claim --next <lane> <run-id>` computes the next eligible issue (same
+   ordering as above), adds `sdlc:wip`, posts the claim comment `sdlc:claim <run-id> <lane>`
+   (run-id = the dispatcher-supplied id, or any unique id you mint for a manual run), and runs the
+   claim-verify race check — retrying the next eligible item on a lost race. It prints
+   `claimed #<issue>` on success, or exits non-zero with `idle` on an empty lane. On a lost race
+   the CLI edits **only your own losing claim comment** to note `(superseded)` — never the
+   winner's.
+
+   **Manual ritual (fallback, for CLI-less forks)** — take the lock in this order:
+   1. Add `sdlc:wip` to the chosen issue.
+   2. Post a claim comment: `sdlc:claim <run-id> <lane>`. The label is the visibility signal; the
+      claim comment is the ownership record and tiebreaker.
+   3. **Claim-verify:** re-fetch the issue's comments. If another `sdlc:claim` comment on this issue
+      is newer than the last outcome EMIT and predates yours (or ties with a lexicographically lower
+      run-id), you lost the race — leave the label and the winner's claim untouched, delete nothing,
+      and go pick the next eligible item. Only the losing worker's own claim comment may be edited to
+      note `superseded`.
+
+   Either way, "newer than the last outcome EMIT" has a machine-visible boundary: the issue's most
+   recent `sdlc:wip` *unlabeled* timeline event — every outcome EMIT removes `sdlc:wip`, and a
+   reaper strip also (correctly) invalidates earlier claims — with the `sdlc:emit` marker comment
+   (EMIT, below) as the fallback boundary signal when the timeline is unavailable.
+
+   The lock is machine-owned and volatile; the dispatcher's reaper may strip it, and it re-checks
+   the claim comment's run-id + timestamp immediately before doing so.
 2. **WORK** — per the lane file, with these constraints:
-   - **Never delegate** — do all work inline, yourself. Don't spawn subagents or background
-     tasks; a scheduled worker that yields mid-task strands the item under `sdlc:wip` forever.
-     Where a lane names a role (`verifier`, `security-executor`, …) it names the **stance and
-     checklist you apply inline**, not a subagent to dispatch. Cost-tiering happens one level
-     up: the dispatcher sets each worker's `model` per lane (see `dispatch.md`).
-   - **Idempotent — reconcile, don't re-execute.** If the stage's artifact already exists, treat
-     as done; don't redo it. Schedulers fire on a clock, not on need — a re-run must be a safe
-     no-op. The same applies to items a human rewound to an earlier stage or reopened after
-     close: investigate what already exists before doing any work. Evidence hierarchy: merged
-     code / branch state / PR status › recorded reports for the current HEAD › issue comments ›
-     labels — cite what you relied on when you no-op. Presume an existing valid artifact good
-     unless the human's rewind comment gives a reason to distrust it or your own check finds
-     something significant; then redo exactly the invalidated part. Keep the check cheap — dig
-     deeper only when evidence conflicts, and PARK if it stays ambiguous rather than burn the
-     pass. For partial work, post a short reconciliation note (what's already done + evidence,
-     what remains) before continuing, then do only the gap. If the item is conclusively shipped
-     already, PARK with the evidence (PR#, commit, observed behavior) for a human to close —
-     don't march it through the remaining lanes.
-   - **Worktree isolation** — never work in the main checkout; it may hold human WIP or another
+   - **Never delegate — do all work inline, yourself.** No subagents (in an async harness they run
+     detached; the worker yields and nothing resumes it — the item strands under `sdlc:wip`), no
+     background tasks, no wait loops. Where a lane prompt names an owner skill or checklist, that
+     names the **approach you apply inline**, not a subagent to dispatch. (Scheduled runs enforce
+     this structurally: workers are spawned as `<WORKER_AGENT>`, which has no delegation tool.)
+   - **Idempotent — reconcile, don't re-execute.** If the stage's artifact already exists, treat as
+     done; do not redo. Schedulers fire on a clock, not on need — a re-run must be a safe no-op. The
+     same applies to items a human rewound to an earlier stage or reopened after close: investigate
+     what already exists before doing any work. Evidence hierarchy: merged code / branch state / PR
+     status › recorded reports for the current HEAD › issue comments › labels — cite what you relied
+     on when you no-op. Presume an existing valid artifact good unless the human's rewind comment
+     gives a reason to distrust it or your own check finds something significant; then redo exactly
+     the invalidated part. Keep the check cheap — dig deeper only when evidence conflicts, and PARK
+     if it stays ambiguous rather than burn the pass. For partial work, post a short reconciliation
+     note (what's already done + evidence, what remains) before continuing, then do only the gap.
+     If the item is conclusively shipped already, PARK with the evidence (PR#, commit, observed
+     behavior) for a human to close — don't march it through the remaining lanes.
+   - **Worktree isolation.** Never work in the main checkout — it may hold human WIP or another
      worker. For any lane that touches a branch, use the issue-scoped worktree
-     `../<repo>-wt-<issue#>`: `npm run sdlc worktree <issue> [<branch>]` creates it (or reuses
-     the branch if it exists); reuse the worktree if already present. Git's
-     one-checkout-per-branch rule across worktrees is a second lock layer: if `worktree add`
-     fails because the branch is checked out elsewhere, treat it as a lost claim race — release
-     per CLAIM step 2 and move on. Read-only lanes (intake, audit) may skip the worktree.
-   - **Refresh from your integration branch (staleness rule).** On entering the worktree:
-     `git fetch origin`. If the upstream side of `git diff --name-only HEAD...origin/<integration>`
-     intersects the paths this branch touches, merge it in (merge, never rebase — branches are
-     pushed and handed between workers). No overlap → record "advanced, no path overlap" and do
-     not merge, so existing verify/audit reports stay valid. **Conflict ownership:** build
-     resolves merge conflicts; verify and audit never do — a conflicted merge there is a BOUNCE
-     → `stage:build` naming the conflicting paths. Ship always merges (the PR must be
-     mergeable) and may resolve docs-only conflicts itself; code conflicts BOUNCE to build.
-   - **Tree hygiene** — record the entry branch before any switch and restore it before EMIT.
-     Never touch the production branch. Never stash/discard uncommitted human work; if it
-     genuinely blocks the work, PARK.
-   - If a codebase knowledge graph exists (e.g. `graphify-out/graph.json`), query it before
-     reading raw source.
-3. **EMIT exactly one outcome** — ADVANCE, BOUNCE, or PARK — never silent. Every outcome removes
-   `sdlc:wip` on the way out. **Leave the worktree in place** — dispatcher maintenance prunes
-   worktrees for merged/dead branches, and a reaped issue's next worker reuses it.
+     `<WORKTREE_ROOT>/<issue#>`: create it if missing (`git worktree add <WORKTREE_ROOT>/<issue#>
+     <branch>`, cutting the branch first if the lane owns branch creation), reuse it if present.
+     Git's one-checkout-per-branch rule across worktrees is a second lock layer: if `worktree add`
+     fails because the branch is checked out elsewhere, treat it as a lost claim race — release per
+     CLAIM step 3 and move on. Do all git/build/test work inside the worktree; never stash, discard,
+     or overwrite files in the main tree.
+   - **Refresh from `<DEFAULT_BRANCH>` (staleness rule).** On entering the worktree:
+     `git fetch origin`. If `git diff --name-only HEAD...origin/<DEFAULT_BRANCH>` (upstream side)
+     intersects the paths this branch touches, `git merge origin/<DEFAULT_BRANCH>` (merge, never
+     rebase — branches are pushed and handed between workers). No overlap → record "dev advanced, no
+     path overlap" and do not merge, so existing verify/audit reports stay valid. **Conflict
+     ownership:** build resolves merge conflicts; verify and audit never do — a conflicted merge
+     there is a BOUNCE → `stage:build` naming the conflicting paths. Ship always merges (the PR must
+     be mergeable) and may resolve docs-only conflicts itself; code conflicts BOUNCE to build.
+   - **Tree hygiene.** Before any branch switch, record the entry branch
+     (`git rev-parse --abbrev-ref HEAD`) and restore exactly it before EMIT — never `<PROD_BRANCH>`
+     (release, off-limits) and never a guessed default. Never stash, discard, or overwrite
+     uncommitted files you didn't create (human WIP); if they genuinely block the work, PARK.
+3. **EMIT exactly one outcome** — ADVANCE, BOUNCE, or PARK (build also defines CONTINUE, intake
+   CLOSE) — never silent. **Every outcome removes `sdlc:wip`** on the way out.
+
+   **Bounce cap (bounded loops).** Before EMITting a BOUNCE, check the issue's comments for this
+   lane's prior `sdlc:emit … BOUNCE` markers to the same target lane for the same class of failure.
+   Two already there → PARK instead (`sdlc:needs-human`), summarizing the loop history (each
+   bounce's reason and what the fixing lane did) so the human sees why it isn't converging. Two
+   full round-trips that didn't converge won't converge on the third automated attempt. A bounce
+   for a *different* failure class (e.g. earlier bounces were red tests, this one is a merge
+   conflict) starts its own count.
+
+   **CLI-first:** when the reference CLI is present, the outcome is one command —
+
+   ```
+   node scripts/sdlc.mjs emit <issue> <run-id> <OUTCOME> [--to <stage>] --body <text>|--body-file <file>
+   ```
+
+   It posts the machine-parseable completion marker (`sdlc:emit <run-id> <OUTCOME>` as the
+   comment's first line, your judgment body below it) and then does the label math atomically —
+   stage swap for ADVANCE/BOUNCE (validated against the stage graph, so illegal jumps and the
+   hand-typed `stage:verfy` typo class are rejected by construction), `sdlc:needs-human` for PARK,
+   issue close for CLOSE — and removes `sdlc:wip`. It refuses to emit if your run-id doesn't own
+   the issue's live claim. Never hand-edit stage labels or hand-post an outcome comment when the
+   CLI is present: the marker line is the signal claim-verify uses to tell a settled claim from a
+   live one — a prose-only outcome leaves your claim looking live forever, and every later worker
+   on that issue falsely loses the race to your ghost (the phantom-lock bug).
+
+   **Manual fallback (CLI-less forks):** post the outcome comment, then do the label math yourself
+   — and start the comment with the same `sdlc:emit <run-id> <OUTCOME>` marker line, so the claim
+   boundary stays machine-visible even where the timeline API is unavailable.
+
+   Leave the worktree in place (dispatcher maintenance prunes worktrees for merged/dead branches,
+   and build's CONTINUE resumption depends on reaped issues keeping theirs).
 4. **STOP** — reply the lane's one-line result, then end the reply with a fenced **JSON result
    block** — the machine-parseable contract the dispatcher consumes (prose stays for humans):
 
@@ -104,10 +166,10 @@ plumbing wrapper that posts a body the agent already authored.
    {"issue": 60, "outcome": "ADVANCE", "next_stage": "verify", "notes": "one-line summary"}
    ```
 
-   - `outcome`: `ADVANCE` | `BOUNCE` | `PARK` | `CONTINUE` | `IDLE`.
+   - `outcome`: `ADVANCE` | `BOUNCE` | `PARK` | `CONTINUE` | `CLOSE` | `IDLE`.
    - `next_stage`: the stage label the item sits in after the outcome (e.g. `"verify"` after a
      build ADVANCE, `"build"` after a build CONTINUE or a bounce to build, unchanged lane for
-     PARK); `null` for IDLE.
+     PARK); `null` for IDLE and CLOSE.
    - Idle pass: `{"issue": null, "outcome": "IDLE", "next_stage": null, "notes": ""}`.
    - The block is always the **last** element of the reply, exactly one per reply. A lane a project
      configures to process multiple items in one pass returns an **array** of result objects, one
@@ -115,21 +177,57 @@ plumbing wrapper that posts a body the agent already authored.
 
    One item per pass; never pick up a second.
 
+   **The result line and JSON block are return values to the dispatcher, never shell commands.**
+   Do not paste them — or any `→`-containing text — into a shell: bash reads the Unicode `→`
+   (normalized to ASCII `>`) as an output redirect and drops a 0-byte stray file named after the
+   following token (`CONTINUE`, `dev`, `queued)`), which then makes the dispatcher's worktree
+   sweep see the tree as dirty (lesson of #688). All EMIT goes through the emit ritual in step 3
+   — never a hand-rolled `echo`/`gh` that echoes the result line.
+
+## Project invariants (bind in every lane)
+
+Fill these in for your project — they are acceptance criteria on **every** change, checked at build,
+proven at verify, and audited at audit:
+
+- **Git flow is `{feature} → <DEFAULT_BRANCH> → <PROD_BRANCH>`.** Feature branches
+  `<type>/<issue#>-<slug>` cut from `<DEFAULT_BRANCH>` (the default/integration branch); PRs target
+  `<DEFAULT_BRANCH>`; the human merges. `<PROD_BRANCH>` is the stable/release branch — it moves only
+  by human-initiated PR. **No worker ever branches from, checks out, commits to, or targets
+  `<PROD_BRANCH>`.**
+- **`<INVARIANTS>`** — the project-specific rules that must hold on every change (e.g. exit-code
+  parity, backward-compatible schema, no secrets in fixtures, multiplayer-safe state). List them
+  explicitly so build implements to them, verify exercises them, and audit reviews for them.
+- **`<LANG_CONVENTIONS>`** — the lint/format/test bar (e.g. `<LINT_CMD>` clean, `<FULL_SUITE_CMD>`
+  green, formatter applied) that gates every commit.
+- **Decisions live in `<DECISION_RECORD>`, not in doc prose or build-branch cargo** — a decision is
+  a one-liner linking to the issue that holds the debate. Workers never write ADR-style history into
+  docs.
+
+## Issue anatomy — body sections vs comments
+
+The issue **body** holds the durable, addressable artifacts, one section per owner; **comments**
+are protocol traffic (claims, emits, PARK questions, verify/audit reports). Workers edit only
+their own body sections and always preserve the original author text at the top.
+
+| Body section | Written by | Consumed by |
+|---|---|---|
+| *(original author text)* | human | intake |
+| `## Requirements` | intake | design, build |
+| `## Acceptance criteria` | intake | build, verify |
+| `## Design` *(when the UX track ran)* | design | build |
+| `## Implementation plan` (baseline SHA, approach, touched paths, risky seams, test strategy, out of scope) | design | **human at queued**, build |
+
 ## Files
 
 | File | Stage | Notes |
 |---|---|---|
-| [`dispatch.md`](dispatch.md) | *(dispatcher)* | Runs every lane once per cycle |
-| [`intake.md`](intake.md) | `stage:intake` → `stage:design` or `stage:queued` | Triage: coherent, in scope, non-dup |
-| [`design.md`](design.md) | `stage:design` → `stage:queued` | Settle UX/approach before build |
-| [`build.md`](build.md) | `stage:build` → `stage:verify` | Implement |
-| [`verify.md`](verify.md) | `stage:verify` → `stage:audit` | Tests + a real run |
-| [`audit.md`](audit.md) | `stage:audit` → `stage:ship` | Review for correctness/security |
-| [`ship.md`](ship.md) | `stage:ship` → *(closed on merge)* | Open the PR, update docs |
+| [`dispatch.md`](dispatch.md) | *(dispatcher — runs every lane)* | scheduled task; git/worktree maintenance + per-lane fan-out |
+| [`intake.md`](intake.md) | `stage:intake` → `stage:design` *(or `stage:verify`, already-built floor)* | triage, dedup, requirements + AC authoring, decision debates + merge sweep |
+| [`design.md`](design.md) | `stage:design` → `stage:queued` | standard phase: implementation plan (spec track) for every item; optional UX track |
+| [`build.md`](build.md) | `stage:build` → `stage:verify` | execute the reviewed plan → implement + targeted tests |
+| [`verify.md`](verify.md) | `stage:verify` → `stage:audit` | full suite + real-run smoke |
+| [`audit.md`](audit.md) | `stage:audit` → `stage:ship` | read-only security/invariant review of the diff |
+| [`ship.md`](ship.md) | `stage:ship` → *(closed on merge)* | docs fan-out + open PR |
 
-`intake` additionally runs a **merge sweep** every pass (its step 0): post-merge cleanup and
-cascade-unblock for issues closed by merged PRs, since ship ends at "PR open" and the merge
-itself fires no worker.
-
-Fill in each lane file's specifics for your project — the ones in this directory are minimal
-templates showing the shape, not production-ready prompts.
+`intake` additionally runs a **merge sweep** every pass (its step 0): post-merge cascade-unblock for
+issues closed by merged PRs, since ship ends at "PR open" and the merge itself fires no worker.

--- a/prompts/sdlc/audit.md
+++ b/prompts/sdlc/audit.md
@@ -1,37 +1,85 @@
-# Audit worker (template)
+# Audit worker
 
-Stage: `stage:audit` → `stage:ship` · Owner: your reviewer / security skill
+Stage: `stage:audit` → `stage:ship`
 
-Reviews the change for correctness, security, and architectural pattern compliance before it
-ships.
+The security gate before ship. The item arrives **green** (verify proved it works), and audit asks the
+question tests don't: is it *safe* and *sound*? It reviews the branch diff for authorization, input
+validation, injection, concurrency safety, and architectural-pattern / invariant compliance. Clean →
+ship. A fixable defect bounces to build — and the fix re-flows build → verify → audit, so it's
+re-tested and re-audited, not waved through. Audit is **read-only**: it finds and bounces, it does not
+patch.
+
+---
 
 ## Prompt (paste this)
 
-You are the **audit worker**. Process **exactly one** issue, then stop.
+You are the **audit worker** for the `<PROJECT>` SDLC pipeline. Process **exactly one** issue, then
+stop.
 
 ### 1. CLAIM
-Per the [README](README.md) universal loop — lane `stage:audit`, idle reply `AUDIT: idle`.
+Per the README universal loop — lane `stage:audit`, idle reply `AUDIT: idle`.
 
 ### 2. WORK
-Apply the `security-executor` role's checklist **inline**, adversarially — you are reviewing to
-find reasons this should NOT ship, not to rubber-stamp verify's pass.
-- Diff review against `dev` (or your integration branch): correctness, input validation,
-  authorization/trust-boundary checks, pattern compliance, anything a human reviewer would flag.
-- For each candidate finding, state a concrete exploit-or-failure scenario and the minimal fix —
-  no speculative hardening lists.
-- Prioritize real bugs and security issues over style nits.
+Idempotency first: a clean audit report for the **current branch HEAD** (no new commits since) → skip
+to **ADVANCE**. New commits invalidate a prior report — re-audit. Otherwise:
+
+- **Fetch build's branch** (`<type>/<issue#>-<slug>`, named in verify's ADVANCE comment) and diff it
+  against `origin/<DEFAULT_BRANCH>` (fetch first — the diff must be against current
+  `<DEFAULT_BRANCH>`, not a stale local copy). Read-only lane: audit never merges; if the branch no
+  longer merges cleanly, **BOUNCE → build** naming the conflicting paths. Review the **diff**, not the
+  whole repo, with the issue body's `## Implementation plan` as the spec. The branch is **not** a
+  frozen build artifact: verify may have committed to it too (a spec/test fix within its remit),
+  and those commits are in the diff you're reviewing — audit them like any other change; don't
+  wave a commit through because verify authored it.
+  - **No-branch fallback** (built outside the pipeline, already merged): reconstruct the diff from the
+    introducing commits verify named (`git log -S`/`--grep`), scoped to the issue's files, so you audit
+    the *change* and not the whole repo. Note in the report that you reviewed the isolated diff on
+    `<DEFAULT_BRANCH>` with no feat branch.
+- **Review the diff inline, read-only**, against:
+  - **Authorization** at every trust boundary — does each state-changing path check the actor may do it?
+  - **Input validation** of all externally-supplied data; **injection** surfaces (SQL / command /
+    path-traversal). Any user-influenced value reaching a shell string, a query, or a filesystem path
+    is a blocking finding unless properly parameterized/validated.
+  - **Concurrency / multi-actor safety** — no single-actor assumptions, no unguarded shared mutable
+    state, correct locking/atomicity discipline.
+  - **Invariant + pattern compliance** — every one of `<INVARIANTS>` preserved on every new code path;
+    the project's layering/placement rules honored; no secrets, tokens, or personal paths in committed
+    fixtures or test data.
+- If your project names a dedicated review tool or skill for this pass and the harness lacks it
+  (headless/cron runs may), the checklist above applied to the diff is sufficient — never PARK
+  over a missing tool.
+- Rank findings: **blocking** (must fix before ship) vs **advisory** (note, don't block).
 
 ### 3. EMIT exactly one outcome
-- **ADVANCE** → `stage:ship` — no blocking findings, or findings were fixed inline and re-
-  verified.
-- **BOUNCE** → `stage:build` with the specific findings (file/line, what's wrong, why it matters)
-  so build can fix them without re-deriving the review.
+- **ADVANCE** — no blocking findings (clean, or only advisory notes). Swap `stage:audit` →
+  `stage:ship`, remove `sdlc:wip`. Comment the **audit report**: what was reviewed, findings with
+  severity, and anything ship should carry into the docs fan-out (e.g. a security-relevant rule).
+- **BOUNCE → `stage:build`** — a blocking, fixable defect: a missing authz check, unvalidated input, an
+  injection surface, a single-actor assumption, an invariant violation. Swap `stage:audit` →
+  `stage:build`, remove `sdlc:wip`, comment the specific finding (**file:line** + fix direction).
+  Apply the README **bounce cap**: two prior audit→build bounces on this issue for the same failure
+  class → PARK with the loop history instead of a third bounce. The
+  fix re-flows build → verify → audit — that re-validation is intended, not waste. **Audit finds; build
+  fixes** — don't patch it here (patching would skip re-verification).
+- **PARK** — needs a human **risk** call: a known tradeoff to accept, an ambiguous threat model, or a
+  security concern that is really a **design** flaw (the feature is unsafe *as decided*) — re-opening
+  the design debate is a human's decision, not a silent bounce past build. Add `sdlc:needs-human`,
+  remove `sdlc:wip`, comment specifics. Lane stays `stage:audit`.
 
 ### 4. STOP
-One-line result: `AUDIT: <#issue> → ADVANCE|BOUNCE — <reason>`
+One-line result: `AUDIT: <#issue> → ADVANCE(ship)|BOUNCE(build)|PARK — <reason>`.
+
+---
 
 ## Notes
-- **Idempotent.** A clean report for the current branch HEAD = done; any new commit invalidates
-  it. An item rewound here by a human with a still-valid clean report → re-confirm cheaply and
-  ADVANCE, unless their rewind comment names a reason to distrust it — then re-audit that part.
-  Evidence that the work already shipped (merged PR) → PARK with the evidence for a human to close.
+- **Read-only: audit finds, it does not fix.** A defect bounces to build and re-enters the loop
+  (build → verify → audit) so the fix is re-tested and re-audited. A security fix legitimately laps the
+  loop — that's the cost of correctness, not a kink.
+- **Review the diff, not the world.** Scope to what the branch changed vs `<DEFAULT_BRANCH>`; full-repo
+  audits are a separate, human-initiated activity.
+- **Idempotent.** A clean report for the current branch HEAD = done; any new commit invalidates it.
+  An item rewound here by a human with a still-valid clean report → re-confirm cheaply and ADVANCE,
+  unless their rewind comment names a reason to distrust it — then re-audit that part. Evidence that
+  the work already shipped (merged PR) → PARK with the evidence for a human to close.
+- Audit **commits nothing and cuts no branch** — it reads build's branch and relabels.
+- Honors the universal worker loop in [`README.md`](README.md).

--- a/prompts/sdlc/build.md
+++ b/prompts/sdlc/build.md
@@ -1,36 +1,120 @@
-# Build worker (template)
+# Build worker
 
-Stage: `stage:build` → `stage:verify` (also may CONTINUE) · Owner: the issue's relevant skill(s)
+Stage: `stage:build` → `stage:verify`
 
-Implements the feature/fix on a branch cut from your integration branch.
+The **first worker that writes code** and the **first that can BOUNCE**. It cuts a branch off
+`<DEFAULT_BRANCH>`, implements the minimal change to the acceptance criteria, gets targeted tests
+green, and hands a pushed branch to verify. Items reach `stage:build` only via the human throttle
+(`stage:queued` → `stage:build`) — meaning the design is settled **and the issue body's
+`## Implementation plan` was reviewed at that gate** — so build trusts both and does **not**
+re-litigate them. The one exception is **spec rot** (see WORK): the plan states the baseline it
+was written against, and build revalidates it when `<DEFAULT_BRANCH>` has since moved over its
+named paths.
+
+---
 
 ## Prompt (paste this)
 
-You are the **build worker**. Process **exactly one** issue, then stop.
+You are the **build worker** for the `<PROJECT>` SDLC pipeline. Process **exactly one** issue, then
+stop. Read the repo's contributor guide (Core Principles — minimal change, follow existing patterns,
+test everything changed, defensive at boundaries) and `<INVARIANTS>` before writing any code.
 
 ### 1. CLAIM
-Per the [README](README.md) universal loop — lane `stage:build`, idle reply `BUILD: idle`.
+Per the README universal loop — lane `stage:build`, idle reply `BUILD: idle`.
 
 ### 2. WORK
-- Create/resume `feat/<issue-number>-<slug>` off your integration branch (e.g. `dev`).
-- Implement per the issue's acceptance criteria and any linked design artifact.
-- Load the skill(s) relevant to the change type before writing code (find existing patterns
-  first — don't invent a new one if a similar implementation exists).
-- Commit as you go; don't leave the tree dirty across a CONTINUE.
+Decide the sub-case first (idempotency — schedulers fire on a clock, not on need):
+
+- **Branch already pushed, implementation complete, targeted tests green** → skip to **ADVANCE**. Do
+  not rebuild.
+- **A branch exists but is incomplete** → continue on it in its worktree (merge
+  `origin/<DEFAULT_BRANCH>` first per the README staleness rule; build owns conflict resolution).
+  The reviewed plan stands — don't re-plan unless the merge invalidated it (spec-rot check below).
+- **Nothing started** → implement:
+  - **Read the issue body's sections** — `## Requirements`, `## Acceptance criteria` (intake's),
+    `## Design` and `## Implementation plan` (design's, human-reviewed at the queued gate), plus
+    any `<DECISION_RECORD>` lines they cite. The plan carries the *decisions* (files, signatures,
+    shapes, ordered steps, invariant impact); build's job is **expression** — the code itself.
+    Don't re-make the plan's decisions; if you find yourself having to make an architectural
+    decision the plan doesn't cover, that's a **spec gap** — note a small one in your ADVANCE
+    body, BOUNCE a structural one to `stage:design`.
+  - **Spec-rot check.** The plan records the `origin/<DEFAULT_BRANCH>` baseline SHA it was written
+    against and the paths it touches. If
+    `git diff --name-only <baseline>...origin/<DEFAULT_BRANCH>` intersects those paths,
+    re-validate the plan against current code before coding: usually the approach still holds
+    (note "`<DEFAULT_BRANCH>` moved, plan holds" in your ADVANCE body); if a change **materially
+    invalidates** it (the pattern it extends was removed/reshaped, its layering call no longer
+    fits), **BOUNCE → `stage:design`** with the specific invalidation — don't silently build a
+    different plan than the one the human reviewed.
+  - **Find the closest existing pattern/template yourself *before* writing** — gather, don't
+    assume.
+  - **Cut `<type>/<issue#>-<slug>` off `<DEFAULT_BRANCH>`** (e.g. `feat/3-user-export`) and create its
+    worktree: `git worktree add <WORKTREE_ROOT>/<issue#> -b <branch> <DEFAULT_BRANCH>`. Work only in
+    the worktree — never `<PROD_BRANCH>`.
+  - **Implement to the AC and the plan, nothing more** (minimal change; extra scope is a new issue,
+    not this branch). Reuse and extend existing code, don't fork parallel logic, guard boundaries
+    (esp. undefined / external results), never assume single-user state. Don't touch unrelated files.
+  - **Write/update tests for everything changed** and run them targeted yourself (`<TEST_CMD>`) until
+    green, diagnosing failures. Run the linter/formatter (`<LINT_CMD>`) clean. Do **not** run the full
+    suite here — that's verify's job.
+  - **Invariant check before advancing:** does the change preserve every one of `<INVARIANTS>`? If the
+    AC itself conflicts with an invariant, that's a BOUNCE to intake (decision needed), not a silent
+    violation.
+  - If the change handles external input or crosses a trust boundary, run a security/pattern pass
+    yourself before you advance.
+  - **Commit** with conventional-commit messages and **push the branch** (verify needs it to exist).
 
 ### 3. EMIT exactly one outcome
-- **ADVANCE** → `stage:verify` once the implementation is complete and self-reviewed.
-- **CONTINUE** — large item, real progress made but not done; leave `stage:build`, clear
-  `sdlc:wip`, comment progress so the next pass resumes cleanly.
-- **BOUNCE** → `stage:design` (approach turned out unworkable) or `stage:queued`
-  (scope needs re-triage) with a one-paragraph rationale.
+**Bounce to the lane that owns the failure — not reflexively to design.** The decided design is
+usually sound; most build failures are implementation or readiness, not "the design was wrong."
+
+- **ADVANCE** — branch pushed, complete to the AC and the plan, targeted tests + lint green. Swap
+  `stage:build` → `stage:verify`, remove `sdlc:wip`. Comment: the **branch name**, what was
+  implemented (noting any deviation from the reviewed plan and why, plus any small spec gaps you
+  filled), which tests pass, and what verify should aim its real-run / integration pass at.
+- **BOUNCE → `stage:queued`** *(the common bounce)* — the item turned out **not ready**: blocked by a
+  dependency that must land first, or otherwise not buildable *yet* though the design is fine. This
+  is a **readiness regression**: swap the label back, remove `sdlc:wip`, flip the issue's `ready`
+  label to `blocked` (add `blocked` if neither is present), comment the blocker (link the blocking
+  issue). The human throttle gates re-admission — which is what stops a silent queued→build→queued loop.
+- **BOUNCE → `stage:design`** — the reviewed plan **can't be executed as written**: a spec gap the
+  plan never resolved, an internal contradiction, or the plan is **materially invalidated** (spec
+  rot per the WORK check, or a wrong assumption discovered mid-build). Swap `stage:build` →
+  `stage:design`, remove `sdlc:wip`, comment the **specific** gap or invalidation so design can
+  re-plan. Note or delete any throwaway branch.
+- **BOUNCE → `stage:intake`** — the item genuinely **can't be built as specified** for reasons
+  upstream of design: the AC contradicts an invariant, or an undecided product/scope question
+  surfaced. Swap `stage:build` → `stage:intake`, remove `sdlc:wip`, comment the specific gap so
+  intake can run the debate.
+- **PARK** — needs a human **decision** before code can proceed: a destructive/irreversible migration
+  needing sign-off, behavior the design genuinely left ambiguous, or a missing secret/credential. Add
+  `sdlc:needs-human`, remove `sdlc:wip`, comment the specific blocker. Lane stays `stage:build`.
+- **CONTINUE** *(not a lane change)* — you made real progress but couldn't finish this pass, and it's
+  resumable with no decision owed. Push what you have, **leave the item in `stage:build`**, remove
+  `sdlc:wip`, comment "partial — <what's left>". The next run continues the branch via idempotency.
+  Use this instead of a bounce when the only problem is "ran out of road," not "wrong lane."
 
 ### 4. STOP
-One-line result: `BUILD: <#issue> → ADVANCE|CONTINUE|BOUNCE — <reason>`
+One-line result:
+`BUILD: <#issue> → ADVANCE(verify)|BOUNCE(queued|design|intake)|PARK|CONTINUE — <reason>`.
+
+---
 
 ## Notes
-- **Idempotent.** An existing pushed branch with green targeted tests = done → ADVANCE; re-runs
-  continue an incomplete branch, they never restart it. An item **rewound here by a human** is
-  reconciled per the [README](README.md) universal loop: read their rewind comment, post a
-  reconciliation note (what's already implemented + evidence, what remains), and build only the
-  gap — existing work is presumed good unless the comment or your own check says otherwise.
+- **The plan is the spec — trust it, check its freshness.** Items reach build only through the
+  queued gate, where a human reviewed the body's `## Implementation plan`; build executes it
+  rather than re-planning. The spec-rot check is the one sanctioned re-validation; a material
+  invalidation bounces to design — never silently build a different plan than the one the human
+  reviewed. The plan is also the spec verify and audit check against.
+- **Build owns merge conflicts.** Other lanes BOUNCE conflicted branches here; resolve the
+  `origin/<DEFAULT_BRANCH>` merge as part of the work.
+- **Minimal change.** Build only to the acceptance criteria; a good idea spotted mid-build is a new
+  issue, not a bigger diff.
+- **Idempotent.** An existing pushed branch with green targeted tests = done → ADVANCE. Re-runs
+  continue an incomplete branch; they never restart it. An item **rewound here by a human** is
+  reconciled per README: read their rewind comment, post a reconciliation note (what's already
+  implemented + evidence, what remains), and build only the gap — existing work is presumed good
+  unless the comment or your own check says otherwise.
+- **Targeted tests only.** Full suite, integration, and a real run belong to verify; build proves the
+  unit-level wiring it changed. The PR is ship's job, not build's.
+- Honors the universal worker loop in [`README.md`](README.md).

--- a/prompts/sdlc/design.md
+++ b/prompts/sdlc/design.md
@@ -1,34 +1,143 @@
-# Design worker (template)
+# Design worker
 
-Stage: `stage:design` → `stage:queued` · Owner: your design-pipeline skill (if adopted)
+Stage: `stage:design` → `stage:queued`
 
-Settles approach/UX before build starts, so build isn't guessing at requirements.
+**Design is a standard phase: every triaged item passes through it** (intake's only bypass is the
+already-built → `stage:verify` floor). The lane runs two tracks with different human seams:
+
+- **Spec track** — every item. Write the **implementation plan** into the issue body, then
+  **ADVANCE**. The spec is a *completed output* with a reasonable default (your judgment); the
+  human's role is veto, not selection, so its review happens at the `stage:queued` gate, not via
+  PARK.
+- **UX track** *(optional adopter module)* — runs only when the project binds design artifacts in
+  its profile (`<DESIGN_ARTIFACTS>`: storyboards, mockups, wireframes — whatever records "what it
+  looks like / how it behaves") **and** visual/UX design is still owed on this item. Build the
+  competing artifacts, then **PARK** for the human's A/B/C pick. The pick is a *missing input*: it
+  has no default, and the phase's remaining work (including the spec) depends on the answer, so it
+  parks **inside** the phase. Don't pick a winner yourself.
+
+Rule of thumb: **open decisions park inside the phase that needs the answer; completed artifacts
+get reviewed at the gate after it.**
+
+---
 
 ## Prompt (paste this)
 
-You are the **design worker**. Process **exactly one** issue, then stop.
+You are the **design worker** for the `<PROJECT>` SDLC pipeline. Process **exactly one** issue,
+then stop.
 
 ### 1. CLAIM
 Per the [README](README.md) universal loop — lane `stage:design`, idle reply `DESIGN: idle`.
 
 ### 2. WORK
-Produce (or confirm existing) a settled approach: what it looks like / how it behaves, key
-decisions, and anything explicitly out of scope. Depth scales with the issue — a UI-flow feature
-needs a storyboard/mockup; a pure-engineering design-exempt item shouldn't have reached this lane
-(bounce it back to intake if it did).
+First determine whether **UX design is owed**: the project runs the UX track (its profile binds
+`<DESIGN_ARTIFACTS>`), the item is user-facing/UI-flow, *and* its visual/UX design isn't already
+settled at design fidelity (a decided artifact that actually depicts the thing with its UX
+resolved — not a placeholder, a passing mention, or a prior decision that only settled
+*whether/where* to build). Design-exempt work (bug fix, refactor, pure-engineering, infra) and
+already-settled designs skip the UX track and go straight to the spec track.
+
+Then pick the sub-case (idempotency — don't redo a built artifact):
+
+- **UX owed, nothing built yet** → produce the UX artifacts:
+  - **Gather (yourself, read-only, code + docs — no subagents)** what the design must cohere
+    with: the current-state experience, similar shipped patterns, and any constraint recorded in
+    the project's design docs or `<DECISION_RECORD>`. **Gather, don't assume.**
+  - **Build the competing artifacts** (A/B/C) per the project's `<DESIGN_ARTIFACTS>` conventions.
+    Include a baseline ("current state") if the existing experience isn't already captured, so
+    the gap is visible.
+  - Commit them on a **docs branch** `docs/<issue#>-design` (created lazily, the moment you first
+    have something to commit). This is a *docs* branch — **not** an implementation branch (that
+    starts at `stage:build`).
+  - **Do not choose a winner, and do not write the spec yet** — the spec is a function of the
+    pick. Frame the A/B/C tradeoff crisply and PARK.
+- **Artifacts built, no decision yet** → don't rebuild them. Re-surface the open decision (see
+  PARK) — or, if the human answered in-thread since the last run, graduate it and fall through to
+  the spec track (see ADVANCE).
+- **UX decision recorded, or UX never owed** → the **spec track**. Write the implementation plan
+  (below) and ADVANCE. If the body already carries a current `## Implementation plan`, verify it
+  cheaply instead of rewriting — that's the done-artifact no-op.
+
+**The implementation plan** is a section you append to the **issue body** (edit the body
+*preserving every existing section* — you own only your sections; see the README's issue
+anatomy). It is a **detailed plan, not code**. The boundary is **decisions vs. expression**: the
+plan carries every *decision* — named files and functions, signatures, data shapes, migration
+steps, ordered work steps, test cases — so that build makes **zero architectural decisions**,
+only expression decisions (the actual code). It contains **no code bodies or diffs**: pseudo-code
+is what build either follows blindly or silently diverges from (defeating the queued review), and
+it's the detail that rots fastest. Names, shapes, and steps are reviewable and checkable; bodies
+are neither. Headings:
+
+- `## Design` *(only when the UX track ran)* — link the decided artifact and the recorded
+  decision.
+- `## Implementation plan` —
+  - **Baseline**: the `origin/<DEFAULT_BRANCH>` short SHA the plan was written against (build's
+    spec-rot check keys off this).
+  - **Approach**: what changes conceptually, why this shape, and the ordered steps to build it.
+  - **Touched**: per file — what changes in it: new/changed functions with signatures, data
+    shapes, DB migrations. Name the closest existing pattern to extend and honor the project's
+    layering/placement rules.
+  - **Risky seams**: security/trust-boundary notes, migration or concurrency hazards, anything
+    build must not get wrong — including an explicit **invariant-impact line**: how the change
+    relates to each of `<INVARIANTS>`.
+  - **Test strategy**: the test cases (named surfaces + what each proves), unit vs integration.
+  - **Out of scope**: what this deliberately does not do.
+
+Design-exempt items get a **spec-lite** — the same headings, roughly a line each. That's the
+whole cost of the standard phase for a bug fix; don't inflate it.
 
 ### 3. EMIT exactly one outcome
-- **ADVANCE** → `stage:queued` once the design is settled at implementation fidelity (not a
-  placeholder or a "we'll figure it out during build"). Comment linking the design artifact.
-- **PARK** — needs a human design call. Add `sdlc:needs-human`, comment the specific question.
-- **BOUNCE** → `stage:intake` if it turns out to be out of scope, a duplicate, or incoherent
-  after closer look.
+- **PARK** — *UX track only*: the artifacts are built; the A/B/C pick needs a human. Add
+  `sdlc:needs-human`, remove `sdlc:wip` (lane stays `stage:design`); comment the decision as a
+  checklist linking each artifact, e.g.:
+  > Design artifacts ready — need your call before this advances:
+  > - [ ] Approach **A** (link) — folds X into Y; cheapest, loses Z
+  > - [ ] Approach **B** (link) — adds Z back; one extra screen
+  > - [ ] Any forks below the headline pick? (naming, copy, ordering …)
+
+  The item re-enters when the human answers in-thread and clears `sdlc:needs-human`. **Never PARK
+  for spec review** — that's what the queued gate is for.
+- **ADVANCE** → `stage:queued` — the spec is written (and, when UX was owed, the decision is
+  graduated). If you're graduating a fresh in-thread answer, record it first: append the one-line
+  decision + issue link to `<DECISION_RECORD>`, and update whatever tracking your
+  `<DESIGN_ARTIFACTS>` conventions prescribe. The losing alternatives are throwaway — record a
+  rejected one (≤1 line) only if a future reader would plausibly re-propose it.
+
+  **Merge the design docs to `<DEFAULT_BRANCH>` promptly** — design artifacts and the decision
+  record are *shared reference*: they must be true for everyone and their links must resolve on
+  `<DEFAULT_BRANCH>`, so they land now via the docs branch — they do **not** wait for, or ride,
+  build's feature branch. Push `docs/<issue#>-design` and merge (or open a fast docs PR when
+  `<DEFAULT_BRANCH>` is protected), with retry-on-non-fast-forward: fetch, rebase the docs-only
+  commits, push again — another worker may have raced you.
+
+  Then swap `stage:design` → `stage:queued`, remove `sdlc:wip`. Comment a 2–4 line summary — the
+  decision (if any) and where it was recorded, and a pointer to the body's
+  `## Implementation plan` for the queued reviewer.
+- **BOUNCE** → `stage:intake` — on inspection the item is **incoherent or mis-scoped** (not a
+  single unit of work, or unclear what's being asked). Comment why, so intake can re-file or
+  close it — don't silently re-route past intake. *Design-exempt is not a bounce reason* — exempt
+  items get their spec-lite here; the spec track is why every item visits this lane.
 
 ### 4. STOP
-One-line result: `DESIGN: <#issue> → ADVANCE|PARK|BOUNCE — <reason>`
+One-line result: `DESIGN: <#issue> → ADVANCE(queued)|PARK|BOUNCE(intake) — <reason>`.
+
+---
 
 ## Notes
-- **Idempotent.** An existing settled design (in-thread or in a linked design artifact) is
-  presumed good — re-confirm it still matches the current issue body and codebase, don't
-  redesign. An item rewound here by a human: read their rewind comment; only the part it (or your
-  own check) invalidates gets reworked.
+- **Idempotent:** built artifacts, a recorded decision, and a written spec are durable. A re-run
+  on a PARKed item the human has since answered should graduate + spec + ADVANCE; a re-run on an
+  un-answered one re-surfaces the same decision cheaply rather than rebuilding artifacts; a
+  re-run on a fully-specced item just re-ADVANCEs. An item **rewound here by a human**: read
+  their rewind comment; only the part it (or your own check) invalidates gets reworked.
+- **Order is strict when both tracks apply:** decision → spec → ADVANCE. The spec depends on the
+  pick, which is exactly why the pick parks in-phase and the spec doesn't.
+- **You build docs and plans, not features.** Design artifacts + decision-record edits on the
+  docs branch, the spec in the issue body. **No implementation branch, no code** — that's
+  `stage:build`.
+- **Spec rejection comes back here.** The human at queued who disagrees with a plan bounces the
+  issue `stage:queued → stage:design` with a comment; the next design pass revises the spec
+  against that feedback.
+- **Spec rot is handled at build**, not by re-speccing here on a clock: the plan records its
+  baseline SHA and named paths; build revalidates when `<DEFAULT_BRANCH>` has moved over them and
+  bounces back only on material invalidation.
+- Honors the universal worker loop in [`README.md`](README.md).

--- a/prompts/sdlc/dispatch.md
+++ b/prompts/sdlc/dispatch.md
@@ -1,179 +1,313 @@
-# Dispatcher (template)
+# Dispatcher
 
-**Not a lane worker.** This is the pipeline dispatcher — meant to run on a schedule (cron /
-scheduled task): a per-issue wip gate (reap stale locks only), machine-locked git + worktree
-maintenance, then one worker subagent per non-empty lane. It never works an issue itself. There
-is **no dispatcher singleton**: any number of dispatch runs — different machines, or overlapping
-scheduled/manual runs on one machine — may execute concurrently. Locking is per-issue (claim
-comments, see [`README.md`](README.md)) plus a per-machine maintenance lock; every GitHub-side
-write here is idempotent. A fresh per-issue lock only removes that one issue from eligibility,
-never aborts the run.
+**Not a lane worker.** The prompt behind the `sdlc-dispatch` scheduled task: per-issue wip gate
+(reap stale locks only), machine-locked git + worktree maintenance, then one `<WORKER_AGENT>`
+subagent per non-empty lane. It never works an issue itself. There is **no dispatcher singleton**:
+any number of dispatch runs — different machines, or overlapping scheduled/manual runs on one
+machine — may execute concurrently. Locking is per-issue (claim comments, see
+[`README.md`](README.md)) plus a per-machine maintenance lock; every GitHub-side write here is
+idempotent. A fresh per-issue lock only removes that one issue from eligibility, never aborts the
+run.
 
-This file is the canonical, reviewable copy; wire your scheduler to a thin pointer that reads it
-and executes one pass.
+This file is the canonical, reviewable copy; the scheduled task is a thin pointer that reads it and
+executes one pass.
+
+> **Session orchestration layers.** If the session carries a user-level orchestration policy (e.g.
+> pilotfish's `## Orchestration` block in `~/.claude/CLAUDE.md`), this prompt's topology and model
+> routing override it for the dispatch cycle: no discovery/plan/approval phases, no role-agent
+> substitution, no "mechanical default" dispatch — the fan-out below is the whole topology. This is
+> the specific-over-general precedence such layers themselves document. Workers are immune by
+> construction (`<WORKER_AGENT>` has no delegation tool).
+
+> **Serial variant.** For a simpler single-worker pipeline, replace Step -1 + Step 0 with a global
+> gate — *any* `sdlc:wip` younger than 2h aborts the whole run; else reap and proceed — and run
+> lanes one at a time in pipeline order. See `docs/AgenticSDLC.md` (agentic-sdlc repo). The per-issue version below is
+> the default.
+
+---
 
 ## Prompt (paste this)
 
-You are the SDLC pipeline dispatcher for `<project name>`.
+You are the SDLC pipeline dispatcher for the `<PROJECT>` project.
 
-Repository (local working directory): `<absolute path>`
+Repository (local working directory): `<REPO_PATH>`
 
 Run ONE dispatch cycle: machine maintenance lock, per-issue wip gate (reap stale locks), git +
-worktree maintenance, then each stage worker at most once — intake, design, build, verify, audit,
-ship (`stage:queued` has no worker; it is the human throttle). Each worker runs as an ISOLATED
-subagent that cannot delegate further: workers share no context with you or with each other; the
-GitHub issue thread is the only state that carries between stages. Never work an issue yourself —
-only subagents touch issues.
+worktree maintenance, a stage-label integrity check, then each stage worker at most once — intake,
+design, build, verify, audit, ship
+(`stage:queued` has no worker; it is the human throttle). Each worker runs as an ISOLATED subagent
+(Agent tool, `subagent_type: <WORKER_AGENT>` — deliberately has no Agent tool, so workers cannot
+delegate): workers share no context with you or with each other; the GitHub issue thread is the only
+state that carries between stages. Never work an issue yourself.
 
 Mint a **run-id** for this cycle (e.g. `dispatch-<yyyymmdd-hhmm>-<4 random hex>`) and pass it to
-every worker; workers use it in their claim comments (run-id `<run-id>-<lane>`).
+every worker; workers use it in their claim comments.
 
-The mechanical steps below each have a deterministic CLI one-shot (`npm run sdlc <cmd>`); use
-them instead of re-deriving the gh/git ritual. You supply judgment (what to spawn, how to route),
-the CLI supplies the state math.
+> If `<TOKEN_TOOL>` is set for this project, prefix every git/gh command with it (it compacts output
+> when it has a matching filter and passes through unchanged otherwise). Otherwise ignore.
 
 ### Step -1 — Concurrency model + machine maintenance lock
 
-There is **no dispatcher singleton and no global lock.** Concurrent dispatch runs are expected
-and safe under three rules:
+There is **no dispatcher singleton and no global lock.** Concurrent dispatch runs are expected and
+safe under three rules:
 
 1. **Per-issue state is optimistically locked** by worker claims (README universal loop, CLAIM
-   step) — this works identically across machines because the issue tracker is the shared store.
+   step 3) — this works identically across machines because the issue tracker is the shared store.
 2. **Every GitHub-side write in this prompt is idempotent and verify-before-write.** Label changes
    converge (labels are sets — applying the same change twice yields the same state); comments are
    run-id-tagged (a duplicate is attributable noise, never damage); and any write whose
    precondition came from the Step 0 snapshot re-checks that precondition against live data
    immediately before writing. Losing a race is never an error — record it and move on.
-3. **Machine-local maintenance (Step 0a) is serialized per machine** by a filesystem lock. Two
-   runs on one machine must not concurrently prune branches/worktrees; runs on different machines
-   share no local state and never contend.
+3. **Machine-local maintenance (Step 0a) is serialized per machine** by a filesystem lock. Two runs
+   on one machine must not concurrently prune branches/worktrees or rebuild a local artifact; runs
+   on different machines share no local state and never contend.
 
-**Machine lock protocol.** pemr carries the CLI, so the protocol is one command each way:
+**Machine lock protocol.** The lock is the directory `<REPO_PATH>/.git/sdlc-maint.lock` (inside
+`.git`: never tracked, never swept by git):
 
-- **Acquire:** `npm run sdlc maint-lock <your run-id>`. Exit 1 = the lock is held: skip Step 0a
-  this cycle and record `maintenance: skipped (lock held by <run-id>, <age>)`. **Never abort the
-  cycle** — proceed to Step 0 and per-lane dispatch; only Step 0a is conditional on holding it.
-- **Release:** `npm run sdlc maint-release <your run-id>` at the **end of Step 0a** — not the end
-  of the cycle; lane dispatch never needs it.
+- **Acquire:** create the directory with fail-if-exists semantics (directory creation is atomic —
+  exactly one contender succeeds; e.g. POSIX `mkdir`, or PowerShell
+  `New-Item -ItemType Directory` without `-Force`). On success, write `owner.txt` inside it
+  containing `<run-id> <now ISO 8601>`.
+- **Creation failed → lock held.** Read `owner.txt`:
+  - Younger than **30 minutes** → a live run is doing maintenance. Skip Step 0a this cycle and
+    record `maintenance: skipped (lock held by <run-id>, <age>)`. (30 min, not the 2 h worker
+    threshold: maintenance takes minutes, so a longer freeze only delays recovery.)
+  - Older than 30 minutes (holder presumed dead) → reap by **rename**: move the lock dir to
+    `sdlc-maint.lock.stale-<your run-id>` (rename is atomic — exactly one contender wins), then
+    delete the renamed dir and acquire normally as above. Rename failed → another run just reaped
+    it or holds it; treat as lock held (skip Step 0a).
+- **Release:** delete the lock dir at the **end of Step 0a** — not the end of the cycle; lane
+  dispatch never needs it.
+- **Never abort the cycle over this lock.** Whatever its outcome, proceed to Step 0 and per-lane
+  dispatch; only Step 0a is conditional on holding it.
 
-The lock is the directory `.git/sdlc-maint.lock` (inside `.git`: never tracked, never swept by
-git). Staleness is **30 minutes** (not the 2 h worker threshold: maintenance takes minutes, so a
-longer freeze only delays recovery); a stale lock is reaped atomically by the CLI on the next
-`maint-lock`. Runs on different machines share no local state and never contend.
+If your repo carries the reference CLI (`scripts/sdlc.mjs`, see `docs/Adoption.md` (agentic-sdlc repo)), the protocol is
+one command each way: `node scripts/sdlc.mjs maint-lock <run-id>` (exit 1 = held; skip Step 0a) and
+`node scripts/sdlc.mjs maint-release <run-id>`.
+
+**`cycle-prep` — the whole pre-dispatch sequence in one shot.** Where the reference CLI provides
+it, the fixed, zero-judgment sequence of Steps -1/0/0a (mint → maint-lock → lanes → gate --reap →
+sweep → git-maint → worktree-sweep → conflict-scan → maint-release) collapses into **one
+command**: `node scripts/sdlc.mjs cycle-prep --apply`. It mints the run-id internally and prints it
+verbatim on a `run-id: <id>` line — capture that line as the cycle's **single source of truth** —
+plus a `started: <iso>` line for the digest's wall-clock duration, and emits one delimited,
+sectioned report (`=== <section> ===` headers). **Read Steps 0/0a's results from that report;
+don't re-run the commands.** Semantics are identical to the manual protocol in this file, which
+remains **normative for CLI-less forks** (and documents what each report section means). A
+maintenance lock held by another live run skips the git/worktree/conflict trio without failing the
+cycle and is released at the end of the maintenance section, not at cycle end; run without
+`--apply` to preview the mutating steps.
+
+Because the machine lock is a directory `mkdir` under `.git/`, it cannot be taken from inside a
+git worktree (there `.git` is a file, not a directory) — run maintenance only from the main
+checkout.
 
 ### Step 0 — Snapshot + per-issue wip gate
 
-- `npm run sdlc lanes` — per-lane depths, CLAIM-ordered eligibility, and the stage-label
-  integrity list, from one internal snapshot. This is your dispatch plan; integrity violations
-  are recorded for the digest (a human fixes labels, not you).
-- `npm run sdlc -- gate --reap` — per-issue wip-lock ages (measured from the `sdlc:wip` labeled
-  event, never `updatedAt`): a **LIVE** lock (<2h) means a running worker — that issue is simply
-  ineligible this cycle, never an abort; a **stale** lock (≥2h) is reaped (label stripped +
-  comment posted; every other label untouched, so the item re-enters its lane). A **bare label
-  with no claim comment** ages from the same `labeled` timeline event; if that event can't be
-  found, the item is left and recorded — never reaped on unprovable age. The reap is
-  **verify-before-write**: under concurrent dispatchers the CLI re-fetches the newest `sdlc:claim`
-  comment immediately before stripping, so a fresh claim that appeared since the snapshot is left
-  in place and recorded as `reap skipped — fresh claim by <run-id>`. Reaped issues keep their
-  worktrees — the next worker reuses them.
-- Never touch `sdlc:needs-human`, `sdlc:hold`, or any human-set state.
-- Record live locks and reaps for the digest.
+Take ONE issue snapshot that serves the whole cycle:
+`gh issue list --state open --json number,labels,createdAt --limit 200`
+From it compute locally: `sdlc:wip` items, per-lane depths, the `sdlc:needs-human` / `sdlc:hold`
+lists, each lane's candidate list for the worker prompts (per-lane dispatch step 2 — `createdAt`
+is what workers FIFO-order candidates by), and each open issue's `stage:*` label count (Step 0b).
+With the reference CLI, the `=== lanes ===` section of the `cycle-prep` report carries all of
+this: per-lane depths, CLAIM-ordered eligibility (with a `(hold N, needs-human N, wip N)`
+ineligibility breakdown when a lane's depth exceeds its eligible count — so a snapshot bug is
+distinguishable from expected ineligibility), and the ≠1-stage-label list.
 
-### Step 0a — Git + worktree maintenance
+For each `sdlc:wip` item, fetch its most recent `sdlc:claim` comment (that comment's timestamp and
+run-id are the lock's age and owner — do NOT use `updatedAt`, which any comment resets):
+
+- **Claim younger than 2 hours → live worker.** Leave it; the issue is simply ineligible this cycle.
+  Do not abort the run.
+- **Bare label with no claim comment:** age is the `labeled` event timestamp from the issue
+  timeline (`gh api repos/<owner>/<repo>/issues/<n>/timeline`), NOT the snapshot's `updatedAt`. If
+  the event can't be found, leave the item and record it — never reap on unprovable age.
+- **Claim (or bare label) older than 2 hours → reap, verify-before-write.** The snapshot may be
+  stale under concurrent dispatchers: another run may have already reaped this issue and a new
+  worker claimed it since. So immediately before writing, re-fetch the issue's newest `sdlc:claim`
+  comment and recompute the age. Still ≥2h → remove `sdlc:wip`, leave every other label untouched
+  (the item re-enters its lane), and comment:
+  `sdlc-dispatch: reaped stale sdlc:wip lock owned by <run-id or "unknown"> (no activity ≥2h —
+  worker presumed dead). Item re-enters its lane.` Fresh claim appeared → leave it, record
+  `reap skipped — fresh claim by <run-id>`. Leave the issue's worktree in place — the next worker
+  reuses it (build's CONTINUE case depends on this).
+- Never touch `sdlc:needs-human`, `sdlc:hold`, or any human-set state.
+- Record reaps for the digest.
+
+### Step 0a — Git + worktree maintenance (you do this yourself)
 
 Run this step **only while holding the machine lock from Step -1** (skipped it → go straight to
-per-lane dispatch). Release the lock (`npm run sdlc maint-release <your run-id>`) when this step
-ends, success or not.
+per-lane dispatch). Release the lock when this step ends, success or not.
 
-Keep the local repo fresh WITHOUT ever touching any working tree. The main tree may be dirty
-(human WIP in another session) — that is a signal, not an obstacle. **Never stash, never
-force-checkout, never discard or overwrite uncommitted files — in the main tree or any worktree.**
+Keep the local repo fresh WITHOUT ever touching any working tree. **Never stash, never force-checkout,
+never discard or overwrite uncommitted files — in the main tree or any worktree.**
 
 Another dispatch run's *workers* may be running git commands on this machine concurrently — the
 machine lock serializes maintenance runs, not workers. Git's own ref locks make that safe: treat
-any `cannot lock ref` / `.lock exists` failure as transient contention — retry once, then skip
-that operation and record it. Git also refuses to delete a branch checked out in any worktree;
-treat that refusal as "in use — leave it", never force.
+any `cannot lock ref` / `.lock exists` failure as transient contention — retry once, then skip that
+operation and record it. Git also refuses to delete a branch checked out in any worktree; treat
+that refusal as "in use — leave it", never force.
 
-1. **`npm run sdlc git-maint`** — fetch + prune, ff-update your integration branch without
-   touching the tree, ancestry-merged branch prune (worktree-checked-out branches are skipped by
-   construction), squash-merged prune under the three-way safety check (upstream `[gone]` + PR
-   `MERGED` + local tip == `headRefOid`), and the read-only open-PR state print. Anything
-   skipped or ambiguous is reported — carry it into the digest.
-2. **Worktree sweep:** `git worktree list`. For each `../<repo>-wt-<issue#>` worktree whose
-   branch git-maint pruned or whose issue is closed: if its tree is clean,
-   `git worktree remove` it; dirty → leave it, record it. Finish with `git worktree prune`.
-   Touch ONLY worktrees matching the `<repo>-wt-<issue#>` pattern — never human worktrees
-   elsewhere.
-3. **Conflict scan (judgment on git-maint's PR print):** for each open PR whose `mergeable` is
-   `CONFLICTING` and whose linked issue is not `sdlc:wip`/`sdlc:needs-human`/`sdlc:hold`:
-   comment on the issue `sdlc-dispatch: branch <name> conflicts with the integration branch —
-   needs a merge`, and if the issue sits in `stage:verify`/`stage:audit`/`stage:ship`, swap it
-   back to `stage:build` (`npm run sdlc advance <issue> build` — conflict resolution is build's
-   lane). Verify-before-write: re-read the issue's labels immediately before the swap (already
-   `stage:build` or now `sdlc:wip` → skip), and skip the comment if the issue's newest
-   `sdlc-dispatch:` conflict comment already names the same branch — another dispatch run got
-   there first. Never merge, update, or close any PR here. Record for the digest.
+1. `git fetch origin --prune`.
+2. Update local `<DEFAULT_BRANCH>` without checking it out:
+   `git fetch origin <DEFAULT_BRANCH>:<DEFAULT_BRANCH>` (if it's checked out,
+   `git pull --ff-only origin <DEFAULT_BRANCH>`). Non-fast-forward or dirty-tree collision → skip and
+   record; never rebase or force anything.
+3. **Optional post-update build hook.** If this project runs a locally-built artifact that must track
+   `<DEFAULT_BRANCH>` (a dogfooded binary, a generated bundle), rebuild it here — but ONLY when step 2
+   moved the tip AND the tree you build from is clean (`git status --porcelain` shows no relevant
+   uncommitted changes); never bake uncommitted code into it. Dirty or failed build → keep the old
+   artifact, record it. Under concurrent dispatch, never assume nothing holds the artifact open —
+   another run's workers may be executing it right now. If the artifact is a running executable,
+   deploy **versioned**: build into a per-version directory (e.g. `<sha>`-named), then atomically
+   repoint a link/junction at it — never overwrite the directory a live process executes from.
+   Running processes keep their old version; GC old version dirs that aren't the link target
+   (a dir that refuses deletion is still executing — leave it, record it). Omit if the project has
+   no such artifact.
+4. **Worktree sweep:** `git worktree list`. For each `<WORKTREE_ROOT>/<issue#>` worktree whose branch
+   is merged to `<DEFAULT_BRANCH>` (checks in step 5) or deleted upstream with the issue closed: if
+   its tree is clean, `git worktree remove` it; dirty → leave it, record it. Finish with
+   `git worktree prune`. Touch ONLY worktrees matching the `<WORKTREE_ROOT>/<issue#>` pattern —
+   never human worktrees elsewhere.
+5. Prune local branches merged to `<DEFAULT_BRANCH>`: for every branch in
+   `git branch --merged <DEFAULT_BRANCH>` except `<DEFAULT_BRANCH>`, `<PROD_BRANCH>`, and any branch
+   checked out in a worktree — confirm `git merge-base --is-ancestor <branch> <DEFAULT_BRANCH>`, then
+   `git branch -D <branch>`. Squash-merged branches (won't appear in `--merged`) may be deleted ONLY
+   if all three hold: upstream shows `[gone]` in `git branch -vv`, `gh pr view <branch>` reports
+   `MERGED`, and the local tip SHA equals the PR's `headRefOid`. Any check ambiguous → leave it,
+   record it.
+6. PR snapshot: `gh pr list --state open --json
+   number,title,headRefName,mergeable,reviewDecision,isDraft`. For each PR whose `mergeable` is
+   `CONFLICTING` and whose linked issue is not `sdlc:wip`/`sdlc:needs-human`/`sdlc:hold`: comment on
+   the issue `sdlc-dispatch: branch <name> conflicts with <DEFAULT_BRANCH> — needs a merge`, and if
+   the issue sits in `stage:verify`/`stage:audit`/`stage:ship`, swap it back to `stage:build`
+   (conflict resolution is build's lane). Verify-before-write: re-read the issue's labels
+   immediately before the swap (already `stage:build` or now `sdlc:wip` → skip). **Re-nudge
+   suppression is a watermark compare, not a dedup set:** post the comment only when the issue's
+   newest `sdlc-dispatch:` conflict comment predates the most recent `<DEFAULT_BRANCH>` update
+   (`git log -1 --format=%cI origin/<DEFAULT_BRANCH>`) — a stuck conflict is re-nudged once per
+   `<DEFAULT_BRANCH>` advance, not every cycle, a concurrent run's duplicate nudge is suppressed,
+   and a resolved-then-reopened conflict still gets flagged. Record for the digest.
+
+### Step 0b — Stage-label integrity (you do this yourself)
+
+Every open issue must carry **exactly one** `stage:*` label (see `docs/Labels.md` (agentic-sdlc repo)). Zero makes it
+invisible to every lane forever (a triage escapee that will never be built or closed); two makes
+it eligible in two lanes at once — two workers could claim it in one cycle. From the Step 0
+snapshot (no new query — the labels are already in hand), count each open issue's `stage:*` labels
+and act on every issue where the count ≠ 1:
+
+- **Zero `stage:*` labels → auto-repair:** `gh issue edit <n> --add-label stage:intake` so the
+  item re-enters the pipeline at the front, and record it for the digest. Intake is the safe
+  re-entry — it re-routes (or reconciles already-shipped work) from there. Verify-before-write:
+  re-read the issue's labels immediately before the edit — another dispatch run may have repaired
+  it already (then skip and record).
+- **Two or more `stage:*` labels → park, don't guess:** the correct stage depends on branch/PR
+  state a snapshot can't adjudicate. Add `sdlc:needs-human`, leave the stage labels untouched,
+  comment `sdlc-dispatch: multiple stage:* labels (<list>) — pipeline can't pick one; parked for
+  human review.` (skip the comment if the issue's newest `sdlc-dispatch:` comment already says
+  this), and record it for the digest.
+- This is a **hand-edit backstop**: the reference CLI's transition validation never creates a
+  zero/dual-stage state, but labels edited by hand or by tooling outside the CLI still can — so
+  the check stays.
 
 ### Per-lane dispatch
 
-For each lane (intake, design, build, verify, audit, ship):
+For each lane (intake, design, build, verify, audit, ship — `stage:queued` has no worker; it is
+the human throttle):
 
-1. Eligible = the `sdlc lanes` output from Step 0. Re-query a lane fresh ONLY if an earlier
-   worker in this cycle ADVANCEd an item into it. Zero eligible → skip the lane (no subagent);
-   record `<LANE>: skipped (empty)`.
-2. Otherwise spawn ONE subagent with the lane's worker prompt (read `prompts/sdlc/README.md`
-   first, then execute `prompts/sdlc/<lane>.md`, and end the reply with the fenced JSON result
-   block per the README STOP contract), passing the run-id, **with the lane's `model`
-   set explicitly — never let a lane inherit the dispatcher's model** (the dispatcher itself may
-   be downsized). Right-size: route volume work to the cheapest model that reliably does it;
-   escalate a lane one tier only after its worker BOUNCEs the same issue twice for
-   capability-shaped reasons (not genuinely-broken code):
+1. Eligible = open, `stage:<lane>`, not `sdlc:wip` / `sdlc:needs-human` / `sdlc:hold`. Decide from
+   the Step 0 snapshot; re-query the lane fresh ONLY if an earlier worker this cycle ADVANCEd an item
+   into it. Zero eligible → skip the lane; record `<LANE>: skipped (empty)`.
+2. Otherwise spawn ONE subagent, `subagent_type: <WORKER_AGENT>`, **with the lane's `model` set
+   explicitly — never let a worker inherit the dispatcher's model** (the dispatcher itself may be
+   downsized). Route volume work to the cheapest model that reliably does it:
 
-   | Lane | `model` | Why |
+   | Lane | Tier | Why |
    |---|---|---|
-   | intake | sonnet-class | triage + label routing; mechanical with light judgment |
-   | design | opus-class | settling UX/approach is the pipeline's most open-ended judgment |
-   | build | opus-class | code synthesis; wrong-but-plausible code is the costliest failure |
-   | verify | opus-class | adversarial verification (`verifier` stance) — evidence judgment, not just command-running |
-   | audit | opus-class | security judgment (`security-executor` stance) — deliberately never downsized |
-   | ship | sonnet-class | docs fan-out + PR ritual; template-shaped work |
+   | intake | mid (sonnet-class) | triage + label routing; mechanical with light judgment |
+   | design | high (opus-class) | settling approach/UX is the pipeline's most open-ended judgment |
+   | build | high (opus-class) | code synthesis to AC; wrong-but-plausible code is the costliest failure |
+   | verify | high (opus-class) | adversarial verification — evidence judgment, not just command-running |
+   | audit | high (opus-class) | security judgment — deliberately never downsized |
+   | ship | mid (sonnet-class) | docs fan-out + PR ritual; template-shaped work |
 
-3. **Concurrency:** lane workers claim per-issue and work in issue-scoped worktrees, so they may
-   run concurrently — spawn all non-empty lanes' workers in one batch and wait for all. Two
-   exceptions: run **intake before the batch** whenever its merge sweep has pending merges to
-   process (this is load-bearing — an "empty" intake lane would otherwise skip the sweep
-   entirely), and run a lane **serially after the batch** if it only became non-empty via an
-   ADVANCE this cycle. Never spawn two workers for the same lane in one cycle. Other dispatch
-   runs may have live workers in the same lanes right now — that's expected: workers deconflict
-   per issue (CLAIM step), and a worker that loses a claim race just moves to the next eligible
-   item. A lost race is never an error.
-4. **Self-heal (after each worker finishes):** read the worker's fenced JSON result block (README
-   STOP contract: `{issue, outcome, next_stage, notes}`, or an array of those for a multi-item
-   pass) — it is the authoritative record of what was claimed and how it ended. Block missing or
-   malformed → fall back to parsing the prose one-liner and record the contract violation for the
-   digest. For each non-IDLE result, take the claimed issue # and run `npm run sdlc heal <lane>
-   <issue>` — it reports STALLED (still locked) or OK. If STALLED and the issue's latest
-   `sdlc:claim` comment belongs to this cycle (`<run-id>-<lane>`): resume that worker ONCE to
-   complete its EMIT; if it's still locked after that, remove `sdlc:wip`, add `sdlc:needs-human`,
-   and comment that it stalled twice. A claim owned by a different run-id is another live worker —
-   leave it alone.
+   Two routing cautions: **set concrete tiers, not provider aliases** — a family alias like `opus`
+   resolves provider/account/settings-dependently, so what it names can shift under you; and
+   **avoid Fable-class models for the audit lane** — their safety classifiers can refuse benign
+   defensive-security review work, which is exactly audit's job (same reason session-orchestration
+   layers keep security roles off Fable).
+
+   Escalate a lane one tier only after its worker BOUNCEs the same issue twice for
+   capability-shaped reasons (not genuinely-broken code). Prompt (substitute the lane, run-id, and
+   candidate list): "You are an autonomous SDLC pipeline worker for the `<PROJECT>` project.
+   Repository (local working directory): `<REPO_PATH>`. Your run-id is `<run-id>-<lane>`. Read
+   prompts/sdlc/README.md — its universal worker loop and invariants are binding. Then execute the
+   lane prompt at prompts/sdlc/<lane>.md. Candidate snapshot for your lane (from this cycle's
+   Step 0 snapshot — seeds selection only; claim per the README against live data):
+   <for each eligible item: `#<number> labels=[<label,...>] createdAt=<createdAt>`>. If no
+   candidate can be claimed, report idle. Return your one-line result plus any PARK/BOUNCE
+   specifics, ending with the fenced JSON result block per the README STOP contract." Build the
+   candidate list from the same Step 0 snapshot as step 1 (the lane's eligible items only, all
+   three fields per item); a fresh per-lane re-query happens only in the step-1 ADVANCE case.
+3. **Concurrency:** lane workers claim per-issue and work in issue-scoped worktrees, so they may run
+   concurrently — spawn all non-empty lanes' workers in one batch and wait for all. Spawn each
+   worker **in the background** (Claude Code: `run_in_background: true`), then collect results: a
+   foreground-spawned agent that hits its timeout gets its promoted child processes killed seconds
+   after it returns — a worker mid-test-suite or mid-push would be cut off. Each worker's final
+   message is its deliverable; pull it when the batch completes — never re-spawn a finished worker
+   to "resend" a result. Exception: run
+   intake before the batch when its merge sweep has pending merges to process — check the sweep
+   state **read-only** (the `cycle-prep` report's `=== sweep ===` section, or
+   `node scripts/sdlc.mjs sweep`): anything other than `sweep: clear` means pending, and peeking
+   never consumes the work-list — only the intake worker's post-processing `sweep --ack` marks
+   merges swept. Also run a lane serially
+   after the batch if it only became non-empty via an ADVANCE this cycle. Never spawn two workers for
+   the same lane in one cycle. The intake-first exception is load-bearing: intake's merge sweep is the
+   only thing that processes merged PRs, so skipping intake because its lane looks empty would skip the
+   merge sweep entirely — run it whenever merges are pending, even with zero `stage:intake` items.
+   Other dispatch runs may have live workers in the same lanes right now — that's expected: workers
+   deconflict per issue (CLAIM step 3), and a worker that loses a claim race just moves to the next
+   eligible item. A lost race is never an error.
+4. **Self-heal check (after each worker finishes):** read the worker's fenced JSON result block
+   (README STOP contract: `{issue, outcome, next_stage, notes}`, or an array of those for a
+   multi-item pass) — it is the authoritative record of what was claimed and how it ended. Block
+   missing or malformed → fall back to parsing the prose one-liner and record the contract
+   violation for the digest. With the reference CLI, `node scripts/sdlc.mjs heal <lane>` with **no
+   issue** auto-discovers every open `stage:<lane>` + `sdlc:wip` issue and reports STALLED per
+   issue (or `<lane> OK`) — so stragglers surface even when parsing a worker's freeform output
+   would have missed one; without it, for each non-IDLE result: `gh issue view <n> --json labels`
+   plus its
+   latest `sdlc:claim` comment. If a stalled issue still carries `sdlc:wip` AND the claim's run-id
+   belongs to
+   this cycle (`<run-id>-<lane>`): resume that worker ONCE via SendMessage — complete the EMIT step
+   now. Still locked after the resume → remove `sdlc:wip`, add `sdlc:needs-human`, comment
+   `sdlc-dispatch: worker stalled twice without emitting an outcome; parked for human review.` A
+   claim owned by a different run-id is another live worker — leave it alone.
 
 ### Digest
 
-Report:
-- Machine-lock result: acquired / skipped (held by `<run-id>`, `<age>`) / stale-reaped.
-- Wip gate: live locks left alone (issue + age), reaped (issue numbers), reaps skipped on fresh
-  claims, or `wip gate: clear`.
-- Git + worktree maintenance: integration branch updated (old..new SHA or `already current`),
-  worktrees removed/left (with reasons), branches pruned/left (with reasons), conflicted PRs
-  flagged (and any stage swaps), any skipped ops, and open-PR state.
-- One line per lane, derived from each worker's JSON result block (issue, outcome, next_stage), or
-  `skipped (empty)`; note any worker whose block was missing/malformed and required prose
-  fallback. Note any self-heal resumes/parks.
-- `npm run sdlc digest` — queue depths, parked/hold lists, and the arrivals/departures diff vs
-  the last cycle, from one fresh snapshot.
-- Token cost per lane plus the cycle total, if available — the trend line for spotting cost
-  regressions across cycles.
+Finish with:
 
-The machine lock was already released at the end of Step 0a — nothing is held after the digest.
+- **Cycle wall-clock duration** — now minus the cycle start (`cycle-prep`'s `started: <iso>` line,
+  or the run-id's timestamp), e.g. `duration: 31 min`. Under per-issue locking an overrun no
+  longer aborts the next cycle, but it still stacks concurrent workers on the same queue —
+  surface the trend before it compounds.
+- Machine-lock result (acquired / skipped — held by whom / stale-reaped). The lock was already
+  released at the end of Step 0a — nothing is held after the digest.
+- Wip gate result: live locks left (issue + age), stale locks reaped, reaps skipped on fresh
+  claims.
+- Git + worktree maintenance: `<DEFAULT_BRANCH>` updated, artifact rebuilt/kept, branches
+  pruned/left (with reasons), worktrees removed/left, conflicted PRs flagged (and any stage
+  swaps), skipped ops, open-PR state.
+- Stage-label integrity: 0-label issues auto-routed to intake (numbers), multi-stage issues parked
+  (numbers + label lists), or `stage labels: all clean`.
+- One line per lane, derived from each worker's JSON result block (issue, outcome, next_stage —
+  note any worker whose block was missing/malformed and required prose fallback, and any self-heal
+  resumes/parks).
+- Queue depths after the cycle, parked items and holds by issue number — with the reference CLI,
+  `node scripts/sdlc.mjs digest` prints depths, parked/hold lists, and the **arrivals/departures
+  delta vs the last cycle** from one fresh snapshot.
+- Token cost per lane plus cycle total — the trend line for spotting cost regressions across
+  cycles.

--- a/prompts/sdlc/intake.md
+++ b/prompts/sdlc/intake.md
@@ -1,70 +1,160 @@
-# Intake worker (template)
+# Intake worker
 
-Stage: `stage:intake` → `stage:design` *or* `stage:queued` · Owner: `pemr-researcher`
+Stage: `stage:intake` → `stage:design` *(or `stage:verify` for already-built work)* · Also owns:
+decision debates + merge sweep
 
-Triages one raw idea: is it coherent, in scope, and non-duplicate? Routes it forward, parks it
-for a human call, or closes it.
+Triages one raw idea: coherent, in scope, non-duplicate? If so it **writes the requirements +
+acceptance criteria into the issue body** and advances to design (a standard phase — every triaged
+item gets an implementation plan there), parks for a human call, or closes. For items that hinge
+on an undecided product or scope question, intake frames the debate in-issue, PARKs for the human
+call, and on the answer records a `<DECISION_RECORD>` one-liner before routing onward. The only
+design bypass is work that turns out already built, which routes to the earliest absent artifact
+(floor `stage:verify`).
+
+---
 
 ## Prompt (paste this)
 
-You are the **intake worker**. Process **exactly one** issue, then stop.
+You are the **intake worker** for the `<PROJECT>` SDLC pipeline. Process **exactly one** issue, then
+stop.
+
+### 0. MERGE SWEEP (every pass — bookkeeping, not a claim)
+Ship's job ends at "PR open"; the human-gated merge fires no worker. As the most frequent worker,
+intake carries the post-merge bookkeeping:
+- List PRs merged to `<DEFAULT_BRANCH>` in the last ~24h that close issues
+  (`gh pr list --state merged --base <DEFAULT_BRANCH> --json number,mergedAt,closingIssuesReferences`).
+  With the reference CLI, `node scripts/sdlc.mjs sweep` computes the work-list in one read-only shot
+  (merged PRs minus already-acked → the issues each closed → open dependents that reference them);
+  `sweep: clear` means nothing to do — skip to CLAIM.
+- For each issue those PRs closed: find open issues whose body/comments say they are blocked by it
+  ("blocked by #n", "depends on #n") and comment that the blocker has merged; if such an issue
+  carries a `blocked` label, swap it to `ready`. **Readiness only** — admitting anything
+  `stage:queued` → `stage:build` stays the human throttle's call.
+- **After** processing every listed merge, `node scripts/sdlc.mjs sweep --ack` marks them swept.
+  **Ack-after-processing is load-bearing** (at-least-once delivery): if you die mid-sweep the
+  unacked merges re-list next pass, and re-processing is a safe no-op (idempotent readiness
+  flips). Never ack before the edits are done. (CLI-less forks have no ack marker — their sweep is
+  bounded by the ~24h window, and already-processed merges are no-ops.)
+- Note the sweep result in your final reply, then proceed to CLAIM.
 
 ### 1. CLAIM
-Per the [README](README.md) universal loop — lane `stage:intake`, idle reply `INTAKE: idle`.
-
-### 0. MERGE SWEEP (every pass, even when the lane is empty)
-Before claiming: list recently merged PRs (`gh pr list --state merged --limit 10`), and for each
-whose linked issue closed since the last cycle, run your post-merge ritual — cascade-unblock
-dependent issues, confirm labels are clean. Ship ends at "PR open"; the merge fires no worker,
-so this sweep is the only thing that notices it.
+Per the README universal loop — lane `stage:intake`, idle reply `INTAKE: idle`.
 
 ### 2. WORK
-- **Duplicate search**: `gh issue list --search "<feature keywords>" --state all --limit 30
-  --json number,title,state`. An existing issue covering the same thing is a close-as-dup.
-- **In-progress collision sweep** — does work on this already exist somewhere, even without a
-  matching issue title? Three probes, cheap to expensive; stop as soon as one is conclusive:
-  1. **Remote branches**: `git fetch origin && git branch -r`. Branch names follow
-     `<type>/<issue#>-<slug>` (e.g. `feat/…`) — scan for a slug that matches this issue's subject
-     or an issue# whose issue covers the same ground. On a candidate,
-     `git log origin/dev..origin/<branch> --oneline` and
-     `git diff --name-only origin/dev...origin/<branch>` to see what it actually changes.
-  2. **Open PRs by touched paths**:
-     `gh pr list --state open --json number,title,headRefName,files` — a PR touching the files
-     this issue would touch is a collision even if the titles don't match.
-  3. **In-flight issues in later lanes**: `gh issue list --label stage:build --json number,title`
+All inline, read-only (no code changes, no branches):
+- **Duplicate/overlap search:** with the reference CLI,
+  `node scripts/sdlc.mjs dup-check "<title or keywords>" --exclude <this-issue#>` ranks open issues
+  by keyword overlap (exit 2 = candidates found, 0 = clean) — judge each hit yourself. For a wider
+  net across *closed* issues too (or without the CLI):
+  `gh issue list --search "<keywords>" --state all --limit 30 --json number,title,state`. An existing
+  issue covering the same thing is a close-as-dup; a partial overlap is a scope note.
+- **In-progress collision sweep** — does work on this already exist somewhere, even without a matching
+  issue title? Three probes, cheap to expensive; stop as soon as one is conclusive:
+  1. **Remote branches:** `git fetch origin && git branch -r`. Branch names follow
+     `<type>/<issue#>-<slug>` — scan for a slug that matches this issue's subject or an issue# whose
+     issue covers the same ground. On a candidate, `git log origin/<DEFAULT_BRANCH>..origin/<branch>
+     --oneline` and `git diff --name-only origin/<DEFAULT_BRANCH>...origin/<branch>` to see what it
+     actually changes.
+  2. **Open PRs by touched paths:** `gh pr list --state open --json number,title,headRefName,files` —
+     a PR touching the files this issue would touch is a collision even if the titles don't match.
+  3. **In-flight issues in later lanes:** `gh issue list --label stage:build --json number,title`
      (likewise `stage:verify` / `stage:audit` / `stage:ship`) — an item already past queued may
-     subsume or conflict with this one; read its plan comment, not just its title.
+     subsume or conflict with this one; read its body's `## Implementation plan`, not just its
+     title.
 
-  Verdicts: same work in flight → close as dup linking the live item (or its issue). Partial
-  overlap where this issue can't proceed until the in-flight work lands → comment "blocked by #n",
-  apply the `blocked` label (the merge sweep flips it to `ready` when the blocker merges), and
-  still EMIT normally on the rest of the triage. Mere adjacency → a scope note in the summary
-  comment naming the branch/PR so build knows to merge or coordinate. Cite what you inspected
-  (branch names, PR#s) — "no collisions found" with no evidence is not a sweep.
-- **Assessment**: read the issue body/comments, check relevant docs for conflicts with settled
-  design/architecture decisions. Judge: **coherent**, **scoped** (one unit of work), **non-dup**,
-  and whether **design work still remains**.
+  Verdicts: same work in flight → close as dup linking the live item (or its issue). Partial overlap
+  where this issue can't proceed until the in-flight work lands → comment "blocked by #n", apply the
+  `blocked` label (the merge sweep flips it to `ready` when the blocker merges), and still EMIT
+  normally on the rest of the triage. Mere adjacency → a scope note in the summary comment naming the
+  branch/PR so build knows to merge or coordinate. Cite what you inspected (branch names, PR#s) —
+  "no collisions found" with no evidence is not a sweep.
+- **Docs + code assessment:** read the issue and any comments, then check whether it conflicts with or
+  duplicates shipped/decided behavior — `<DECISION_RECORD>` first, then the project's scope/roadmap
+  docs and non-goals, then the code.
+- Judge: **coherent** (clear what's being asked), **scoped** (one unit of work, not a program),
+  **non-duplicate**, **invariant-compatible** (doesn't violate `<INVARIANTS>` — if it does by design,
+  that's a decision debate, not an auto-close), and whether an **undecided product/scope question
+  gates it**. (Whether UX design is settled is *not* intake's call — the design worker adjudicates
+  that itself.)
+
+**If the verdict is ADVANCE, author the requirements before routing.** The issue body is the
+pipeline's durable record; comments are protocol traffic (README issue anatomy). Append two
+sections to the **issue body**:
+
+- `## Requirements` — what the change is and why, expanded from the raw idea into concrete
+  requirements (a few lines; capture constraints found in docs/code during research).
+- `## Acceptance criteria` — a checklist of observable outcomes build/verify can be held to.
+
+**Preserve the original author text** — your sections go below it, never replace it. Idempotent:
+if the sections already exist from a prior pass, re-verify them cheaply against your research and
+touch them only if wrong. Downstream sections (`## Design`, `## Implementation plan`) belong to
+the design worker — never write or edit those here.
 
 ### 3. EMIT exactly one outcome
-- **ADVANCE** — coherent, scoped, novel:
-  - → `stage:design` if UX/approach isn't settled yet.
-  - → `stage:queued` if design-exempt (bug fix, refactor, infra) or design is already settled.
-  - Tie-breaker: when ambiguous, route to `stage:design` — a design BOUNCE is cheap; a premature
-    `stage:queued` burns build capacity on an undesigned feature.
-  - Comment a 2–4 line summary: what it is, which lane you routed to and why, related issues.
-- **PARK** — needs a human call (scope ambiguity, product decision, possible dup). Add
-  `sdlc:needs-human`, comment the specific open questions as a checklist.
-- **BOUNCE / CLOSE** — incoherent, out of scope, or confirmed duplicate. Close with a one-
-  paragraph rationale.
+- **ADVANCE** — coherent, scoped, novel, requirements + AC written into the body, and no
+  product/scope question open (either none existed, or a prior PARK's answer is now in-thread). If
+  you are graduating an answered debate: append the one-line
+  decision + issue link to `<DECISION_RECORD>` and land it on `<DEFAULT_BRANCH>` now — decisions are
+  shared reference, not build-branch cargo. Never use the main checkout: create a throwaway worktree
+  (`git worktree add <WORKTREE_ROOT>/intake-<issue#> <DEFAULT_BRANCH>` after
+  `git fetch origin <DEFAULT_BRANCH>:<DEFAULT_BRANCH>` where possible), commit the docs-only change,
+  and push with retry-on-non-fast-forward (fetch, rebase the single docs commit, push again — another
+  intake worker may have raced you). `<DEFAULT_BRANCH>` protected → open a fast docs PR instead.
+  Remove the throwaway worktree when done.
+
+  Route to **`stage:design`** — design is a standard phase: its UX track runs only when design is
+  still owed, but every item gets its implementation plan (spec track) there, so there is no
+  intake → queued shortcut and nothing for intake to adjudicate about design-settledness.
+
+  **Already-built items (built outside the pipeline) — route to the earliest *absent* artifact,
+  floor `stage:verify`.** If research finds the work is *already implemented and merged to
+  `<DEFAULT_BRANCH>`* (it shipped outside the pipeline and was never closed), do **not** route by
+  design-settledness, and do **not** jump it forward to `stage:ship` just to close it. Route it to
+  the **earliest lane whose artifact is genuinely missing** — and the floor is **`stage:verify`**,
+  never later. Intake is read-only: it can confirm the code *exists*, but not that it *meets the
+  acceptance criteria* (a test run + a real run — verify's job) or that it's *safe* (audit's). So
+  an already-built-but-never-verified item goes `stage:intake → stage:verify`; verify and audit
+  then produce their missing artifacts and ship closes it on PR merge. (The verify/audit/ship
+  workers each carry a *no-branch fallback* for exactly this case — this routing is what makes
+  those fallbacks reachable.)
+
+  Swap `stage:intake` → `stage:design` (or `stage:verify` per the routing above), remove
+  `sdlc:wip`. Comment a 2–4 line summary: what it is, the parent feature it grows from, **which
+  lane you routed to and why**, the decision recorded (if any), links to related issues.
+- **PARK** — a product/scope question gates the work, or scope is ambiguous, or it's a
+  possible-but-unconfirmed dup. Frame the debate **in the issue** (options, tradeoffs, a recommendation
+  — this is the debate the record will point to). Add `sdlc:needs-human`, remove `sdlc:wip`, lane stays
+  `stage:intake`. Comment the specific questions as a checklist, e.g.:
+  > Need from you before this advances:
+  > - [ ] Is offline support in scope for v1, or post-launch?
+  > - [ ] Is this a dup of #412 (same idea)?
+- **BOUNCE / CLOSE** — incoherent, out of scope (check the non-goals), or a confirmed duplicate. Close
+  with a one-paragraph rationale (link the dup). Remove `sdlc:wip`.
 
 ### 4. STOP
-One-line result: `INTAKE: <#issue> → ADVANCE(design|queued)|PARK|CLOSE — <reason>`
+One-line result: `INTAKE: <#issue> → ADVANCE(design|verify)|PARK|CLOSE — <reason>`
+(append `· SWEEP: <n> merges processed` when the merge sweep found any).
+
+---
 
 ## Notes
-- No code changes, no branches — intake only reads and relabels. The collision sweep's git
-  commands (`fetch`, `branch -r`, `log`, `diff`) are read-only too — they inspect remote branches
-  without checking anything out.
-- Idempotent: if the issue already has an intake comment from a prior run, re-confirm cheaply
-  rather than re-researching from scratch. A **reopened** issue is reconciled, not re-triaged from
-  scratch: if the evidence (merged PR, code on `dev`) shows it already shipped, PARK with that
-  evidence for a human to close rather than advancing it back into the pipeline.
+- **Intake owns the product/scope debates** (UX picks belong to design). It never picks
+  the winner of a debate — it frames and parks; the human decides in-thread; the next pass graduates
+  the answer into `<DECISION_RECORD>`.
+- **`gh` is in scope here** — intake's duplicate search legitimately uses it inline even though the
+  research approach is otherwise read-only. The collision sweep's git commands (`fetch`, `branch -r`,
+  `log`, `diff`) are read-only too — they inspect remote branches without checking anything out.
+- **Idempotent — unless the thread says otherwise:** a prior intake summary comment → re-confirm the
+  verdict cheaply, don't re-research. A PARKed item with an in-thread answer should ADVANCE next
+  pass. **Exception:** a bounce/comment asking for re-evaluation (e.g. a long-held issue returned as
+  possibly stale) overrides the cheap path — run the full WORK pass as if the artifacts didn't
+  exist: dup-check again (including the closed-issue search — it may have shipped meanwhile),
+  re-check docs, re-validate `## Requirements`/`## Acceptance criteria` in place, and note what
+  changed. **The in-thread instruction beats the idempotency shortcut.** A **reopened** issue is
+  reconciled, not re-triaged from scratch: if the evidence (merged PR, code on `<DEFAULT_BRANCH>`)
+  shows it already shipped, PARK with that evidence for a human to close rather than advancing it
+  back into the pipeline.
+- **No code changes, no branches.** Intake reads, relabels, and edits only the issue body's
+  `## Requirements` / `## Acceptance criteria` sections; its sole repo edit is the
+  `<DECISION_RECORD>` graduation via the throwaway docs-only worktree.
+- Honors the universal worker loop in [`README.md`](README.md).

--- a/prompts/sdlc/ship.md
+++ b/prompts/sdlc/ship.md
@@ -1,42 +1,82 @@
-# Ship worker (template)
+# Ship worker
 
-Stage: `stage:ship` → *(closed on merge)* · Owner: your doc/issue-lifecycle skill
+Stage: `stage:ship` → *(closed on merge)*
 
-Opens the PR and updates any docs the change invalidated. Ship's job ends at "PR open" — the
-merge itself (human-gated) is what actually closes the issue; it fires no worker.
+The terminal worker. The item arrives **audited** (green + safe); ship fans the change out to its
+documentation sinks and opens the PR (`feat → <DEFAULT_BRANCH>`, `Closes #`). The **PR merge** —
+human-gated, like the `stage:queued` throttle — is the real terminal event: on merge the issue
+auto-closes and dependents cascade-unblock (via intake's merge sweep). Ship's job ends at "PR open."
+
+---
 
 ## Prompt (paste this)
 
-You are the **ship worker**. Process **exactly one** issue, then stop.
+You are the **ship worker** for the `<PROJECT>` SDLC pipeline. Process **exactly one** issue, then
+stop.
 
 ### 1. CLAIM
-Per the [README](README.md) universal loop — lane `stage:ship`, idle reply `SHIP: idle`.
+Per the README universal loop — lane `stage:ship`, idle reply `SHIP: idle`.
 
 ### 2. WORK
-Idempotency first: a PR for this branch already open with the docs fan-out done → skip to
-**ADVANCE**; a PR for this branch already **merged** with the issue still open → PARK with the
-merge evidence for a human to close (intake's merge sweep normally handles these). Otherwise:
-- **Merge the integration branch (`dev`) into the feature branch unconditionally** — the PR must
-  be mergeable, and ship is the lane that always merges (per the README staleness rule).
-  Docs-only conflicts you may resolve yourself; **code conflicts BOUNCE → `stage:build`** naming
-  the conflicting paths (never PARK for a merge conflict — conflict resolution is build's lane).
-- Push the branch, open a PR against `dev` (or your integration branch) with a summary and a
-  link to the issue (`Closes #<n>`).
-- Update any L3 docs the change invalidated or that document new behavior (see
-  `docs/Documentation.md`; when applying the tiered-docs discipline, the `pemr-doc-tiers` skill at
-  `.github/skills/pemr-doc-tiers/SKILL.md` carries the naming/sizing/placement rules — apply them
-  inline).
-- No-branch fallback: if the feature was already merged outside the pipeline, skip PR creation
-  and instead comment confirming it's live, then close.
+Idempotency first: a PR for this branch already open with the docs fan-out done → skip to **ADVANCE**.
+A PR for this branch already **merged** with the issue still open → PARK with the merge evidence for a
+human to close (intake's merge sweep normally handles these).
+Otherwise, in the issue's worktree (`<WORKTREE_ROOT>/<issue#>`) on build's branch
+(`<type>/<issue#>-<slug>`):
+
+- **Merge `origin/<DEFAULT_BRANCH>` unconditionally** — ship is the exception to the staleness rule's
+  overlap check, because the PR must be mergeable. Docs-only conflicts you may resolve yourself; any
+  code conflict is a **BOUNCE → build** naming the conflicting paths.
+
+> **No-branch fallback** (item built outside the pipeline, already merged to `<DEFAULT_BRANCH>`): ship
+> cuts a **fresh branch off `<DEFAULT_BRANCH>`** carrying only the still-missing artifacts — the docs
+> fan-out plus any test the earlier stages left uncommitted (verify flags these). The PR is then
+> docs/tests-only (the code is already merged) but still `Closes #<issue>` on merge. Say so explicitly
+> in the PR body so a reviewer isn't thrown by the absent implementation diff, and link the introducing
+> commit verify/audit named.
+
+- **Docs fan-out — by necessity, not ritual** (a sink fires only when the change earns it). Route to
+  `<DOCS_SINKS>` — the project's documentation targets — using this discipline (when a sink is a
+  tiered reference tree and the `documentation-tiers` skill is installed, apply its
+  naming/sizing/placement rules inline — see `skills/documentation-tiers/SKILL.md`):
+  - **User-facing docs** (guide / README) — whenever user-visible behavior changed (new command, flag,
+    output, or UI). Written in user voice, **true to what actually shipped** — if docs and code diverge,
+    the code wins.
+  - **Architecture / design docs** — *only if* the component model or an invariant changed, or the
+    implementation rationale is non-obvious. Usually skipped for a routine change.
+  - **Decisions were already recorded at intake** — do **not** re-log them or add ADR-style history;
+    current/future-facing prose only.
+  - Retire any tracking-board entry for the now-shipped item and close its roadmap entry.
+- **Commit the docs to the same feat branch** — code and its docs ship together in one PR.
+- **Open the PR** `<type>/<issue#>-<slug>` → `<DEFAULT_BRANCH>`. Body: what shipped, `Closes #<issue>`,
+  and links to the verify + audit report comments. End the PR body with any attribution your repo
+  policy requires.
 
 ### 3. EMIT exactly one outcome
-- **ADVANCE** — PR opened (or already-shipped confirmed). Comment the PR link. Leave
-  `stage:ship` on; the issue closes when the PR merges.
-- **BOUNCE** → `stage:build` if the merge from `dev` hits code conflicts, or opening the PR
-  surfaces a missing piece that needs code changes.
-- **PARK** — needs a human decision the pipeline can't make (docs contradict shipped behavior
-  and must be reconciled, or merge policy is unclear). Add `sdlc:needs-human`, remove
-  `sdlc:wip`, comment specifics. Lane stays `stage:ship`.
+- **ADVANCE (terminal)** — docs fanned out and the PR is open. Remove `stage:ship` and `sdlc:wip`.
+  Comment the ship summary + PR link. The **PR merge is the terminal event** (human-gated, like the
+  queued throttle): on merge, `Closes #` auto-closes the issue, and intake's **merge sweep** runs the
+  cascade-unblock on a later pass. Ship does **not** force-close before merge — the code isn't on
+  `<DEFAULT_BRANCH>` yet, so closing early would lie.
+- **BOUNCE → `stage:build`** — a real code problem surfaces at the last look (something verify/audit
+  missed, or a code merge conflict). Swap `stage:ship` → `stage:build`, remove `sdlc:wip`, comment the
+  specific issue. Rare — the earlier gates should have caught code.
+- **PARK** — needs a human: the fan-out exposes a docs/behavior contradiction a human must reconcile,
+  or merge policy needs a human decision. Add `sdlc:needs-human`, remove `sdlc:wip`, comment specifics.
+  Lane stays `stage:ship`. (Code merge conflicts BOUNCE to build, not PARK.)
 
 ### 4. STOP
-One-line result: `SHIP: <#issue> → ADVANCE|BOUNCE|PARK — <reason>`
+One-line result: `SHIP: <#issue> → ADVANCE(PR open)|BOUNCE(build)|PARK — <reason>`.
+
+---
+
+## Notes
+- **Docs route by necessity, not ritual.** User-facing docs whenever behavior changed; everything else
+  only when earned.
+- **A shipped doc is 100% true.** Write for what *actually shipped*, not what was planned — if they
+  diverge, the code wins.
+- **The merge closes the issue, not ship.** Ship opens the PR; the human (or CI) merges; `Closes #`
+  does the rest. Modelling merge as human-gated mirrors the `stage:queued` throttle on the other end.
+- Ship reuses build's `feat/<issue>` branch (commits docs there), opens the one PR, and is the only
+  worker that opens a PR.
+- Honors the universal worker loop in [`README.md`](README.md).

--- a/prompts/sdlc/verify.md
+++ b/prompts/sdlc/verify.md
@@ -1,40 +1,96 @@
-# Verify worker (template)
+# Verify worker
 
-Stage: `stage:verify` → `stage:audit` · Owner: your test-validator skill/agent
+Stage: `stage:verify` → `stage:audit`
 
-Confirms the build actually works: automated tests plus a real run of the changed path.
+The gate between "code written" and "audited." It takes build's pushed branch and proves the change
+**actually works** — the full suite green **and a real run** that walks every acceptance criterion
+through the running software. Build only proved the targeted wiring it touched; verify is where that
+gets the broad check plus eyes-on behavior. It is the canonical **BOUNCE-back-to-build**: a red test
+or an unmet AC sends the item straight back on the same branch. Verify **validates; it does not fix.**
+
+---
 
 ## Prompt (paste this)
 
-You are the **verify worker**. Process **exactly one** issue, then stop.
+You are the **verify worker** for the `<PROJECT>` SDLC pipeline. Process **exactly one** issue, then
+stop.
 
 ### 1. CLAIM
-Per the [README](README.md) universal loop — lane `stage:verify`, idle reply `VERIFY: idle`.
+Per the README universal loop — lane `stage:verify`, idle reply `VERIFY: idle`.
 
 ### 2. WORK
-Apply the `verifier` role's adversarial stance **inline** (you are fresh context relative to the
-build worker — that's the point): treat the issue's acceptance criteria as a **claim to refute**,
-not a checklist to tick. Assume the build is broken until your own evidence says otherwise.
-- Check out the issue's branch (no-branch fallback: if it doesn't exist but the feature is
-  already merged, verify against the integration branch instead).
-- Run targeted tests yourself — do not trust test results reported in the build worker's
-  comments; reproduce them. Add/update tests if coverage is missing for the acceptance criteria.
-- Exercise the actual feature (start the app / hit the endpoint / drive the UI) and probe the
-  edges the builder plausibly missed: empty input, error paths, repeated use, the seam between
-  changed and unchanged code. Read the diff for what it *doesn't* handle.
+Idempotency first: a green verify report for the **current branch HEAD** (no new commits since it was
+written) → skip to **ADVANCE**. New commits invalidate a prior report — re-verify. Otherwise:
+
+- **Enter the issue's worktree** on build's branch (`<type>/<issue#>-<slug>`, named in build's ADVANCE
+  comment) — `<WORKTREE_ROOT>/<issue#>`, create from the pushed branch if missing — and pull latest.
+  Apply the README staleness rule: merge `origin/<DEFAULT_BRANCH>` only if its changes overlap the
+  branch's touched paths; a conflicted merge is an immediate **BOUNCE → build** naming the conflicting
+  paths (verify never resolves conflicts). A merge adds commits and thus invalidates any prior green
+  report — that re-validation is intended.
+  - **No-branch fallback** (built outside the pipeline, already on `<DEFAULT_BRANCH>`): validate on
+    `<DEFAULT_BRANCH>`; identify the introducing commits (`git log -S`/`--grep`, or the files the
+    issue names) and name them in your report so audit can isolate the same diff. Any new test then
+    has no branch home — flag it for ship.
+- **Run the full suite yourself** — `<FULL_SUITE_CMD>` (not just the targeted files build ran; the
+  point here is to catch regressions build's narrow run couldn't see), plus `<LINT_CMD>` and any
+  project-mandated extra gate (race detector, type-check, integration pass) — everything `<INVARIANTS>`
+  and `<LANG_CONVENTIONS>` require. Diagnose failures rather than papering over them.
+- **Known environment limitations — honor them, don't re-derive them.** If the project's profile
+  declares `<KNOWN_ENV_LIMITS>` (a gate that cannot run in this environment, its accepted
+  substitute, and the report wording), run the substitute and note the substitution in your report
+  in the declared wording — don't spend the pass rediscovering the limitation. A declared
+  limitation is **not** a PARK: PARK is for a genuinely un-standable environment, not a standing,
+  accepted one.
+- **Real run against the acceptance criteria** — green tests alone are **never** an ADVANCE:
+  - Build/launch the software (`<BUILD_CMD>`) and exercise **each AC** through the real thing with
+    real inputs. For each of `<INVARIANTS>`, force the path that would violate it and assert it holds.
+  - Script the smoke as a **repeatable test** (`<SMOKE_CMD>` / a committed e2e or smoke spec) —
+    that committed spec is the **gating** real run, repeatable and schedule-friendly; interactive
+    or ad-hoc exploration is *exploratory only*, never the gate. If the repo has a smoke/e2e
+    harness already, extend it; don't fork a second pattern. Commit any new spec to the **same feat
+    branch** in the worktree and push (verify extends the suite; it cuts no new branch).
+  - **Don't silently skip an AC — keep a coverage ledger.** Record in the report which ACs are
+    unit-covered vs exercised end-to-end, and call out anything the real run could not demonstrate
+    (e.g. a server-side rejection only a unit test can force). Note any AC whose behavior is
+    environment-dependent as unverified-on-<other-env> rather than skipping silently.
+  - If the environment genuinely cannot stand up, **PARK** — never ADVANCE on unit tests alone.
+- **Check the diff against the issue body's `## Implementation plan`** — the reviewed plan is the
+  spec; an unexplained deviation (files touched outside the plan with no ADVANCE-comment
+  rationale) is a BOUNCE.
 
 ### 3. EMIT exactly one outcome
-- **ADVANCE** → `stage:audit` — verdict **CONFIRMED**: every acceptance claim checked against
-  evidence you produced in this pass. Comment what you ran and observed.
-- **BOUNCE** → `stage:build` — verdict **REFUTED**: at least one claim failed. Comment the exact
-  repro (command, input, observed vs. expected) so build needs no rediscovery. Do not fix it
-  yourself — a verifier that edits stops being independent.
+- **ADVANCE** — full suite + all mandated gates green **and** every AC exercised through the real run.
+  Swap `stage:verify` → `stage:audit`, remove `sdlc:wip`. Comment the **verify report**: suites run
+  and results, the per-AC coverage ledger (which ACs were walked and how — unit vs end-to-end),
+  evidence, and what audit should aim its security/invariant pass at.
+- **BOUNCE → `stage:build`** — any test red, any AC unmet, any invariant violated, or a regression.
+  Swap `stage:verify` → `stage:build`, remove `sdlc:wip`, comment the **specific** failure (test name
+  + output, or the AC with observed-vs-expected). Build fixes on the same branch (idempotent continue).
+  Apply the README **bounce cap**: two prior verify→build bounces on this issue for the same failure
+  class → PARK with the loop history instead of a third bounce.
+  **Verify validates; it does not fix** — don't patch the code yourself.
+- **PARK** — needs a human call: the environment won't stand up, a nondeterministic/flaky failure
+  needs judgment, the AC's expected behavior is genuinely ambiguous, or the change **meets the AC but
+  the real run shows the decided design was wrong** (a late design miss — re-opening the debate is a
+  human's call, not a silent bounce past build). Add `sdlc:needs-human`, remove `sdlc:wip`, comment
+  specifics.
 
 ### 4. STOP
-One-line result: `VERIFY: <#issue> → ADVANCE|BOUNCE — <reason>`
+One-line result: `VERIFY: <#issue> → ADVANCE(audit)|BOUNCE(build)|PARK — <reason>`.
+
+---
 
 ## Notes
-- **Idempotent.** A green report for the current branch HEAD = done; any new commit invalidates
-  it. An item rewound here by a human with a still-valid green report → re-confirm cheaply and
-  ADVANCE, unless their rewind comment names a reason to distrust it — then re-verify that part.
-  Evidence that the work already shipped (merged PR) → PARK with the evidence for a human to close.
+- **Verify validates; it does not fix.** A red result bounces to build — resist patching code here. It
+  keeps the stage boundary clean and the fix on build's accountable branch.
+- **A real run is mandatory, not optional.** Green tests without walking the ACs in the running
+  software is a half-done verify; behavior bugs hide where unit tests don't look.
+- **Idempotent.** A green report for the current branch HEAD = done. Any new commit invalidates it.
+  An item rewound here by a human with a still-valid green report → re-confirm cheaply and ADVANCE,
+  unless their rewind comment names a reason to distrust it — then re-verify that part. Evidence that
+  the work already shipped (merged PR) → PARK with the evidence for a human to close.
+- **Reuse build's `feat/<issue>` branch** for new tests; don't cut a new one. (Exception: the
+  no-branch fallback — an item built outside the pipeline is verified on `<DEFAULT_BRANCH>`, and its
+  new specs are handed to ship for a home.)
+- Honors the universal worker loop in [`README.md`](README.md).

--- a/scripts/sdlc.mjs
+++ b/scripts/sdlc.mjs
@@ -1,28 +1,46 @@
 #!/usr/bin/env node
 /**
- * `sdlc` — deterministic one-shots for the Agentic SDLC pipeline's issue
- * state-machine ritual (issue #609). The dbmate analog for our pipeline: the
- * stage graph *is* a schema, so transitions are validated against it and the
- * hand-typed `stage:verify`/`stage:audit` typo class is killed by construction.
+ * `sdlc` — reference implementation of the deterministic one-shots for the
+ * agentic SDLC pipeline's issue state-machine ritual. Adopters COPY this file
+ * into their repo and adapt the constants below; it is not a library you
+ * depend on. The dbmate analog for the pipeline: the stage graph *is* a
+ * schema, so transitions are validated against it and the hand-typed
+ * `stage:verfy` label-typo class is killed by construction.
  *
  * Only deterministic label/branch math lives here. Report and comment *bodies*
  * stay judgment (the agent writes them); `sdlc comment` is a thin plumbing
  * wrapper that posts a body the agent already authored to a file.
  *
- * Commands (worker-side — issue #609):
+ * Commands (worker-side):
  *   sdlc claim   <issue> [<run-id> <lane>]  add sdlc:wip (+ claim comment), print branch + status
+ *   sdlc claim   --next <lane> <run-id>     CLI picks the next eligible issue for the lane + claims it
+ *   sdlc emit    <issue> <run-id> <outcome>  post the machine-parseable outcome comment
+ *                                     (`sdlc:emit <run-id> <OUTCOME>`) + do the label math in one
+ *                                     shot — the completion signal `claim --verify` keys off
  *   sdlc advance <issue> <to-stage>   validate transition, swap stage label, drop sdlc:wip
  *   sdlc context <issue>              branch + status + issue labels/state + open PRs for branch
  *   sdlc worktree <issue> [<branch>]  add a sibling git worktree for the issue's branch
  *   sdlc comment <issue> <file>       post a body-file comment (plumbing only)
+ *   sdlc dup-check "<keywords>"       rank open-issue dup candidates (exit 2 if any); judgment stays with the caller
  *
- * Commands (dispatcher-side — issue #615; each a pure function of gh/git/fs state):
- *   sdlc gate     [--reap]            per-issue wip-lock ages from timeline events → LIVE/REAP/CLEAR (#613)
- *   sdlc maint-lock    <run-id>       acquire the per-machine maintenance lock (.git/sdlc-maint.lock)
+ * Commands (dispatcher-side; each a pure function of gh/git/fs state):
+ *   sdlc gate     [--reap]            per-issue wip-lock ages from timeline events → LIVE/REAP/CLEAR;
+ *                                     --reap re-verifies each stale lock against live data before writing
+ *   sdlc mint                         coin + print this cycle's run-id (`run-id: <id>` line)
+ *   sdlc maint-lock    <run-id>       acquire the per-machine maintenance lock (.git/sdlc-maint.lock);
+ *                                     exit 1 = held: skip Step 0a, never abort the cycle
  *   sdlc maint-release <run-id>       release the maintenance lock (idempotent)
- *   sdlc lanes                        per-lane depth + eligibility + the ≠1 stage-label check (#614)
- *   sdlc heal     [<lane>] <issue>    post-worker self-heal: did the worker clear its lock?
- *   sdlc git-maint                    fetch, ff dev, prune ancestry/squash-merged branches, PR state
+ *   sdlc lanes                        per-lane depth + eligibility + the ≠1 stage-label check
+ *   sdlc heal     [<lane>] [<issue>]  post-worker self-heal: did the worker clear its lock? (lane-only = auto-discover)
+ *   sdlc git-maint                    fetch, ff default branch, prune ancestry/squash-merged branches, PR state
+ *   sdlc worktree-sweep [--apply]     remove clean issue-scoped worktrees whose branch is gone/merged or issue closed
+ *   sdlc conflict-scan [--apply]      comment + bounce-to-build issues whose open PR conflicts with the default branch
+ *   sdlc sweep    [--state <file>]    read-only merge-sweep work-list for intake step 0:
+ *                                     merged PRs → closed issues → blocked dependents; `sweep: clear` if none;
+ *                                     writes nothing — `sweep --ack` (run after processing) marks merges swept
+ *   sdlc cycle-prep [--apply]         the whole pre-dispatch sequence (mint→maint-lock→lanes→gate --reap→
+ *                                     sweep→git-maint→worktree-sweep→conflict-scan→maint-release) in one
+ *                                     delimited, machine-readable report
  *   sdlc digest   [--state <file>]    queue depths, parked/hold lists, arrivals-diff vs last cycle
  *
  * The stage graph (forward pipeline edges + the documented bounces):
@@ -31,17 +49,33 @@
  * parks (see prompts/sdlc/README.md).
  *
  * Usage:
- *   node scripts/sdlc.mjs <command> [args...]
+ *   node scripts/sdlc.mjs <command> [args...]   (or: npm run sdlc <command>)
  */
 
 import { execFileSync } from 'child_process';
+import { randomBytes } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+// --- Adapt to your repo -------------------------------------------------------
+// These are the only project-specific knobs. `<DEFAULT_BRANCH>` is the
+// integration branch PRs target; `<PROD_BRANCH>` is the release branch no
+// worker ever touches. The worktree name function must match the
+// `<WORKTREE_ROOT>/<issue#>` pattern your prompts use — the dispatcher's sweep
+// only touches worktrees matching it.
+export const DEFAULT_BRANCH = 'dev'; // adapt to your repo (e.g. 'main')
+export const PROD_BRANCH = 'main'; // pemr: main is prod (flow: feature → dev → main)
+/** Sibling-worktree name for an issue: <repoName>-wt-<issue#>. */
+export const worktreeName = (repoName, issue) => `${repoName}-wt-${issue}`;
+
 export const WIP_LABEL = 'sdlc:wip';
 
-/** Ordered pipeline stages. */
+/**
+ * Ordered pipeline stages. Design is a standard phase of the spec; folding it
+ * into intake is a *declared adopter deviation* — if you declare it, drop
+ * 'design' here and remove its edges from STAGE_GRAPH below.
+ */
 export const STAGES = ['intake', 'design', 'queued', 'build', 'verify', 'audit', 'ship'];
 
 /**
@@ -52,14 +86,21 @@ export const STAGES = ['intake', 'design', 'queued', 'build', 'verify', 'audit',
  * rejected — that is what fixes the label-typo class of bug.
  */
 export const STAGE_GRAPH = {
-  intake: ['design', 'queued'],
+  // 'design' is the standard forward edge; 'queued' is the shortcut for
+  // adopters who declare the fold-design-into-intake deviation; 'verify' is
+  // the already-built floor route (an item arrives with its implementation
+  // already landed and only needs verification).
+  intake: ['design', 'queued', 'verify'],
   design: ['queued', 'intake'],
-  queued: ['build'],
+  // 'build' is the forward edge; 'design' is the human spec-rejection bounce
+  // at the throttle gate.
+  queued: ['build', 'design'],
   build: ['verify', 'queued', 'design', 'intake'],
   verify: ['audit', 'build'],
   audit: ['ship', 'build'],
-  // ship has no *forward* edge — its only edge is the conflict/late-code
-  // bounce back to build (ship.md BOUNCE rule; dispatch.md step 0a.3).
+  // ship has no *forward* edge (the ship worker opens a PR; the merge closes
+  // the issue) — its only edge is the conflict bounce back to build when an
+  // open PR conflicts with the default branch (dispatch step 0a.3).
   ship: ['build'],
 };
 
@@ -120,7 +161,7 @@ export function planAdvance(labelNames, toStage) {
   return { from, to: toStage, removeLabels, addLabels: [`stage:${toStage}`] };
 }
 
-// --- Pure dispatcher-side helpers (issue #615) ---------------------------------
+// --- Pure dispatcher-side helpers ----------------------------------------------
 
 /** Lanes that have a worker (queued is the workerless human throttle). */
 export const WORKER_LANES = ['intake', 'design', 'build', 'verify', 'audit', 'ship'];
@@ -155,10 +196,9 @@ export function priorityRank(labelNames) {
 }
 
 /**
- * The per-issue wip-lock gate decision (issue #613/#615; per-issue concurrency).
- * `wipItems` is `[{ number, ageMs }]` — age measured from the `sdlc:wip`
- * labeled event, NOT the issue's updatedAt (which any later comment/edit
- * falsely refreshes). Pure.
+ * The per-issue wip-lock gate decision. `wipItems` is `[{ number, ageMs }]` —
+ * age measured from the `sdlc:wip` labeled event, NOT the issue's updatedAt
+ * (which any later comment/edit falsely refreshes). Pure.
  *
  * Locking is per-issue: a fresh lock means a LIVE worker — that one issue is
  * simply ineligible this cycle; it never aborts the run. A stale lock
@@ -198,15 +238,26 @@ export function planMaintLock(state, thresholdMs = MAINT_STALE_MS) {
  * timeline event (see `lastUnlabeledAt`), or null if the label was never
  * removed. Every outcome EMIT removes `sdlc:wip`, so claims at/before that
  * event are settled history — and a reaper strip also (correctly) invalidates
- * earlier claims, which an outcome-comment heuristic would miss. Winner =
- * earliest live claim; ties break to the lexicographically lower run-id. Pure.
+ * earlier claims. The `sdlc:emit`/legacy outcome-comment markers are kept as a
+ * second settle signal so an unavailable timeline (boundary null) degrades to
+ * the pre-boundary behavior instead of resurrecting settled claims (which
+ * would make `emit` falsely refuse ownership). Winner = earliest live claim;
+ * ties break to the lexicographically lower run-id. Pure.
  */
 export function planClaimVerify(comments, myRunId, boundaryIso = null) {
-  const claims = [];
+  // `sdlc:emit …` is the protocol marker posted by `sdlc emit`; the bare
+  // ADVANCE/BOUNCE/PARK/CONTINUE prefixes are legacy hand-posted outcomes kept
+  // for issues whose history predates the emit command.
+  const OUTCOME = /^(sdlc:emit\s|ADVANCE|BOUNCE|PARK|CONTINUE|sdlc-dispatch: reaped)/;
+  let claims = [];
   for (const c of comments ?? []) {
+    if (OUTCOME.test(c.body ?? '')) {
+      claims = []; // claims before an outcome are settled history
+      continue;
+    }
     const m = c.body?.match(/^sdlc:claim\s+(\S+)/);
     if (!m) continue;
-    if (boundaryIso && c.createdAt <= boundaryIso) continue; // settled history
+    if (boundaryIso && c.createdAt <= boundaryIso) continue; // settled by unlabel event
     claims.push({ runId: m[1], createdAt: c.createdAt });
   }
   if (!claims.some((c) => c.runId === myRunId)) {
@@ -217,6 +268,48 @@ export function planClaimVerify(comments, myRunId, boundaryIso = null) {
     return a.runId < b.runId ? -1 : 1;
   })[0];
   return { won: winner.runId === myRunId, winner: winner.runId, reason: null };
+}
+
+/** Worker outcomes `sdlc emit` accepts (prompts/sdlc/README.md EMIT step). */
+export const EMIT_OUTCOMES = ['ADVANCE', 'BOUNCE', 'PARK', 'CONTINUE', 'CLOSE'];
+
+/**
+ * Compute the label edit (and whether to close) for a worker's EMIT. Pure.
+ *
+ *   ADVANCE/BOUNCE --to <stage>  planAdvance label math (stage swap + wip drop)
+ *   ADVANCE from ship (no --to)  terminal: remove stage:ship + wip, add nothing
+ *   PARK                          drop wip, add sdlc:needs-human
+ *   CONTINUE                      drop wip only (build's not-a-lane-change outcome)
+ *   CLOSE                         drop wip, close the issue (intake dup/incoherent)
+ *
+ * Throws SdlcError on an unknown outcome, a missing/illegal target stage, or a
+ * BOUNCE without a target.
+ */
+export function planEmit(labelNames, outcome, toStage) {
+  if (!EMIT_OUTCOMES.includes(outcome)) {
+    throw new SdlcError(`unknown outcome "${outcome}" (valid: ${EMIT_OUTCOMES.join(', ')})`);
+  }
+  const labels = labelNames ?? [];
+  const wipRemove = labels.includes(WIP_LABEL) ? [WIP_LABEL] : [];
+  if (outcome === 'ADVANCE' || outcome === 'BOUNCE') {
+    if (!toStage) {
+      if (outcome === 'ADVANCE' && currentStage(labels) === 'ship') {
+        // Terminal ADVANCE: PR is open; the merge closes the issue.
+        return { removeLabels: ['stage:ship', ...wipRemove], addLabels: [], close: false };
+      }
+      throw new SdlcError(`${outcome} requires a target stage: sdlc emit <issue> <run-id> ${outcome} --to <stage>`);
+    }
+    const plan = planAdvance(labels, toStage);
+    return { removeLabels: plan.removeLabels, addLabels: plan.addLabels, close: false };
+  }
+  if (outcome === 'PARK') {
+    return { removeLabels: wipRemove, addLabels: ['sdlc:needs-human'], close: false };
+  }
+  if (outcome === 'CONTINUE') {
+    return { removeLabels: wipRemove, addLabels: [], close: false };
+  }
+  // CLOSE
+  return { removeLabels: wipRemove, addLabels: [], close: true };
 }
 
 /**
@@ -249,14 +342,16 @@ export function lastUnlabeledAt(timelineEvents, label) {
 }
 
 /**
- * Per-lane eligibility + depth from ONE open-issue snapshot, plus the ≠1
- * `stage:*` integrity check (issue #614). `issues` is
+ * Per-lane eligibility + depth from ONE open-issue snapshot, plus the
+ * stage-label integrity check. `issues` is
  * `[{ number, labels:[{name}]|[name], createdAt }]`. Pure.
  *
  * Eligible = has that stage, not wip and not parked/hold; ordered exactly as a
  * worker's CLAIM would pick — priority (critical › medium › future › none),
- * then FIFO by createdAt. `integrity` lists every issue whose stage-label count
- * is not exactly 1 (0 = invisible to every lane, >1 = eligible in two lanes).
+ * then FIFO by createdAt. `integrity` lists every issue whose stage-label
+ * state is corrupt (see the zero-vs-flagged rule below). Each lane also
+ * carries an `ineligible` breakdown ({hold, needs-human, wip} counts) so the
+ * lanes report can explain a deep-but-idle lane at a glance.
  */
 export function computeLanes(issues) {
   const norm = (issues ?? []).map((i) => ({
@@ -267,7 +362,7 @@ export function computeLanes(issues) {
 
   const lanes = {};
   for (const lane of WORKER_LANES.concat('queued')) {
-    lanes[lane] = { depth: 0, eligible: [] };
+    lanes[lane] = { depth: 0, eligible: [], ineligible: { hold: 0, 'needs-human': 0, wip: 0 } };
   }
 
   const integrity = [];
@@ -290,6 +385,14 @@ export function computeLanes(issues) {
       const locked = issue.labels.includes(WIP_LABEL);
       if (!parked && !locked) {
         lanes[stage].eligible.push(issue);
+      } else if (issue.labels.includes('sdlc:hold')) {
+        // One bucket per ineligible issue so the breakdown sums to depth −
+        // eligible count. Precedence: hold › needs-human › wip.
+        lanes[stage].ineligible.hold += 1;
+      } else if (issue.labels.includes('sdlc:needs-human')) {
+        lanes[stage].ineligible['needs-human'] += 1;
+      } else {
+        lanes[stage].ineligible.wip += 1;
       }
     }
   }
@@ -307,20 +410,66 @@ export function computeLanes(issues) {
   return { lanes, integrity };
 }
 
+/**
+ * Render a lane's ineligibility breakdown, e.g. `(hold 12, needs-human 4)`, from
+ * the `ineligible` bucket counts a `computeLanes` lane carries. Pure.
+ * Zero-count buckets are omitted; returns `''` when nothing is ineligible (a
+ * fully-eligible lane, where depth == eligible count, prints unchanged). Bucket
+ * order is fixed: hold, needs-human, wip.
+ */
+export function laneIneligibilityBreakdown(lane) {
+  const buckets = lane?.ineligible ?? {};
+  const parts = ['hold', 'needs-human', 'wip']
+    .filter((k) => (buckets[k] ?? 0) > 0)
+    .map((k) => `${k} ${buckets[k]}`);
+  return parts.length ? `(${parts.join(', ')})` : '';
+}
+
 /** Post-worker self-heal check: did the worker clear its lock? Pure. */
 export function planHeal(labelNames) {
   return { stillLocked: (labelNames ?? []).includes(WIP_LABEL) };
 }
 
 /**
- * Which local branches are safe to delete as ancestry-merged into the
- * integration branch. `mergedBranches` is the raw `git branch --merged` line
- * list. Never returns dev, main, master, or the current branch. Pure — the
- * caller still re-confirms each with `git merge-base --is-ancestor` before
- * deleting.
+ * Lane self-heal discovery: every open issue still carrying BOTH
+ * `stage:<lane>` and `sdlc:wip` — a worker that claimed but never emitted an
+ * outcome (a settled outcome drops wip and swaps the stage). Returns the stalled
+ * issue numbers in ascending order. `issues` is `[{ number, labels }]`. Pure —
+ * lets `sdlc heal <lane>` find its own targets with no issue argument.
+ */
+export function planHealLane(issues, lane) {
+  return (issues ?? [])
+    .map((i) => ({
+      number: i.number,
+      labels: (i.labels ?? []).map((l) => (typeof l === 'string' ? l : l.name)),
+    }))
+    .filter((i) => i.labels.includes(WIP_LABEL) && i.labels.includes(`stage:${lane}`))
+    .map((i) => i.number)
+    .sort((a, b) => a - b);
+}
+
+/**
+ * Mint a dispatcher cycle run-id: `dispatch-<yyyymmdd>-<hhmm>-<hex4>`,
+ * matching the format the dispatcher used to build by hand. `now` and `hex` are
+ * injectable for deterministic tests; `hex` defaults to 2 random bytes. Pure.
+ */
+export function mintRunId(now = new Date(), hex = null) {
+  const pad = (n) => String(n).padStart(2, '0');
+  const yyyymmdd = `${now.getUTCFullYear()}${pad(now.getUTCMonth() + 1)}${pad(now.getUTCDate())}`;
+  const hhmm = `${pad(now.getUTCHours())}${pad(now.getUTCMinutes())}`;
+  const suffix = hex ?? randomBytes(2).toString('hex');
+  return `dispatch-${yyyymmdd}-${hhmm}-${suffix}`;
+}
+
+/**
+ * Which local branches are safe to delete as ancestry-merged into the default
+ * branch. `mergedBranches` is the raw `git branch --merged <DEFAULT_BRANCH>`
+ * line list. Never returns the default branch, the prod branch, or the current
+ * branch. Pure — the caller still re-confirms each with
+ * `git merge-base --is-ancestor` before deleting.
  */
 export function planBranchPrune(mergedBranches, currentBranch) {
-  const keep = new Set(['dev', 'main', 'master', currentBranch]);
+  const keep = new Set([DEFAULT_BRANCH, PROD_BRANCH, currentBranch]);
   return (mergedBranches ?? [])
     .map((line) => {
       // `git branch` marks the current branch with `* ` and a branch checked
@@ -338,7 +487,7 @@ export function planBranchPrune(mergedBranches, currentBranch) {
 
 /** Branch names whose upstream shows `[gone]` in `git branch -vv` output. Pure. */
 export function parseGoneBranches(branchVvOutput, currentBranch) {
-  const keep = new Set(['dev', 'main', 'master', currentBranch]);
+  const keep = new Set([DEFAULT_BRANCH, PROD_BRANCH, currentBranch]);
   const gone = [];
   for (const line of (branchVvOutput ?? '').split(/\r?\n/)) {
     if (!line.trim()) continue;
@@ -366,11 +515,161 @@ export function canDeleteSquashMerged({ upstreamGone, prState, localTip, headRef
 }
 
 /**
- * Digest numbers from a snapshot: per-lane depth, parked/hold lists, and — when
- * a previous snapshot's open-issue numbers are supplied — the arrivals/departures
- * diff vs last cycle. `issues` is `[{ number, labels }]`. Pure.
+ * Parse `git worktree list --porcelain` into the issue-scoped sibling trees this
+ * sweep owns: those whose path basename matches `worktreeName(repoName, <issue#>)`.
+ * The main checkout and any human-named worktree never match, so they are never
+ * candidates — the pattern is the safety boundary. Pure.
+ *
+ * @param {string} porcelain  raw `git worktree list --porcelain` output
+ * @param {string} repoName   the main repo dir basename
+ * @returns {Array<{ path: string, branch: string|null, issue: number }>}
  */
-export function computeDigest(issues, prevNumbers = null) {
+export function parseWorktrees(porcelain, repoName) {
+  // Derive the regex from worktreeName() itself, so an adopter's rename of the
+  // worktree convention automatically re-scopes the sweep: mark the issue slot
+  // with a placeholder, escape the literal parts, swap in a digit capture.
+  const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const marker = '\u0000';
+  const pattern = new RegExp(
+    `^${worktreeName(repoName, marker).split(marker).map(esc).join('(\\d+)')}$`,
+  );
+  const trees = [];
+  for (const block of (porcelain ?? '').split(/\r?\n\r?\n/)) {
+    const lines = block.split(/\r?\n/).filter(Boolean);
+    if (!lines.length) continue;
+    let wtPath = null;
+    let branch = null;
+    for (const line of lines) {
+      if (line.startsWith('worktree ')) wtPath = line.slice('worktree '.length).trim();
+      else if (line.startsWith('branch ')) {
+        branch = line.slice('branch '.length).trim().replace(/^refs\/heads\//, '');
+      }
+    }
+    if (!wtPath) continue;
+    // basename regardless of separator (git prints POSIX slashes even on Windows).
+    const base = wtPath.split(/[\\/]/).filter(Boolean).pop() ?? '';
+    const m = base.match(pattern);
+    if (m) trees.push({ path: wtPath, branch, issue: Number(m[1]) });
+  }
+  return trees;
+}
+
+/**
+ * Classify a worktree's `git status --porcelain` output for sweep tolerance.
+ * Returns `{ clean, strays }`. A tree is "clean modulo strays" — `clean:true`
+ * with the stray paths listed — only when EVERY porcelain entry is an untracked
+ * (`??`) path AND every such path is 0 bytes; those strays are provably not work
+ * (mangled `> OUTCOME` redirects per #688) and may be cleared. Any tracked
+ * modification, any untracked file with size > 0, or an unreadable/quoted path →
+ * `clean:false` with no strays (real work — never touch). Pure: `sizeOf(relPath)`
+ * is injected so the caller supplies filesystem access; it may throw, which is
+ * treated conservatively as dirty.
+ *
+ * @param {string} porcelain raw `git status --porcelain` output
+ * @param {(relPath:string)=>number} sizeOf byte size of a path within the tree
+ * @returns {{ clean: boolean, strays: string[] }}
+ */
+export function classifyStatusForSweep(porcelain, sizeOf) {
+  const lines = String(porcelain ?? '')
+    .split('\n')
+    .map((l) => l.replace(/\r$/, ''))
+    .filter((l) => l.length > 0);
+  if (lines.length === 0) return { clean: true, strays: [] };
+  const strays = [];
+  for (const line of lines) {
+    // porcelain v1 untracked entries are exactly '?? <path>'. Anything else
+    // (tracked staged/modified, quoted special-char path) is real → dirty.
+    if (!line.startsWith('?? ')) return { clean: false, strays: [] };
+    const rel = line.slice(3);
+    if (rel.startsWith('"')) return { clean: false, strays: [] }; // quoted path — treat as real
+    let size;
+    try {
+      size = sizeOf(rel);
+    } catch {
+      return { clean: false, strays: [] };
+    }
+    if (size !== 0) return { clean: false, strays: [] };
+    strays.push(rel);
+  }
+  return { clean: true, strays };
+}
+
+/**
+ * Unlink symlink/junction entries at the root of a worktree that is about to be
+ * removed. On Windows, `git worktree remove` recurses THROUGH an NTFS junction
+ * and deletes the junction TARGET's contents (#723: a sweep emptied a shared
+ * main-checkout `node_modules/.bin` via a stale worktree's `node_modules`
+ * junction before aborting on a locked file). Removing the link itself — never
+ * its target — is safe on every platform: `lstat` reports junctions as
+ * symlinks, and a non-recursive `rmSync` unlinks the reparse point without
+ * touching what it points at. Only root entries are scanned; the lane
+ * convention creates at most one root-level `node_modules` junction.
+ *
+ * @param {string} treePath worktree root about to be handed to `git worktree remove`
+ * @param {(msg:string)=>void} log progress logger
+ * @returns {string[]} names of the entries that were unlinked
+ */
+export function unlinkWorktreeRootLinks(treePath, log = () => {}) {
+  const removed = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(treePath, { withFileTypes: true });
+  } catch {
+    return removed; // tree already gone — nothing to protect
+  }
+  for (const ent of entries) {
+    const full = path.join(treePath, ent.name);
+    try {
+      if (!fs.lstatSync(full).isSymbolicLink()) continue;
+      fs.rmSync(full, { recursive: false, force: true });
+      removed.push(ent.name);
+      log(`  unlinked ${ent.name} (junction/symlink — git worktree remove would delete through it)`);
+    } catch (err) {
+      log(`  could not unlink ${full}: ${String(err.message).split('\n')[0]}`);
+    }
+  }
+  return removed;
+}
+
+/**
+ * Decide which issue-scoped worktrees to remove. A tree is removable ONLY when
+ * it is clean AND done — done meaning its branch is gone/merged OR its issue is
+ * closed. Dirty-but-done trees and still-active trees are left with a reason, so
+ * uncommitted work is never destroyed. Pure — the caller gathers each tree's
+ * `clean` / `branchGone` / `issueClosed` status and executes the plan.
+ *
+ * @param {Array<{path,branch,issue,clean,branchGone,issueClosed}>} trees
+ * @returns {{ remove: Array, leave: Array }} each entry carries a `reason`
+ */
+export function planWorktreeSweep(trees) {
+  const remove = [];
+  const leave = [];
+  for (const t of trees ?? []) {
+    const done = [];
+    if (t.branchGone) done.push('branch gone/merged');
+    if (t.issueClosed) done.push('issue closed');
+    if (done.length === 0) {
+      leave.push({ ...t, reason: 'active (branch present, issue open)' });
+    } else if (!t.clean) {
+      leave.push({ ...t, reason: `dirty — ${done.join(', ')} but uncommitted changes present` });
+    } else {
+      remove.push({ ...t, reason: done.join(', ') });
+    }
+  }
+  return { remove, leave };
+}
+
+/**
+ * Digest numbers from a snapshot: per-lane depth, parked/hold lists, and — when
+ * a previous snapshot is supplied — the arrivals/departures diff vs last cycle
+ * plus per-list parked/hold deltas (so the near-identical parked/hold lists can
+ * be reported as "no change" instead of re-listing every cycle). `issues` is
+ * `[{ number, labels }]`. `prev` is either the legacy array of last cycle's open
+ * issue numbers, or `{ current, parked, hold }` from the persisted state. Pure.
+ */
+export function computeDigest(issues, prev = null) {
+  const prevObj = Array.isArray(prev) ? { current: prev } : prev;
+  const prevNumbers = prevObj ? (prevObj.current ?? null) : null;
   const norm = (issues ?? []).map((i) => ({
     number: i.number,
     labels: (i.labels ?? []).map((l) => (typeof l === 'string' ? l : l.name)),
@@ -392,35 +691,249 @@ export function computeDigest(issues, prevNumbers = null) {
   let arrivals = null;
   let departures = null;
   if (prevNumbers) {
-    const prev = new Set(prevNumbers);
+    const prevSet = new Set(prevNumbers);
     const now = new Set(current);
-    arrivals = current.filter((n) => !prev.has(n));
+    arrivals = current.filter((n) => !prevSet.has(n));
     departures = prevNumbers.filter((n) => !now.has(n));
   }
 
-  return { depths, parked, hold, current, arrivals, departures };
+  const diffSet = (prevArr, nowArr) => {
+    const p = new Set(prevArr);
+    const n = new Set(nowArr);
+    const added = nowArr.filter((x) => !p.has(x));
+    const removed = prevArr.filter((x) => !n.has(x));
+    return { added, removed, changed: added.length > 0 || removed.length > 0 };
+  };
+  const parkedDelta = prevObj && Array.isArray(prevObj.parked) ? diffSet(prevObj.parked, parked) : null;
+  const holdDelta = prevObj && Array.isArray(prevObj.hold) ? diffSet(prevObj.hold, hold) : null;
+
+  return { depths, parked, hold, current, arrivals, departures, parkedDelta, holdDelta };
+}
+
+/**
+ * The intake merge-sweep work-list (intake.md step 0). Pure.
+ *
+ * Maps recently-merged PRs → the issues each closed → the open issues that
+ * *depend on* those closed issues (a `#<n>` reference in the body), flagging
+ * which dependents carry the `blocked` label — the cascade-unblock candidates
+ * intake flips Blocked → Ready. A PR already in `sweptPrs`, one that closed no
+ * issue, or (when `sinceMs` is given) one merged at/before that cutoff is
+ * skipped, so the sweep is idempotent and bounded. No I/O and no writes — the
+ * intake worker consumes the list and performs the actions itself.
+ *
+ * @param {Array}  mergedPrs   `[{ number, mergedAt, title, closes: [issueNum] }]`
+ * @param {Array}  openIssues  `[{ number, title, labels: [name]|[{name}], body }]`
+ * @param {object} [opts]      `{ sinceMs: number|null, sweptPrs: Array<number> }`
+ * @returns {{ items: Array, closedIssues: number[], empty: boolean }}
+ */
+export function computeSweep(mergedPrs, openIssues, { sinceMs = null, sweptPrs = [] } = {}) {
+  const swept = new Set((sweptPrs ?? []).map(Number));
+  const issues = (openIssues ?? []).map((i) => ({
+    number: i.number,
+    title: i.title ?? '',
+    labels: (i.labels ?? []).map((l) => (typeof l === 'string' ? l : l.name)),
+    body: i.body ?? '',
+  }));
+
+  // Open issues that reference `#<closedNum>` in their body (word-boundaried so
+  // `#12` never matches `#123`), flagged if they carry the `blocked` label.
+  const dependentsOf = (closedNum) => {
+    const ref = new RegExp(`#${closedNum}(?!\\d)`);
+    return issues
+      .filter((i) => i.number !== closedNum && ref.test(i.body))
+      .map((i) => ({ number: i.number, title: i.title, blocked: i.labels.includes('blocked') }));
+  };
+
+  const items = [];
+  for (const pr of mergedPrs ?? []) {
+    if (swept.has(Number(pr.number))) continue;
+    if (sinceMs !== null && pr.mergedAt && new Date(pr.mergedAt).getTime() <= sinceMs) continue;
+    const closes = (pr.closes ?? []).map((n) => ({ number: n, dependents: dependentsOf(n) }));
+    if (!closes.length) continue; // closed no issue — nothing to cascade
+    items.push({ number: pr.number, mergedAt: pr.mergedAt ?? null, title: pr.title ?? '', closes });
+  }
+
+  const closedIssues = [...new Set(items.flatMap((it) => it.closes.map((c) => c.number)))];
+  return { items, closedIssues, empty: items.length === 0 };
+}
+
+/**
+ * The next `sweptPrs` marker after an ack (intake.md step 0). Pure.
+ *
+ * Retains only prior swept PRs still present in the fetched merged list (bounds
+ * the marker to ≤ the fetch limit) plus every PR merged inside the window.
+ * `newlyAcked` is the in-window set not already marked — what this ack adds.
+ *
+ * @param {Array}  mergedPrs  `[{ number, mergedAt }]`
+ * @param {object} [opts]     `{ sinceMs: number|null, sweptPrs: Array<number> }`
+ * @returns {{ nextSwept: number[], newlyAcked: number[] }}
+ */
+export function computeSweepAck(mergedPrs, { sinceMs = null, sweptPrs = [] } = {}) {
+  const prior = (sweptPrs ?? []).map(Number);
+  const fetchedNums = new Set((mergedPrs ?? []).map((p) => Number(p.number)));
+  const inWindow = (mergedPrs ?? [])
+    .filter((p) => sinceMs === null || (p.mergedAt && new Date(p.mergedAt).getTime() > sinceMs))
+    .map((p) => Number(p.number));
+  const priorSet = new Set(prior);
+  const nextSwept = [...new Set([...prior.filter((n) => fetchedNums.has(n)), ...inWindow])];
+  const newlyAcked = inWindow.filter((n) => !priorSet.has(n));
+  return { nextSwept, newlyAcked };
+}
+
+/**
+ * Stages a conflicting-PR issue is bounced back to `build` from. A PR only
+ * exists once ship opens it, so a still-labelled issue with an open conflicting
+ * PR was bounced back into the pipeline; verify/audit/ship all return to build,
+ * where conflict resolution lives (dispatch step 0a.3). A post-ship *stageless*
+ * issue (terminal ADVANCE dropped stage:ship) gets the nudge comment only.
+ */
+export const CONFLICT_BOUNCE_STAGES = ['verify', 'audit', 'ship'];
+
+/** The fixed conflict-nudge comment body (deterministic template — no judgment). */
+export function conflictCommentBody(branch) {
+  return `sdlc-dispatch: branch ${branch} conflicts with ${DEFAULT_BRANCH} — needs a merge`;
+}
+
+/**
+ * Deterministic conflict-scan plan (dispatch step 0a.3). Pure.
+ *
+ *   `prs`           `[{ number, headRefName, baseRefName, mergeable, linkedIssues:[num] }]`
+ *   `issueInfo`     `{ [number]: { state, labels:[name], comments:[{ body, createdAt }] } }`
+ *   `baseUpdatedAt` the base branch's tip commit ISO time — a conflict comment at
+ *                   or after it counts as already-posted-since-the-last-base-change
+ *                   (idempotency); null disables the watermark (any prior comment
+ *                   suppresses).
+ *   `baseBranch`    only PRs targeting this branch are considered (default DEFAULT_BRANCH).
+ *
+ * For each open CONFLICTING PR into `baseBranch`, and each linked issue that is
+ * open and not wip/needs-human/hold, plan the fixed conflict comment (unless one
+ * already exists since the last base-branch update) and, when the issue sits in
+ * verify/audit/ship, a bounce back to build. Never plans any PR mutation.
+ */
+export function planConflictScan(prs, issueInfo = {}, baseUpdatedAt = null, baseBranch = DEFAULT_BRANCH) {
+  const watermark = baseUpdatedAt ? new Date(baseUpdatedAt).getTime() : null;
+  const actions = [];
+  const skipped = [];
+  for (const pr of prs ?? []) {
+    if (pr.baseRefName && pr.baseRefName !== baseBranch) continue;
+    if (pr.mergeable !== 'CONFLICTING') continue;
+    const branch = pr.headRefName;
+    const linked = pr.linkedIssues ?? [];
+    if (linked.length === 0) {
+      skipped.push({ pr: pr.number, reason: 'no linked issue' });
+      continue;
+    }
+    for (const num of linked) {
+      const info = issueInfo?.[num];
+      if (!info || info.state === 'CLOSED') {
+        skipped.push({ pr: pr.number, issue: num, reason: 'linked issue closed or not found' });
+        continue;
+      }
+      const labels = info.labels ?? [];
+      if (labels.includes(WIP_LABEL) || PARK_LABELS.some((p) => labels.includes(p))) {
+        skipped.push({ pr: pr.number, issue: num, reason: 'issue is wip/needs-human/hold' });
+        continue;
+      }
+      const body = conflictCommentBody(branch);
+      const alreadyPosted = (info.comments ?? []).some(
+        (c) =>
+          (c.body ?? '').startsWith(body) &&
+          (watermark === null || new Date(c.createdAt).getTime() >= watermark),
+      );
+      if (alreadyPosted) {
+        skipped.push({
+          pr: pr.number,
+          issue: num,
+          reason: `conflict comment already posted since last ${baseBranch} update`,
+        });
+        continue;
+      }
+      let stage = null;
+      try {
+        stage = currentStage(labels);
+      } catch {
+        stage = null; // post-ship stageless (or corrupt) — comment only, never guess a stage
+      }
+      const advanceTo = CONFLICT_BOUNCE_STAGES.includes(stage) ? 'build' : null;
+      actions.push({ pr: pr.number, issue: num, branch, comment: body, stage, advanceTo });
+    }
+  }
+  return { actions, skipped };
+}
+
+// --- Duplicate-candidate scoring ------------------------------------------------
+
+/**
+ * Common words carrying no discriminating signal — dropped from a dup-check
+ * query so a phrase like "add a bar to the menu" scores on {add, bar, menu},
+ * not on {a, to, the}.
+ */
+export const DUP_STOPWORDS = new Set([
+  'a', 'an', 'and', 'or', 'of', 'to', 'in', 'on', 'for', 'is', 'it', 'with',
+  'by', 'as', 'at', 'be', 'this', 'that', 'from', 'into', 'over', 'per', 'the',
+  'when', 'via', 'not', 'no', 'so', 'if', 'but', 'are', 'was', 'has', 'can',
+]);
+
+/** Lowercase alphanumeric tokens of a string (defensive over null/undefined). */
+export function dupTokens(text) {
+  return String(text ?? '').toLowerCase().match(/[a-z0-9]+/g) ?? [];
+}
+
+/** The de-duplicated, meaningful (non-stopword, length ≥ 2) terms of a query. */
+export function dupQueryTerms(query) {
+  return [...new Set(dupTokens(query).filter((t) => t.length >= 2 && !DUP_STOPWORDS.has(t)))];
+}
+
+/**
+ * Rank open issues by keyword overlap with a query — the deterministic dup-check
+ * baseline (a semantic backend is a deferred phase 2). Judgment (is it REALLY a
+ * dup) stays with the caller; this only supplies the candidate set. Pure — the
+ * caller injects the open-issue snapshot.
+ *
+ *   `query`   free-text title/keywords.
+ *   `issues`  `[{ number, title, body, labels }]` (labels: name-strings or {name}).
+ *   `opts`    { titleWeight=3, bodyWeight=1, labelWeight=1, limit=10, exclude=null }.
+ *
+ * Per query term: a title hit scores `titleWeight`, else a body hit scores
+ * `bodyWeight`; a label hit adds `labelWeight` on top (a hint, not a substitute).
+ * Ranked by descending score, then ascending issue number (stable + deterministic).
+ * Zero-score issues drop out. `exclude` omits one issue (e.g. the query's own).
+ */
+export function scoreDupCandidates(query, issues, opts = {}) {
+  const { titleWeight = 3, bodyWeight = 1, labelWeight = 1, limit = 10, exclude = null } = opts;
+  const terms = dupQueryTerms(query);
+  if (terms.length === 0) return [];
+  const excludeNum = exclude == null || exclude === '' ? null : Number(String(exclude).replace(/^#/, ''));
+  const scored = [];
+  for (const issue of issues ?? []) {
+    if (excludeNum != null && Number(issue.number) === excludeNum) continue;
+    const titleSet = new Set(dupTokens(issue.title));
+    const bodySet = new Set(dupTokens(issue.body));
+    const labelSet = new Set(
+      (issue.labels ?? []).flatMap((l) => dupTokens(typeof l === 'string' ? l : l?.name)),
+    );
+    let score = 0;
+    const hits = [];
+    for (const term of terms) {
+      let termScore = 0;
+      if (titleSet.has(term)) termScore += titleWeight;
+      else if (bodySet.has(term)) termScore += bodyWeight;
+      if (labelSet.has(term)) termScore += labelWeight;
+      if (termScore > 0) {
+        score += termScore;
+        hits.push(term);
+      }
+    }
+    if (score > 0) scored.push({ number: Number(issue.number), title: issue.title ?? '', score, hits });
+  }
+  scored.sort((a, b) => b.score - a.score || a.number - b.number);
+  return limit && limit > 0 ? scored.slice(0, limit) : scored;
 }
 
 // --- I/O boundary: gh / git executors (injectable for tests) -------------------
 
 const defaultGh = (args) => execFileSync('gh', args, { encoding: 'utf8' });
 const defaultGit = (args) => execFileSync('git', args, { encoding: 'utf8' });
-
-/**
- * Integration branch for this repo, detected from origin/HEAD (falls back to
- * `dev`, the template default). Memoized per process.
- */
-let cachedIntegrationBranch = null;
-function integrationBranch(git) {
-  if (cachedIntegrationBranch) return cachedIntegrationBranch;
-  try {
-    const ref = git(['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD']).trim();
-    cachedIntegrationBranch = ref.replace(/^refs\/remotes\/origin\//, '') || 'dev';
-  } catch {
-    cachedIntegrationBranch = 'dev';
-  }
-  return cachedIntegrationBranch;
-}
 
 /** Fetch an issue's label names via gh. */
 function fetchLabelNames(gh, issue) {
@@ -450,9 +963,111 @@ function fmtAge(ms) {
   return h > 0 ? `${h}h${m}m` : `${m}m`;
 }
 
+/** An issue's comments as `[{ body, createdAt }]` (chronological). */
+function fetchLockComments(gh, issue) {
+  return JSON.parse(
+    gh(['issue', 'view', String(issue), '--json', 'comments', '--jq', '[.comments[] | {body: .body, createdAt: .createdAt}]']),
+  );
+}
+
+/**
+ * The claim-verify boundary for an issue: the newest `sdlc:wip` unlabeled
+ * timeline event. Unavailable → null, which degrades safe (planClaimVerify
+ * falls back to the outcome-marker settle signal alone).
+ */
+function fetchClaimBoundary(gh, issue) {
+  try {
+    const timeline = JSON.parse(
+      gh(['api', `repos/{owner}/{repo}/issues/${issue}/timeline`, '--paginate']),
+    );
+    return lastUnlabeledAt(timeline, WIP_LABEL);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * README CLAIM step 3: on a lost race, only the loser's own claim comment may
+ * be edited to note `superseded` — the winner's claim and the label stay
+ * untouched. Cosmetic: losing cleanly matters more than the note.
+ */
+function markClaimSuperseded(gh, commentUrl, runId, lane) {
+  const own = String(commentUrl ?? '').match(/issuecomment-(\d+)/);
+  if (!own) return;
+  try {
+    gh(['api', '-X', 'PATCH', `repos/{owner}/{repo}/issues/comments/${own[1]}`, '-f', `body=sdlc:claim ${runId} ${lane} (superseded)`]);
+  } catch {
+    // cosmetic — losing cleanly matters more than the note
+  }
+}
+
 // --- Commands ------------------------------------------------------------------
 
+/** Shared success report for a won claim (single or --next). */
+function reportClaim(git, log, issue, runId, lane) {
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
+  const status = git(['status', '--short']).trimEnd();
+  log(runId ? `claimed #${issue} (+${WIP_LABEL}, claim ${runId} ${lane})` : `claimed #${issue} (+${WIP_LABEL})`);
+  log(`branch: ${branch}`);
+  log(status ? `status:\n${status}` : 'status: clean');
+}
+
+/**
+ * `sdlc claim --next <lane> <run-id>`: let the CLI pick the next eligible issue
+ * for the lane (same ordering as `computeLanes()` / the worker CLAIM rule) and
+ * claim it atomically with the same `--verify` race check as a single claim.
+ * On a lost race it retries the next eligible item; an empty lane exits non-zero
+ * with `idle` so a worker can pass straight through.
+ */
+function cmdClaimNext(args, nextIdx, { gh, git, log }) {
+  const lane = args[nextIdx + 1];
+  // Everything that is neither the --next flag, its lane value, nor another
+  // flag is positional; the sole positional is the run-id.
+  const positional = args.filter((a, i) => i !== nextIdx && i !== nextIdx + 1 && !a.startsWith('--'));
+  const runId = positional[0];
+  if (!lane || lane.startsWith('--')) {
+    throw new SdlcError('claim --next requires a lane and run-id: sdlc claim --next <lane> <run-id>');
+  }
+  if (!runId) {
+    throw new SdlcError('claim --next requires a run-id: sdlc claim --next <lane> <run-id>');
+  }
+  if (!WORKER_LANES.includes(lane)) {
+    throw new SdlcError(`unknown lane "${lane}" (valid: ${WORKER_LANES.join(', ')})`);
+  }
+
+  const { lanes } = computeLanes(snapshotOpenIssues(gh));
+  const eligible = lanes[lane]?.eligible ?? [];
+  if (eligible.length === 0) {
+    log(`claim --next ${lane}: idle — no eligible issues.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  for (const number of eligible) {
+    const issue = String(number);
+    gh(['issue', 'edit', issue, '--add-label', WIP_LABEL]);
+    const myCommentUrl = String(gh(['issue', 'comment', issue, '--body', `sdlc:claim ${runId} ${lane}`]) ?? '').trim();
+    const result = planClaimVerify(fetchLockComments(gh, issue), runId, fetchClaimBoundary(gh, issue));
+    if (result.won) {
+      log(`claim: verified — ${runId} owns #${issue}.`);
+      reportClaim(git, log, issue, runId, lane);
+      return;
+    }
+    // Lost this one: leave the winner's label untouched, mark our own losing
+    // claim superseded, and try the next eligible item (README CLAIM step 2).
+    markClaimSuperseded(gh, myCommentUrl, runId, lane);
+    log(`claim: LOST race on #${issue} to ${result.winner ?? '(unknown)'} — trying next eligible.`);
+  }
+  log(`claim --next ${lane}: idle — every eligible issue lost to a concurrent claim.`);
+  process.exitCode = 1;
+}
+
 function cmdClaim(args, { gh, git, log }) {
+  const nextIdx = args.indexOf('--next');
+  if (nextIdx >= 0) {
+    cmdClaimNext(args, nextIdx, { gh, git, log });
+    return;
+  }
   const verify = args.includes('--verify');
   const positional = args.filter((a) => a !== '--verify');
   const issue = requireIssue(positional[0]);
@@ -472,38 +1087,75 @@ function cmdClaim(args, { gh, git, log }) {
     myCommentUrl = String(gh(['issue', 'comment', issue, '--body', `sdlc:claim ${runId} ${lane}`]) ?? '').trim();
   }
   if (verify) {
-    // Boundary = newest sdlc:wip unlabel event; unavailable → null, which
-    // treats every claim as live (safe: strictly more competitors, never fewer).
-    let boundary = null;
-    try {
-      const timeline = JSON.parse(gh(['api', `repos/{owner}/{repo}/issues/${issue}/timeline`, '--paginate']));
-      boundary = lastUnlabeledAt(timeline, WIP_LABEL);
-    } catch {
-      boundary = null;
-    }
-    const result = planClaimVerify(fetchIssueComments(gh, issue), runId, boundary);
+    const result = planClaimVerify(fetchLockComments(gh, issue), runId, fetchClaimBoundary(gh, issue));
     if (!result.won) {
-      // README CLAIM iii: the winner's claim and the label stay untouched; only
-      // our own claim comment may be marked superseded.
-      const own = myCommentUrl?.match(/issuecomment-(\d+)/);
-      if (own) {
-        try {
-          gh(['api', '-X', 'PATCH', `repos/{owner}/{repo}/issues/comments/${own[1]}`, '-f', `body=sdlc:claim ${runId} ${lane} (superseded)`]);
-        } catch {
-          // cosmetic — losing cleanly matters more than the note
-        }
-      }
+      markClaimSuperseded(gh, myCommentUrl, runId, lane);
       log(`claim: LOST race on #${issue} to ${result.winner ?? '(unknown)'} — leave the label, pick the next item.`);
       process.exitCode = 1;
       return;
     }
     log(`claim: verified — ${runId} owns #${issue}.`);
   }
-  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
-  const status = git(['status', '--short']).trimEnd();
-  log(runId ? `claimed #${issue} (+${WIP_LABEL}, claim ${runId} ${lane})` : `claimed #${issue} (+${WIP_LABEL})`);
-  log(`branch: ${branch}`);
-  log(status ? `status:\n${status}` : 'status: clean');
+  reportClaim(git, log, issue, runId, lane);
+}
+
+function cmdEmit(args, { gh, log }) {
+  const toIdx = args.indexOf('--to');
+  const bodyIdx = args.indexOf('--body');
+  const bodyFileIdx = args.indexOf('--body-file');
+  const toStage = toIdx >= 0 ? args[toIdx + 1] : null;
+  const bodyText = bodyIdx >= 0 ? args[bodyIdx + 1] : null;
+  const bodyFile = bodyFileIdx >= 0 ? args[bodyFileIdx + 1] : null;
+  const flagValueIdx = new Set(
+    [toIdx, bodyIdx, bodyFileIdx].filter((i) => i >= 0).map((i) => i + 1),
+  );
+  const positional = args.filter((a, i) => !a.startsWith('--') && !flagValueIdx.has(i));
+  const issue = requireIssue(positional[0]);
+  const runId = positional[1];
+  const outcome = positional[2];
+  if (!runId || !outcome) {
+    throw new SdlcError('emit requires a run-id and outcome: sdlc emit <issue> <run-id> <outcome> [--to <stage>] [--body <text>|--body-file <file>]');
+  }
+  if (bodyText !== null && bodyFile !== null) {
+    throw new SdlcError('emit takes --body or --body-file, not both');
+  }
+
+  // Ownership: only the live claim's winner may settle it. A worker that lost
+  // its race (or whose claim was already settled/reaped) must not emit.
+  const verdict = planClaimVerify(fetchLockComments(gh, issue), runId, fetchClaimBoundary(gh, issue));
+  if (!verdict.won) {
+    throw new SdlcError(
+      verdict.reason === 'own claim not found'
+        ? `emit refused: no live sdlc:claim for ${runId} on #${issue} (already settled or never claimed)`
+        : `emit refused: #${issue} is owned by ${verdict.winner}, not ${runId}`,
+    );
+  }
+
+  const labels = fetchLabelNames(gh, issue);
+  const plan = planEmit(labels, outcome, toStage);
+
+  // Marker comment first: it is the completion record claim --verify keys off.
+  // If the label edit below then fails, heal reports STALLED but no later
+  // claimer can falsely lose to this (now settled) claim.
+  const body = bodyFile ? fs.readFileSync(bodyFile, 'utf8') : (bodyText ?? '');
+  const marker = `sdlc:emit ${runId} ${outcome}${toStage ? ` → stage:${toStage}` : ''}`;
+  gh(['issue', 'comment', issue, '--body', body ? `${marker}\n\n${body}` : marker]);
+
+  if (plan.removeLabels.length || plan.addLabels.length) {
+    const editArgs = ['issue', 'edit', issue];
+    for (const label of plan.removeLabels) editArgs.push('--remove-label', label);
+    for (const label of plan.addLabels) editArgs.push('--add-label', label);
+    gh(editArgs);
+  }
+  if (plan.close) {
+    gh(['issue', 'close', issue]);
+  }
+  const labelNote = [
+    plan.removeLabels.length ? `removed ${plan.removeLabels.join(', ')}` : null,
+    plan.addLabels.length ? `added ${plan.addLabels.join(', ')}` : null,
+    plan.close ? 'closed' : null,
+  ].filter(Boolean).join('; ');
+  log(`emit: #${issue} ${outcome}${toStage ? ` → stage:${toStage}` : ''} (${labelNote || 'no label change'})`);
 }
 
 function cmdAdvance(args, { gh, log }) {
@@ -552,15 +1204,14 @@ function cmdWorktree(args, { git, log }, root) {
   const issue = requireIssue(args[0]);
   const branch = args[1] ?? `feat/${issue}`;
   const repoName = path.basename(root);
-  const target = path.resolve(root, '..', `${repoName}-wt-${issue}`);
+  const target = path.resolve(root, '..', worktreeName(repoName, issue));
   git(['fetch', 'origin']);
-  // Reuse an existing branch if present; otherwise create it off the
-  // integration branch's remote tip.
+  // Reuse an existing branch if present; otherwise create it off the default branch.
   const existing = git(['branch', '--list', branch]).trim();
   if (existing) {
     git(['worktree', 'add', target, branch]);
   } else {
-    git(['worktree', 'add', '-b', branch, target, `origin/${integrationBranch(git)}`]);
+    git(['worktree', 'add', '-b', branch, target, `origin/${DEFAULT_BRANCH}`]);
   }
   log(`worktree: ${target} (branch ${branch})`);
 }
@@ -575,13 +1226,51 @@ function cmdComment(args, { gh, log }) {
   log(`#${issue}: comment posted from ${file}`);
 }
 
+/**
+ * `sdlc dup-check "<title or keywords>" [--limit N] [--exclude <issue>]`:
+ * deterministic dup-candidate search over open issues. Prints ranked
+ * `#<n> <title> (score N)` or `no candidates`, and sets exit code 2 when any
+ * candidate is found — so a caller (intake's dup step, retro triage, the
+ * issue-filing ritual) can branch on it (0 = clean, 2 = review these, 1 = usage
+ * error). Judgment stays with the caller; the CLI only supplies the set.
+ */
+function cmdDupCheck(args, { gh, log }) {
+  const limitIdx = args.indexOf('--limit');
+  const excludeIdx = args.indexOf('--exclude');
+  const limit = limitIdx >= 0 ? Number(args[limitIdx + 1]) : 10;
+  const exclude = excludeIdx >= 0 ? args[excludeIdx + 1] : null;
+  const flagValueIdx = new Set([limitIdx, excludeIdx].filter((i) => i >= 0).map((i) => i + 1));
+  const positional = args.filter((a, i) => !a.startsWith('--') && !flagValueIdx.has(i));
+  const query = positional.join(' ').trim();
+  if (!query) {
+    throw new SdlcError('dup-check requires a query: sdlc dup-check "<title or keywords>" [--limit N] [--exclude <issue>]');
+  }
+  const terms = dupQueryTerms(query);
+  if (terms.length === 0) {
+    throw new SdlcError(`dup-check: no usable search terms in "${query}" (all stopwords or too short)`);
+  }
+  const issues = snapshotOpenIssues(gh, 'number,title,body,labels');
+  const candidates = scoreDupCandidates(query, issues, { limit, exclude });
+  if (candidates.length === 0) {
+    log(`dup-check: no candidates for "${query}" — ${issues.length} open issue(s) scanned (terms: ${terms.join(', ')}).`);
+    return; // exit 0 — clean
+  }
+  log(`dup-check: ${candidates.length} candidate(s) for "${query}" (terms: ${terms.join(', ')}):`);
+  for (const c of candidates) {
+    log(`  #${c.number} ${c.title} (score ${c.score})`);
+  }
+  log('dup-check: judge each — the CLI ranks, you decide. Exit 2 = candidates found.');
+  process.exitCode = 2; // candidates found — caller must judge
+}
+
 function cmdGate(args, { gh, log }) {
   const reap = args.includes('--reap');
   const snapshot = snapshotOpenIssues(gh, 'number,labels,updatedAt');
   const wip = snapshot.filter((i) => (i.labels ?? []).some((l) => l.name === WIP_LABEL));
   const now = Date.now();
   const wipItems = wip.map((i) => {
-    // Accurate age from the sdlc:wip labeled event, not updatedAt (issue #613).
+    // Accurate age from the sdlc:wip labeled event, not updatedAt (which any
+    // later comment falsely refreshes).
     let addedAt = null;
     try {
       const timeline = JSON.parse(
@@ -604,11 +1293,12 @@ function cmdGate(args, { gh, log }) {
     log(`gate: REAP #${it.number} (stale ${fmtAge(it.ageMs)})`);
     if (reap) {
       // Verify-before-write: the snapshot may be stale under concurrent
-      // dispatchers — another run may have reaped and a new worker claimed
-      // since. Re-fetch the newest claim and recompute the age before writing.
+      // dispatchers — another run may have reaped this issue and a new worker
+      // claimed it since. Re-fetch the newest claim and recompute the age
+      // immediately before writing.
       let freshAgeMs = null;
       try {
-        const claims = fetchIssueComments(gh, it.number).filter((c) => /^sdlc:claim\s/.test(c.body ?? ''));
+        const claims = fetchLockComments(gh, it.number).filter((c) => /^sdlc:claim\s/.test(c.body ?? ''));
         const newest = claims[claims.length - 1];
         if (newest) freshAgeMs = Date.now() - new Date(newest.createdAt).getTime();
       } catch {
@@ -633,10 +1323,10 @@ function cmdGate(args, { gh, log }) {
   if (plan.decision === 'clear') log('gate: CLEAR — no wip locks.');
 }
 
-function fetchIssueComments(gh, issue) {
-  return JSON.parse(
-    gh(['issue', 'view', String(issue), '--json', 'comments', '--jq', '[.comments[] | {body: .body, createdAt: .createdAt}]']),
-  );
+function cmdMint(args, { log }) {
+  // Coin the cycle run-id (single source of truth), printed on its own
+  // `run-id:` line so the dispatcher can capture it and hand it to workers.
+  log(`run-id: ${mintRunId()}`);
 }
 
 /** The machine maintenance-lock directory (inside .git: never tracked or swept). */
@@ -675,7 +1365,7 @@ function cmdMaintLock(args, { log }, root) {
   try {
     acquire();
     log(`maint-lock: ACQUIRED ${runId}`);
-    return;
+    return { status: 'acquired' };
   } catch (err) {
     if (err?.code !== 'EEXIST') throw err;
   }
@@ -684,7 +1374,7 @@ function cmdMaintLock(args, { log }, root) {
   if (plan.action === 'skip') {
     log(`maint-lock: HELD by ${owner.runId} (${fmtAge(owner.ageMs)}) — skip maintenance this cycle; never abort over this lock.`);
     process.exitCode = 1;
-    return;
+    return { status: 'held', owner: owner.runId, age: fmtAge(owner.ageMs) };
   }
   // Stale (holder presumed dead) → reap by rename: atomic, exactly one contender wins.
   const stale = `${dir}.stale-${runId}`;
@@ -693,7 +1383,7 @@ function cmdMaintLock(args, { log }, root) {
   } catch {
     log('maint-lock: HELD — another run just reaped or holds it; skip maintenance this cycle.');
     process.exitCode = 1;
-    return;
+    return { status: 'held', owner: owner.runId, age: fmtAge(owner.ageMs) };
   }
   fs.rmSync(stale, { recursive: true, force: true });
   try {
@@ -701,9 +1391,10 @@ function cmdMaintLock(args, { log }, root) {
   } catch {
     log('maint-lock: HELD — lost the post-reap acquire race; skip maintenance this cycle.');
     process.exitCode = 1;
-    return;
+    return { status: 'held', owner: owner.runId, age: fmtAge(owner.ageMs) };
   }
   log(`maint-lock: REAPED stale lock from ${owner.runId} (${fmtAge(owner.ageMs)}); ACQUIRED ${runId}`);
+  return { status: 'reaped', owner: owner.runId, age: fmtAge(owner.ageMs) };
 }
 
 function cmdMaintRelease(args, { log }, root) {
@@ -729,31 +1420,64 @@ function cmdLanes(args, { gh, log }) {
   for (const lane of WORKER_LANES.concat('queued')) {
     const l = lanes[lane];
     const elig = l.eligible.length ? l.eligible.map((n) => `#${n}`).join(', ') : '—';
-    log(`${lane}: depth ${l.depth}, eligible ${elig}`);
+    const breakdown = laneIneligibilityBreakdown(l);
+    log(`${lane}: depth ${l.depth}, eligible ${elig}${breakdown ? ` ${breakdown}` : ''}`);
   }
   if (integrity.length) {
-    log('integrity (≠1 stage label — needs human):');
+    log('integrity (corrupt stage-label state — needs human):');
     for (const v of integrity) {
-      const desc = v.stages.length === 0 ? 'no stage label' : `stages: ${v.stages.join(', ')}`;
+      const desc = v.stages.length === 0 ? 'no stage label (but wip/needs-human)' : `stages: ${v.stages.join(', ')}`;
       log(`  #${v.number}: ${desc}`);
     }
   } else {
-    log('integrity: clean (every open issue has exactly one stage label)');
+    log('integrity: clean');
   }
 }
 
 function cmdHeal(args, { gh, log }) {
-  // Accept `heal <lane> <issue>` or `heal <issue>`; lane is advisory only.
-  const issueArg = args.length >= 2 ? args[1] : args[0];
-  const lane = args.length >= 2 ? args[0] : null;
-  const issue = requireIssue(issueArg);
-  const labels = fetchLabelNames(gh, issue);
-  const { stillLocked } = planHeal(labels);
-  const laneNote = lane ? ` (${lane})` : '';
-  if (stillLocked) {
-    log(`heal: #${issue}${laneNote} STALLED — still carries ${WIP_LABEL}; worker did not emit an outcome.`);
-  } else {
-    log(`heal: #${issue}${laneNote} OK — lock cleared; ${stagesOf(labels)[0] ? `now stage:${stagesOf(labels)[0]}` : 'no stage label'}.`);
+  // Three forms:
+  //   heal <lane> <issue>  explicit issue, lane advisory (self-heal after a known worker)
+  //   heal <issue>         explicit issue, no lane
+  //   heal <lane>          NO issue → auto-discover every stalled wip issue in the lane
+  const isIssueArg = (a) => /^#?\d+$/.test(String(a ?? ''));
+  let lane = null;
+  let issueArg = null;
+  if (args.length >= 2) {
+    lane = args[0];
+    issueArg = args[1];
+  } else if (args.length === 1) {
+    if (isIssueArg(args[0])) issueArg = args[0];
+    else lane = args[0];
+  }
+
+  if (issueArg) {
+    // Single-issue check (explicit issue given).
+    const issue = requireIssue(issueArg);
+    const labels = fetchLabelNames(gh, issue);
+    const { stillLocked } = planHeal(labels);
+    const laneNote = lane ? ` (${lane})` : '';
+    if (stillLocked) {
+      log(`heal: #${issue}${laneNote} STALLED — still carries ${WIP_LABEL}; worker did not emit an outcome.`);
+    } else {
+      log(`heal: #${issue}${laneNote} OK — lock cleared; ${stagesOf(labels)[0] ? `now stage:${stagesOf(labels)[0]}` : 'no stage label'}.`);
+    }
+    return;
+  }
+
+  // Lane auto-discovery: no issue argument — find every stalled wip issue myself.
+  if (!lane) {
+    throw new SdlcError('heal requires a lane and/or issue: sdlc heal [<lane>] [<issue>]');
+  }
+  if (!WORKER_LANES.includes(lane)) {
+    throw new SdlcError(`unknown lane "${lane}" (valid: ${WORKER_LANES.join(', ')})`);
+  }
+  const stalled = planHealLane(snapshotOpenIssues(gh, 'number,labels'), lane);
+  if (stalled.length === 0) {
+    log(`heal: ${lane} OK — no stalled ${WIP_LABEL} issues in stage:${lane}.`);
+    return;
+  }
+  for (const number of stalled) {
+    log(`heal: #${number} (${lane}) STALLED — still carries ${WIP_LABEL}; worker did not emit an outcome.`);
   }
 }
 
@@ -762,36 +1486,34 @@ function cmdGitMaint(args, { git, gh, log }) {
 
   git(['fetch', 'origin', '--prune']);
 
-  const integ = integrationBranch(git);
-
-  // Update the integration branch without touching the working tree.
-  const integBefore = (() => {
+  // Update the default branch without touching the working tree.
+  const devBefore = (() => {
     try {
-      return git(['rev-parse', integ]).trim();
+      return git(['rev-parse', DEFAULT_BRANCH]).trim();
     } catch {
       return null;
     }
   })();
   try {
-    if (current === integ) git(['pull', '--ff-only', 'origin', integ]);
-    else git(['fetch', 'origin', `${integ}:${integ}`]);
-    const integAfter = git(['rev-parse', integ]).trim();
+    if (current === DEFAULT_BRANCH) git(['pull', '--ff-only', 'origin', DEFAULT_BRANCH]);
+    else git(['fetch', 'origin', `${DEFAULT_BRANCH}:${DEFAULT_BRANCH}`]);
+    const devAfter = git(['rev-parse', DEFAULT_BRANCH]).trim();
     log(
-      integBefore === integAfter
-        ? `${integ} update: already current`
-        : `${integ} update: ${integBefore?.slice(0, 8)}..${integAfter.slice(0, 8)}`,
+      devBefore === devAfter
+        ? `${DEFAULT_BRANCH} update: already current`
+        : `${DEFAULT_BRANCH} update: ${devBefore?.slice(0, 8)}..${devAfter.slice(0, 8)}`,
     );
   } catch (err) {
-    log(`${integ} update: skipped (${String(err.message).split('\n')[0]})`);
+    log(`${DEFAULT_BRANCH} update: skipped (${String(err.message).split('\n')[0]})`);
   }
 
   // Ancestry-merged prune.
-  const merged = git(['branch', '--merged', integ]).split(/\r?\n/);
+  const merged = git(['branch', '--merged', DEFAULT_BRANCH]).split(/\r?\n/);
   const candidates = planBranchPrune(merged, current);
   const pruned = [];
   for (const b of candidates) {
     try {
-      git(['merge-base', '--is-ancestor', b, integ]); // throws (nonzero) if not ancestor
+      git(['merge-base', '--is-ancestor', b, DEFAULT_BRANCH]); // throws (nonzero) if not ancestor
       git(['branch', '-D', b]);
       pruned.push(b);
     } catch {
@@ -839,29 +1561,260 @@ function cmdGitMaint(args, { git, gh, log }) {
   }
 }
 
+function cmdWorktreeSweep(args, { git, gh, log, statSize = (p) => fs.statSync(p).size }, root) {
+  const apply = args.includes('--apply');
+  const repoName = path.basename(root);
+
+  let trees;
+  try {
+    trees = parseWorktrees(git(['worktree', 'list', '--porcelain']), repoName);
+  } catch (err) {
+    log(`worktree-sweep: could not list worktrees (${String(err.message).split('\n')[0]})`);
+    return;
+  }
+  if (!trees.length) {
+    log('worktree-sweep: no issue-scoped worktrees.');
+    return;
+  }
+
+  // Fetch/prune first so origin refs and ancestry are current before we judge.
+  try {
+    git(['fetch', 'origin', '--prune']);
+  } catch (err) {
+    log(`worktree-sweep: fetch failed (${String(err.message).split('\n')[0]}) — judging on stale refs.`);
+  }
+
+  const enriched = trees.map((t) => {
+    // Clean = no uncommitted changes in that tree. A tree whose only content is
+    // 0-byte untracked strays (mangled `> OUTCOME` redirects, #688) counts as
+    // "clean modulo strays": clean:true plus the stray paths to clear on --apply.
+    // Defensive: an unreadable tree is treated as dirty so it is never removed.
+    let clean = false;
+    let strays = [];
+    try {
+      const porcelain = git(['-C', t.path, 'status', '--porcelain']);
+      const classified = classifyStatusForSweep(porcelain, (rel) =>
+        statSize(path.join(t.path, rel)),
+      );
+      clean = classified.clean;
+      strays = classified.strays;
+    } catch {
+      clean = false;
+      strays = [];
+    }
+
+    // branchGone/merged: no branch ref, OR the branch is ancestry-merged into
+    // origin/<DEFAULT_BRANCH>, OR its PR is MERGED. All are positive "landed"
+    // signals — none fires on a fresh never-pushed branch, so in-progress work
+    // is safe.
+    let branchGone = false;
+    if (!t.branch) {
+      branchGone = true; // detached worktree with no branch
+    } else {
+      try {
+        git(['show-ref', '--verify', '--quiet', `refs/heads/${t.branch}`]);
+        // branch exists locally — check merged / PR state
+        let merged = false;
+        try {
+          git(['merge-base', '--is-ancestor', t.branch, `origin/${DEFAULT_BRANCH}`]);
+          merged = true;
+        } catch {
+          merged = false;
+        }
+        if (!merged) {
+          try {
+            const prs = JSON.parse(gh(['pr', 'list', '--head', t.branch, '--state', 'merged', '--json', 'number']));
+            merged = Array.isArray(prs) && prs.length > 0;
+          } catch {
+            merged = false;
+          }
+        }
+        branchGone = merged;
+      } catch {
+        branchGone = true; // branch ref no longer exists
+      }
+    }
+
+    // issueClosed: the owning issue is CLOSED. Ambiguous/unreadable → false.
+    let issueClosed = false;
+    try {
+      const state = JSON.parse(gh(['issue', 'view', String(t.issue), '--json', 'state'])).state;
+      issueClosed = state === 'CLOSED';
+    } catch {
+      issueClosed = false;
+    }
+
+    return { ...t, clean, strays, branchGone, issueClosed };
+  });
+
+  const plan = planWorktreeSweep(enriched);
+
+  for (const t of plan.leave) {
+    log(`worktree-sweep: LEAVE ${t.path} (#${t.issue}) — ${t.reason}`);
+  }
+  for (const t of plan.remove) {
+    const strayCount = t.strays?.length ?? 0;
+    const strayNote = strayCount
+      ? ` (${apply ? 'cleared' : 'after clearing'} ${strayCount} 0-byte stray)`
+      : '';
+    log(`worktree-sweep: REMOVE ${t.path} (#${t.issue}) — ${t.reason}${strayNote}`);
+    if (apply) {
+      // A 0-byte stray blocks `git worktree remove` as an untracked change; clear
+      // the provably-empty files first (classify already vetted size === 0).
+      for (const rel of t.strays ?? []) {
+        const full = path.join(t.path, rel);
+        try {
+          fs.rmSync(full);
+          log(`  cleared 0-byte stray: ${full}`);
+        } catch (err) {
+          log(`  could not clear stray ${full}: ${String(err.message).split('\n')[0]}`);
+        }
+      }
+      // #723: unlink any root-level junction (e.g. node_modules → main checkout)
+      // BEFORE git touches the tree — git worktree remove follows junctions on
+      // Windows and would delete the shared target's contents through it.
+      unlinkWorktreeRootLinks(t.path, log);
+      try {
+        git(['worktree', 'remove', t.path]);
+        log(`  removed: ${t.path}`);
+      } catch (err) {
+        // Report (don't fail) on permission errors etc. — stale admin dirs can
+        // survive a kill and refuse deletion; the prune below still runs.
+        log(`  could not remove ${t.path}: ${String(err.message).split('\n')[0]}`);
+      }
+    }
+  }
+
+  if (plan.remove.length && !apply) {
+    log('worktree-sweep: run with --apply to remove the clean stale worktree(s).');
+  }
+  if (apply) {
+    try {
+      git(['worktree', 'prune']);
+      log('worktree-sweep: pruned worktree admin metadata.');
+    } catch (err) {
+      log(`worktree-sweep: prune reported (${String(err.message).split('\n')[0]}) — continuing.`);
+    }
+  }
+  if (!plan.remove.length) log('worktree-sweep: nothing to remove.');
+}
+
+function cmdConflictScan(args, { gh, git, log }) {
+  const apply = args.includes('--apply');
+
+  // The default branch's tip commit time is the idempotency watermark: a
+  // conflict comment older than the last base-branch change is stale, so a
+  // re-nudge is warranted; a newer one means we already flagged this since the
+  // base branch last moved.
+  let baseUpdatedAt = null;
+  try {
+    baseUpdatedAt = git(['log', '-1', '--format=%cI', `origin/${DEFAULT_BRANCH}`]).trim() || null;
+  } catch {
+    baseUpdatedAt = null;
+  }
+
+  const prs = JSON.parse(
+    gh([
+      'pr', 'list', '--state', 'open', '--base', DEFAULT_BRANCH,
+      '--json', 'number,headRefName,baseRefName,mergeable,closingIssuesReferences',
+      '--limit', '200',
+    ]),
+  ).map((p) => ({
+    number: p.number,
+    headRefName: p.headRefName,
+    baseRefName: p.baseRefName,
+    mergeable: p.mergeable,
+    linkedIssues: (p.closingIssuesReferences ?? []).map((r) => r.number),
+  }));
+
+  // Fetch labels/comments/state for every issue linked by a conflicting PR.
+  const issueInfo = {};
+  const wanted = new Set();
+  for (const pr of prs) {
+    if (pr.mergeable === 'CONFLICTING') for (const n of pr.linkedIssues) wanted.add(n);
+  }
+  for (const n of wanted) {
+    try {
+      const v = JSON.parse(gh(['issue', 'view', String(n), '--json', 'state,labels,comments']));
+      issueInfo[n] = {
+        state: v.state,
+        labels: (v.labels ?? []).map((l) => l.name),
+        comments: (v.comments ?? []).map((c) => ({ body: c.body, createdAt: c.createdAt })),
+      };
+    } catch {
+      // leave undefined → planned as "linked issue closed or not found"
+    }
+  }
+
+  const { actions, skipped } = planConflictScan(prs, issueInfo, baseUpdatedAt);
+
+  if (!actions.length && !skipped.length) {
+    log(`conflict-scan: no conflicting PRs into ${DEFAULT_BRANCH}.`);
+    return;
+  }
+
+  for (const a of actions) {
+    const adv = a.advanceTo ? ` + advance #${a.issue} stage:${a.stage} → stage:${a.advanceTo}` : '';
+    log(`conflict-scan: PR #${a.pr} (${a.branch}) → comment #${a.issue}${adv}`);
+    if (apply) {
+      gh(['issue', 'comment', String(a.issue), '--body', a.comment]);
+      if (a.advanceTo) {
+        const plan = planAdvance(issueInfo[a.issue].labels, a.advanceTo);
+        const editArgs = ['issue', 'edit', String(a.issue)];
+        for (const l of plan.removeLabels) editArgs.push('--remove-label', l);
+        for (const l of plan.addLabels) editArgs.push('--add-label', l);
+        gh(editArgs);
+      }
+    }
+  }
+  for (const s of skipped) {
+    log(`conflict-scan: skipped ${s.issue ? `#${s.issue} ` : ''}(PR #${s.pr}) — ${s.reason}`);
+  }
+  if (!apply && actions.length) {
+    log('conflict-scan: dry run — re-run with --apply to post comments + advance.');
+  }
+}
+
 function cmdDigest(args, { gh, log }, root) {
   const idx = args.indexOf('--state');
   const statePath = idx >= 0 && args[idx + 1] ? args[idx + 1] : path.join(root, '.sdlc-cache', 'last-digest.json');
 
-  let prevNumbers = null;
+  let prev = null;
   try {
     if (fs.existsSync(statePath)) {
-      prevNumbers = JSON.parse(fs.readFileSync(statePath, 'utf8')).current ?? null;
+      const saved = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+      prev = { current: saved.current ?? null, parked: saved.parked ?? null, hold: saved.hold ?? null };
     }
   } catch {
-    prevNumbers = null;
+    prev = null;
   }
 
   const snapshot = snapshotOpenIssues(gh, 'number,labels');
-  const d = computeDigest(snapshot, prevNumbers);
+  const d = computeDigest(snapshot, prev);
+
+  const fmtList = (nums) => (nums.length ? nums.map((n) => `#${n}`).join(', ') : 'none');
+  // Diff-style: the parked/hold lists barely change cycle-to-cycle, so report
+  // "no change" when they're identical and only annotate the +/− delta otherwise,
+  // instead of re-listing every number every cycle.
+  const fmtParkLine = (label, list, delta) => {
+    if (delta && !delta.changed) return `${label}: no change (${list.length})`;
+    let line = `${label}: ${fmtList(list)}`;
+    if (delta && delta.changed) {
+      const parts = [];
+      if (delta.added.length) parts.push(`+${delta.added.map((n) => `#${n}`).join(', ')}`);
+      if (delta.removed.length) parts.push(`-${delta.removed.map((n) => `#${n}`).join(', ')}`);
+      if (parts.length) line += ` (${parts.join(' ')})`;
+    }
+    return line;
+  };
 
   log(
     `depths: ${WORKER_LANES.concat('queued')
       .map((l) => `${l} ${d.depths[l]}`)
       .join(' / ')}`,
   );
-  log(`parked (needs-human): ${d.parked.length ? d.parked.map((n) => `#${n}`).join(', ') : 'none'}`);
-  log(`hold: ${d.hold.length ? d.hold.map((n) => `#${n}`).join(', ') : 'none'}`);
+  log(fmtParkLine('parked (needs-human)', d.parked, d.parkedDelta));
+  log(fmtParkLine('hold', d.hold, d.holdDelta));
   if (d.arrivals !== null) {
     log(`arrivals vs last cycle: ${d.arrivals.length ? d.arrivals.map((n) => `#${n}`).join(', ') : 'none'}`);
     log(`departures vs last cycle: ${d.departures.length ? d.departures.map((n) => `#${n}`).join(', ') : 'none'}`);
@@ -871,44 +1824,224 @@ function cmdDigest(args, { gh, log }, root) {
 
   try {
     fs.mkdirSync(path.dirname(statePath), { recursive: true });
-    fs.writeFileSync(statePath, JSON.stringify({ at: new Date().toISOString(), current: d.current }, null, 2));
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify({ at: new Date().toISOString(), current: d.current, parked: d.parked, hold: d.hold }, null, 2),
+    );
   } catch (err) {
     log(`digest: could not persist snapshot (${String(err.message).split('\n')[0]})`);
   }
 }
 
-const USAGE = `sdlc — deterministic SDLC pipeline one-shots
+function cmdSweep(args, { gh, log }, root) {
+  const stateIdx = args.indexOf('--state');
+  const windowIdx = args.indexOf('--window');
+  const ack = args.includes('--ack');
+  const statePath =
+    stateIdx >= 0 && args[stateIdx + 1]
+      ? args[stateIdx + 1]
+      : path.join(root, '.sdlc-cache', 'last-sweep.json');
+  const windowHours = windowIdx >= 0 && args[windowIdx + 1] ? Number(args[windowIdx + 1]) : 24;
+
+  let sweptPrs = [];
+  try {
+    if (fs.existsSync(statePath)) {
+      sweptPrs = JSON.parse(fs.readFileSync(statePath, 'utf8')).sweptPrs ?? [];
+    }
+  } catch {
+    sweptPrs = [];
+  }
+
+  const prs = JSON.parse(
+    gh([
+      'pr', 'list', '--state', 'merged', '--base', DEFAULT_BRANCH,
+      '--json', 'number,mergedAt,title,closingIssuesReferences', '--limit', '50',
+    ]),
+  );
+  const mergedPrs = prs.map((p) => ({
+    number: p.number,
+    mergedAt: p.mergedAt,
+    title: p.title,
+    closes: (p.closingIssuesReferences ?? []).map((r) => r.number),
+  }));
+  const sinceMs = Number.isFinite(windowHours) ? Date.now() - windowHours * 3600000 : null;
+
+  // --ack: the only mode that writes the marker. Run it AFTER processing the
+  // work-list so a worker that dies mid-processing re-lists the same merges on
+  // the next pass (at-least-once; the cascade-unblock itself is idempotent).
+  if (ack) {
+    const { nextSwept, newlyAcked } = computeSweepAck(mergedPrs, { sinceMs, sweptPrs });
+    try {
+      fs.mkdirSync(path.dirname(statePath), { recursive: true });
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({ at: new Date().toISOString(), sweptPrs: nextSwept }, null, 2),
+      );
+      log(
+        newlyAcked.length
+          ? `sweep: acked ${newlyAcked.length} merge${newlyAcked.length === 1 ? '' : 's'} (${newlyAcked.map((n) => `#${n}`).join(', ')})`
+          : 'sweep: ack — nothing new',
+      );
+    } catch (err) {
+      log(`sweep: could not persist marker (${String(err.message).split('\n')[0]})`);
+    }
+    return;
+  }
+
+  const openIssues = JSON.parse(
+    gh(['issue', 'list', '--state', 'open', '--json', 'number,title,labels,body', '--limit', '200']),
+  );
+  const { items, empty } = computeSweep(mergedPrs, openIssues, { sinceMs, sweptPrs });
+
+  if (empty) {
+    log('sweep: clear');
+    return;
+  }
+  for (const it of items) {
+    log(`PR #${it.number} (merged ${it.mergedAt ?? '?'}) ${it.title}`);
+    for (const c of it.closes) {
+      log(`  closed #${c.number}`);
+      if (c.dependents.length) {
+        for (const d of c.dependents) {
+          log(`    dependent #${d.number}${d.blocked ? ' [blocked → unblock]' : ''} ${d.title}`);
+        }
+      } else {
+        log('    dependents: none');
+      }
+    }
+  }
+  log('sweep: run `sdlc sweep --ack` after processing to mark these swept');
+}
+
+/**
+ * `sdlc cycle-prep [--apply]`: the whole fixed, zero-judgment pre-dispatch
+ * sequence in one shot — mint → maint-lock → lanes → gate --reap → sweep →
+ * (git-maint → worktree-sweep → conflict-scan) → maint-release — emitting one
+ * delimited, machine-readable report so the dispatcher runs `cycle-prep`,
+ * reads it, spawns workers, then `digest`.
+ *
+ * Semantics are identical to the individual subcommands (they are literally
+ * invoked here): the run-id is minted internally and printed verbatim on its own
+ * `run-id:` line; the machine maintenance lock guards Step 0a exactly as before —
+ * the git/worktree/conflict maintenance trio runs ONLY while this run holds the
+ * lock, and the lock is released at the end of that section regardless. A lock
+ * held by another live run is a normal outcome (maintenance skipped, cycle
+ * continues), NOT a cycle-prep failure, so its exit-1 signal is not propagated.
+ * gate always reaps (verify-before-write, as dispatch Step 0 does). `--apply`
+ * propagates to worktree-sweep/conflict-scan (default: preview).
+ */
+function cmdCyclePrep(args, deps, root) {
+  const { log } = deps;
+  const apply = args.includes('--apply');
+  const runId = mintRunId();
+  const startedAt = new Date().toISOString();
+
+  // run-id first, on its own line, byte-identical to `sdlc mint` — the dispatcher
+  // captures this as the cycle's single source of truth. `started:` stamps the
+  // cycle start so digest can compute wall-clock duration.
+  log(`run-id: ${runId}`);
+  log(`started: ${startedAt}`);
+
+  const section = (name) => log(`\n=== ${name} ===`);
+
+  // Machine maintenance lock (dispatch Step -1). A held-by-other lock sets
+  // exitCode 1 for the standalone command; here it is expected, so restore the
+  // prior exit code — a skipped maintenance section is not a cycle-prep failure.
+  section('maint-lock');
+  const savedExit = process.exitCode;
+  const lock = cmdMaintLock([runId], deps, root);
+  const weHoldLock = lock.status === 'acquired' || lock.status === 'reaped';
+  if (!weHoldLock) process.exitCode = savedExit;
+
+  try {
+    // Snapshot + per-issue wip gate + merge-sweep peek (dispatch Step 0) — run
+    // every cycle whether or not we hold the maintenance lock.
+    section('lanes');
+    cmdLanes([], deps, root);
+
+    section('gate');
+    cmdGate(['--reap'], deps, root);
+
+    section('sweep');
+    cmdSweep([], deps, root);
+
+    if (weHoldLock) {
+      // Git + worktree maintenance (dispatch Step 0a) — only while holding the lock.
+      section('git-maint');
+      cmdGitMaint([], deps, root);
+
+      section('worktree-sweep');
+      cmdWorktreeSweep(apply ? ['--apply'] : [], deps, root);
+
+      section('conflict-scan');
+      cmdConflictScan(apply ? ['--apply'] : [], deps, root);
+    } else {
+      section('maintenance');
+      log(`maintenance: skipped (lock held by ${lock.owner ?? 'another run'}${lock.age ? `, ${lock.age}` : ''}) — Step 0a not run this cycle.`);
+    }
+  } finally {
+    // Release at the end of the maintenance section (success or not), never at
+    // cycle end — but only if this run actually acquired/reaped the lock.
+    if (weHoldLock) {
+      section('maint-release');
+      cmdMaintRelease([runId], deps, root);
+    }
+  }
+
+  section('summary');
+  const maintNote = weHoldLock ? (apply ? 'applied' : 'previewed') : 'skipped';
+  log(`cycle-prep: run-id ${runId}, started ${startedAt}, maintenance ${maintNote}.`);
+}
+
+const USAGE = `sdlc — deterministic SDLC pipeline one-shots (reference implementation)
 
   Worker-side:
   sdlc claim    <issue> [<run-id> <lane>] [--verify]  add ${WIP_LABEL} + claim comment; --verify exits 1 on a lost race
-  sdlc advance  <issue> <to-stage>  validate + swap stage label, drop ${WIP_LABEL}
+  sdlc claim    --next <lane> <run-id>                CLI picks the next eligible issue for the lane + claims it; exits 1 with idle if none
+  sdlc emit     <issue> <run-id> <ADVANCE|BOUNCE|PARK|CONTINUE|CLOSE> [--to <stage>] [--body <text>|--body-file <file>]
+                                    post the sdlc:emit marker comment + do the outcome's label math
+  sdlc advance  <issue> <to-stage>  validate + swap stage label, drop ${WIP_LABEL} (dispatcher-side swaps; workers use emit)
   sdlc context  <issue>             branch + status + issue labels/state + PRs
   sdlc worktree <issue> [<branch>]  add a sibling git worktree for the branch
   sdlc comment  <issue> <file>      post a body-file comment (plumbing)
+  sdlc dup-check "<keywords>" [--limit N] [--exclude <issue>]  rank open-issue dup candidates; exit 2 if any found, 0 if clean
 
   Dispatcher-side:
-  sdlc gate     [--reap]            per-issue wip-lock ages (timeline-based) → LIVE/REAP/CLEAR
+  sdlc gate     [--reap]            per-issue wip-lock ages (timeline-based) → LIVE/REAP/CLEAR; --reap re-verifies before writing
+  sdlc mint                         coin + print this cycle's run-id
   sdlc maint-lock    <run-id>       acquire the per-machine maintenance lock (exit 1 = held: skip Step 0a, never abort)
   sdlc maint-release <run-id>       release the maintenance lock (idempotent)
-  sdlc lanes                        per-lane depth + eligibility + ≠1 stage integrity
-  sdlc heal     [<lane>] <issue>    post-worker self-heal check (still locked?)
-  sdlc git-maint                    fetch, ff dev, prune merged branches, PR state
+  sdlc lanes                        per-lane depth + eligibility + stage-label integrity
+  sdlc heal     [<lane>] [<issue>]  post-worker self-heal check (still locked?); lane-only auto-discovers stalled wip issues
+  sdlc git-maint                    fetch, ff ${DEFAULT_BRANCH}, prune merged branches, PR state
+  sdlc worktree-sweep [--apply]     remove clean issue-scoped worktrees whose branch is gone/merged or issue closed
+  sdlc conflict-scan [--apply]      nudge + bounce-to-build issues whose open PR conflicts with ${DEFAULT_BRANCH}
+  sdlc sweep    [--state <file>] [--window <hours>]  merged PRs → closed issues → blocked dependents (read-only, writes nothing)
+  sdlc sweep --ack [--state <file>] [--window <hours>]  mark the window's merges swept (run AFTER processing the work-list)
+  sdlc cycle-prep [--apply]         the whole pre-dispatch sequence in one shot (mint→maint-lock→lanes→gate --reap→sweep→git-maint→worktree-sweep→conflict-scan→maint-release), one delimited report
   sdlc digest   [--state <file>]    depths, parked/hold, arrivals-diff vs last cycle
 
 Stages: ${STAGES.join(' → ')}`;
 
 const COMMANDS = {
   claim: cmdClaim,
+  emit: cmdEmit,
   advance: cmdAdvance,
   context: cmdContext,
   worktree: cmdWorktree,
   comment: cmdComment,
+  'dup-check': cmdDupCheck,
   gate: cmdGate,
+  mint: cmdMint,
   'maint-lock': cmdMaintLock,
   'maint-release': cmdMaintRelease,
   lanes: cmdLanes,
   heal: cmdHeal,
   'git-maint': cmdGitMaint,
+  'worktree-sweep': cmdWorktreeSweep,
+  'conflict-scan': cmdConflictScan,
+  sweep: cmdSweep,
+  'cycle-prep': cmdCyclePrep,
   digest: cmdDigest,
 };
 
@@ -923,6 +2056,7 @@ export function runSdlc(argv, deps = {}) {
     git = defaultGit,
     log = (msg) => console.log(msg),
     root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'),
+    statSize,
   } = deps;
   const [command, ...rest] = argv;
   if (!command || command === '--help' || command === '-h') {
@@ -933,7 +2067,7 @@ export function runSdlc(argv, deps = {}) {
   if (!handler) {
     throw new SdlcError(`unknown command "${command}"\n\n${USAGE}`);
   }
-  handler(rest, { gh, git, log }, root);
+  handler(rest, { gh, git, log, statSize }, root);
 }
 
 // Only run when invoked directly, so tests can import the pure helpers.

--- a/test/sdlc.test.mjs
+++ b/test/sdlc.test.mjs
@@ -1,0 +1,1432 @@
+// Tests for scripts/sdlc.mjs — zero-dependency, node's built-in runner:
+//   node --test              (default discovery finds test/*.test.mjs)
+//   node --test "test/*.test.mjs"
+// (On Node ≥22 the positional arg is a glob, so a bare directory like
+// `node --test test/` may not resolve on every platform — prefer the forms above.)
+// Ported (and generalized) from an adopting project's Mocha/Chai suite.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import {
+  DEFAULT_BRANCH,
+  STAGES,
+  STAGE_GRAPH,
+  WIP_LABEL,
+  WIP_STALE_MS,
+  SdlcError,
+  isValidStage,
+  isValidTransition,
+  currentStage,
+  planAdvance,
+  planEmit,
+  EMIT_OUTCOMES,
+  runSdlc,
+  planClaimVerify,
+  lastUnlabeledAt,
+  computeLanes,
+  laneIneligibilityBreakdown,
+  planHealLane,
+  mintRunId,
+  parseWorktrees,
+  planWorktreeSweep,
+  unlinkWorktreeRootLinks,
+  classifyStatusForSweep,
+  computeDigest,
+  computeSweep,
+  computeSweepAck,
+  planConflictScan,
+  conflictCommentBody,
+  CONFLICT_BOUNCE_STAGES,
+  dupTokens,
+  dupQueryTerms,
+  scoreDupCandidates,
+} from '../scripts/sdlc.mjs';
+
+/** Build a fake gh/git executor that records calls and returns canned output. */
+function fakeExec(responses = {}) {
+  const calls = [];
+  const fn = (args) => {
+    calls.push(args);
+    const key = args.join(' ');
+    return responses[key] ?? '';
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+/** assert.throws with an SdlcError class + message-regex check. */
+function throwsSdlc(fn, re) {
+  assert.throws(fn, (err) => err instanceof SdlcError && (!re || re.test(err.message)));
+}
+
+describe('stage graph', () => {
+  it('lists every stage in pipeline order', () => {
+    assert.deepEqual(STAGES, ['intake', 'design', 'queued', 'build', 'verify', 'audit', 'ship']);
+  });
+
+  it('has a graph node for every declared stage and vice versa', () => {
+    assert.deepEqual(Object.keys(STAGE_GRAPH).sort(), [...STAGES].sort());
+  });
+
+  it('only points to declared stages', () => {
+    for (const [from, tos] of Object.entries(STAGE_GRAPH)) {
+      for (const to of tos) {
+        assert.equal(isValidStage(to), true, `${from} → ${to}`);
+      }
+    }
+  });
+
+  it('gives ship no forward edge — only the conflict bounce back to build', () => {
+    assert.deepEqual(STAGE_GRAPH.ship, ['build']);
+  });
+});
+
+describe('isValidTransition', () => {
+  it('accepts the forward pipeline edges', () => {
+    assert.equal(isValidTransition('queued', 'build'), true);
+    assert.equal(isValidTransition('build', 'verify'), true);
+    assert.equal(isValidTransition('audit', 'ship'), true);
+  });
+
+  it('accepts documented bounces', () => {
+    assert.equal(isValidTransition('build', 'queued'), true);
+    assert.equal(isValidTransition('build', 'design'), true);
+    assert.equal(isValidTransition('verify', 'build'), true);
+    assert.equal(isValidTransition('queued', 'design'), true); // human spec-rejection bounce
+    assert.equal(isValidTransition('ship', 'build'), true); // conflict bounce
+  });
+
+  it('accepts the intake shortcuts: queued (declared fold deviation) and verify (already-built floor)', () => {
+    assert.equal(isValidTransition('intake', 'queued'), true);
+    assert.equal(isValidTransition('intake', 'verify'), true);
+  });
+
+  it('rejects skip-ahead jumps', () => {
+    assert.equal(isValidTransition('build', 'ship'), false);
+    assert.equal(isValidTransition('build', 'audit'), false);
+    assert.equal(isValidTransition('queued', 'verify'), false);
+  });
+
+  it('rejects an unknown source stage', () => {
+    assert.equal(isValidTransition('bogus', 'build'), false);
+  });
+});
+
+describe('currentStage', () => {
+  it('returns the single stage in the label set', () => {
+    assert.equal(currentStage(['priority:critical', 'stage:build', WIP_LABEL]), 'build');
+  });
+
+  it('throws when there is no stage label', () => {
+    throwsSdlc(() => currentStage(['bug', WIP_LABEL]), /no stage/);
+  });
+
+  it('throws on multiple stage labels', () => {
+    throwsSdlc(() => currentStage(['stage:build', 'stage:verify']), /multiple/);
+  });
+
+  it('throws on an unrecognized stage label (the typo class)', () => {
+    throwsSdlc(() => currentStage(['stage:verfy']), /unknown stage/);
+  });
+});
+
+describe('planAdvance', () => {
+  it('advances forward and drops sdlc:wip when present', () => {
+    const plan = planAdvance(['stage:build', WIP_LABEL], 'verify');
+    assert.equal(plan.from, 'build');
+    assert.equal(plan.to, 'verify');
+    assert.deepEqual([...plan.removeLabels].sort(), ['stage:build', WIP_LABEL].sort());
+    assert.deepEqual(plan.addLabels, ['stage:verify']);
+  });
+
+  it('does not try to remove sdlc:wip when it is absent', () => {
+    const plan = planAdvance(['stage:build'], 'queued');
+    assert.deepEqual(plan.removeLabels, ['stage:build']);
+  });
+
+  it('rejects an illegal transition with a helpful message', () => {
+    throwsSdlc(() => planAdvance(['stage:build'], 'ship'), /illegal transition stage:build → stage:ship/);
+  });
+
+  it('rejects an unknown target stage', () => {
+    throwsSdlc(() => planAdvance(['stage:build'], 'verfy'), /unknown target/);
+  });
+
+  it('rejects a no-op advance to the current stage', () => {
+    throwsSdlc(() => planAdvance(['stage:build'], 'build'), /already at/);
+  });
+});
+
+describe('planEmit', () => {
+  it('ADVANCE with a target reuses the advance label math', () => {
+    assert.deepEqual(planEmit(['stage:build', WIP_LABEL], 'ADVANCE', 'verify'), {
+      removeLabels: ['stage:build', WIP_LABEL],
+      addLabels: ['stage:verify'],
+      close: false,
+    });
+  });
+
+  it('BOUNCE with a legal bounce edge swaps back', () => {
+    const p = planEmit(['stage:verify', WIP_LABEL], 'BOUNCE', 'build');
+    assert.deepEqual(p.removeLabels, ['stage:verify', WIP_LABEL]);
+    assert.deepEqual(p.addLabels, ['stage:build']);
+  });
+
+  it('terminal ADVANCE from ship needs no target and removes the stage', () => {
+    assert.deepEqual(planEmit(['stage:ship', WIP_LABEL], 'ADVANCE'), {
+      removeLabels: ['stage:ship', WIP_LABEL],
+      addLabels: [],
+      close: false,
+    });
+  });
+
+  it('ADVANCE without a target off any other stage is rejected', () => {
+    throwsSdlc(() => planEmit(['stage:build', WIP_LABEL], 'ADVANCE'), /requires a target stage/);
+  });
+
+  it('BOUNCE always requires a target', () => {
+    throwsSdlc(() => planEmit(['stage:ship', WIP_LABEL], 'BOUNCE'), /requires a target stage/);
+  });
+
+  it('ADVANCE/BOUNCE reject illegal transitions', () => {
+    throwsSdlc(() => planEmit(['stage:build', WIP_LABEL], 'ADVANCE', 'ship'), /illegal transition/);
+  });
+
+  it('PARK drops wip and parks for a human, keeping the stage', () => {
+    assert.deepEqual(planEmit(['stage:design', WIP_LABEL], 'PARK'), {
+      removeLabels: [WIP_LABEL],
+      addLabels: ['sdlc:needs-human'],
+      close: false,
+    });
+  });
+
+  it('CONTINUE only drops wip', () => {
+    assert.deepEqual(planEmit(['stage:build', WIP_LABEL], 'CONTINUE'), {
+      removeLabels: [WIP_LABEL],
+      addLabels: [],
+      close: false,
+    });
+  });
+
+  it('CLOSE drops wip and closes', () => {
+    assert.deepEqual(planEmit(['stage:intake', WIP_LABEL], 'CLOSE'), {
+      removeLabels: [WIP_LABEL],
+      addLabels: [],
+      close: true,
+    });
+  });
+
+  it('rejects unknown outcomes', () => {
+    throwsSdlc(() => planEmit(['stage:build'], 'FROBNICATE'), /unknown outcome/);
+    assert.deepEqual(EMIT_OUTCOMES, ['ADVANCE', 'BOUNCE', 'PARK', 'CONTINUE', 'CLOSE']);
+  });
+});
+
+describe('runSdlc emit', () => {
+  const COMMENTS_KEY = 'issue view 609 --json comments --jq [.comments[] | {body: .body, createdAt: .createdAt}]';
+  const LABELS_KEY = 'issue view 609 --json labels --jq .labels[].name';
+  const ownClaim = JSON.stringify([
+    { body: 'sdlc:claim run-a build', createdAt: '2026-07-09T12:00:00Z' },
+  ]);
+
+  it('posts the marker comment before the label edit', () => {
+    const gh = fakeExec({
+      [COMMENTS_KEY]: ownClaim,
+      [LABELS_KEY]: 'stage:build\nsdlc:wip\n',
+    });
+    const logs = [];
+    runSdlc(['emit', '609', 'run-a', 'ADVANCE', '--to', 'verify', '--body', 'tests green'], {
+      gh,
+      log: (m) => logs.push(m),
+    });
+
+    const commentIdx = gh.calls.findIndex((c) => c[1] === 'comment');
+    const editIdx = gh.calls.findIndex((c) => c[1] === 'edit');
+    assert.ok(commentIdx > -1);
+    assert.ok(editIdx > commentIdx, 'marker comment must precede the label edit');
+    assert.deepEqual(gh.calls[commentIdx], [
+      'issue', 'comment', '609', '--body',
+      'sdlc:emit run-a ADVANCE → stage:verify\n\ntests green',
+    ]);
+    assert.deepEqual(gh.calls[editIdx], [
+      'issue', 'edit', '609',
+      '--remove-label', 'stage:build', '--remove-label', WIP_LABEL,
+      '--add-label', 'stage:verify',
+    ]);
+    assert.ok(logs.join('\n').includes('ADVANCE → stage:verify'));
+  });
+
+  it('refuses to emit when another run-id owns the live claim', () => {
+    const gh = fakeExec({
+      [COMMENTS_KEY]: JSON.stringify([
+        { body: 'sdlc:claim run-old build', createdAt: '2026-07-09T11:00:00Z' },
+        { body: 'sdlc:claim run-a build', createdAt: '2026-07-09T12:00:00Z' },
+      ]),
+    });
+    throwsSdlc(
+      () => runSdlc(['emit', '609', 'run-a', 'ADVANCE', '--to', 'verify'], { gh, log: () => {} }),
+      /owned by run-old/,
+    );
+    assert.equal(gh.calls.some((c) => c[1] === 'comment' || c[1] === 'edit'), false);
+  });
+
+  it('refuses to emit when the claim was already settled', () => {
+    const gh = fakeExec({
+      [COMMENTS_KEY]: JSON.stringify([
+        { body: 'sdlc:claim run-a build', createdAt: '2026-07-09T12:00:00Z' },
+        { body: 'sdlc:emit run-a ADVANCE → stage:verify', createdAt: '2026-07-09T12:30:00Z' },
+      ]),
+    });
+    throwsSdlc(
+      () => runSdlc(['emit', '609', 'run-a', 'ADVANCE', '--to', 'verify'], { gh, log: () => {} }),
+      /no live sdlc:claim/,
+    );
+  });
+
+  it('CLOSE comments, drops wip, and closes the issue', () => {
+    const gh = fakeExec({
+      [COMMENTS_KEY]: JSON.stringify([
+        { body: 'sdlc:claim run-a intake', createdAt: '2026-07-09T12:00:00Z' },
+      ]),
+      [LABELS_KEY]: 'stage:intake\nsdlc:wip\n',
+    });
+    runSdlc(['emit', '609', 'run-a', 'CLOSE', '--body', 'duplicate of #123'], { gh, log: () => {} });
+    assert.equal(gh.calls.some((c) => c[1] === 'close'), true);
+    const edit = gh.calls.find((c) => c[1] === 'edit');
+    assert.deepEqual(edit, ['issue', 'edit', '609', '--remove-label', WIP_LABEL]);
+  });
+
+  it('requires run-id and outcome', () => {
+    throwsSdlc(() => runSdlc(['emit', '609', 'run-a'], { gh: fakeExec(), log: () => {} }), /requires a run-id and outcome/);
+  });
+});
+
+describe('planClaimVerify', () => {
+  const t = (min) => new Date(Date.UTC(2026, 6, 9, 12, min)).toISOString();
+
+  it('wins when mine is the only claim', () => {
+    const r = planClaimVerify([{ body: 'sdlc:claim run-a build', createdAt: t(1) }], 'run-a');
+    assert.equal(r.won, true);
+  });
+
+  it('loses to an earlier claim', () => {
+    const r = planClaimVerify(
+      [
+        { body: 'sdlc:claim run-a build', createdAt: t(1) },
+        { body: 'sdlc:claim run-b build', createdAt: t(2) },
+      ],
+      'run-b',
+    );
+    assert.equal(r.won, false);
+    assert.equal(r.winner, 'run-a');
+  });
+
+  it('breaks a timestamp tie to the lexicographically lower run-id', () => {
+    const r = planClaimVerify(
+      [
+        { body: 'sdlc:claim run-b build', createdAt: t(1) },
+        { body: 'sdlc:claim run-a build', createdAt: t(1) },
+      ],
+      'run-a',
+    );
+    assert.equal(r.won, true);
+  });
+
+  it('ignores claims settled by a prior legacy outcome comment', () => {
+    const r = planClaimVerify(
+      [
+        { body: 'sdlc:claim run-old build', createdAt: t(0) },
+        { body: 'BOUNCE → stage:build — flaky test', createdAt: t(1) },
+        { body: 'sdlc:claim run-a build', createdAt: t(2) },
+      ],
+      'run-a',
+    );
+    assert.equal(r.won, true);
+  });
+
+  it('reports not-found when my claim comment is absent', () => {
+    const r = planClaimVerify([], 'run-a');
+    assert.equal(r.won, false);
+    assert.equal(r.reason, 'own claim not found');
+  });
+
+  it('treats an sdlc:emit marker as settling prior claims', () => {
+    const r = planClaimVerify(
+      [
+        { body: 'sdlc:claim run-old intake', createdAt: t(0) },
+        { body: 'sdlc:emit run-old ADVANCE → stage:queued\n\nIntake summary: …', createdAt: t(1) },
+        { body: 'sdlc:claim run-a build', createdAt: t(2) },
+      ],
+      'run-a',
+    );
+    assert.equal(r.won, true);
+  });
+
+  it('does NOT settle on a freeform prose outcome (the phantom-lock bug)', () => {
+    // Regression: an "Intake summary: …" comment is not a completion signal;
+    // only sdlc:emit / legacy outcome prefixes / a reap / the timeline
+    // boundary settle claims.
+    const r = planClaimVerify(
+      [
+        { body: 'sdlc:claim run-old intake', createdAt: t(0) },
+        { body: 'Intake summary: deterministic work-list generator …', createdAt: t(1) },
+        { body: 'sdlc:claim run-a build', createdAt: t(2) },
+      ],
+      'run-a',
+    );
+    assert.equal(r.won, false);
+    assert.equal(r.winner, 'run-old');
+  });
+
+  it('the timeline boundary settles claims at/before the last sdlc:wip unlabel', () => {
+    // A reaper strip removes the label with NO outcome comment — the unlabeled
+    // event is the machine-visible boundary invalidating the dead worker's claim.
+    const r = planClaimVerify(
+      [
+        { body: 'sdlc:claim run-dead build', createdAt: t(0) },
+        { body: 'sdlc:claim run-a build', createdAt: t(2) },
+      ],
+      'run-a',
+      t(1), // boundary: reaper stripped sdlc:wip between the two claims
+    );
+    assert.equal(r.won, true);
+  });
+
+  it('a null boundary degrades to outcome-marker settling only', () => {
+    const r = planClaimVerify(
+      [
+        { body: 'sdlc:claim run-dead build', createdAt: t(0) },
+        { body: 'sdlc:claim run-a build', createdAt: t(2) },
+      ],
+      'run-a',
+      null,
+    );
+    assert.equal(r.won, false);
+    assert.equal(r.winner, 'run-dead');
+  });
+
+  it('a boundary equal to my own claim time settles mine too (own claim not found)', () => {
+    const r = planClaimVerify(
+      [{ body: 'sdlc:claim run-a build', createdAt: t(1) }],
+      'run-a',
+      t(1),
+    );
+    assert.equal(r.won, false);
+    assert.equal(r.reason, 'own claim not found');
+  });
+});
+
+describe('lastUnlabeledAt', () => {
+  it('returns the most recent matching unlabeled event (the claim boundary)', () => {
+    const events = [
+      { event: 'labeled', label: { name: WIP_LABEL }, created_at: '2026-07-08T01:00:00Z' },
+      { event: 'unlabeled', label: { name: WIP_LABEL }, created_at: '2026-07-08T02:00:00Z' },
+      { event: 'unlabeled', label: { name: 'bug' }, created_at: '2026-07-08T05:00:00Z' },
+      { event: 'unlabeled', label: { name: WIP_LABEL }, created_at: '2026-07-08T04:00:00Z' },
+    ];
+    assert.equal(lastUnlabeledAt(events, WIP_LABEL), '2026-07-08T04:00:00Z');
+  });
+
+  it('returns null when the label was never removed', () => {
+    assert.equal(
+      lastUnlabeledAt(
+        [{ event: 'labeled', label: { name: WIP_LABEL }, created_at: '2026-07-08T01:00:00Z' }],
+        WIP_LABEL,
+      ),
+      null,
+    );
+  });
+});
+
+describe('computeLanes', () => {
+  const issues = [
+    { number: 10, createdAt: '2026-07-01T00:00:00Z', labels: ['stage:build', 'priority:future'] },
+    { number: 11, createdAt: '2026-07-02T00:00:00Z', labels: ['stage:build', 'priority:critical'] },
+    { number: 12, createdAt: '2026-07-03T00:00:00Z', labels: ['stage:build', WIP_LABEL] },
+    { number: 13, createdAt: '2026-07-04T00:00:00Z', labels: ['stage:build', 'sdlc:hold'] },
+    { number: 14, createdAt: '2026-07-05T00:00:00Z', labels: ['stage:build', 'stage:verify'] },
+    { number: 15, createdAt: '2026-07-06T00:00:00Z', labels: ['bug'] },
+    { number: 16, createdAt: '2026-07-07T00:00:00Z', labels: [WIP_LABEL] },
+  ];
+
+  it('counts depth including locked and parked items', () => {
+    const { lanes } = computeLanes(issues);
+    assert.equal(lanes.build.depth, 5); // 10,11,12,13,14
+  });
+
+  it('excludes wip/hold/needs-human from eligible and orders by priority then FIFO', () => {
+    const { lanes } = computeLanes(issues);
+    // 11 (critical) before 10 (future); 12 (wip) and 13 (hold) excluded;
+    // 14 is dual-stage but still eligible for build.
+    assert.deepEqual(lanes.build.eligible, [11, 10, 14]);
+  });
+
+  it('flags multi-stage issues and stage-less issues carrying machine flags', () => {
+    const { integrity } = computeLanes(issues);
+    const byNum = Object.fromEntries(integrity.map((v) => [v.number, v.stages]));
+    assert.deepEqual(byNum[14], ['build', 'verify']);
+    // 15 has no stage label and no machine flag — a legitimate state.
+    assert.equal(byNum[15], undefined);
+    // 16 has no stage label but a stuck sdlc:wip — corrupt, flag it.
+    assert.deepEqual(byNum[16], []);
+    assert.equal(byNum[10], undefined);
+  });
+
+  it('buckets ineligible items by hold/needs-human/wip, summing to depth − eligible', () => {
+    const { lanes } = computeLanes(issues);
+    // build depth 5, eligible [11,10,14] → 2 ineligible: #12 wip, #13 hold.
+    assert.deepEqual(lanes.build.ineligible, { hold: 1, 'needs-human': 0, wip: 1 });
+    const b = lanes.build;
+    const inelig = b.ineligible.hold + b.ineligible['needs-human'] + b.ineligible.wip;
+    assert.equal(inelig, b.depth - b.eligible.length);
+  });
+
+  it('buckets each ineligible item once, hold › needs-human › wip precedence', () => {
+    const { lanes } = computeLanes([
+      { number: 20, createdAt: '2026-07-01T00:00:00Z', labels: ['stage:audit', 'sdlc:hold', WIP_LABEL] },
+      { number: 21, createdAt: '2026-07-02T00:00:00Z', labels: ['stage:audit', 'sdlc:needs-human', WIP_LABEL] },
+    ]);
+    assert.deepEqual(lanes.audit.ineligible, { hold: 1, 'needs-human': 1, wip: 0 });
+  });
+});
+
+describe('laneIneligibilityBreakdown', () => {
+  it('renders only non-zero buckets in hold, needs-human, wip order', () => {
+    assert.equal(
+      laneIneligibilityBreakdown({ ineligible: { hold: 12, 'needs-human': 4, wip: 0 } }),
+      '(hold 12, needs-human 4)',
+    );
+    assert.equal(laneIneligibilityBreakdown({ ineligible: { hold: 0, 'needs-human': 0, wip: 1 } }), '(wip 1)');
+  });
+
+  it('returns empty string for a fully-eligible lane (all buckets zero)', () => {
+    assert.equal(laneIneligibilityBreakdown({ ineligible: { hold: 0, 'needs-human': 0, wip: 0 } }), '');
+    assert.equal(laneIneligibilityBreakdown({}), '');
+  });
+});
+
+describe('planHealLane', () => {
+  const issues = [
+    { number: 10, labels: ['stage:build', WIP_LABEL] },
+    { number: 11, labels: ['stage:build'] }, // healthy: emitted, wip gone
+    { number: 12, labels: ['stage:verify', WIP_LABEL] }, // different lane
+    { number: 13, labels: [{ name: 'stage:build' }, { name: WIP_LABEL }] }, // object labels
+  ];
+
+  it('finds only stage:<lane> issues that still carry sdlc:wip', () => {
+    assert.deepEqual(planHealLane(issues, 'build'), [10, 13]);
+  });
+
+  it('is empty when no wip issue sits in the lane (the zero case)', () => {
+    assert.deepEqual(planHealLane(issues, 'audit'), []);
+    assert.deepEqual(planHealLane([], 'build'), []);
+  });
+
+  it('returns the single stalled issue (the one case)', () => {
+    assert.deepEqual(planHealLane(issues, 'verify'), [12]);
+  });
+});
+
+describe('runSdlc heal (lane auto-discovery arg parsing)', () => {
+  it('heal <lane> with no issue auto-discovers every stalled wip issue', () => {
+    const gh = fakeExec({
+      'issue list --state open --json number,labels --limit 200': JSON.stringify([
+        { number: 7, labels: [{ name: 'stage:build' }, { name: WIP_LABEL }] },
+        { number: 8, labels: [{ name: 'stage:build' }] }, // healthy
+        { number: 9, labels: [{ name: 'stage:build' }, { name: WIP_LABEL }] },
+      ]),
+    });
+    const logs = [];
+    runSdlc(['heal', 'build'], { gh, log: (m) => logs.push(m) });
+    const out = logs.join('\n');
+    assert.ok(out.includes('#7 (build) STALLED'));
+    assert.ok(out.includes('#9 (build) STALLED'));
+    assert.ok(!out.includes('#8'));
+  });
+
+  it('heal <lane> with no stalled issues reports the lane OK', () => {
+    const gh = fakeExec({
+      'issue list --state open --json number,labels --limit 200': JSON.stringify([
+        { number: 8, labels: [{ name: 'stage:build' }] },
+      ]),
+    });
+    const logs = [];
+    runSdlc(['heal', 'build'], { gh, log: (m) => logs.push(m) });
+    assert.ok(logs.join('\n').includes('build OK — no stalled'));
+  });
+
+  it('heal <lane> <issue> still checks the explicit issue', () => {
+    const gh = fakeExec({
+      'issue view 5 --json labels --jq .labels[].name': `stage:build\n${WIP_LABEL}\n`,
+    });
+    const logs = [];
+    runSdlc(['heal', 'build', '5'], { gh, log: (m) => logs.push(m) });
+    assert.ok(logs.join('\n').includes('STALLED'));
+  });
+
+  it('heal rejects an unknown lane-only argument', () => {
+    throwsSdlc(() => runSdlc(['heal', 'bogus'], { gh: fakeExec(), log: () => {} }), /unknown lane/);
+  });
+});
+
+describe('runSdlc claim --next', () => {
+  const LANES_KEY = 'issue list --state open --json number,labels,createdAt,title --limit 200';
+  const commentsKey = (n) =>
+    `issue view ${n} --json comments --jq [.comments[] | {body: .body, createdAt: .createdAt}]`;
+
+  it('picks the highest-priority/oldest eligible issue and claims it', () => {
+    const gh = fakeExec({
+      [LANES_KEY]: JSON.stringify([
+        { number: 10, labels: [{ name: 'stage:build' }, { name: 'priority:future' }], createdAt: '2026-07-01T00:00:00Z' },
+        { number: 11, labels: [{ name: 'stage:build' }, { name: 'priority:critical' }], createdAt: '2026-07-05T00:00:00Z' },
+        { number: 12, labels: [{ name: 'stage:build' }, { name: 'priority:critical' }], createdAt: '2026-07-02T00:00:00Z' },
+      ]),
+      [commentsKey(12)]: JSON.stringify([
+        { body: 'sdlc:claim run-a build', createdAt: '2026-07-09T12:00:00Z' },
+      ]),
+    });
+    const git = fakeExec({ 'rev-parse --abbrev-ref HEAD': 'feat/12\n' });
+    const logs = [];
+    runSdlc(['claim', '--next', 'build', 'run-a'], { gh, git, log: (m) => logs.push(m) });
+
+    // #12 is critical and oldest of the two criticals → picked first.
+    assert.ok(gh.calls.some((c) => JSON.stringify(c) === JSON.stringify(['issue', 'edit', '12', '--add-label', WIP_LABEL])));
+    assert.ok(logs.join('\n').includes('claimed #12'));
+    assert.notEqual(process.exitCode, 1);
+  });
+
+  it('retries the next eligible item after a lost race', () => {
+    const gh = fakeExec({
+      [LANES_KEY]: JSON.stringify([
+        { number: 20, labels: [{ name: 'stage:build' }], createdAt: '2026-07-01T00:00:00Z' },
+        { number: 21, labels: [{ name: 'stage:build' }], createdAt: '2026-07-02T00:00:00Z' },
+      ]),
+      // #20 was claimed earlier by run-b → run-a loses; #21 is uncontested.
+      [commentsKey(20)]: JSON.stringify([
+        { body: 'sdlc:claim run-b build', createdAt: '2026-07-09T11:00:00Z' },
+        { body: 'sdlc:claim run-a build', createdAt: '2026-07-09T12:00:00Z' },
+      ]),
+      [commentsKey(21)]: JSON.stringify([
+        { body: 'sdlc:claim run-a build', createdAt: '2026-07-09T12:00:00Z' },
+      ]),
+    });
+    const git = fakeExec({ 'rev-parse --abbrev-ref HEAD': 'feat/21\n' });
+    const logs = [];
+    runSdlc(['claim', '--next', 'build', 'run-a'], { gh, git, log: (m) => logs.push(m) });
+
+    assert.ok(logs.join('\n').includes('LOST race on #20'));
+    assert.ok(logs.join('\n').includes('claimed #21'));
+  });
+
+  it('exits 1 with idle on an empty lane', () => {
+    const prev = process.exitCode;
+    const gh = fakeExec({ [LANES_KEY]: JSON.stringify([]) });
+    const logs = [];
+    runSdlc(['claim', '--next', 'build', 'run-a'], { gh, git: fakeExec(), log: (m) => logs.push(m) });
+
+    assert.ok(logs.join('\n').includes('idle'));
+    assert.equal(process.exitCode, 1);
+    process.exitCode = prev; // don't leak into the test runner's exit
+  });
+
+  it('rejects an unknown lane and requires a run-id', () => {
+    throwsSdlc(
+      () => runSdlc(['claim', '--next', 'nonsense', 'run-a'], { gh: fakeExec(), git: fakeExec(), log: () => {} }),
+      /unknown lane/,
+    );
+    throwsSdlc(
+      () => runSdlc(['claim', '--next', 'build'], { gh: fakeExec(), git: fakeExec(), log: () => {} }),
+      /run-id/,
+    );
+  });
+});
+
+describe('mintRunId', () => {
+  it('formats dispatch-<yyyymmdd>-<hhmm>-<hex4> from a fixed clock + hex', () => {
+    const now = new Date(Date.UTC(2026, 6, 10, 1, 22));
+    assert.equal(mintRunId(now, '46d3'), 'dispatch-20260710-0122-46d3');
+  });
+
+  it('zero-pads month, day, hour, and minute', () => {
+    const now = new Date(Date.UTC(2026, 0, 3, 4, 5));
+    assert.equal(mintRunId(now, 'abcd'), 'dispatch-20260103-0405-abcd');
+  });
+
+  it('mints a 4-hex-char suffix by default', () => {
+    assert.match(mintRunId(new Date(Date.UTC(2026, 6, 10, 1, 22))), /^dispatch-20260710-0122-[0-9a-f]{4}$/);
+  });
+});
+
+describe('worktree-sweep helpers', () => {
+  const porcelain = [
+    'worktree /x/example-repo',
+    'HEAD aaa',
+    `branch refs/heads/${DEFAULT_BRANCH}`,
+    '',
+    'worktree /x/example-repo-wt-500',
+    'HEAD bbb',
+    'branch refs/heads/feat/500',
+    '',
+    'worktree /x/example-repo-wt-641',
+    'HEAD ccc',
+    'detached',
+    '',
+    'worktree /x/my-scratch-tree',
+    'HEAD ddd',
+    'branch refs/heads/wip/scratch',
+  ].join('\n');
+
+  it('parseWorktrees keeps only worktreeName-pattern trees, extracting issue + branch', () => {
+    const trees = parseWorktrees(porcelain, 'example-repo');
+    assert.deepEqual(trees, [
+      { path: '/x/example-repo-wt-500', branch: 'feat/500', issue: 500 },
+      { path: '/x/example-repo-wt-641', branch: null, issue: 641 },
+    ]);
+  });
+
+  it('parseWorktrees ignores the main checkout and human-named worktrees', () => {
+    const paths = parseWorktrees(porcelain, 'example-repo').map((t) => t.path);
+    assert.ok(!paths.includes('/x/example-repo'));
+    assert.ok(!paths.includes('/x/my-scratch-tree'));
+  });
+
+  it('parseWorktrees returns [] on empty input', () => {
+    assert.deepEqual(parseWorktrees('', 'example-repo'), []);
+  });
+
+  it('planWorktreeSweep removes clean + done, leaves active/dirty', () => {
+    const trees = [
+      { path: 'a', branch: 'feat/1', issue: 1, clean: true, branchGone: false, issueClosed: true },
+      { path: 'b', branch: 'feat/2', issue: 2, clean: true, branchGone: true, issueClosed: false },
+      { path: 'c', branch: 'feat/3', issue: 3, clean: false, branchGone: true, issueClosed: true },
+      { path: 'd', branch: 'feat/4', issue: 4, clean: true, branchGone: false, issueClosed: false },
+    ];
+    const { remove, leave } = planWorktreeSweep(trees);
+    assert.deepEqual(remove.map((t) => t.issue), [1, 2]);
+    assert.deepEqual(leave.map((t) => t.issue), [3, 4]);
+    assert.match(leave.find((t) => t.issue === 3).reason, /dirty/);
+    assert.match(leave.find((t) => t.issue === 4).reason, /active/);
+  });
+
+  it('planWorktreeSweep never removes a dirty tree even when fully done', () => {
+    const { remove, leave } = planWorktreeSweep([
+      { path: 'x', branch: 'feat/9', issue: 9, clean: false, branchGone: true, issueClosed: true },
+    ]);
+    assert.deepEqual(remove, []);
+    assert.equal(leave.length, 1);
+  });
+
+  it('planWorktreeSweep removes a done tree that is clean-modulo-strays', () => {
+    const { remove, leave } = planWorktreeSweep([
+      { path: 's', branch: 'feat/5', issue: 5, clean: true, strays: ['stray'], branchGone: true, issueClosed: true },
+    ]);
+    assert.deepEqual(remove.map((t) => t.issue), [5]);
+    assert.deepEqual(remove[0].strays, ['stray']);
+    assert.deepEqual(leave, []);
+  });
+});
+
+describe('unlinkWorktreeRootLinks (#723 — junction-safe sweep)', () => {
+  /** Make a scratch area with a link target holding a canary file. */
+  function makeScratch() {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'sdlc-wt-links-'));
+    const target = path.join(base, 'shared-target');
+    fs.mkdirSync(path.join(target, 'sub'), { recursive: true });
+    fs.writeFileSync(path.join(target, 'canary.txt'), 'canary');
+    fs.writeFileSync(path.join(target, 'sub', 'deep.txt'), 'deep');
+    const tree = path.join(base, 'wt');
+    fs.mkdirSync(tree);
+    return { base, target, tree };
+  }
+
+  it('unlinks a root node_modules junction without touching its target', () => {
+    const { base, target, tree } = makeScratch();
+    try {
+      // 'junction' type is honored on Windows (no admin needed) and ignored
+      // elsewhere, where a plain directory symlink is created instead.
+      fs.symlinkSync(target, path.join(tree, 'node_modules'), 'junction');
+      fs.writeFileSync(path.join(tree, 'regular.txt'), 'keep');
+
+      const removed = unlinkWorktreeRootLinks(tree);
+
+      assert.deepEqual(removed, ['node_modules']);
+      assert.equal(fs.existsSync(path.join(tree, 'node_modules')), false);
+      assert.equal(fs.existsSync(path.join(tree, 'regular.txt')), true);
+      // The whole point: the shared target survives intact.
+      assert.equal(fs.readFileSync(path.join(target, 'canary.txt'), 'utf8'), 'canary');
+      assert.equal(fs.readFileSync(path.join(target, 'sub', 'deep.txt'), 'utf8'), 'deep');
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves plain files and directories alone, returns [] when no links', () => {
+    const { base, tree } = makeScratch();
+    try {
+      fs.mkdirSync(path.join(tree, 'real-dir'));
+      fs.writeFileSync(path.join(tree, 'file.txt'), 'x');
+      assert.deepEqual(unlinkWorktreeRootLinks(tree), []);
+      assert.equal(fs.existsSync(path.join(tree, 'real-dir')), true);
+      assert.equal(fs.existsSync(path.join(tree, 'file.txt')), true);
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it('returns [] for a missing tree path', () => {
+    assert.deepEqual(unlinkWorktreeRootLinks(path.join(os.tmpdir(), 'sdlc-no-such-tree-xyz')), []);
+  });
+});
+
+describe('classifyStatusForSweep', () => {
+  it('empty status → clean, no strays', () => {
+    assert.deepEqual(classifyStatusForSweep('', () => 0), { clean: true, strays: [] });
+  });
+
+  it('only 0-byte untracked strays → clean-modulo-strays', () => {
+    const r = classifyStatusForSweep('?? stray\n?? stray)\n', () => 0);
+    assert.equal(r.clean, true);
+    assert.deepEqual(r.strays, ['stray', 'stray)']);
+  });
+
+  it('an untracked file with content → dirty, no strays', () => {
+    assert.deepEqual(classifyStatusForSweep('?? notes.txt\n', () => 42), { clean: false, strays: [] });
+  });
+
+  it('a tracked modification → dirty even alongside 0-byte strays', () => {
+    assert.deepEqual(classifyStatusForSweep(' M src/x.js\n?? stray\n', () => 0), { clean: false, strays: [] });
+  });
+
+  it('an unreadable stray path (sizeOf throws) → dirty', () => {
+    const r = classifyStatusForSweep('?? stray\n', () => {
+      throw new Error('ENOENT');
+    });
+    assert.deepEqual(r, { clean: false, strays: [] });
+  });
+
+  it('a quoted special-char path → dirty (not cleared)', () => {
+    assert.deepEqual(classifyStatusForSweep('?? "wë ird"\n', () => 0), { clean: false, strays: [] });
+  });
+});
+
+describe('runSdlc worktree-sweep', () => {
+  const porcelain = [
+    'worktree /x/example-repo',
+    'HEAD aaa',
+    `branch refs/heads/${DEFAULT_BRANCH}`,
+    '',
+    'worktree /x/example-repo-wt-500',
+    'HEAD bbb',
+    'branch refs/heads/feat/500',
+    '',
+    'worktree /x/example-repo-wt-641',
+    'HEAD ccc',
+    'branch refs/heads/feat/641',
+  ].join('\n');
+
+  /** Exec fake that throws for the given arg-join keys (simulates git nonzero exit). */
+  function exec(responses = {}, throwKeys = []) {
+    const calls = [];
+    const fn = (args) => {
+      calls.push(args);
+      const key = args.join(' ');
+      if (throwKeys.includes(key)) throw new Error(`nonzero: ${key}`);
+      return responses[key] ?? '';
+    };
+    fn.calls = calls;
+    return fn;
+  }
+
+  it('removes a clean closed-issue worktree, leaves an active one (with --apply)', () => {
+    const git = exec(
+      { 'worktree list --porcelain': porcelain },
+      [
+        `merge-base --is-ancestor feat/500 origin/${DEFAULT_BRANCH}`,
+        `merge-base --is-ancestor feat/641 origin/${DEFAULT_BRANCH}`,
+      ],
+    );
+    const gh = exec({
+      'pr list --head feat/500 --state merged --json number': '[]',
+      'pr list --head feat/641 --state merged --json number': '[]',
+      'issue view 500 --json state': '{"state":"CLOSED"}',
+      'issue view 641 --json state': '{"state":"OPEN"}',
+    });
+    const logs = [];
+    runSdlc(['worktree-sweep', '--apply'], { git, gh, log: (m) => logs.push(m), root: '/x/example-repo' });
+    const out = logs.join('\n');
+    assert.ok(out.includes('REMOVE /x/example-repo-wt-500 (#500)'));
+    assert.ok(out.includes('LEAVE /x/example-repo-wt-641 (#641)'));
+    assert.ok(git.calls.some((c) => JSON.stringify(c) === JSON.stringify(['worktree', 'remove', '/x/example-repo-wt-500'])));
+    assert.equal(git.calls.some((c) => c[0] === 'worktree' && c[1] === 'remove' && c[2] === '/x/example-repo-wt-641'), false);
+    assert.ok(git.calls.some((c) => JSON.stringify(c) === JSON.stringify(['worktree', 'prune'])));
+  });
+
+  it('without --apply, reports the plan and removes nothing', () => {
+    const git = exec(
+      { 'worktree list --porcelain': porcelain },
+      [
+        `merge-base --is-ancestor feat/500 origin/${DEFAULT_BRANCH}`,
+        `merge-base --is-ancestor feat/641 origin/${DEFAULT_BRANCH}`,
+      ],
+    );
+    const gh = exec({
+      'pr list --head feat/500 --state merged --json number': '[]',
+      'pr list --head feat/641 --state merged --json number': '[]',
+      'issue view 500 --json state': '{"state":"CLOSED"}',
+      'issue view 641 --json state': '{"state":"OPEN"}',
+    });
+    const logs = [];
+    runSdlc(['worktree-sweep'], { git, gh, log: (m) => logs.push(m), root: '/x/example-repo' });
+    assert.ok(logs.join('\n').includes('run with --apply'));
+    assert.equal(git.calls.some((c) => c[0] === 'worktree' && c[1] === 'remove'), false);
+  });
+
+  it('clears a 0-byte untracked stray on a done tree, then removes it (--apply)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sdlc-sweep-'));
+    const wtPath = path.join(tmp, 'example-repo-wt-500');
+    fs.mkdirSync(wtPath);
+    const strayPath = path.join(wtPath, 'stray');
+    fs.writeFileSync(strayPath, ''); // 0-byte stray
+    try {
+      const listPorcelain = [
+        `worktree ${tmp}/example-repo`,
+        'HEAD aaa',
+        `branch refs/heads/${DEFAULT_BRANCH}`,
+        '',
+        `worktree ${wtPath}`,
+        'HEAD bbb',
+        'branch refs/heads/feat/500',
+      ].join('\n');
+      const git = exec(
+        {
+          'worktree list --porcelain': listPorcelain,
+          [`-C ${wtPath} status --porcelain`]: '?? stray\n',
+        },
+        [`merge-base --is-ancestor feat/500 origin/${DEFAULT_BRANCH}`],
+      );
+      const gh = exec({
+        'pr list --head feat/500 --state merged --json number': '[]',
+        'issue view 500 --json state': '{"state":"CLOSED"}',
+      });
+      const logs = [];
+      runSdlc(['worktree-sweep', '--apply'], {
+        git,
+        gh,
+        log: (m) => logs.push(m),
+        root: `${tmp}/example-repo`,
+      });
+      const out = logs.join('\n');
+      assert.ok(out.includes(`REMOVE ${wtPath} (#500)`));
+      assert.ok(out.includes('cleared 1 0-byte stray'));
+      assert.equal(fs.existsSync(strayPath), false);
+      assert.ok(git.calls.some((c) => JSON.stringify(c) === JSON.stringify(['worktree', 'remove', wtPath])));
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves a done tree whose untracked stray has content (>0 bytes)', () => {
+    const git = exec(
+      {
+        'worktree list --porcelain': porcelain,
+        '-C /x/example-repo-wt-641 status --porcelain': '?? notes.txt\n',
+        '-C /x/example-repo-wt-500 status --porcelain': '?? notes.txt\n',
+      },
+      [
+        `merge-base --is-ancestor feat/500 origin/${DEFAULT_BRANCH}`,
+        `merge-base --is-ancestor feat/641 origin/${DEFAULT_BRANCH}`,
+      ],
+    );
+    const gh = exec({
+      'pr list --head feat/500 --state merged --json number': '[]',
+      'pr list --head feat/641 --state merged --json number': '[]',
+      'issue view 500 --json state': '{"state":"CLOSED"}',
+      'issue view 641 --json state': '{"state":"CLOSED"}',
+    });
+    const logs = [];
+    // statSize reports content → not a stray → dirty → left.
+    runSdlc(['worktree-sweep', '--apply'], {
+      git,
+      gh,
+      log: (m) => logs.push(m),
+      root: '/x/example-repo',
+      statSize: () => 42,
+    });
+    const out = logs.join('\n');
+    assert.match(out, /LEAVE \/x\/example-repo-wt-500 \(#500\).*dirty/);
+    assert.equal(git.calls.some((c) => c[1] === 'remove'), false);
+  });
+});
+
+describe('computeDigest', () => {
+  const issues = [
+    { number: 20, labels: ['stage:queued'] },
+    { number: 21, labels: ['stage:build'] },
+    { number: 22, labels: ['stage:build', 'sdlc:needs-human'] },
+    { number: 23, labels: ['stage:design', 'sdlc:hold'] },
+  ];
+
+  it('tallies depths and parked/hold lists', () => {
+    const d = computeDigest(issues);
+    assert.equal(d.depths.build, 2);
+    assert.equal(d.depths.queued, 1);
+    assert.deepEqual(d.parked, [22]);
+    assert.deepEqual(d.hold, [23]);
+  });
+
+  it('diffs arrivals and departures against a prior snapshot', () => {
+    const d = computeDigest(issues, [20, 21, 99]);
+    assert.deepEqual(d.arrivals, [22, 23]);
+    assert.deepEqual(d.departures, [99]);
+  });
+
+  it('reports no diff when no prior snapshot given', () => {
+    assert.equal(computeDigest(issues).arrivals, null);
+  });
+
+  it('reports parked/hold deltas as unchanged when the prior lists match', () => {
+    const d = computeDigest(issues, { current: [20, 21, 22, 23], parked: [22], hold: [23] });
+    assert.deepEqual(d.parkedDelta, { added: [], removed: [], changed: false });
+    assert.deepEqual(d.holdDelta, { added: [], removed: [], changed: false });
+  });
+
+  it('reports parked/hold additions and removals against the prior lists', () => {
+    const d = computeDigest(issues, { current: [21, 22, 99], parked: [99], hold: [] });
+    assert.deepEqual(d.parkedDelta, { added: [22], removed: [99], changed: true });
+    assert.deepEqual(d.holdDelta, { added: [23], removed: [], changed: true });
+  });
+
+  it('treats a legacy array prev as current-numbers-only (no parked/hold delta)', () => {
+    const d = computeDigest(issues, [20, 21, 99]);
+    assert.equal(d.parkedDelta, null);
+    assert.equal(d.holdDelta, null);
+    assert.deepEqual(d.arrivals, [22, 23]);
+  });
+});
+
+describe('computeSweep', () => {
+  const openIssues = [
+    { number: 30, title: 'dependent, blocked', labels: ['blocked'], body: 'blocked on #10' },
+    { number: 31, title: 'dependent, ready', labels: ['ready'], body: 'follows #10 nicely' },
+    { number: 32, title: 'unrelated', labels: [], body: 'mentions #100 not the closed one' },
+    { number: 33, title: 'near-miss', labels: [], body: 'refs #101, a different issue entirely' },
+  ];
+  const mergedPrs = [
+    { number: 500, mergedAt: '2026-07-10T00:00:00Z', title: 'feat: thing', closes: [10] },
+  ];
+
+  it('maps a merged PR → closed issue → its dependents, flagging blocked ones', () => {
+    const { items, closedIssues, empty } = computeSweep(mergedPrs, openIssues);
+    assert.equal(empty, false);
+    assert.deepEqual(closedIssues, [10]);
+    assert.equal(items.length, 1);
+    const closed = items[0].closes[0];
+    assert.equal(closed.number, 10);
+    assert.deepEqual(
+      closed.dependents.map((d) => ({ number: d.number, blocked: d.blocked })),
+      [
+        { number: 30, blocked: true },
+        { number: 31, blocked: false },
+      ],
+    );
+  });
+
+  it('word-boundaries references so #10 never matches #101 or #100', () => {
+    const { items } = computeSweep(mergedPrs, openIssues);
+    const depNums = items[0].closes[0].dependents.map((d) => d.number);
+    assert.ok(!depNums.includes(32)); // #100
+    assert.ok(!depNums.includes(33)); // #101
+  });
+
+  it('is clear when no merged PR closed an issue', () => {
+    const noClose = [{ number: 501, mergedAt: '2026-07-10T00:00:00Z', title: 'chore', closes: [] }];
+    const r = computeSweep(noClose, openIssues);
+    assert.equal(r.empty, true);
+    assert.deepEqual(r.items, []);
+  });
+
+  it('skips PRs already in sweptPrs (idempotent)', () => {
+    assert.equal(computeSweep(mergedPrs, openIssues, { sweptPrs: [500] }).empty, true);
+  });
+
+  it('skips PRs merged at/before the sinceMs cutoff (bounded window)', () => {
+    const cutoff = new Date('2026-07-10T12:00:00Z').getTime();
+    assert.equal(computeSweep(mergedPrs, openIssues, { sinceMs: cutoff }).empty, true);
+    const earlier = new Date('2026-07-09T00:00:00Z').getTime();
+    assert.equal(computeSweep(mergedPrs, openIssues, { sinceMs: earlier }).empty, false);
+  });
+
+  it('accepts object-form labels and tolerates missing bodies', () => {
+    const issues = [{ number: 40, title: 'x', labels: [{ name: 'blocked' }], body: 'needs #10' }];
+    const { items } = computeSweep(mergedPrs, issues);
+    assert.deepEqual(items[0].closes[0].dependents, [{ number: 40, title: 'x', blocked: true }]);
+    const noDeps = computeSweep(mergedPrs, [{ number: 41, body: '' }]);
+    assert.deepEqual(noDeps.items[0].closes[0].dependents, []);
+  });
+});
+
+describe('computeSweepAck', () => {
+  const mergedPrs = [
+    { number: 500, mergedAt: '2026-07-10T00:00:00Z' },
+    { number: 501, mergedAt: '2026-07-08T00:00:00Z' },
+  ];
+
+  it('marks all in-window merges and reports the newly-acked ones', () => {
+    const { nextSwept, newlyAcked } = computeSweepAck(mergedPrs, { sweptPrs: [500] });
+    assert.deepEqual([...nextSwept].sort(), [500, 501]);
+    assert.deepEqual(newlyAcked, [501]);
+  });
+
+  it('excludes merges at/before the sinceMs cutoff from the marker', () => {
+    const cutoff = new Date('2026-07-09T00:00:00Z').getTime();
+    const { nextSwept, newlyAcked } = computeSweepAck(mergedPrs, { sinceMs: cutoff });
+    assert.deepEqual(nextSwept, [500]);
+    assert.deepEqual(newlyAcked, [500]);
+  });
+
+  it('drops prior swept PRs no longer in the fetched list (bounded marker)', () => {
+    const { nextSwept } = computeSweepAck(mergedPrs, { sweptPrs: [400, 500] });
+    assert.ok(!nextSwept.includes(400));
+    assert.deepEqual([...nextSwept].sort(), [500, 501]);
+  });
+
+  it('is a no-op ack when everything in the window is already swept', () => {
+    const { nextSwept, newlyAcked } = computeSweepAck(mergedPrs, { sweptPrs: [500, 501] });
+    assert.deepEqual([...nextSwept].sort(), [500, 501]);
+    assert.deepEqual(newlyAcked, []);
+  });
+});
+
+describe('planConflictScan', () => {
+  const BASE_TS = '2026-07-05T00:00:00Z';
+  const info = (over = {}) => ({ state: 'OPEN', labels: [], comments: [], ...over });
+
+  it('plans a comment (no advance) for a build-stage issue', () => {
+    const prs = [
+      { number: 90, headRefName: 'feat/1-x', baseRefName: DEFAULT_BRANCH, mergeable: 'CONFLICTING', linkedIssues: [1] },
+    ];
+    const { actions, skipped } = planConflictScan(prs, { 1: info({ labels: ['stage:build'] }) }, BASE_TS);
+    assert.deepEqual(skipped, []);
+    assert.equal(actions.length, 1);
+    assert.equal(actions[0].pr, 90);
+    assert.equal(actions[0].issue, 1);
+    assert.equal(actions[0].advanceTo, null);
+    assert.equal(actions[0].comment, `sdlc-dispatch: branch feat/1-x conflicts with ${DEFAULT_BRANCH} — needs a merge`);
+  });
+
+  it('plans a bounce back to build for verify/audit/ship issues', () => {
+    for (const stage of CONFLICT_BOUNCE_STAGES) {
+      const prs = [
+        { number: 9, headRefName: 'feat/9', baseRefName: DEFAULT_BRANCH, mergeable: 'CONFLICTING', linkedIssues: [9] },
+      ];
+      const { actions } = planConflictScan(prs, { 9: info({ labels: [`stage:${stage}`] }) }, BASE_TS);
+      assert.equal(actions[0].advanceTo, 'build', stage);
+      assert.equal(actions[0].stage, stage);
+    }
+  });
+
+  it('ignores non-conflicting PRs and PRs not targeting the base branch', () => {
+    const prs = [
+      { number: 1, headRefName: 'a', baseRefName: DEFAULT_BRANCH, mergeable: 'MERGEABLE', linkedIssues: [1] },
+      { number: 2, headRefName: 'b', baseRefName: 'some-other-branch', mergeable: 'CONFLICTING', linkedIssues: [2] },
+    ];
+    const out = planConflictScan(prs, { 1: info(), 2: info() }, BASE_TS);
+    assert.deepEqual(out.actions, []);
+    assert.deepEqual(out.skipped, []);
+  });
+
+  it('excludes wip / needs-human / hold and closed/missing issues', () => {
+    const prs = [
+      { number: 1, headRefName: 'a', baseRefName: DEFAULT_BRANCH, mergeable: 'CONFLICTING', linkedIssues: [10] },
+      { number: 2, headRefName: 'b', baseRefName: DEFAULT_BRANCH, mergeable: 'CONFLICTING', linkedIssues: [11] },
+      { number: 3, headRefName: 'c', baseRefName: DEFAULT_BRANCH, mergeable: 'CONFLICTING', linkedIssues: [12] },
+      { number: 4, headRefName: 'd', baseRefName: DEFAULT_BRANCH, mergeable: 'CONFLICTING', linkedIssues: [13] },
+    ];
+    const issueInfo = {
+      10: info({ labels: ['stage:build', WIP_LABEL] }),
+      11: info({ labels: ['stage:build', 'sdlc:needs-human'] }),
+      12: info({ state: 'CLOSED', labels: ['stage:build'] }),
+      // 13 intentionally absent (not found)
+    };
+    const { actions, skipped } = planConflictScan(prs, issueInfo, BASE_TS);
+    assert.deepEqual(actions, []);
+    assert.deepEqual(skipped.map((s) => s.issue), [10, 11, 12, 13]);
+  });
+
+  it('skips a PR with no linked issue', () => {
+    const prs = [
+      { number: 7, headRefName: 'z', baseRefName: DEFAULT_BRANCH, mergeable: 'CONFLICTING', linkedIssues: [] },
+    ];
+    const { actions, skipped } = planConflictScan(prs, {}, BASE_TS);
+    assert.deepEqual(actions, []);
+    assert.deepEqual(skipped, [{ pr: 7, reason: 'no linked issue' }]);
+  });
+
+  it('is idempotent: suppresses a comment already posted at/after the base watermark', () => {
+    const prs = [
+      { number: 1, headRefName: 'feat/1-x', baseRefName: DEFAULT_BRANCH, mergeable: 'CONFLICTING', linkedIssues: [1] },
+    ];
+    const body = conflictCommentBody('feat/1-x');
+    const issueInfo = {
+      1: info({ labels: ['stage:build'], comments: [{ body, createdAt: '2026-07-06T00:00:00Z' }] }),
+    };
+    const { actions, skipped } = planConflictScan(prs, issueInfo, BASE_TS);
+    assert.deepEqual(actions, []);
+    assert.ok(skipped[0].reason.includes('already posted'));
+  });
+
+  it('re-nudges when the prior comment predates the last base-branch update', () => {
+    const prs = [
+      { number: 1, headRefName: 'feat/1-x', baseRefName: DEFAULT_BRANCH, mergeable: 'CONFLICTING', linkedIssues: [1] },
+    ];
+    const body = conflictCommentBody('feat/1-x');
+    const issueInfo = {
+      1: info({ labels: ['stage:build'], comments: [{ body, createdAt: '2026-07-04T00:00:00Z' }] }),
+    };
+    // watermark compares timestamps, not strings (Z vs +00:00 offsets differ lexically).
+    const { actions } = planConflictScan(prs, issueInfo, '2026-07-05T00:00:00+00:00');
+    assert.equal(actions.length, 1);
+  });
+});
+
+describe('dup-check scoring', () => {
+  it('tokenizes defensively and drops stopwords / short terms from a query', () => {
+    assert.deepEqual(dupTokens('Add a Bottom-Menu bar!'), ['add', 'a', 'bottom', 'menu', 'bar']);
+    assert.deepEqual(dupTokens(null), []);
+    assert.deepEqual(dupQueryTerms('add a bar to the menu'), ['add', 'bar', 'menu']);
+  });
+
+  it('weights title hits over body hits and adds a label-hint bonus', () => {
+    const issues = [
+      { number: 10, title: 'Bottom menu bar', body: 'unrelated', labels: ['ui'] },
+      { number: 11, title: 'unrelated', body: 'a bottom menu bar someday', labels: [] },
+      { number: 12, title: 'nothing here', body: 'nothing', labels: [] },
+    ];
+    const ranked = scoreDupCandidates('bottom menu bar', issues);
+    // #10: 3 title terms ×3 = 9; #11: 3 body terms ×1 = 3; #12 drops (score 0).
+    assert.deepEqual(ranked.map((c) => c.number), [10, 11]);
+    assert.equal(ranked[0].score, 9);
+    assert.equal(ranked[1].score, 3);
+  });
+
+  it('label token hits add on top of a title/body hit', () => {
+    const issues = [{ number: 20, title: 'x', body: 'y', labels: [{ name: 'client' }, 'ui'] }];
+    const ranked = scoreDupCandidates('ui', issues);
+    assert.equal(ranked[0].score, 1); // label-only hit → labelWeight 1
+  });
+
+  it('ranks by score desc then issue number asc, and honours limit', () => {
+    const issues = [
+      { number: 3, title: 'menu', body: '', labels: [] },
+      { number: 1, title: 'menu', body: '', labels: [] },
+      { number: 2, title: 'menu bar', body: '', labels: [] },
+    ];
+    const ranked = scoreDupCandidates('menu bar', issues, { limit: 2 });
+    assert.deepEqual(ranked.map((c) => c.number), [2, 1]); // #2 score 6; tie 1<3
+  });
+
+  it('excludes the query’s own issue and returns nothing for an all-stopword query', () => {
+    const issues = [{ number: 5, title: 'menu bar', body: '', labels: [] }];
+    assert.deepEqual(scoreDupCandidates('menu', issues, { exclude: 5 }), []);
+    assert.deepEqual(scoreDupCandidates('menu', issues, { exclude: '#5' }), []);
+    assert.deepEqual(scoreDupCandidates('the a of', issues), []);
+  });
+});
+
+describe('sdlc dup-check command', () => {
+  const listKey = 'issue list --state open --json number,title,body,labels --limit 200';
+
+  it('prints ranked candidates and sets exit code 2 when any are found', () => {
+    const prev = process.exitCode;
+    process.exitCode = undefined;
+    const gh = fakeExec({
+      [listKey]: JSON.stringify([
+        { number: 10, title: 'Bottom menu bar', body: '', labels: ['ui'] },
+        { number: 11, title: 'unrelated thing', body: '', labels: [] },
+      ]),
+    });
+    const logs = [];
+    runSdlc(['dup-check', 'bottom menu bar'], { gh, log: (m) => logs.push(m) });
+    assert.ok(logs.join('\n').includes('#10 Bottom menu bar (score'));
+    assert.ok(!logs.join('\n').includes('#11'));
+    assert.equal(process.exitCode, 2);
+    process.exitCode = prev; // don't leak into the runner's exit
+  });
+
+  it('reports clean and leaves exit code untouched when nothing matches', () => {
+    const prev = process.exitCode;
+    process.exitCode = undefined;
+    const gh = fakeExec({
+      [listKey]: JSON.stringify([{ number: 11, title: 'unrelated thing', body: '', labels: [] }]),
+    });
+    const logs = [];
+    runSdlc(['dup-check', 'bottom menu bar'], { gh, log: (m) => logs.push(m) });
+    assert.ok(logs.join('\n').includes('no candidates'));
+    assert.notEqual(process.exitCode, 2);
+    process.exitCode = prev;
+  });
+
+  it('errors on a missing query or an all-stopword query', () => {
+    throwsSdlc(() => runSdlc(['dup-check'], { gh: fakeExec(), log: () => {} }), /requires a query/);
+    throwsSdlc(() => runSdlc(['dup-check', 'the a of'], { gh: fakeExec(), log: () => {} }), /no usable search terms/);
+  });
+});
+
+describe('cycle-prep (one-shot pre-dispatch sequence)', () => {
+  /** A throwaway repo root with a .git dir for the maintenance lock. */
+  const makeRoot = () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sdlc-cycle-prep-test-'));
+    fs.mkdirSync(path.join(root, '.git'));
+    return root;
+  };
+  const lockDir = (root) => path.join(root, '.git', 'sdlc-maint.lock');
+
+  /** Canned gh/git responses for an empty, idle pipeline. */
+  const idleGh = (extra = {}) => fakeExec({
+    'issue list --state open --json number,labels,createdAt,title --limit 200': '[]',
+    'issue list --state open --json number,labels,updatedAt --limit 200': '[]',
+    [`pr list --state merged --base ${DEFAULT_BRANCH} --json number,mergedAt,title,closingIssuesReferences --limit 50`]: '[]',
+    'issue list --state open --json number,title,labels,body --limit 200': '[]',
+    'pr list --state open --json number,title,headRefName,mergeable,reviewDecision,isDraft': '[]',
+    [`pr list --state open --base ${DEFAULT_BRANCH} --json number,headRefName,baseRefName,mergeable,closingIssuesReferences --limit 200`]: '[]',
+    ...extra,
+  });
+  const idleGit = () => fakeExec({
+    'rev-parse --abbrev-ref HEAD': `${DEFAULT_BRANCH}\n`,
+    [`rev-parse ${DEFAULT_BRANCH}`]: 'abc123def\n',
+    [`branch --merged ${DEFAULT_BRANCH}`]: '',
+    'branch -vv': '',
+    'worktree list --porcelain': '',
+    [`log -1 --format=%cI origin/${DEFAULT_BRANCH}`]: '2026-07-05T00:00:00+00:00\n',
+  });
+
+  it('runs the full sequence on an idle cycle: run-id first, delimited sections, lock released', () => {
+    const root = makeRoot();
+    try {
+      const logs = [];
+      runSdlc(['cycle-prep'], { gh: idleGh(), git: idleGit(), log: (m) => logs.push(m), root });
+      const out = logs.join('\n');
+      // run-id line preserved verbatim, printed first (single source of truth).
+      assert.match(logs[0], /^run-id: dispatch-\d{8}-\d{4}-[0-9a-f]{4}$/);
+      assert.match(logs[1], /^started: \d{4}-\d{2}-\d{2}T/);
+      // Every section, clearly delimited, in order.
+      const sections = logs.filter((l) => l.startsWith('\n=== ')).map((l) => l.replace(/[\n= ]/g, ''));
+      assert.deepEqual(sections, [
+        'maint-lock', 'lanes', 'gate', 'sweep',
+        'git-maint', 'worktree-sweep', 'conflict-scan', 'maint-release', 'summary',
+      ]);
+      // Identical semantics to the individual commands.
+      assert.ok(out.includes('maint-lock: ACQUIRED'));
+      assert.ok(out.includes('intake: depth 0'));
+      assert.ok(out.includes('gate: CLEAR'));
+      assert.ok(out.includes('sweep: clear'));
+      assert.ok(out.includes('worktree-sweep: no issue-scoped worktrees.'));
+      assert.ok(out.includes(`conflict-scan: no conflicting PRs into ${DEFAULT_BRANCH}.`));
+      assert.ok(out.includes('maint-release: RELEASED'));
+      assert.ok(out.includes('maintenance previewed'));
+      // Lock released at the end of the maintenance section.
+      assert.equal(fs.existsSync(lockDir(root)), false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('lock held by a live run → maintenance skipped, prep continues, no failure exit, lock untouched', () => {
+    const root = makeRoot();
+    try {
+      fs.mkdirSync(lockDir(root));
+      fs.writeFileSync(path.join(lockDir(root), 'owner.txt'), `run-live ${new Date().toISOString()}\n`);
+
+      const prevExit = process.exitCode;
+      const logs = [];
+      const git = idleGit();
+      runSdlc(['cycle-prep'], { gh: idleGh(), git, log: (m) => logs.push(m), root });
+      const out = logs.join('\n');
+      assert.ok(out.includes('HELD by run-live'));
+      // Step 0 still runs...
+      assert.ok(out.includes('gate: CLEAR'));
+      assert.ok(out.includes('sweep: clear'));
+      // ...but the maintenance trio does not.
+      assert.ok(out.includes('maintenance: skipped (lock held by run-live'));
+      assert.ok(!out.includes('=== git-maint ==='));
+      assert.equal(git.calls.some((c) => c[0] === 'fetch'), false);
+      // A held lock is a normal outcome, never a cycle-prep failure...
+      assert.equal(process.exitCode ?? undefined, prevExit ?? undefined);
+      // ...and the live holder's lock is left in place (no release).
+      assert.equal(fs.existsSync(lockDir(root)), true);
+      assert.ok(!out.includes('maint-release'));
+    } finally {
+      process.exitCode = undefined;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reap path: a stale wip lock inside the report is reaped (gate --reap semantics)', () => {
+    const root = makeRoot();
+    try {
+      const oldIso = new Date(Date.now() - 5 * 3600000).toISOString();
+      const gh = idleGh({
+        'issue list --state open --json number,labels,updatedAt --limit 200': JSON.stringify([
+          { number: 7, labels: [{ name: 'stage:build' }, { name: WIP_LABEL }], updatedAt: oldIso },
+        ]),
+        'api repos/{owner}/{repo}/issues/7/timeline --paginate': JSON.stringify([
+          { event: 'labeled', label: { name: WIP_LABEL }, created_at: oldIso },
+        ]),
+        'issue view 7 --json comments --jq [.comments[] | {body: .body, createdAt: .createdAt}]':
+          JSON.stringify([{ body: 'sdlc:claim run-dead build', createdAt: oldIso }]),
+      });
+      const logs = [];
+      runSdlc(['cycle-prep'], { gh, git: idleGit(), log: (m) => logs.push(m), root });
+      const out = logs.join('\n');
+      assert.ok(out.includes('gate: REAP #7'));
+      assert.ok(out.includes(`reaped: removed ${WIP_LABEL} from #7`));
+      assert.equal(gh.calls.some((c) => c[0] === 'issue' && c[1] === 'edit' && c[2] === '7'), true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('runSdlc gate --reap verify-before-write', () => {
+  it('re-verifies against the newest claim and skips a fresh one', () => {
+    // Snapshot says #5 is wip and its labeled event is ancient (stale), but by
+    // write time another run has reaped it and a NEW worker claimed it — the
+    // fresh claim must suppress the reap.
+    const oldIso = new Date(Date.now() - 5 * 3600000).toISOString();
+    const freshIso = new Date(Date.now() - 5 * 60000).toISOString();
+    const gh = fakeExec({
+      'issue list --state open --json number,labels,updatedAt --limit 200': JSON.stringify([
+        { number: 5, labels: [{ name: 'stage:build' }, { name: WIP_LABEL }], updatedAt: oldIso },
+      ]),
+      'api repos/{owner}/{repo}/issues/5/timeline --paginate': JSON.stringify([
+        { event: 'labeled', label: { name: WIP_LABEL }, created_at: oldIso },
+      ]),
+      'issue view 5 --json comments --jq [.comments[] | {body: .body, createdAt: .createdAt}]':
+        JSON.stringify([{ body: 'sdlc:claim run-new build', createdAt: freshIso }]),
+    });
+    const logs = [];
+    runSdlc(['gate', '--reap'], { gh, log: (m) => logs.push(m) });
+    assert.ok(logs.join('\n').includes('reap skipped — fresh claim'));
+    assert.equal(gh.calls.some((c) => c[0] === 'issue' && c[1] === 'edit'), false);
+  });
+});
+
+describe('usage', () => {
+  it('prints usage with no command', () => {
+    const logs = [];
+    runSdlc([], { log: (m) => logs.push(m) });
+    assert.ok(logs.join('\n').includes('deterministic SDLC pipeline'));
+  });
+
+  it('rejects an unknown command', () => {
+    throwsSdlc(() => runSdlc(['frobnicate'], { log: () => {} }), /unknown command/);
+  });
+
+  it('WIP_STALE_MS is two hourly cycles', () => {
+    assert.equal(WIP_STALE_MS, 2 * 60 * 60 * 1000);
+  });
+});


### PR DESCRIPTION
Resyncs pemr's agentic-sdlc adoption from upstream `C:\Claude\agentic-sdlc` at `3e0db2d` (last sync was 2026-07-16; this picks up the four upstream commits of Jul 26–27, minus the ADO-only profile rework which doesn't apply).

## What's ported

**CLI** — `scripts/sdlc.mjs` is now the upstream reference implementation verbatim except two lines (usage path; `PROD_BRANCH = 'main'`). New commands: `emit` (marker-before-label-math one-shot), `claim --next` with lost-race retry, `mint`, `cycle-prep`, `heal <lane>` auto-discovery, `worktree-sweep`, `conflict-scan` (base-update watermark), `sweep --ack`, `dup-check`, lanes ineligibility breakdown, digest parked/hold deltas. Stage graph gains queued→design and intake→verify edges. Retires the f6124bb origin/HEAD integration-branch detection — behaviorally equivalent here (origin/HEAD → `dev`) and keeps the file diffable against upstream.

**Tests** — `test/sdlc.test.mjs`: the repo's first test suite (130 zero-dep `node:test` tests over the pure planners). `npm test` green.

**Prompts** — all 8 lane/dispatch files replaced with upstream (audit/build/design/ship/verify byte-identical; README/dispatch/intake differ only by `tools/`→`scripts/` path rewrites and "(agentic-sdlc repo)" doc-ref annotations). Brings the design-standard phase, emit/claim protocol, plan-trust + spec-rot check, per-AC coverage ledger, dispatch Step 0b stage-label integrity, bounded bounce loops, and background worker spawn. `PROFILE.md` rewritten as the placeholder binding table.

**Docs** — `Development_AgenticSDLC.md`: bounce caps, background spawn, model-tier routing (Fable-class off the audit lane), full CLI command list; fixes stale dispatcher-singleton prose.

## Verification

- `npm test`: 130/130 pass.
- Fresh-context verifier diff-confirmed every file against upstream `3e0db2d`: only the intended divergences exist (details in the commit message).

## Before enabling the scheduled dispatcher

`<LINT_CMD>` and `<SMOKE_CMD>` are still **unbound** in `prompts/sdlc/PROFILE.md`, and the new build/verify prompts instruct workers to run them. Bind both first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
