### PR TITLE
docs(architecture): require rekey after migration 006 (#94)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -363,7 +363,7 @@ indefinitely until one of them is restated. Run the `pemr rekey` dry-run and the
 `observation` keys carried the assertion's `observed_at`, so one condition restated by three
 documents is three stored rows that all recompute onto the single date-free key 006 gave the
 type — the legacy shape behind #86's apparently duplicated condition bullets, correct storage
-under the old identity and a fused pair under the new one. A collision quarantines its own
+under the old identity and a three-way fusion under the new one. A collision quarantines its own
 table only (above), so the clean tables are still written and the fusion is settled in the
 dictionary or the data before a re-run.
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -346,6 +346,22 @@ refuse until the rekey is applied — `document reassign` and `commit-extraction
 keys through the same function, so they see the drift first. Rekeying does **not** recover
 a value already lost to a pre-fix collision: that needs the source document re-extracted.
 
+`rekey` is also a **required upgrade step after migration 006**, and unlike the #71 case it
+is not collision-free. 006 promoted allergy/condition rows out of `observation`, but the new
+keys are a sha256 over dictionary-normalized fields — which SQL cannot compute — so the
+backfill carried each row's *old*, per-document key forward verbatim. Those rows sit on keys
+layer-2 dedup will never derive again, so re-committing an already-stored allergy or
+condition lands a **second row reported as `new`** — no duplicate, no conflict, no signal
+(issue #94, the mechanism behind #86's apparently duplicated condition bullets). Run the
+`pemr rekey` dry-run and then `pemr rekey --apply` against any **pre-006** database before
+its next allergy/condition `commit-extraction`. `pemr migrate` prints that follow-up when 006
+actually moves rows, so the step is signposted the moment it is owed — but nothing enforces
+it (a fresh `--create` has nothing to rekey, and prints nothing). Expect collisions here
+where the #71 migration had none: the old keys were per-document, so the same condition
+recorded by two documents recomputes onto one key. That quarantines its own table only
+(above), so the clean tables are still written and the fused pair is settled in the
+dictionary or the data before a re-run.
+
 The **measured value is deliberately *not* in the key** — temporal identity carries the
 draw instead. `collected_at`/`observed_at` are used at full precision (timestamp when the
 document gives one, date when it only gives a date), not truncated to the date. Two draws

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -350,16 +350,21 @@ a value already lost to a pre-fix collision: that needs the source document re-e
 is not collision-free. 006 promoted allergy/condition rows out of `observation`, but the new
 keys are a sha256 over dictionary-normalized fields — which SQL cannot compute — so the
 backfill carried each row's *old*, per-document key forward verbatim. Those rows sit on keys
-layer-2 dedup will never derive again, so re-committing an already-stored allergy or
-condition lands a **second row reported as `new`** — no duplicate, no conflict, no signal
-(issue #94, the mechanism behind #86's apparently duplicated condition bullets). Run the
-`pemr rekey` dry-run and then `pemr rekey --apply` against any **pre-006** database before
-its next allergy/condition `commit-extraction`. `pemr migrate` prints that follow-up when 006
-actually moves rows, so the step is signposted the moment it is owed — but nothing enforces
-it (a fresh `--create` has nothing to rekey, and prints nothing). Expect collisions here
-where the #71 migration had none: the old keys were per-document, so the same condition
-recorded by two documents recomputes onto one key. That quarantines its own table only
-(above), so the clean tables are still written and the fused pair is settled in the
+layer-2 dedup will never derive again, so skipping the rekey **blocks the next ingest rather
+than forking it**: a `commit-extraction` that re-states one of those facts hits the drift
+guard above, raises `DictionaryDriftError` naming `pemr rekey --apply`, and writes nothing
+(issue #94). Signposting and enforcement are two different mechanisms here — `pemr migrate`
+*signposts*, printing the follow-up when 006 actually moves rows (a fresh `--create` has
+nothing to rekey and prints nothing), while `commit-extraction` *enforces*, but only for the
+identity being re-filed: unrelated ingests still pass, so a database can run on stale keys
+indefinitely until one of them is restated. Run the `pemr rekey` dry-run and then `pemr rekey
+--apply` against any **pre-006** database before its next allergy/condition
+`commit-extraction`. Expect collisions here where the #71 migration had none: the old
+`observation` keys carried the assertion's `observed_at`, so one condition restated by three
+documents is three stored rows that all recompute onto the single date-free key 006 gave the
+type — the legacy shape behind #86's apparently duplicated condition bullets, correct storage
+under the old identity and a fused pair under the new one. A collision quarantines its own
+table only (above), so the clean tables are still written and the fusion is settled in the
 dictionary or the data before a re-run.
 
 The **measured value is deliberately *not* in the key** — temporal identity carries the

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -684,6 +684,61 @@ def test_migrated_006_rows_rekey_per_table_when_one_table_collides(tmp_path, cap
         conn.close()
 
 
+def test_post_006_stale_key_blocks_the_recommit_instead_of_forking_it(tmp_path, capsys):
+    """Pins the post-006 upgrade paragraph in `docs/Architecture.md` §3 (issue #94).
+
+    A pre-006 database carries its old per-document `observation` keys through 006, so
+    the next `commit-extraction` that re-states one of those facts is *refused* naming
+    `pemr rekey --apply` and writes nothing -- it does not silently fork a second row
+    (that was the pre-guard behaviour the doc used to describe). Enforcement is narrow:
+    an unrelated condition still commits while the stale key sits there, which is why
+    the doc has to tell operators to run the rekey rather than wait to be stopped.
+    """
+    staged = _stage_pre_006(tmp_path)
+    assert _run(tmp_path, "migrate", "--create", "--migrations-dir", str(staged)) == 0
+    assert _run(tmp_path, "person", "add", "--slug", "jane-doe", "--name", "Jane") == 0
+    conn = db.connect(tmp_path / "cli.db")
+    conn.execute(
+        "INSERT INTO observation (person_id, obs_type, key, observed_at, dedup_key,"
+        " dedup_base) VALUES (1, 'condition', 'Hypertension', '2024-01-02', 'c1', 'c1')"
+    )
+    conn.commit()
+    conn.close()
+    assert _run(tmp_path, "migrate") == 0
+    assert "1 allergy/condition row" in capsys.readouterr().out
+
+    note = tmp_path / "visit.txt"
+    note.write_bytes(b"problem list: hypertension")
+    assert _run(tmp_path, "ingest", str(note), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources")) == 0
+    capsys.readouterr()
+
+    same = _write_json(tmp_path, "same.json",
+                       {"condition": [{"name": "Hypertension", "status": "active"}]})
+    assert _run(tmp_path, "commit-extraction", "--document", "1", "--json", str(same)) == 1
+    err = capsys.readouterr().err
+    assert "no longer matches the current dictionary" in err
+    assert "rekey --apply" in err
+    conn = db.connect(tmp_path / "cli.db")
+    try:  # refused, not forked
+        assert conn.execute(
+            "SELECT COUNT(*) AS n FROM condition").fetchone()["n"] == 1
+    finally:
+        conn.close()
+
+    other = _write_json(tmp_path, "other.json",
+                        {"condition": [{"name": "Asthma", "status": "active"}]})
+    assert _run(tmp_path, "commit-extraction", "--document", "1", "--json",
+                str(other)) == 0
+    assert "1 new" in capsys.readouterr().out
+
+    # ... and the remedy the message names actually clears it.
+    assert _run(tmp_path, "rekey", "--apply") == 0
+    capsys.readouterr()
+    assert _run(tmp_path, "commit-extraction", "--document", "1", "--json", str(same)) == 0
+    assert "0 new, 1 duplicate" in capsys.readouterr().out
+
+
 def test_migrate_of_a_fresh_database_has_no_rekey_followup(tmp_path, capsys):
     """Nothing moved, nothing to rekey - a note nobody must act on trains people to
     skip notes."""


### PR DESCRIPTION
## What shipped

Documents `pemr rekey --apply` as a **required** post-migration-006 upgrade step for
pre-006 databases, replacing #94's original (stale-by-the-time-of-build) assumption that
skipping it silently forks a duplicate row. Current behavior, confirmed against
`pemr/dedup.py`'s `_assert_no_key_drift` (shipped in `44a578d`, the day after 006 landed):
skipping rekey **blocks** the next allergy/condition `commit-extraction` for the identity
being re-filed (`DictionaryDriftError`, nothing written) rather than forking it — `pemr
migrate` only signposts the step, `commit-extraction` is what actually enforces it, and only
narrowly.

- `docs/Architecture.md` §3 — one new paragraph in the existing `pemr rekey` narrative,
  right after the issue-#71 rekey-as-migration paragraph. States the requirement, why (006's
  backfill carries the old per-document key forward because the new key is a sha256 over
  dictionary-normalized fields SQL can't compute), the accurate refusal symptom, and that
  collisions here are expected where #71 had none (one condition restated by three documents
  collapses onto one date-free key — the mechanism behind #86's apparently duplicated
  bullets).
- `tests/test_cli_phase2.py` — one additive spec
  (`test_post_006_stale_key_blocks_the_recommit_instead_of_forking_it`) pinning the paragraph's
  load-bearing claims at the operator level (refusal-not-fork, nothing written, the guard's
  narrowness) so the doc can't silently drift from behavior again the way it did once already.
- Ship fixed one cosmetic nit audit flagged as non-blocking: the paragraph's three-document
  example said "a fused pair" (leftover from the two-row allergy case) where the actual
  fusion is three-onto-one; now reads "a three-way fusion."

No code paths touched — `pemr/cli.py`, `pemr/dedup.py`, migrations, and the schema are all
absent from the diff. `_migration_followups` (AC #3) is confirmed present and byte-unchanged.

## Deferred, not dropped

**AC #2** (run `pemr rekey --apply` against the real database cited in #86) stays deferred to
a human — it is a write against live personal medical data, which a pipeline worker must not
perform. #92's merge (PR #101, per-table collision isolation) removed the technical blocker,
so the procedure is now: `pemr backup` → `pemr rekey` (dry run; expect `condition` to rekey
clean and `allergy` to report a collision) → settle the colliding allergy pair (dictionary if
the payloads differ, data if identical) → `pemr rekey --apply`.

## Follow-ups noted, not opened here (per audit)

- `rekey`'s collision message misdiagnoses a legacy-shape (006) fusion as a dictionary
  conflict when it's really a data one, since the payloads differ on `onset_on`.
- Stale pre-guard "inserts a second row" wording still in `migrations/006_condition_allergy.sql`
  L110-113 and the `_migration_followups` docstring in `pemr/cli.py` (internal comments only,
  `pemr/cli.py` is out of bounds under AC #3).

## Reports

- Verify (ADVANCE to audit): https://github.com/meridun/pemr/issues/94#issuecomment-5220011562
- Audit (ADVANCE to ship): https://github.com/meridun/pemr/issues/94#issuecomment-5220075192

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)
