### PR TITLE
fix(rekey): isolate dedup_key collisions to the table that holds them

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -308,11 +308,20 @@ the rows it excluded on that basis (`other_assays`) instead of dropping them sil
 commit time, so a new synonym changes the key a *future* commit derives for a fact already
 in the DB: layer-2 dedup misses it and the same fact lands twice. `pemr rekey` re-derives
 every stored key under the current dictionary (dry-run by default, `--apply` to write,
-values and provenance untouched). It aborts whole if two rows would recompute to one key,
+values and provenance untouched). Two rows that recompute to one key are a **collision**,
 and the message names which of the two causes it is: *different* payloads mean the new
 synonym fuses two distinct facts (e.g. a CMP `ALB` and an SPEP `Albumin` off one draw) and
 the fix belongs in the dictionary; *identical* payloads mean one fact was filed twice, once
 under a pre-drift key, and the fix belongs in the data.
+
+**A collision quarantines its own table, not the run** (issue #92). The record tables are
+scanned independently, so a fused pair in `allergy` says nothing about `condition`. The
+scan therefore never stops at the first collision: it reports every collision in every
+table — a dry run writes nothing by definition, so it has to be usable as a full survey —
+and `--apply` writes the tables that came out clean, leaves the colliding ones on their
+stored keys, and names them (`skipped: collision` per table, plus a `skipped` list in
+`--json`). Exit code is 1 whenever any collision was found, in both output modes: partial
+progress is fine, silent partial progress is not.
 
 **Ingesting against drifted keys is refused, not silently forked.** Until the rekey is
 applied, a stored row's frozen key is invisible to layer-2 dedup, so re-filing that same
@@ -324,8 +333,8 @@ rekey --apply` to run. The check is deliberately narrow — unrelated drift else
 database is a maintenance chore, not a reason to refuse an ingest.
 
 `rekey` is also the whole **migration for the issue-#71 key change**, and it is safe by
-construction: a qualifier can only *add* precision, so two rows can never fuse and
-`RekeyCollisionError` is unreachable from that change alone. Procedure: `pemr rekey`
+construction: a qualifier can only *add* precision, so two rows can never fuse and a
+collision is unreachable from that change alone. Procedure: `pemr rekey`
 (dry-run) → read the moved labels → for any that should have stayed collapsed, add a full
 parenthesized synonym key → re-run the dry-run → `pemr rekey --apply`. Rows whose names
 carry no parenthetical do not move at all (the qualifier is folded into the existing key

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -320,8 +320,11 @@ scan therefore never stops at the first collision: it reports every collision in
 table — a dry run writes nothing by definition, so it has to be usable as a full survey —
 and `--apply` writes the tables that came out clean, leaves the colliding ones on their
 stored keys, and names them (`skipped: collision` per table, plus a `skipped` list in
-`--json`). Exit code is 1 whenever any collision was found, in both output modes: partial
-progress is fine, silent partial progress is not.
+`--json`). `--json`'s `changed` list is every key the scan computed as moving, not only
+the ones written — a row in a skipped table still shows up there, so a consumer must
+cross-reference `skipped` to tell written from withheld. Exit code is 1 whenever any
+collision was found, in both output modes: partial progress is fine, silent partial
+progress is not.
 
 **Ingesting against drifted keys is refused, not silently forked.** Until the rekey is
 applied, a stored row's frozen key is invisible to layer-2 dedup, so re-filing that same
@@ -404,11 +407,13 @@ The staged key names the family the conflict was actually staged against; the re
 exists only for the case where `rekey` has already moved that family off it. Preferring the
 derived base would misfire on a dictionary edit that **fuses two identities**: the derived
 base then holds a different, pre-existing family, and the resolution would overwrite (or
-join) an unrelated record while the conflict's own row went untouched — and `rekey` refuses
-to run in that state, so the database stays there. Conversely, numbering an admitted row on
-a stale base that no row carries would give it a key not derivable from its own columns,
-which collides the family on the next `rekey` and — because `rekey` is all-or-nothing across
-every table — blocks every later dictionary edit, `document reassign` included.
+join) an unrelated record while the conflict's own row went untouched — and `rekey` flags
+the fused pair as a collision and quarantines that table, leaving it on stored keys rather
+than writing the overwrite. Conversely, numbering an admitted row on a stale base that no
+row carries would give it a key not derivable from its own columns, which collides the
+family on the next `rekey`: a collision blocks only the table that holds it, not the whole
+run (issue #92), but that is still enough to block `--apply` and `document reassign` on
+that table until the collision is fixed.
 
 **Intra-payload collisions are rejected, not staged.** Two rows in *one* submission that
 derive the same key and disagree fail validation (pass 1) and roll the batch back, naming

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -1011,11 +1011,14 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
         except db.NotMigratedError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 1
-        except dedup.RekeyCollisionError as exc:
-            print(f"error: {exc}", file=sys.stderr)
-            return 1
     finally:
         conn.close()
+
+    # A collision blocks its own table only (issue #92), so it is a partial failure:
+    # the clean tables are reported (and, under --apply, written) and the exit code
+    # still says something was left undone. Same rc in --json mode as in text mode.
+    writable = report.writable()
+    rc = 1 if report.collisions else 0
 
     if args.json:
         _print_json({
@@ -1031,25 +1034,53 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
                 }
                 for c in report.changes
             ],
+            # `changed` is every key that moves; `skipped` names the tables whose
+            # changes were withheld, so a consumer can tell written from withheld.
+            "skipped": report.blocked,
+            "collisions": [
+                {
+                    "record_type": c.record_type,
+                    "row_id": c.row_id,
+                    "label": c.label,
+                    "clash_row_id": c.clash_row_id,
+                    "clash_label": c.clash_label,
+                    "kind": c.kind,
+                    "message": c.message,
+                }
+                for c in report.collisions
+            ],
         })
-        return 0
+        return rc
 
     for record_type, count in report.scanned.items():
         changed = sum(1 for c in report.changes if c.record_type == record_type)
-        print(f"{record_type}: {changed}/{count} key(s) change")
+        blocked = " (skipped: collision)" if record_type in report.blocked else ""
+        print(f"{record_type}: {changed}/{count} key(s) change{blocked}")
     for c in report.changes:
         print(f"  {c.record_type} #{c.row_id}  {c.label}")
-    if not report.changes:
-        print("all dedup keys already match the current dictionary")
-        return 0
-    if report.applied:
-        print(f"rekeyed {len(report.changes)} row(s)")
-    else:
+
+    for collision in report.collisions:
+        print(f"error: {collision.message}", file=sys.stderr)
+    if report.collisions:
         print(
-            f"dry run: {len(report.changes)} row(s) would change - "
+            f"error: {len(report.collisions)} collision(s) left "
+            f"{len(report.blocked)} table(s) on their stored keys: "
+            f"{', '.join(report.blocked)} - fix the collisions above and re-run",
+            file=sys.stderr,
+        )
+
+    if not report.changes and not report.collisions:
+        print("all dedup keys already match the current dictionary")
+    elif report.applied:
+        print(f"rekeyed {len(writable)} row(s)")
+    elif writable:
+        print(
+            f"dry run: {len(writable)} row(s) would change - "
             "re-run with --apply (back up first: `pemr backup`)"
         )
-    return 0
+    else:
+        print("dry run: no row outside the skipped table(s) needs a new key")
+    return rc
 
 
 def _cmd_review_conflicts(args: argparse.Namespace) -> int:

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -1229,14 +1229,39 @@ class RekeyChange:
 
 
 @dataclass
+class RekeyCollision:
+    """Two rows in one table that recompute onto a single ``dedup_key``.
+
+    Collected, not raised (issue #92): a collision in ``allergy`` says nothing about
+    ``condition``, so it blocks its own table and no other. ``kind`` names which of the
+    two causes it is — see :func:`rekey`.
+    """
+    record_type: str
+    row_id: int
+    label: str
+    clash_row_id: int
+    clash_label: str
+    kind: str               # "fused" (dictionary merges two facts) | "doubled" (data)
+    message: str            # full diagnosis, ready to print
+
+
+@dataclass
 class RekeyReport:
     scanned: dict[str, int] = field(default_factory=dict)      # type -> rows examined
     changes: list[RekeyChange] = field(default_factory=list)
+    collisions: list[RekeyCollision] = field(default_factory=list)
     applied: bool = False
 
+    @property
+    def blocked(self) -> list[str]:
+        """Record types left untouched because they hold at least one collision."""
+        return sorted({c.record_type for c in self.collisions})
 
-class RekeyCollisionError(Exception):
-    """Two rows recompute to one dedup_key — the dictionary would fuse distinct facts."""
+    def writable(self) -> list[RekeyChange]:
+        """The subset of :attr:`changes` that is safe to write: every table that has no
+        collision. This is what ``apply=True`` actually writes."""
+        blocked = set(self.blocked)
+        return [c for c in self.changes if c.record_type not in blocked]
 
 
 def rekey(
@@ -1253,16 +1278,26 @@ def rekey(
     tables and re-derives each key, so stored rows keep deduping after a dictionary
     edit. Values, provenance and row ids are untouched — only ``dedup_key`` moves.
 
-    Dry-run by default: pass ``apply=True`` to write. If two rows in a table recompute
-    to the same key nothing is written and :class:`RekeyCollisionError` is raised, with
-    a message that names which of the two causes it is:
+    Dry-run by default: pass ``apply=True`` to write. Two rows in one table that
+    recompute to the same key are a **collision**, and each one names which of the two
+    causes it is:
 
-    * the rows carry *different* payloads — the dictionary would merge two distinct
-      facts (typically two methods for one analyte off one draw): fix the dictionary;
-    * the rows carry the *same* payload — one fact was filed twice, once under a
-      pre-drift key, so it is the data that needs fixing. :func:`_assert_no_key_drift`
-      refuses the ingest that would create this state, so it should only be reachable
-      in a database that drifted before that guard existed.
+    * ``"fused"`` — the rows carry *different* payloads, so the dictionary would merge
+      two distinct facts (typically two methods for one analyte off one draw): fix the
+      dictionary;
+    * ``"doubled"`` — the rows carry the *same* payload, so one fact was filed twice,
+      once under a pre-drift key, and it is the data that needs fixing.
+      :func:`_assert_no_key_drift` refuses the ingest that would create this state, so
+      it should only be reachable in a database that drifted before that guard existed.
+
+    Collisions are **collected, never raised** (issue #92). The tables are scanned
+    independently, so a collision quarantines only its own table: scanning always covers
+    every table and reports every collision it finds (a dry run is a survey and must not
+    stop at the first problem), and ``apply=True`` writes
+    :meth:`RekeyReport.writable` — the changes of the tables that came out clean —
+    leaving the colliding tables on their stored keys and naming them in
+    :attr:`RekeyReport.blocked`. Callers surface a non-empty ``collisions`` as a failure;
+    partial progress with an explicit account of what was skipped beats all-or-nothing.
     """
     db.require_migrated(conn)
     report = RekeyReport(applied=False)
@@ -1281,28 +1316,38 @@ def rekey(
             key = occurrence_key(base, occurrence)
             clash = seen.get(key)
             if clash is not None:
+                label, clash_label = (_rekey_label(record_type, row),
+                                      _rekey_label(record_type, clash))
                 if _rows_equal(record_type, clash, payload):
                     # Same payload, two keys: not a dictionary fault at all - one fact
                     # was filed twice, once under a pre-drift key and once under the
                     # current one. Say so, because "fix the dictionary" is exactly the
                     # wrong advice here (`_assert_no_key_drift` now stops new ingests
                     # from reaching this state).
-                    raise RekeyCollisionError(
+                    kind, message = "doubled", (
                         f"{record_type}: {pk} {row[pk]} and {pk} {clash[pk]} "
-                        f"({_rekey_label(record_type, row)!r}) hold the SAME fact "
+                        f"({label!r}) hold the SAME fact "
                         "under two dedup_keys - it was filed a second time by an "
                         "ingest that ran against drifted keys before this rekey. The "
                         "dictionary is fine; the data is doubled. Drop the duplicate "
                         "(`pemr document rm` on the document that re-filed it, or "
-                        "resolve it by hand) and re-run; nothing was written"
+                        f"resolve it by hand) and re-run; {record_type} was not written"
                     )
-                raise RekeyCollisionError(
-                    f"{record_type}: {pk} {row[pk]} "
-                    f"({_rekey_label(record_type, row)!r}) and {pk} {clash[pk]} "
-                    f"({_rekey_label(record_type, clash)!r}) recompute to the same "
-                    "dedup_key - the dictionary maps two distinct facts onto one "
-                    "canonical name; nothing was written"
-                )
+                else:
+                    kind, message = "fused", (
+                        f"{record_type}: {pk} {row[pk]} ({label!r}) and "
+                        f"{pk} {clash[pk]} ({clash_label!r}) recompute to the same "
+                        "dedup_key - the dictionary maps two distinct facts onto one "
+                        f"canonical name; {record_type} was not written"
+                    )
+                report.collisions.append(RekeyCollision(
+                    record_type, row[pk], label, clash[pk], clash_label, kind, message,
+                ))
+                # Keep scanning: report-only mode is a survey, so the run must find
+                # every collision in every table rather than stop at the first. The
+                # first-seen row stays the incumbent for this key, so a third row on it
+                # is reported against the same anchor instead of chaining.
+                continue
             seen[key] = row
             if key != row["dedup_key"]:
                 report.changes.append(RekeyChange(
@@ -1310,20 +1355,21 @@ def rekey(
                     row["dedup_key"], key, base,
                 ))
 
-    if apply and report.changes:
+    writable = report.writable()
+    if apply and writable:
         # One transaction: a half-rekeyed table dedups inconsistently. Two passes,
         # because `UNIQUE(dedup_key)` is enforced per statement: if two rows swap keys
         # (or one takes a key another is about to vacate) a single-pass update trips
         # the index mid-flight. Park every moving row on a unique placeholder first.
         with conn:
-            for change in report.changes:
+            for change in writable:
                 conn.execute(
                     f"UPDATE {change.record_type} SET dedup_key = ? "
                     f"WHERE {change.record_type}_id = ?",
                     (f"rekey-pending-{change.record_type}-{change.row_id}",
                      change.row_id),
                 )
-            for change in report.changes:
+            for change in writable:
                 # dedup_base moves with the key: base and key are injective in each
                 # other for a fixed occurrence, so a changed key means a changed base.
                 conn.execute(

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -641,6 +641,49 @@ def test_migrate_prints_the_rekey_followup_when_006_moves_rows(tmp_path, capsys)
     assert capsys.readouterr().out.strip() == "up to date"
 
 
+def test_migrated_006_rows_rekey_per_table_when_one_table_collides(tmp_path, capsys):
+    """The issue-#92 report verbatim: 006 carries the old observation keys forward, the
+    follow-up `rekey --apply` hits a collision in `allergy`, and the conditions — which
+    have no collision among them — must still be rekeyed rather than held hostage."""
+    staged = _stage_pre_006(tmp_path)
+    assert _run(tmp_path, "migrate", "--create", "--migrations-dir", str(staged)) == 0
+    conn = db.connect(tmp_path / "cli.db")
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane-doe', 'Jane')")
+    for i, (sub, reaction) in enumerate((("PCN", "rash"),
+                                         ("Penicillin", "anaphylaxis")), start=1):
+        conn.execute(
+            "INSERT INTO observation (person_id, obs_type, key, value_text, dedup_key,"
+            " dedup_base) VALUES (1, 'allergy', ?, ?, ?, ?)",
+            (sub, reaction, f"a{i}", f"a{i}"))
+    for i, name in enumerate(("T2DM", "HTN"), start=1):
+        conn.execute(
+            "INSERT INTO observation (person_id, obs_type, key, dedup_key, dedup_base)"
+            " VALUES (1, 'condition', ?, ?, ?)", (name, f"c{i}", f"c{i}"))
+    conn.commit()
+    conn.close()
+    assert _run(tmp_path, "migrate") == 0
+    assert "4 allergy/condition row" in capsys.readouterr().out
+
+    new = _dict_file(tmp_path, "fuse006.toml",
+                     '"pcn" = "penicillin"\n"t2dm" = "type 2 diabetes"\n')
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 1
+    captured = capsys.readouterr()
+    assert "allergy: 1/2 key(s) change (skipped: collision)" in captured.out
+    assert "condition: 2/2 key(s) change" in captured.out
+    assert "rekeyed 2 row(s)" in captured.out
+    assert "left 1 table(s) on their stored keys: allergy" in captured.err
+
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        # The carried-forward observation keys survive on the blocked table only.
+        assert sorted(r["dedup_key"] for r in
+                      conn.execute("SELECT dedup_key FROM allergy")) == ["a1", "a2"]
+        assert not [r for r in conn.execute("SELECT dedup_key FROM condition")
+                    if r["dedup_key"] in ("c1", "c2")]
+    finally:
+        conn.close()
+
+
 def test_migrate_of_a_fresh_database_has_no_rekey_followup(tmp_path, capsys):
     """Nothing moved, nothing to rekey - a note nobody must act on trains people to
     skip notes."""

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -422,26 +422,62 @@ def test_rekey_json_output(ready, capsys, tmp_path):
     assert change["label"] == "ZZT" and change["old_key"] != change["new_key"]
 
 
-def test_rekey_refuses_a_fusing_dictionary(ready, capsys, tmp_path):
-    """Exit 1 with a pointed message when the dictionary would merge two facts."""
-    old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
-    new = _dict_file(tmp_path, "fuse.toml", '"alb" = "albumin"\n')
+def _seed_fusing_lab_and_movable_condition(ready, capsys, tmp_path, old):
+    """Two lab rows a `"alb" = "albumin"` dictionary fuses, plus a condition whose key
+    merely moves under `"t2dm" = "type 2 diabetes"` — the issue-#92 shape at the CLI."""
     scan = tmp_path / "fuse-scan.txt"
     scan.write_bytes(b"alb 4.2 / albumin 3.6")
     assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
                 "--sources", str(tmp_path / "sources")) == 0
     doc = _document_id(tmp_path)[-1]["document_id"]
-    payload = _write_json(tmp_path, "fuse.json", {"lab_result": [
-        {"test_name": "ALB", "collected_at": "2026-01-02", "value_num": 4.2},
-        {"test_name": "Albumin", "collected_at": "2026-01-02", "value_num": 3.6},
-    ]})
+    payload = _write_json(tmp_path, "fuse.json", {
+        "lab_result": [
+            {"test_name": "ALB", "collected_at": "2026-01-02", "value_num": 4.2},
+            {"test_name": "Albumin", "collected_at": "2026-01-02", "value_num": 3.6},
+        ],
+        "condition": [{"name": "T2DM", "status": "active"}],
+    })
     assert _run(tmp_path, "commit-extraction", "--document", str(doc),
                 "--json", str(payload), "--dictionary", str(old)) == 0
     capsys.readouterr()
 
+
+def test_rekey_refuses_a_fusing_dictionary(ready, capsys, tmp_path):
+    """Exit 1 with a pointed message when the dictionary would merge two facts — and
+    (issue #92) the fused table is skipped by name while the clean one still applies."""
+    old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
+    new = _dict_file(tmp_path, "fuse.toml",
+                     '"alb" = "albumin"\n"t2dm" = "type 2 diabetes"\n')
+    _seed_fusing_lab_and_movable_condition(ready, capsys, tmp_path, old)
+
     assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 1
-    err = capsys.readouterr().err
-    assert "same dedup_key" in err and "nothing was written" in err
+    captured = capsys.readouterr()
+    assert "same dedup_key" in captured.err
+    assert "lab_result was not written" in captured.err
+    assert "left 1 table(s) on their stored keys: lab_result" in captured.err
+    # The unaffected table is rekeyed anyway: one collision, one blocked table.
+    assert "lab_result: 1/2 key(s) change (skipped: collision)" in captured.out
+    assert "rekeyed 1 row(s)" in captured.out
+
+    # Re-run: the condition is now current, so only the fused table is still outstanding.
+    assert _run(tmp_path, "rekey", "--dictionary", str(new)) == 1
+    out = capsys.readouterr().out
+    assert "dry run: no row outside the skipped table(s) needs a new key" in out
+
+
+def test_rekey_json_reports_collisions_and_skipped_tables(ready, capsys, tmp_path):
+    """`--json` keeps exit-code parity with the text mode and says which tables were
+    withheld, so an agent can tell a partial run from a clean one (issue #92)."""
+    old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
+    new = _dict_file(tmp_path, "fuse.toml",
+                     '"alb" = "albumin"\n"t2dm" = "type 2 diabetes"\n')
+    _seed_fusing_lab_and_movable_condition(ready, capsys, tmp_path, old)
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--json") == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["skipped"] == ["lab_result"]
+    assert [c["kind"] for c in payload["collisions"]] == ["fused"]
+    assert [c["record_type"] for c in payload["changed"]] == ["lab_result", "condition"]
 
 
 # --- intake formats at the CLI (issue #66) ------------------------------------

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -478,8 +478,9 @@ def fused(conn):
     # while its own staged key still names the a1c row.
     assert conflict["dedup_key"] == a1c["dedup_base"] != hba1c["dedup_base"]
     assert dedup._derive_base(conflict, _FUSED) == hba1c["dedup_base"]
-    with pytest.raises(dedup.RekeyCollisionError):
-        dedup.rekey(conn, _FUSED)          # the state itself: rekey cannot clear it
+    # The state itself: rekey cannot clear it — lab_result collides, so that table is
+    # skipped and stays on its stored keys.
+    assert dedup.rekey(conn, _FUSED).blocked == ["lab_result"]
     return conflict["conflict_id"]
 
 

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -757,7 +757,7 @@ def test_rekey_is_idempotent(conn):
 
 def test_rekey_refuses_a_dictionary_that_fuses_two_facts(conn):
     """Two methods for one analyte off one draw (CMP ALB vs SPEP Albumin) must not be
-    merged by a synonym: the run aborts whole, leaving every stored key untouched."""
+    merged by a synonym: the colliding table keeps every stored key."""
     doc = _make_document(conn)
     dedup.commit_extraction(conn, doc, {"lab_result": [
         {"test_name": "ALB", "collected_at": "2026-01-02", "value_num": 4.2},
@@ -766,12 +766,95 @@ def test_rekey_refuses_a_dictionary_that_fuses_two_facts(conn):
     before = {r["lab_result_id"]: r["dedup_key"]
               for r in conn.execute("SELECT lab_result_id, dedup_key FROM lab_result")}
 
-    with pytest.raises(dedup.RekeyCollisionError, match="same dedup_key"):
-        dedup.rekey(conn, _rekey_dict(alb="albumin"), apply=True)
+    report = dedup.rekey(conn, _rekey_dict(alb="albumin"), apply=True)
 
+    assert [c.kind for c in report.collisions] == ["fused"]
+    assert "same dedup_key" in report.collisions[0].message
+    assert report.blocked == ["lab_result"] and report.writable() == []
     after = {r["lab_result_id"]: r["dedup_key"]
              for r in conn.execute("SELECT lab_result_id, dedup_key FROM lab_result")}
     assert after == before
+
+
+def _collide_allergy_and_move_condition(conn):
+    """The issue-#92 repro: one table holds a collision, another holds clean work.
+
+    Two allergies the new dictionary fuses (different reactions, so it is a genuine
+    two-facts-into-one), plus a condition whose key merely moves."""
+    dedup.commit_extraction(conn, _make_document(conn), {
+        "allergy": [
+            {"substance": "PCN", "reaction": "rash"},
+            {"substance": "Penicillin", "reaction": "anaphylaxis"},
+        ],
+        "condition": [{"name": "T2DM", "status": "active"}],
+    }, dedup.load_dictionary(DICT_PATH))
+    return _rekey_dict(pcn="penicillin", t2dm="type 2 diabetes")
+
+
+def _keys(conn, record_type, label_column):
+    return {r[label_column]: r["dedup_key"]
+            for r in conn.execute(f"SELECT * FROM {record_type}")}
+
+
+def test_rekey_applies_the_clean_tables_and_skips_only_the_colliding_one(conn):
+    """Acceptance (issue #92): a collision in `allergy` must not block `condition`.
+    The tables are scanned independently, so one bad pair quarantines its own table."""
+    d_new = _collide_allergy_and_move_condition(conn)
+    allergies_before = _keys(conn, "allergy", "substance")
+
+    report = dedup.rekey(conn, d_new, apply=True)
+
+    assert report.applied is True
+    assert report.blocked == ["allergy"]
+    assert [(c.record_type, c.label) for c in report.writable()] \
+        == [("condition", "T2DM")]
+    # The clean table was written...
+    assert _keys(conn, "condition", "name")["T2DM"] == report.writable()[0].new_key
+    # ...and the colliding one kept every stored key.
+    assert _keys(conn, "allergy", "substance") == allergies_before
+
+
+def test_rekey_dry_run_reports_every_collision_instead_of_stopping_at_the_first(conn):
+    """Acceptance (issue #92): report-only mode is a survey — it writes nothing by
+    definition, so it must enumerate all collisions in all tables rather than abort on
+    the first and force a serial edit-and-rerun loop."""
+    d_new = _collide_allergy_and_move_condition(conn)
+    dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
+        {"test_name": "ALB", "collected_at": "2026-01-02", "value_num": 4.2},
+        {"test_name": "Albumin", "collected_at": "2026-01-02", "value_num": 3.6},
+    ]}, dedup.load_dictionary(DICT_PATH))
+    d_new["alb"] = "albumin"
+    before = {t: _keys(conn, t, c) for t, c in
+              (("allergy", "substance"), ("lab_result", "test_name"),
+               ("condition", "name"))}
+
+    report = dedup.rekey(conn, d_new)
+
+    assert report.applied is False
+    assert report.blocked == ["allergy", "lab_result"]     # both, not just the first
+    assert {c.record_type for c in report.collisions} == {"allergy", "lab_result"}
+    assert [c.kind for c in report.collisions] == ["fused", "fused"]
+    assert [(c.record_type, c.label) for c in report.writable()] \
+        == [("condition", "T2DM")]
+    assert {t: _keys(conn, t, c) for t, c in
+            (("allergy", "substance"), ("lab_result", "test_name"),
+             ("condition", "name"))} == before          # a dry run writes nothing
+
+
+def test_rekey_reports_a_third_row_on_the_same_key_against_the_same_anchor(conn):
+    """Scanning continues past a collision within a table too, so a three-way fuse is
+    reported as two pairs rather than one — the survey has to show the whole scope."""
+    dedup.commit_extraction(conn, _make_document(conn), {"allergy": [
+        {"substance": "PCN", "reaction": "rash"},
+        {"substance": "Penicillin", "reaction": "anaphylaxis"},
+        {"substance": "Pen-G", "reaction": "hives"},
+    ]}, dedup.load_dictionary(DICT_PATH))
+
+    report = dedup.rekey(conn, _rekey_dict(pcn="penicillin", **{"pen-g": "penicillin"}))
+
+    assert len(report.collisions) == 2
+    assert {c.clash_label for c in report.collisions} == {"PCN"}   # one anchor, not a chain
+    assert {c.label for c in report.collisions} == {"Penicillin", "Pen-G"}
 
 
 def test_rekey_survives_two_rows_swapping_keys(conn):
@@ -824,7 +907,7 @@ def test_rekey_is_a_no_op_over_a_keep_both_family(conn):
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
 
     report = dedup.rekey(conn, d, apply=True)
-    assert report.changes == []            # no RekeyCollisionError, no key churn
+    assert report.changes == [] and report.collisions == []   # no collision, no churn
     keys = [r["dedup_key"] for r in conn.execute("SELECT * FROM lab_result")]
     assert len(set(keys)) == 2
 
@@ -975,9 +1058,10 @@ def test_rekey_names_a_doubled_fact_instead_of_blaming_the_dictionary(conn):
     dedup._insert_record(conn, "lab_result", row, pid, doc, "stale-base-0000")
     conn.commit()
 
-    with pytest.raises(dedup.RekeyCollisionError, match="SAME fact"):
-        dedup.rekey(conn, None)
-    # Still all-or-nothing, and the dry-run wrote nothing either.
+    report = dedup.rekey(conn, None)
+    assert [c.kind for c in report.collisions] == ["doubled"]
+    assert "SAME fact" in report.collisions[0].message
+    # The colliding table is still all-or-nothing, and the dry-run wrote nothing either.
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
     assert conn.execute(
         "SELECT COUNT(*) AS n FROM lab_result WHERE dedup_key = 'stale-base-0000'"
@@ -992,8 +1076,9 @@ def test_rekey_still_blames_the_dictionary_when_it_fuses_distinct_facts(conn):
         {"test_name": "ALB", "collected_at": "2026-01-02", "value_num": 4.2},
         {"test_name": "Albumin", "collected_at": "2026-01-02", "value_num": 3.6},
     ]}, dedup.load_dictionary(DICT_PATH))
-    with pytest.raises(dedup.RekeyCollisionError, match="two distinct facts"):
-        dedup.rekey(conn, _rekey_dict(alb="albumin"))
+    report = dedup.rekey(conn, _rekey_dict(alb="albumin"))
+    assert [c.kind for c in report.collisions] == ["fused"]
+    assert "two distinct facts" in report.collisions[0].message
 
 
 # --- allergy / condition typed rows (issue #63) -------------------------------

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -556,6 +556,46 @@ def test_reassign_refused_on_dictionary_drift(seeded):
     assert "rekey" in str(exc.value)
 
 
+def test_reassign_across_a_partially_rekeyed_database(conn):
+    """A *partially* rekeyed database is a state that could not exist before issue #92
+    (`rekey` was all-or-nothing), so `reassign` — which recomputes keys through the same
+    function — gets exercised against it: the documents whose rows sit in a rekeyed
+    table move, and only the ones owning the skipped table's stale keys are refused."""
+    persons.add_person(conn, "jane-doe", "Jane Doe")
+    john = persons.add_person(conn, "john-doe", "John Doe")
+    fused = _insert_document(conn, 1, "ee55")
+    clean = _insert_document(conn, 1, "ff66")
+    # Two allergies the new dictionary merges (distinct reactions = two real facts)...
+    dedup.commit_extraction(conn, fused, {"allergy": [
+        {"substance": "PCN", "reaction": "rash"},
+        {"substance": "Penicillin", "reaction": "anaphylaxis"},
+    ]})
+    # ...and, on a second document, a condition whose key merely moves.
+    dedup.commit_extraction(conn, clean, {
+        "condition": [{"name": "T2DM", "status": "active"}]})
+
+    d_new = {"pcn": "penicillin", "t2dm": "type 2 diabetes"}
+    report = dedup.rekey(conn, d_new, apply=True)
+    assert report.blocked == ["allergy"]        # the partial state, as set up
+
+    moved = documents.reassign_document(conn, clean, "john-doe", d_new, apply=True)
+    assert moved.applied is True
+    assert conn.execute(
+        "SELECT person_id FROM condition"
+    ).fetchone()["person_id"] == john.person_id
+
+    stored = [r["dedup_key"] for r in conn.execute("SELECT dedup_key FROM allergy")]
+    with pytest.raises(documents.DictionaryDriftError) as exc:
+        documents.reassign_document(conn, fused, "john-doe", d_new, apply=True)
+    assert "rekey" in str(exc.value)
+    # Refused before any write: the skipped table keeps its keys and its owner.
+    assert [r["dedup_key"] for r in
+            conn.execute("SELECT dedup_key FROM allergy")] == stored
+    assert conn.execute(
+        "SELECT person_id FROM document WHERE document_id = ?", (fused,)
+    ).fetchone()["person_id"] == 1
+
+
 def test_reassign_unknown_document_and_slug(seeded):
     conn = seeded["conn"]
     with pytest.raises(documents.DocumentNotFoundError):


### PR DESCRIPTION
## Summary

`pemr rekey` used to abort the entire run on the first pair of rows that recomputed to
the same `dedup_key` — one ambiguous pair in `allergy` blocked rekeying every other
table, `condition` included, even with zero collisions of its own.

This changes the scan to per-table quarantine, matching the no-silent-caps /
partial-progress principle:

- Report-only mode (`pemr rekey`) never aborts early: it scans every table and reports
  every collision found, so a dry run is usable as a full survey.
- `--apply` writes every table that came out clean and leaves colliding tables on their
  stored keys, naming them (`skipped: collision` per table; a `skipped` list in `--json`).
- Exit code is `1` whenever any collision was found, in both text and `--json` modes, with
  the withheld tables always named on stderr and in the machine-readable payload.
- `docs/Architecture.md` updated: the new quarantine behavior is documented in §3, the two
  stale/loose "rekey is all-or-nothing" references in the conflict-resolution discussion
  are corrected, and a clause was added noting `--json`'s `changed` list includes rows from
  skipped (withheld) tables, not just written ones.

Closes #92

## Reports

- Build → verify: https://github.com/meridun/pemr/issues/92#issuecomment-5211706415
- Verify → audit: https://github.com/meridun/pemr/issues/92#issuecomment-5211834985
- Audit → ship (no blocking findings): https://github.com/meridun/pemr/issues/92#issuecomment-5211912759

## Test plan

- [x] Full suite green (742 passed, per verify and independently confirmed by audit)
- [x] New/updated tests cover the migration-006 and `document reassign` paths
      (`tests/test_dedup.py`, `tests/test_cli_phase2.py`, `tests/test_conflict.py`)
- [x] Docs-only follow-up commit (`1b1f105`) addresses audit's two ship must-fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)