### PR TITLE
fix(render): group Orders & Referrals by normalized item (#93)

### DIFF
--- a/pemr/render.py
+++ b/pemr/render.py
@@ -23,7 +23,10 @@ canonical *vital* vocabulary in ``data/dictionary.example.toml``):
   * **orders**     -> ``observation`` rows with ``obs_type='order'`` for non-medication
     orders mined from the med-list section (DME, outpatient PT, referrals, consults):
     ``key`` = free-text item/order name (no canonical vocabulary), optional
-    ``value_text`` = instructions and/or prescriber/target specialty.
+    ``value_text`` = instructions and/or prescriber/target specialty. Rows are
+    **grouped at render time** by normalized ``key``, newest first, with the
+    collapse disclosed on the line (issue #93) -- the stored rows keep their dates
+    and stay distinct, because an order is an event, not a standing fact.
 
 Output is **ASCII-only** (the cp1252/cp437 Windows-console lesson from phases 2-3):
 plain hyphens, never em-dashes -- a non-ASCII byte crashes a non-UTF-8 console.
@@ -119,15 +122,6 @@ def _ref_range(row: sqlite3.Row | dict) -> str:
 # Read helpers (pure SELECTs; person already resolved to an id)
 # --------------------------------------------------------------------------- #
 
-def _observations(conn: sqlite3.Connection, person_id: int, obs_type: str) -> list[dict]:
-    rows = conn.execute(
-        "SELECT * FROM observation WHERE person_id = ? AND obs_type = ? "
-        "ORDER BY COALESCE(key, ''), observed_at, observation_id",
-        (person_id, obs_type),
-    ).fetchall()
-    return [dict(r) for r in rows]
-
-
 def _conditions(
     conn: sqlite3.Connection, person_id: int, statuses: tuple[str, ...] | str
 ) -> list[dict]:
@@ -191,6 +185,73 @@ def _latest_vitals(
     for r in rows:
         latest[key_token(r["key"], dictionary)] = dict(r)  # ascending -> last wins
     return [latest[k] for k in sorted(latest)]
+
+
+def _order_display(row: dict) -> str:
+    """Display name of an order row: the item name, falling back to the detail text and
+    then to an explicit placeholder (an unnamed order still has to be visible)."""
+    return row["key"] or row["value_text"] or "(unspecified)"
+
+
+def _grouped_orders(
+    conn: sqlite3.Connection, person_id: int, dictionary: dict[str, str] | None
+) -> list[dict]:
+    """``obs_type='order'`` rows folded to one entry per normalized item, newest first.
+
+    A repeated order/referral is restated by every document that mentions it, so a raw
+    row dump renders one identical bullet per document (issue #93). Orders are *events*,
+    not standing facts, so unlike conditions/allergies (issue #63) they must keep their
+    date in the storage dedup key -- a January CBC and a June CBC are two real orders.
+    The collapse therefore happens **here**, at render time: reversible, provenance
+    intact in the DB, and always disclosed by the ``+N earlier`` note on the line.
+
+    Grouped by :func:`key_token`, the same token the observation dedup key uses for
+    ``key`` (issue #71), so the render never disagrees with storage about what counts as
+    one item; ``value_text`` is the fallback identity for a keyless row, matching the
+    display fallback. A row with neither renders on its own -- bucketing all of those
+    together would fabricate a merge.
+
+    Each returned dict is the group's **latest** row (most recent ``observed_at``, then
+    highest ``observation_id``) plus ``group_count`` and ``group_first`` (earliest dated
+    ``observed_at`` among the *earlier* rows, ``""`` when none of them is dated).
+    """
+    rows = conn.execute(
+        "SELECT * FROM observation WHERE person_id = ? AND obs_type = ? "
+        "ORDER BY observed_at, observation_id",
+        (person_id, OBS_ORDER),
+    ).fetchall()
+    groups: dict[object, list[dict]] = {}
+    for r in rows:
+        token = key_token(r["key"], dictionary) or key_token(r["value_text"], dictionary)
+        groups.setdefault(token or ("", r["observation_id"]), []).append(dict(r))
+
+    out = []
+    for members in groups.values():
+        latest = members[-1]                      # ascending -> last is the latest
+        earlier = sorted(
+            d for d in (_date_part(m["observed_at"]) for m in members[:-1]) if d
+        )
+        out.append(dict(latest, group_count=len(members),
+                        group_first=earlier[0] if earlier else ""))
+    # Two stable passes: alphabetical, then latest-date descending (undated sorts last,
+    # keeping its alphabetical order). Orders are actionable events, so recency leads --
+    # matching the other event sections rather than the vitals panel's fixed A-Z.
+    out.sort(key=lambda g: (_order_display(g).lower(), g["observation_id"]))
+    out.sort(key=lambda g: _date_part(g["observed_at"]), reverse=True)
+    return out
+
+
+def _order_line(row: dict) -> str:
+    detail = f" - {row['value_text']}" if row["key"] and row["value_text"] else ""
+    notes = []
+    when = _date_part(row["observed_at"])
+    if when:
+        notes.append(f"ordered {when}")
+    if row["group_count"] > 1:
+        first = f", first {row['group_first']}" if row["group_first"] else ""
+        notes.append(f"+{row['group_count'] - 1} earlier{first}")
+    note = f"  ({'; '.join(notes)})" if notes else ""
+    return f"- {_order_display(row)}{detail}{note}"
 
 
 def _abnormal_labs(conn: sqlite3.Connection, person_id: int) -> list[dict]:
@@ -337,9 +398,7 @@ def render_summary(
     ]
     allergy_lines = [_allergy_line(a) for a in _allergies(conn, person_id)]
     order_lines = [
-        f"- {o['key'] or o['value_text'] or '(unspecified)'}"
-        + (f" - {o['value_text']}" if o["key"] and o["value_text"] else "")
-        for o in _observations(conn, person_id, OBS_ORDER)
+        _order_line(o) for o in _grouped_orders(conn, person_id, dictionary)
     ]
 
     vital_lines = []

--- a/tests/test_cli_phase4.py
+++ b/tests/test_cli_phase4.py
@@ -2,6 +2,7 @@
 stdout (the §5 redirect contract), --out file convenience, unknown-slug/appointment
 rc=1, and unmigrated-DB friendliness."""
 
+import json
 from pathlib import Path
 
 import pytest
@@ -86,6 +87,76 @@ def test_render_unknown_appointment_is_friendly_rc1(ready, capsys):
     tmp_path, _ = ready
     assert _run(tmp_path, "render", "brief", "--appointment", "99999") == 1
     assert "99999" in capsys.readouterr().err
+
+
+def _commit_orders(tmp_path, sha, rows):
+    """Insert one document and commit `obs_type='order'` rows into it *through the CLI*
+    (`commit-extraction --json`), i.e. the way a real ingest session arrives."""
+    conn = db.connect(tmp_path / "cli.db")
+    pid = conn.execute(
+        "SELECT person_id FROM person WHERE slug='jane-doe'"
+    ).fetchone()["person_id"]
+    cur = conn.execute(
+        "INSERT INTO document (sha256, person_id, source_path, ingested_at) "
+        "VALUES (?, ?, 'aa/x.pdf', '2026-01-01T00:00:00')", (sha, pid)
+    )
+    conn.commit()
+    doc = cur.lastrowid
+    conn.close()
+    payload = tmp_path / f"extract-{sha}.json"
+    payload.write_text(json.dumps(
+        {"observation": [dict(r, obs_type="order") for r in rows]}
+    ), encoding="utf-8")
+    assert _run(tmp_path, "commit-extraction", "--document", str(doc),
+                "--json", str(payload)) == 0
+
+
+def test_render_summary_groups_repeated_orders_end_to_end(ready, capsys):
+    """Issue #93, walked through the real CLI: an order restated by three documents is
+    one bullet carrying the latest detail plus the `+N earlier` disclosure; distinct and
+    qualifier-bearing items stay their own bullets; a timestamped row shows a bare date;
+    an undated row shows none; newest first, undated last. (Keyless rows are covered in
+    `tests/test_render.py` -- two undated ones collide on the storage dedup key, so that
+    case cannot be seeded through the commit path.)"""
+    tmp_path, _ = ready
+    _commit_orders(tmp_path, "sha-o1", [
+        {"key": "cervical collar", "value_text": "Dr. Smith, ortho",
+         "observed_at": "2026-01-05"},
+        {"key": "outpatient physical therapy", "observed_at": "2026-01-05"},
+    ])
+    _commit_orders(tmp_path, "sha-o2", [
+        {"key": "cervical collar", "value_text": "Dr. Adams, ortho",
+         "observed_at": "2026-02-01"},
+        {"key": "sleep study", "value_text": "home study",
+         "observed_at": "2026-02-01T09:30:00"},          # timestamp -> bare date
+    ])
+    _commit_orders(tmp_path, "sha-o3", [
+        {"key": "cervical collar", "value_text": "Dr. Jones, ortho",
+         "observed_at": "2026-06-14"},
+        {"key": "outpatient physical therapy (aquatic)", "observed_at": "2026-06-14"},
+        {"key": "wheelchair evaluation", "value_text": "seating clinic"},   # undated
+    ])
+    capsys.readouterr()
+
+    assert _run(tmp_path, "render", "summary", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    section = out.split("## Orders & Referrals")[1].split("\n## ")[0]
+    lines = [ln for ln in section.splitlines() if ln.startswith("- ")]
+    assert lines == [
+        "- cervical collar - Dr. Jones, ortho  (ordered 2026-06-14; +2 earlier, "
+        "first 2026-01-05)",
+        "- outpatient physical therapy (aquatic)  (ordered 2026-06-14)",
+        "- sleep study - home study  (ordered 2026-02-01)",
+        "- outpatient physical therapy  (ordered 2026-01-05)",
+        "- wheelchair evaluation - seating clinic",
+    ]
+    # the collapse is render-only: every stored row survives, keys untouched
+    conn = db.connect(tmp_path / "cli.db")
+    assert conn.execute(
+        "SELECT COUNT(*) AS n FROM observation WHERE obs_type='order'"
+    ).fetchone()["n"] == 7
+    conn.close()
+    assert out.isascii()          # cp1252/cp437 console contract
 
 
 def test_render_on_unmigrated_db_is_friendly(tmp_path, capsys, unmigrated_db):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -209,12 +209,96 @@ def test_summary_orders_and_referrals(seeded):
     """Non-medication `order` observations render under a dedicated section: item name
     with optional prescriber/instructions detail, placed after Allergies before Vitals."""
     md = render.render_summary(seeded, "jane-doe")
-    section = md.split("## Orders & Referrals")[1].split("##")[0]
-    assert "cervical collar - Dr. Smith, ortho" in section   # key - value_text
-    assert "outpatient physical therapy" in section          # bare item, no trailing detail
+    section = md.split("## Orders & Referrals")[1].split("\n## ")[0]
+    assert "- cervical collar - Dr. Smith, ortho  (ordered 2026-02-01)" in section
+    assert "outpatient physical therapy" in section          # bare item, no detail, undated
     assert "outpatient physical therapy - " not in section   # no dangling separator
+    assert "earlier" not in section                          # no group note on singletons
     # placement: after Allergies, before Latest Vitals (clinical-status block stays together)
     assert md.index("## Allergies") < md.index("## Orders & Referrals") < md.index("## Latest Vitals")
+
+
+def _seed_orders(conn, rows):
+    """Extra `obs_type='order'` observations on jane, committed as their own document
+    (the shape a second document restating an order arrives in)."""
+    dedup.commit_extraction(conn, _doc(conn, "jane-doe"), {
+        "observation": [dict(r, obs_type="order") for r in rows],
+    }, dedup.load_dictionary(DICT_PATH))
+
+
+def _orders_section(conn):
+    md = render.render_summary(conn, "jane-doe")
+    return md.split("## Orders & Referrals")[1].split("\n## ")[0]
+
+
+def test_summary_orders_group_repeated_item_and_disclose_the_collapse(seeded):
+    """Issue #93: one order restated across N documents rendered as N identical bullets.
+    It now folds to one bullet carrying the latest detail, and the collapse is *disclosed*
+    -- the count plus the span -- so a reader can never mistake it for a single order."""
+    _seed_orders(seeded, [
+        {"key": "cervical collar", "value_text": "Dr. Jones, ortho",
+         "observed_at": "2026-06-14"},
+        {"key": "cervical collar", "value_text": "Dr. Smith, ortho",
+         "observed_at": "2026-01-05"},
+    ])
+    section = _orders_section(seeded)
+    assert section.count("cervical collar") == 1        # three stored rows, one bullet
+    assert ("- cervical collar - Dr. Jones, ortho  "
+            "(ordered 2026-06-14; +2 earlier, first 2026-01-05)") in section
+    assert "outpatient physical therapy" in section           # distinct key stays distinct
+    # storage is untouched: the collapse is render-only and reversible
+    assert seeded.execute(
+        "SELECT COUNT(*) AS n FROM observation WHERE obs_type='order'"
+    ).fetchone()["n"] == 4
+
+
+def test_summary_orders_qualifier_keeps_its_own_bullet(seeded):
+    """Grouping is on `key_token`, so #71's qualifier-awareness carries over: aquatic PT
+    is a different order from plain outpatient PT, not a restatement of it."""
+    _seed_orders(seeded, [
+        {"key": "outpatient physical therapy (aquatic)", "observed_at": "2026-03-01"},
+    ])
+    section = _orders_section(seeded)
+    assert "- outpatient physical therapy (aquatic)  (ordered 2026-03-01)" in section
+    assert "- outpatient physical therapy\n" in section   # bare row untouched, ungrouped
+
+
+def test_summary_orders_keyless_rows_are_never_bucketed_together(seeded):
+    """An empty group token means "no identity", not "one shared identity": bucketing
+    every keyless row together would fabricate a merge. `value_text` is the fallback
+    identity, matching the display fallback."""
+    _seed_orders(seeded, [
+        {"value_text": "Dr. Ray, cardiology consult", "observed_at": "2026-04-01"},
+        {"observed_at": "2026-04-02"},          # neither item name nor detail
+        {"observed_at": "2026-04-03"},          # ... and another: two bullets, not one
+    ])
+    section = _orders_section(seeded)
+    assert "- Dr. Ray, cardiology consult  (ordered 2026-04-01)" in section
+    assert section.count("(unspecified)") == 2
+    assert "earlier" not in section
+
+
+def test_summary_orders_undated_earlier_row_keeps_the_count(seeded):
+    """A group whose earlier rows carry no date drops the `first <date>` clause but keeps
+    the disclosure -- the reader still learns the order was restated."""
+    _seed_orders(seeded, [
+        {"key": "outpatient physical therapy", "value_text": "8 sessions",
+         "observed_at": "2026-05-01"},
+    ])
+    section = _orders_section(seeded)
+    assert ("- outpatient physical therapy - 8 sessions  "
+            "(ordered 2026-05-01; +1 earlier)") in section
+    assert "first" not in section
+
+
+def test_summary_orders_newest_first_undated_last(seeded):
+    """Orders are actionable events, so the section leads with the most recent (the other
+    event sections' ordering), undated last then alphabetical."""
+    _seed_orders(seeded, [{"key": "sleep study", "observed_at": "2026-07-01"}])
+    section = _orders_section(seeded)
+    assert (section.index("sleep study")
+            < section.index("cervical collar")
+            < section.index("outpatient physical therapy"))
 
 
 def test_summary_latest_vitals_pick(seeded):


### PR DESCRIPTION
## What shipped

`render summary`'s Orders & Referrals section now groups repeated rows at render time instead of
dumping one bullet per stored `observation` row. A referral or order restated across N documents
now renders as one bullet, with the collapse always disclosed (`+N-1 earlier, first <date>`) and
a date clause (`ordered <date>`) that was previously missing entirely.

No storage change: no migration, no dedup-key change, no typed `order` table. `observation` rows
keep their per-document dates and stay distinct in the DB — only the render layer folds them,
reversibly. `AGENTS.md` §2's extractor contract is unaffected (render-side only); the grouping
convention is documented in `render.py`'s module docstring.

- New `_grouped_orders(conn, person_id, dictionary)` helper (`pemr/render.py`), sited next to
  `_latest_vitals`: groups by `key_token(key)` (falling back to `value_text` when `key` is empty),
  latest row per group wins (most recent `observed_at`, then highest `observation_id`), empty
  token never buckets across rows.
- Section order: latest date descending, undated last, alphabetical within.
- Dead `_observations` helper removed (grouping was its only remaining caller).
- `tests/test_render.py` extended; `tests/test_cli_phase4.py` gained an end-to-end CLI-level
  smoke spec exercising the grouping through real `commit-extraction` → `render summary`.

Closes #93

## Reports

- Build: https://github.com/meridun/pemr/issues/93#issuecomment-5218374699
- Verify: https://github.com/meridun/pemr/issues/93#issuecomment-5218485309
- Audit: https://github.com/meridun/pemr/issues/93#issuecomment-5218554649

🤖 Generated with the pemr agentic SDLC pipeline (ship worker, run `dispatch-20260807-1423-2355-ship`)
