### PR TITLE
fix(#87): one emptiness predicate for every route into ocr_text

### DIFF
--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -510,7 +510,7 @@ def _cmd_document_set_text(args: argparse.Namespace) -> int:
         # Read first: the before-size feeds the status line, and resolving the id here
         # means an unknown id outranks an empty file in the error the human sees.
         before = documents.get_document_view(conn, args.document_id)
-        if not text.strip():
+        if not documents.normalize_document_text(text):
             # documents.set_document_text guards this too (so MCP gets it); repeated here
             # only to name the offending path, which the engine never sees.
             raise ValueError(

--- a/pemr/documents.py
+++ b/pemr/documents.py
@@ -37,6 +37,7 @@ detect multi-document attestation and does not pretend to.
 from __future__ import annotations
 
 import sqlite3
+import unicodedata
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -71,6 +72,58 @@ class OcrTextPresentError(ValueError):
 # record fields only), so correcting them is a pure metadata UPDATE. sha256 and
 # source_path are excluded by construction: the blob is content-addressed.
 _EDITABLE_FIELDS = ("doc_date", "category", "provider")
+
+
+# Unicode categories with no visible glyph, stripped alongside whitespace by
+# :func:`normalize_document_text`. `Cf` (format) is the one that matters: it holds
+# U+FEFF -- the survivor of a *doubled* BOM, which `utf-8-sig` only strips once --
+# plus U+200B/U+200C/U+200D and friends. `Cc` (control) is the same defect with a
+# NUL-only payload. Neither is `str.isspace()`, which is why plain `.strip()` let
+# them through (issue #87).
+_INVISIBLE_CATEGORIES = frozenset({"Cf", "Cc"})
+
+# Belt and braces for the zero-widths the issue names by codepoint: their category
+# has moved between Unicode revisions (U+200B was `Zs` before Unicode 4.0.1), and
+# the guard must not depend on which table the running Python ships.
+_INVISIBLE_CHARS = "".join(chr(cp) for cp in (0x200B, 0x200C, 0x200D, 0xFEFF))
+
+
+def _is_invisible(ch: str) -> bool:
+    return (
+        ch.isspace()
+        or ch in _INVISIBLE_CHARS
+        or unicodedata.category(ch) in _INVISIBLE_CATEGORIES
+    )
+
+
+def normalize_document_text(text: str | None) -> str:
+    """The engine's single answer to "is this document text meaningfully empty?".
+
+    Returns the text with every leading/trailing invisible character removed, so
+    ``not normalize_document_text(x)`` *is* the emptiness guard and its return value
+    is what gets stored -- one predicate for both, so a zero-width character can
+    neither pass the guard nor land in ``ocr_text`` (issue #87).
+
+    `str.strip()` alone is not that guard: it removes only characters where
+    ``.isspace()`` is true, so a file (or an MCP ``text`` argument) holding nothing
+    but U+200B, or the U+FEFF left over from a doubled BOM, sailed past every check
+    and stored one invisible character -- making ``has_ocr_text`` /
+    ``ocr_text_populated`` report ``true`` on a document carrying no text, the exact
+    wrong signal `AGENTS.md` §3 tells an agent to trust. Unrecoverable over MCP,
+    where ``document_set_text`` has no ``force``, which is why the fix sits here at
+    the engine layer rather than in `cli.py`'s read path (issue #78 fixed that half).
+
+    The contract is deliberately narrow: **text with no visible content is empty.**
+    Text that is merely *mostly* invisible is text, and nothing here normalises the
+    interior of a real transcription -- only its two ends.
+    """
+    value = text or ""
+    start, end = 0, len(value)
+    while start < end and _is_invisible(value[start]):
+        start += 1
+    while end > start and _is_invisible(value[end - 1]):
+        end -= 1
+    return value[start:end]
 
 
 # --------------------------------------------------------------------------- #
@@ -251,18 +304,20 @@ def set_document_text(
     ``NEW.ocr_text``, so the document becomes visible to `pemr find` with no explicit
     reindex (and a replace stops matching the old text).
 
-    The stored value is ``text.strip()``, matching :func:`ingest.ingest_document`.
+    The stored value is :func:`normalize_document_text` of the input, matching
+    :func:`ingest.ingest_document`.
 
     Raises :class:`DocumentNotFoundError` (unknown id), :class:`OcrTextPresentError` (the
     column is already populated and ``force`` is off — replacing a transcription is not
     cheaply undoable, so the surprising case is refused rather than silently applied), and
-    ``ValueError`` for empty/whitespace-only text. There is deliberately no path to *clear*
-    ``ocr_text``: that only removes FTS visibility, while an empty input is far more likely
-    a wrong or truncated file.
+    ``ValueError`` for text with no visible content — whitespace, but also zero-width and
+    other invisible characters, which `str.strip()` misses (issue #87). There is
+    deliberately no path to *clear* ``ocr_text``: that only removes FTS visibility, while
+    an empty input is far more likely a wrong or truncated file.
     """
     db.require_migrated(conn)
     row = _require_document(conn, document_id)
-    stored = (text or "").strip()
+    stored = normalize_document_text(text)
     if not stored:
         raise ValueError("text is empty - nothing to store; ocr_text unchanged")
     existing = row["ocr_text"] or ""

--- a/pemr/documents.py
+++ b/pemr/documents.py
@@ -309,8 +309,10 @@ def set_document_text(
     :func:`ingest.ingest_document`.
 
     Raises :class:`DocumentNotFoundError` (unknown id), :class:`OcrTextPresentError` (the
-    column is already populated and ``force`` is off — replacing a transcription is not
-    cheaply undoable, so the surprising case is refused rather than silently applied), and
+    column already holds *visible* text and ``force`` is off — replacing a transcription is
+    not cheaply undoable, so the surprising case is refused rather than silently applied;
+    a row holding only invisible characters counts as unpopulated, so it can be repaired
+    over MCP, where there is no ``force`` — issue #87), and
     ``ValueError`` for text with no visible content — whitespace, but also zero-width and
     other invisible characters, which `str.strip()` misses (issue #87). There is
     deliberately no path to *clear* ``ocr_text``: that only removes FTS visibility, while
@@ -321,7 +323,12 @@ def set_document_text(
     stored = normalize_document_text(text)
     if not stored:
         raise ValueError("text is empty - nothing to store; ocr_text unchanged")
-    existing = row["ocr_text"] or ""
+    # Normalised, not raw truthiness: a row holding nothing but invisible characters
+    # (pre-fix ingests, issue #87) counts as *unpopulated*, so it can be repaired over
+    # MCP, where `document_set_text` deliberately has no `force`. The only thing this
+    # lets through without `force` is content with no visible characters, so no real
+    # transcription can be lost.
+    existing = normalize_document_text(row["ocr_text"])
     if existing and not force:
         raise OcrTextPresentError(
             f"document {document_id} already has ocr_text ({len(existing)} chars) - "

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -232,7 +232,10 @@ def _ocr_page_image(png: bytes, label: str) -> str | None:
         return None
     # Bytes in, bytes out: decode explicitly rather than letting `text=True` pick the
     # platform codepage (issue #64 — cp1252 on Windows crashes on tesseract's UTF-8).
-    return proc.stdout.decode("utf-8", errors="replace").strip() or None
+    # `normalize_document_text`, not `.strip()`: tesseract on a blank page can emit
+    # nothing but zero-widths/form-feeds, which must count as "no text" on every
+    # route, not just the supplied-text one (issue #87).
+    return normalize_document_text(proc.stdout.decode("utf-8", errors="replace")) or None
 
 
 def _ocr_pdf(src: Path) -> str | None:
@@ -281,7 +284,7 @@ def _ocr_pdf(src: Path) -> str | None:
             label = f"{src.name} page {index + 1}"
             try:
                 page = doc[index]
-                text = (page.get_text() or "").strip()
+                text = normalize_document_text(page.get_text())
                 if len(text) < PDF_TEXT_LAYER_MIN_CHARS:
                     if have_tesseract is None:
                         have_tesseract = shutil.which("tesseract") is not None
@@ -306,7 +309,7 @@ def _ocr_pdf(src: Path) -> str | None:
                 pages.append(text)
     finally:
         doc.close()
-    return _PAGE_SEPARATOR.join(pages).strip() or None
+    return normalize_document_text(_PAGE_SEPARATOR.join(pages)) or None
 
 
 def run_ocr(path: str | Path) -> str | None:
@@ -353,7 +356,9 @@ def run_ocr(path: str | Path) -> str | None:
             file=sys.stderr,
         )
         return None
-    text = proc.stdout.strip()
+    # Same predicate as every other route into `ocr_text` (issue #87): this return
+    # goes straight out of `extract_text_routed` without passing its normalisation.
+    text = normalize_document_text(proc.stdout)
     return text or None
 
 
@@ -534,7 +539,9 @@ def extract_text_routed(path: str | Path) -> tuple[str | None, str]:
             file=sys.stderr,
         )
         return None, "native"
-    text = text.strip()
+    # Same predicate as the supplied-text route below - one emptiness notion per
+    # column, so `--ocr auto` cannot store what `--ocr-text-file` rejects (issue #87).
+    text = normalize_document_text(text)
     return (text or None), "native"
 
 

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -53,6 +53,7 @@ from typing import Callable, Sequence
 from urllib.parse import urlsplit
 
 from . import db, study as _study
+from .documents import normalize_document_text
 from .models import Document, Person
 
 
@@ -964,7 +965,10 @@ def ingest_document(
 
     # Resolve the text *before* the blob copy so the owner check is pre-write. OCR
     # runs on `src` rather than the copied blob — identical bytes, same result.
-    supplied = ocr_text.strip() if ocr_text else None
+    # `normalize_document_text`, not `.strip()`: a supplied text of nothing but
+    # zero-width characters is empty, and must neither count as supplied nor land in
+    # `ocr_text` (issue #87).
+    supplied = normalize_document_text(ocr_text) or None
     if supplied:
         # An agent transcription is prose off the page: anchors mean what they say.
         ocr_text, route = supplied, "ocr"
@@ -1117,7 +1121,9 @@ def ingest_study_dir(
         )
 
     metadata = _study.read_metadata(scan)
-    supplied = ocr_text.strip() if ocr_text else None
+    # Same guard as the file path: zero-width-only text is empty, so the generated
+    # study summary wins rather than an invisible character (issue #87).
+    supplied = normalize_document_text(ocr_text) or None
     text = supplied or _study.summary_text(scan, metadata)
 
     roster = _roster(conn)

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -303,6 +303,42 @@ def test_ingest_bom_only_ocr_text_file_stores_no_ocr_text(ready, capsys):
     assert shown.out == "" and "has no ocr_text stored" in shown.err
 
 
+def test_ingest_zero_width_only_ocr_text_file_stores_no_ocr_text(ready, capsys):
+    """One U+200B is not text (#87). No encoding fixes this - `utf-8-sig` has nothing
+    to strip - so `.strip()`, which only removes `.isspace()` characters, let it
+    through and reported ocr_text populated on an empty document."""
+    tmp_path = ready
+    scan = tmp_path / "scan.txt"
+    scan.write_bytes(b"some labs")
+    zwsp = tmp_path / "zwsp.txt"
+    zwsp.write_bytes(chr(0x200B).encode("utf-8"))
+
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources"),
+                "--ocr-text-file", str(zwsp)) == 0
+    assert "no ocr_text stored" in capsys.readouterr().err
+    assert _run(tmp_path, "document", "show", "1", "--text") == 0
+    shown = capsys.readouterr()
+    assert shown.out == "" and "has no ocr_text stored" in shown.err
+
+
+def test_ingest_doubled_bom_ocr_text_file_stores_no_ocr_text(ready, capsys):
+    """`utf-8-sig` strips one BOM; the U+FEFF survivor is not `.isspace()` (#87)."""
+    tmp_path = ready
+    scan = tmp_path / "scan.txt"
+    scan.write_bytes(b"some labs")
+    bom = tmp_path / "doublebom.txt"
+    bom.write_bytes((chr(0xFEFF) * 2).encode("utf-8"))
+
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources"),
+                "--ocr-text-file", str(bom)) == 0
+    assert "no ocr_text stored" in capsys.readouterr().err
+    assert _run(tmp_path, "document", "show", "1", "--text") == 0
+    shown = capsys.readouterr()
+    assert shown.out == "" and "has no ocr_text stored" in shown.err
+
+
 def test_ingest_strips_a_leading_bom_from_the_ocr_text_file(ready, capsys):
     """A BOM on a real transcription must not inflate the stored text (#78)."""
     tmp_path = ready

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -291,6 +291,28 @@ def test_set_text_strips_invisible_padding_from_what_it_stores(seeded):
     assert view["ocr_text_chars"] == len("cholesterol panel")
 
 
+def test_set_text_repairs_an_invisible_only_row_without_force(conn):
+    """The recovery half of the fix: an `ocr_text` of nothing but zero-widths (every
+    row ingested before this fix) counts as *unpopulated*, so it is repairable over
+    MCP - where `document_set_text` deliberately has no `force` (#87)."""
+    person = persons.add_person(conn, "jane-doe", "Jane Doe")
+    doc = _insert_document(conn, person.person_id, "ff00", ocr_text=ZWSP)
+    view = documents.set_document_text(conn, doc, "Real transcription of the page.")
+    assert view["has_ocr_text"] is True
+    assert documents.get_document_text(conn, doc) == "Real transcription of the page."
+    assert _fts_text(conn, doc) == "Real transcription of the page."
+
+
+def test_set_text_still_refuses_a_visibly_populated_row_without_force(conn):
+    """The widened check must not widen into "replace anything": text with even one
+    visible character is still guarded by `force` (#87)."""
+    person = persons.add_person(conn, "jane-doe", "Jane Doe")
+    doc = _insert_document(conn, person.person_id, "ff01", ocr_text=ZWSP + "a")
+    with pytest.raises(documents.OcrTextPresentError):
+        documents.set_document_text(conn, doc, "replacement")
+    assert documents.get_document_text(conn, doc) == ZWSP + "a"
+
+
 def test_set_text_leaves_records_and_keys_untouched(seeded):
     conn = seeded["conn"]
     before = [

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -240,6 +240,57 @@ def test_set_text_unknown_document_raises(conn):
         documents.set_document_text(conn, 999, "text")
 
 
+# --- the emptiness predicate (issue #87) -------------------------------------
+#
+# `str.strip()` removes only characters where `.isspace()` is true, so a payload of
+# nothing but zero-width characters used to pass every guard and store one invisible
+# character - `has_ocr_text`/`ocr_text_populated` true on a document carrying no text.
+# Engine-level because MCP's `document_set_text` has no `force` to recover with.
+
+ZWSP = chr(0x200B)          # ZERO WIDTH SPACE
+ZWNJ = chr(0x200C)          # ZERO WIDTH NON-JOINER
+ZWJ = chr(0x200D)           # ZERO WIDTH JOINER
+BOM_CHAR = chr(0xFEFF)      # what a *doubled* BOM leaves behind: `utf-8-sig` eats one
+
+
+@pytest.mark.parametrize("text", ["", "   \n\t ", ZWSP, ZWNJ, ZWJ, BOM_CHAR,
+                                  BOM_CHAR * 2, "\x00", ZWSP + " " + BOM_CHAR])
+def test_normalize_document_text_treats_invisible_only_text_as_empty(text):
+    assert documents.normalize_document_text(text) == ""
+
+
+def test_normalize_document_text_handles_none():
+    assert documents.normalize_document_text(None) == ""
+
+
+def test_normalize_document_text_keeps_visible_text_and_its_interior():
+    # Only the two ends are touched: a zero-width joiner inside a word is part of
+    # the transcription, not padding (the contract is "no visible content is empty").
+    assert documents.normalize_document_text(
+        BOM_CHAR + "  sodium" + ZWJ + " 140  " + ZWSP
+    ) == "sodium" + ZWJ + " 140"
+
+
+def test_set_text_refuses_zero_width_only_text(seeded):
+    conn = seeded["conn"]
+    for empty in (ZWSP, BOM_CHAR * 2, ZWJ + ZWNJ, " " + ZWSP + " "):
+        with pytest.raises(ValueError):
+            documents.set_document_text(conn, seeded["doc"], empty, force=True)
+    assert documents.get_document_text(conn, seeded["doc"]) == "scan text"
+
+
+def test_set_text_strips_invisible_padding_from_what_it_stores(seeded):
+    """Normalise what gets *stored*, not just what gets rejected: a leading
+    zero-width character must never land in `ocr_text` either."""
+    conn = seeded["conn"]
+    documents.set_document_text(
+        conn, seeded["doc"], ZWSP + " cholesterol panel " + BOM_CHAR, force=True
+    )
+    assert documents.get_document_text(conn, seeded["doc"]) == "cholesterol panel"
+    view = documents.get_document_view(conn, seeded["doc"])
+    assert view["ocr_text_chars"] == len("cholesterol panel")
+
+
 def test_set_text_leaves_records_and_keys_untouched(seeded):
     conn = seeded["conn"]
     before = [
@@ -854,6 +905,35 @@ def test_cli_document_set_text_rejects_a_bom_only_file(cli_ready, capsys):
     """
     text = cli_ready / "bomonly.txt"
     text.write_bytes(b"\xef\xbb\xbf")
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "set-text", "1", "--force",
+                "--ocr-text-file", str(text)) == 1
+    assert "is empty - nothing to store" in capsys.readouterr().err
+    assert _run(cli_ready, "document", "show", "1", "--text") == 0
+    assert capsys.readouterr().out == "hba1c 5.7 percent\n"
+
+
+def test_cli_document_set_text_rejects_a_zero_width_only_file(cli_ready, capsys):
+    """One U+200B is three bytes of nothing, not a transcription (#87).
+
+    Untouched by any encoding choice - `utf-8-sig` has nothing to strip - so this is
+    the guard's job, not the read path's (#78 fixed that half).
+    """
+    text = cli_ready / "zwsp.txt"
+    text.write_bytes(chr(0x200B).encode("utf-8"))
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "set-text", "1", "--force",
+                "--ocr-text-file", str(text)) == 1
+    assert "is empty - nothing to store" in capsys.readouterr().err
+    assert _run(cli_ready, "document", "show", "1", "--text") == 0
+    assert capsys.readouterr().out == "hba1c 5.7 percent\n"
+
+
+def test_cli_document_set_text_rejects_a_doubled_bom_file(cli_ready, capsys):
+    """`utf-8-sig` strips exactly one leading BOM; the survivor is U+FEFF, which
+    `str.strip()` then keeps (#87)."""
+    text = cli_ready / "doublebom.txt"
+    text.write_bytes((chr(0xFEFF) * 2).encode("utf-8"))
     capsys.readouterr()
     assert _run(cli_ready, "document", "set-text", "1", "--force",
                 "--ocr-text-file", str(text)) == 1

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -914,6 +914,61 @@ def test_supplied_ocr_text_is_stored_without_invisible_padding(conn, tmp_path, s
     assert result.document.ocr_text == "Sodium 140 mmol/L"
 
 
+# One emptiness notion per column: the *extracted* routes (`--ocr auto`) must answer
+# "is this empty?" the same way the supplied-text route does, or the issue's headline
+# symptom survives on an unenumerated route (#87 audit bounce).
+
+
+def test_extracted_zero_width_only_text_is_no_text_at_all(conn, tmp_path, sources):
+    """The `--ocr auto` native route: a file of nothing but one U+200B is empty."""
+    src = _make_file(tmp_path, "zwsp.txt", chr(0x200B).encode("utf-8"))
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.document.ocr_text is None
+    assert not result.ocr_text_populated
+
+
+def test_extracted_text_is_stored_without_invisible_padding(conn, tmp_path, sources):
+    src = _make_file(
+        tmp_path, "padded.txt",
+        (chr(0xFEFF) * 2 + " Sodium 140 mmol/L " + chr(0x200B)).encode("utf-8"),
+    )
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.document.ocr_text == "Sodium 140 mmol/L"
+
+
+def test_run_ocr_zero_width_only_tesseract_output_is_none(tmp_path, monkeypatch):
+    """tesseract on a blank page can emit invisibles; that is no text, not text."""
+    monkeypatch.setattr(ingest.shutil, "which", lambda _: "/usr/bin/tesseract")
+    monkeypatch.setattr(
+        ingest.subprocess, "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(
+            cmd, 0, stdout=chr(0x200B) + "\n" + chr(0xFEFF), stderr=""
+        ),
+    )
+    assert ingest.run_ocr(_make_file(tmp_path, "scan.jpg", b"jpeg")) is None
+
+
+def test_ocr_pdf_zero_width_text_layer_does_not_clear_the_threshold(
+    tmp_path, monkeypatch
+):
+    """A text layer of 60 zero-width characters used to clear
+    `PDF_TEXT_LAYER_MIN_CHARS` and suppress the tesseract fallback (#87)."""
+    pages = [_FakePage(text=chr(0x200B) * 60, scanned="the labs table")]
+    _install_backend(monkeypatch, _FakeBackend(_FakeDoc(pages)))
+    _install_tesseract(monkeypatch)
+
+    assert ingest.run_ocr(_pdf(tmp_path)) == "the labs table"
+    assert pages[0].pixmap_kwargs is not None
+
+
+def test_ocr_pdf_all_invisible_pages_yield_no_text(tmp_path, monkeypatch):
+    pages = [_FakePage(text=chr(0xFEFF), scanned=chr(0x200B))]
+    _install_backend(monkeypatch, _FakeBackend(_FakeDoc(pages)))
+    _install_tesseract(monkeypatch)
+
+    assert ingest.run_ocr(_pdf(tmp_path)) is None
+
+
 # --- structured text vs. the #61 identity anchor (issue #66 audit bounce) -------
 #
 # Native extraction made text available for `.csv`/`.docx`/`.xlsx`/`.json`, and that text

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -892,6 +892,28 @@ def test_supplied_ocr_text_still_beats_extraction(conn, tmp_path, sources):
     assert result.document.ocr_text == "agent transcription"
 
 
+def test_zero_width_only_ocr_text_is_no_text_at_all(conn, tmp_path, sources):
+    """`.strip()` keeps a zero-width character (it is not `.isspace()`), so a
+    zero-width-only transcription used to count as supplied and report
+    `ocr_text_populated` on a document carrying nothing (#87)."""
+    src = _make_file(tmp_path, "scan.txt", b"a scan with no text")
+    result = ingest.ingest_document(
+        conn, src, "jane-doe", sources, ocr_text=chr(0x200B)
+    )
+    assert result.document.ocr_text is None
+    assert not result.ocr_text_populated
+
+
+def test_supplied_ocr_text_is_stored_without_invisible_padding(conn, tmp_path, sources):
+    """Normalise what is *stored*, not just what is rejected (#87)."""
+    src = _make_file(tmp_path, "scan2.txt", b"another scan")
+    result = ingest.ingest_document(
+        conn, src, "jane-doe", sources,
+        ocr_text=chr(0xFEFF) + "  Sodium 140 mmol/L  " + chr(0x200B),
+    )
+    assert result.document.ocr_text == "Sodium 140 mmol/L"
+
+
 # --- structured text vs. the #61 identity anchor (issue #66 audit bounce) -------
 #
 # Native extraction made text available for `.csv`/`.docx`/`.xlsx`/`.json`, and that text

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -398,6 +398,18 @@ def test_ingest_study_dir_caller_values_win(conn, tmp_path, sources):
     assert doc.ocr_text == "IMPRESSION: no acute findings."
 
 
+def test_ingest_study_dir_zero_width_ocr_text_falls_back_to_the_summary(
+    conn, tmp_path, sources
+):
+    """A zero-width-only `ocr_text` is empty, so the generated study summary wins
+    rather than one invisible character (#87) - `.strip()` kept it."""
+    root = make_study(tmp_path / "disc")
+    result = ingest.ingest_study_dir(
+        conn, root, "jane-doe", sources, ocr_text=chr(0x200B),
+    )
+    assert "DICOM study: disc" in result.document.ocr_text
+
+
 def test_ingest_study_dir_reports_excluded_documents(conn, tmp_path, sources, capsys):
     ingest.ingest_study_dir(conn, make_study(tmp_path / "disc"), "jane-doe", sources)
     err = capsys.readouterr().err


### PR DESCRIPTION
## Summary

The "is this text empty?" guard on `ocr_text` was `str.strip()` in four places
(`documents.py:262`, `ingest.py:967`/`1120`, `cli.py:512`). `str.strip()` only removes
characters where `.isspace()` is true, so a payload of nothing but a zero-width
character (U+200B) or the U+FEFF left over from a *doubled* UTF-8 BOM sailed past
every guard and got stored as `ocr_text` — reporting `ocr_text_populated: true` /
`has_ocr_text: true` on a document that carries no visible text. Over MCP this was
unrecoverable: `document_set_text` has no `force`.

This adds a single shared predicate, `documents.normalize_document_text()`, that
strips whitespace plus Unicode format/control characters (`Cf`/`Cc`) and the
zero-width codepoints U+200B/U+200C/U+200D/U+FEFF from both ends of the text. It is
used as **both** the emptiness guard and the normaliser for what actually gets
stored, so an invisible-only payload can neither pass the guard nor land in
`ocr_text`:

- `pemr/documents.py` — new `normalize_document_text()`; `set_document_text` uses it
  for the emptiness check and to store the value, and treats an existing `ocr_text`
  that normalizes to empty as *unpopulated* (so a pre-fix row can be repaired over
  MCP without `force`).
- `pemr/ingest.py` — all OCR/text-extraction return paths (`_ocr_page_image`,
  `_ocr_pdf`, `run_ocr`, `extract_text_routed`, `ingest_document`,
  `ingest_study_dir`) route through the same predicate instead of `.strip()`.
- `pemr/cli.py` — `_cmd_document_set_text`'s guard mirrors the engine's, naming the
  offending path.

Tests added at the engine level (`tests/test_documents.py`) and one per CLI/ingest
call site (`tests/test_cli_phase2.py`, `tests/test_ingest.py`, `tests/test_study.py`)
covering U+200B-only and doubled-BOM inputs.

No user-facing behavior, command, flag, or output field changed — `ocr_text_populated`
now correctly reflects the invariant it always claimed to (`AGENTS.md` §3), so no docs
fan-out was needed.

Closes #87

Verify report (CONFIRMED, full suite green): https://github.com/meridun/pemr/issues/87#issuecomment-5208373281
Audit report (no blocking findings): https://github.com/meridun/pemr/issues/87#issuecomment-5208432819

🤖 Generated with automated SDLC pipeline (dispatch-20260806-1832-d5f4-ship)