### PR TITLE
feat(sdlc): resync prompts from agentic-sdlc upstream 79ddc87

### DIFF
--- a/docs/Development_AgenticSDLC.md
+++ b/docs/Development_AgenticSDLC.md
@@ -8,7 +8,7 @@ for the stage graph and worker loop), document here:
 - What's been proven to actually work end-to-end vs. what's still untested, so future changes
   know which tails are load-bearing.
 
-Upstream source: `C:\Claude\agentic-sdlc` — last resynced **2026-08-06** at upstream `3e0db2d`
+Upstream source: `C:\Claude\agentic-sdlc` — last resynced **2026-08-06** at upstream `79ddc87`
 (prompts, CLI, tests; placeholder bindings live in
 [prompts/sdlc/PROFILE.md](../prompts/sdlc/PROFILE.md)).
 

--- a/prompts/sdlc/README.md
+++ b/prompts/sdlc/README.md
@@ -106,6 +106,14 @@ comfortably.
      note (what's already done + evidence, what remains) before continuing, then do only the gap.
      If the item is conclusively shipped already, PARK with the evidence (PR#, commit, observed
      behavior) for a human to close — don't march it through the remaining lanes.
+
+     Prior work need not come from the pipeline: a local or `origin` branch whose name reasonably
+     matches the issue or a child of it, work already fully or partially merged to
+     `<DEFAULT_BRANCH>`, and artifacts on a predecessor issue linked in the body (a clone's
+     original — clones copy the body, not the thread) are all reconcilable evidence, slotted into
+     the same hierarchy as their pipeline-native equivalents. Branches that are on neither local
+     nor `origin`, or whose names bear no reasonable relation to the issue, are **not
+     discoverable** — don't hunt for them.
    - **Worktree isolation.** Never work in the main checkout — it may hold human WIP or another
      worker. For any lane that touches a branch, use the issue-scoped worktree
      `<WORKTREE_ROOT>/<issue#>`: create it if missing (`git worktree add <WORKTREE_ROOT>/<issue#>

--- a/prompts/sdlc/build.md
+++ b/prompts/sdlc/build.md
@@ -27,8 +27,13 @@ Decide the sub-case first (idempotency — schedulers fire on a clock, not on ne
 
 - **Branch already pushed, implementation complete, targeted tests green** → skip to **ADVANCE**. Do
   not rebuild.
-- **A branch exists but is incomplete** → continue on it in its worktree (merge
+- **A branch exists but is incomplete** — including a pre-existing branch intake or the plan named
+  (adopt it as-is; don't recut or rename it to the standard pattern — the issue link lives in the
+  body and comments, not the branch name) → continue on it in its worktree (merge
   `origin/<DEFAULT_BRANCH>` first per the README staleness rule; build owns conflict resolution).
+  If the branch isn't the pipeline's, post the README reconciliation note first: diff it against
+  the plan, state what's done with evidence and what remains, then build only the gap — extending
+  its existing tests rather than starting parallel ones.
   The reviewed plan stands — don't re-plan unless the merge invalidated it (spec-rot check below).
 - **Nothing started** → implement:
   - **Read the issue body's sections** — `## Requirements`, `## Acceptance criteria` (intake's),

--- a/prompts/sdlc/design.md
+++ b/prompts/sdlc/design.md
@@ -58,6 +58,13 @@ Then pick the sub-case (idempotency — don't redo a built artifact):
   (below) and ADVANCE. If the body already carries a current `## Implementation plan`, verify it
   cheaply instead of rewriting — that's the done-artifact no-op.
 
+**Salvage sweep (cheap), before writing the plan:** check for pre-existing design or
+implementation notes — in the thread and body, on a predecessor issue linked in the body, and on
+any prior-work branch intake's summary named (read its log/diff, not just its name). Incorporate
+what still holds; reject the rest explicitly, one line each on why, so the queued reviewer sees
+the call. When a partial implementation exists, the plan covers the **gap**: record the branch and
+its HEAD alongside the Baseline, and mark in Touched what's already done vs remaining.
+
 **The implementation plan** is a section you append to the **issue body** (edit the body
 *preserving every existing section* — you own only your sections; see the README's issue
 anatomy). It is a **detailed plan, not code**. The boundary is **decisions vs. expression**: the

--- a/prompts/sdlc/intake.md
+++ b/prompts/sdlc/intake.md
@@ -50,11 +50,13 @@ All inline, read-only (no code changes, no branches):
   issue covering the same thing is a close-as-dup; a partial overlap is a scope note.
 - **In-progress collision sweep** — does work on this already exist somewhere, even without a matching
   issue title? Three probes, cheap to expensive; stop as soon as one is conclusive:
-  1. **Remote branches:** `git fetch origin && git branch -r`. Branch names follow
+  1. **Local + remote branches:** `git fetch origin && git branch -a`. Branch names follow
      `<type>/<issue#>-<slug>` — scan for a slug that matches this issue's subject or an issue# whose
-     issue covers the same ground. On a candidate, `git log origin/<DEFAULT_BRANCH>..origin/<branch>
-     --oneline` and `git diff --name-only origin/<DEFAULT_BRANCH>...origin/<branch>` to see what it
-     actually changes.
+     issue covers the same ground (developer-cut branches may not follow the pattern; a reasonable
+     name match counts, an unrelated name doesn't — unpushed branches on other machines and
+     unrecognizably-named ones are not discoverable). On a candidate, `git log
+     origin/<DEFAULT_BRANCH>..origin/<branch> --oneline` and `git diff --name-only
+     origin/<DEFAULT_BRANCH>...origin/<branch>` to see what it actually changes.
   2. **Open PRs by touched paths:** `gh pr list --state open --json number,title,headRefName,files` —
      a PR touching the files this issue would touch is a collision even if the titles don't match.
   3. **In-flight issues in later lanes:** `gh issue list --label stage:build --json number,title`
@@ -62,7 +64,13 @@ All inline, read-only (no code changes, no branches):
      subsume or conflict with this one; read its body's `## Implementation plan`, not just its
      title.
 
-  Verdicts: same work in flight → close as dup linking the live item (or its issue). Partial overlap
+  Verdicts: a branch or PR that corresponds to **this** issue (or a child work item, or a
+  predecessor issue linked in the body) is **prior work, not a collision** — record the branch
+  name, its HEAD, and what its diff already implements in your summary comment and a one-line
+  pointer in `## Requirements`, so design plans the gap and build resumes it rather than
+  recutting. Work already partially merged to `<DEFAULT_BRANCH>` gets the same treatment: note
+  shipped-vs-missing in `## Requirements`; the AC still describes the full behavior. Otherwise:
+  same work in flight → close as dup linking the live item (or its issue). Partial overlap
   where this issue can't proceed until the in-flight work lands → comment "blocked by #n", apply the
   `blocked` label (the merge sweep flips it to `ready` when the blocker merges), and still EMIT
   normally on the rest of the triage. Mere adjacency → a scope note in the summary comment naming the
@@ -150,7 +158,8 @@ One-line result: `INTAKE: <#issue> → ADVANCE(design|verify)|PARK|CLOSE — <re
   possibly stale) overrides the cheap path — run the full WORK pass as if the artifacts didn't
   exist: dup-check again (including the closed-issue search — it may have shipped meanwhile),
   re-check docs, re-validate `## Requirements`/`## Acceptance criteria` in place, and note what
-  changed. **The in-thread instruction beats the idempotency shortcut.** A **reopened** issue is
+  changed. **The in-thread instruction beats the idempotency shortcut.** A **reopened** issue — or one
+  rewound to intake, cloned from a completed one, or enrolling in-flight developer work — is
   reconciled, not re-triaged from scratch: if the evidence (merged PR, code on `<DEFAULT_BRANCH>`)
   shows it already shipped, PARK with that evidence for a human to close rather than advancing it
   back into the pipeline.


### PR DESCRIPTION
## Summary
- Ports upstream agentic-sdlc prior-work reconciliation guidance (0492203, 79ddc87) into `prompts/sdlc/`:
  - **intake**: collision sweep scans local + remote branches; a branch/PR matching this issue (or a child/predecessor) is prior work to record, not a collision; rewound/cloned/enrolled items reconcile like reopened ones.
  - **design**: salvage sweep before writing the plan; gap-only plans when a partial implementation exists.
  - **build**: adopt pre-existing branches as-is (no recut/rename), post reconciliation note, build only the gap.
  - **README**: shared discoverability rule for prior-work evidence.
- Bumps the resync marker in `docs/Development_AgenticSDLC.md` to `79ddc87`.

All prompt hunks applied verbatim from upstream (pemr prompts are verbatim copies). CLI/tests untouched upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)