### PR TITLE
feat(cli): remove the misleading --ocr tesseract alias

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -467,7 +467,7 @@ For those you get a stderr note telling you to transcribe it yourself and pass
 `tesseract`, and a missing PDF backend all cost you the text, not the document. Extraction is
 capped at 32 MiB per file — `ocr_text` is mirrored into the FTS index, so an unbounded read is
 both a database-size problem and a decompression-bomb surface (a small `.docx` can declare a
-gigabyte of `word/document.xml`). `--ocr tesseract` is a retained alias for `--ocr auto`.
+gigabyte of `word/document.xml`).
 
 Extraction route feeds the owner check: the identity-anchor (`suspect`) verdict is applied
 only to an agent transcription or a tesseract pass, never to natively-extracted text —

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -898,8 +898,8 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
                     doc_date=args.doc_date,
                     category=args.category,
                     provider=args.provider,
-                    # `tesseract` is a retained alias for `auto`: both mean "extract
-                    # by whatever route this file type allows" (ingest.extract_text).
+                    # `--ocr auto` means "extract by whatever route this file type
+                    # allows" (ingest.extract_text).
                     ocr=(args.ocr is not None),
                     ocr_text=ocr_text,
                     force=args.force,
@@ -1797,9 +1797,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_ingest.add_argument("--provider")
     p_ingest.add_argument(
         "--ocr",
-        choices=["auto", "tesseract"],
-        help="pre-fill ocr_text: text/.docx/.xlsx read natively, images/PDF via "
-             "tesseract (soft dependency). 'tesseract' is an alias for 'auto'",
+        choices=["auto"],
+        help="pre-fill ocr_text: text/.docx/.xlsx read natively, PDF page by page "
+             "(text layer + rendered-page OCR), other files via tesseract "
+             "(soft dependency)",
     )
     p_ingest.add_argument(
         "--ocr-text-file",

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -487,17 +487,19 @@ def test_ocr_auto_makes_a_docx_findable(ready, capsys):
     assert "#1" in capsys.readouterr().out
 
 
-def test_ocr_tesseract_is_an_alias_for_auto(ready, capsys):
-    """The old spelling keeps working — it selects the same extraction dispatcher."""
+def test_ocr_tesseract_is_rejected(ready, capsys):
+    """Issue #91: the misleading `tesseract` alias is gone; argparse names `auto`."""
     tmp_path = ready
     csv = tmp_path / "labs.csv"
     csv.write_text("test,value\nferritin,68\n", encoding="utf-8")
 
-    assert _run(tmp_path, "ingest", str(csv), "--person", "jane-doe",
-                "--sources", str(tmp_path / "sources"), "--ocr", "tesseract") == 0
-    capsys.readouterr()
-    assert _run(tmp_path, "find", "--person", "jane-doe", "ferritin") == 0
-    assert "#1" in capsys.readouterr().out
+    with pytest.raises(SystemExit) as exc:
+        _run(tmp_path, "ingest", str(csv), "--person", "jane-doe",
+             "--sources", str(tmp_path / "sources"), "--ocr", "tesseract")
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "invalid choice" in err
+    assert "auto" in err
 
 
 def test_unextractable_format_still_ingests_with_a_note(ready, capsys, monkeypatch):

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -502,6 +502,23 @@ def test_ocr_tesseract_is_rejected(ready, capsys):
     assert "auto" in err
 
 
+def test_ocr_help_names_only_auto_and_no_pdf_tesseract_claim(capsys):
+    """Issue #91: the alias is undiscoverable and the PDF route is described honestly.
+
+    `--ocr tesseract` was misleading in both directions: the value named after the
+    tool never reached it, and the help text claimed PDFs went "via tesseract" when
+    the `_ocr_pdf` branch (#70) uses the embedded text layer plus rendered-page OCR.
+    """
+    with pytest.raises(SystemExit):
+        cli.main(["ingest", "--help"])
+    # argparse wraps the help block, so compare on collapsed whitespace.
+    text = " ".join(capsys.readouterr().out.split())
+    assert "--ocr {auto}" in text
+    assert "alias" not in text
+    assert "images/PDF via tesseract" not in text
+    assert "PDF page by page (text layer + rendered-page OCR)" in text
+
+
 def test_unextractable_format_still_ingests_with_a_note(ready, capsys, monkeypatch):
     from pemr import ingest as ingest_mod
 

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -593,7 +593,7 @@ def test_cli_ingest_study_roundtrip(cli_ready, capsys):
 def test_cli_ingest_study_says_it_ignores_ocr(cli_ready, capsys):
     tmp_path = cli_ready
     assert _cli(tmp_path, "ingest", str(make_study(tmp_path / "disc")),
-                "--person", "jane-doe", "--study", "dicom", "--ocr", "tesseract",
+                "--person", "jane-doe", "--study", "dicom", "--ocr", "auto",
                 "--sources", str(tmp_path / "sources")) == 0
     assert "--ocr is ignored for --study dicom" in capsys.readouterr().err
 


### PR DESCRIPTION
## Summary

- Removes `tesseract` from `--ocr`'s argparse `choices` outright (`choices=["auto", "tesseract"]` -> `choices=["auto"]`) — the value's name was misleading in both directions: on non-PDF files it never invoked tesseract (routed natively via `extract_text_routed`), and on PDFs the `_ocr_pdf` branch (#70) uses the embedded text layer + rendered-page OCR, which tesseract alone cannot decode.
- Corrects the `--ocr` help text, which previously claimed PDFs go "via tesseract" (they don't).
- Drops the stale "retained alias" comment at the `ocr=(args.ocr is not None)` call site and the corresponding sentence in `docs/Architecture.md` §4.
- Replaces the old "tesseract is an alias for auto" test with a rejection test asserting `SystemExit` + argparse's own `invalid choice` message (which names `auto`), and updates `tests/test_study.py`'s `--ocr` invocation to use `auto`.

**This is an intentional, human-approved breaking CLI change.** Per the issue's design bounce ("Remove, don't deprecate — I am currently the only user and this can mostly be considered greenfield"), there is no deprecation shim or grace period: the `tesseract` value is removed in this change, not staged for later removal. A script still passing `--ocr tesseract` gets argparse's own refusal:

```
pemr ingest: error: argument --ocr: invalid choice: 'tesseract' (choose from 'auto')
```

No behavior change otherwise — `ocr=(args.ocr is not None)` already treated both values identically, and no OCR/extraction code (`run_ocr`, `_ocr_pdf`, `extract_text_routed`, `mcp_server.py`) is touched.

Closes #91

## Reports

- Verify: full suite 736 passed (issue #91 comment thread).
- Audit: clean, no blocking findings; two non-blocking advisory notes on test assertion scoping and help-text wording precision (issue #91 comment thread).

## Test plan

- [x] `pytest tests/test_cli_phase2.py tests/test_study.py tests/test_cli_ascii.py` -> 91 passed (audit's independent re-run)
- [x] Full suite green at this HEAD (verify's 736-passed run)
- [x] Swept `*.py`, `*.md`, `pyproject.toml`, `AGENTS.md` for remaining `tesseract`-as-`--ocr`-value references — none found outside the new test's own docstrings

🤖 Generated with [Claude Code](https://claude.com/claude-code)