### PR TITLE
dictionary: [synonyms] additions for lab label variants (abbreviations, long forms, casing)

### DIFF
--- a/data/dictionary.example.toml
+++ b/data/dictionary.example.toml
@@ -68,6 +68,9 @@
 "estimated gfr" = "egfr"
 "bun" = "bun"
 "blood urea nitrogen" = "bun"
+# The stem alone is enough: `Urea Nitrogen (BUN)` is a redundant alias and drops via
+# identity() rule 2 once `urea nitrogen` maps here, so it needs no full-label key.
+"urea nitrogen" = "bun"
 
 # --- Hematology ---
 "hemoglobin" = "hemoglobin"
@@ -92,6 +95,37 @@
 "red cell distribution width" = "rdw"
 "mpv" = "mpv"
 "mean platelet volume" = "mpv"
+
+# --- CBC differential ---
+# The absolute count and the percentage are two different measurements of one cell
+# line, so they get DIFFERENT canonical tokens on purpose — `%` and `(absolute)` are
+# qualifier-distinct (issue #71) and must never fuse. Report short codes pair with the
+# long forms the CSV prints; the `(absolute)` long forms need full-label keys (rule 1)
+# because the parenthetical is meaningful rather than a redundant alias.
+# Ambiguous short codes (`Gran`, `LY`, `MO`) and the bare `Lymphs`/`Eos` spellings stay
+# unmapped pending per-document verification.
+"lym" = "lymphocytes_abs"
+"lymphocytes (absolute)" = "lymphocytes_abs"
+"neu" = "neutrophils_abs"
+"neutrophils (absolute)" = "neutrophils_abs"
+"mono" = "monocytes_abs"
+"monocytes (absolute)" = "monocytes_abs"
+"eo" = "eosinophils_abs"
+"eosinophils (absolute)" = "eosinophils_abs"
+"bas" = "basophils_abs"
+"basophils (absolute)" = "basophils_abs"
+# Percent forms. `MONO` (absolute) vs `MON%` (percent) is the asymmetry the corpus
+# actually prints — not a typo.
+"lym%" = "lymphocytes_pct"
+"lymphocytes %" = "lymphocytes_pct"
+"neu%" = "neutrophils_pct"
+"neutrophils %" = "neutrophils_pct"
+"mon%" = "monocytes_pct"
+"monocytes %" = "monocytes_pct"
+"eo%" = "eosinophils_pct"
+"eosinophils %" = "eosinophils_pct"
+"bas%" = "basophils_pct"
+"basophils %" = "basophils_pct"
 
 # --- Inflammatory markers ---
 # ESR (erythrocyte sedimentation rate). Report labels vary by method, but ESR is a
@@ -119,8 +153,15 @@
 # different assay label and collapsing the two would fuse two rows from one draw.
 "co2" = "co2"
 "carbon dioxide" = "co2"
+# ...which is why the label some reports print in full gets a full-label key (rule 1)
+# instead: `CO2 (Bicarbonate)` IS the CMP total CO2, while a bare `Bicarbonate` row is
+# left to key on its own.
+"co2 (bicarbonate)" = "co2"
 "calcium" = "calcium"
 "ca" = "calcium"
+"magnesium" = "magnesium"
+# `mg` is only ever a test name here — units never route through the dictionary.
+"mg" = "magnesium"
 
 # --- Liver enzymes / bilirubin ---
 "alt" = "alt"
@@ -136,18 +177,31 @@
 "ldh" = "ldh"
 "lactate dehydrogenase" = "ldh"
 
-# --- Serum protein: still unmapped, but no longer unsafe ---
+# --- Serum protein ---
 # A CMP and an SPEP run off the SAME draw both report total protein (`TPro` /
 # `Protein, Total`) and albumin (`ALB` / `Albumin`) — different methods, slightly
-# different numbers, same person + same collected_at. This used to make mapping
-# `alb`->`albumin` / `tpro`->`protein_total` unsafe: it gave those two rows one dedup
-# key and the second landed as a staged CONFLICT.
+# different numbers, same person + same collected_at. Mapping `alb`->`albumin` used to
+# be unsafe for exactly that reason; issue #71's method-aware key fixed it, since the
+# SPEP row's `Albumin (SPEP)` label keys as `albumin (spep)`, distinct from the CMP's
+# bare `albumin`.
 #
-# Issue #71 supplied the method-aware key that block asked for: the SPEP row's
-# `Albumin (SPEP)` label now keys as `albumin (spep)`, distinct from the CMP's bare
-# `albumin`, so the mapping is safe to add. Curating it is a separate pass — add the
-# entries deliberately, alongside whatever full-label keys your reports' SPEP fraction
-# names need, then `pemr rekey`.
+# Total protein IS deliberately fused across the two methods (the SPEP carries the CMP
+# total protein forward — same-draw same-value evidence), whereas the separately
+# measured SPEP fraction labels (`Protein Electrophoresis Albumin Fraction`, the
+# globulin fractions) stay unmapped so they keep keys of their own.
+"alb" = "albumin"
+"albumin" = "albumin"
+"tpro" = "protein_total"
+"total protein" = "protein_total"
+"protein, total" = "protein_total"
+"protein, total (spep)" = "protein_total"
+"protein electrophoresis total protein" = "protein_total"
+# Urine total protein is a different analyte from the serum one, so it keeps its own
+# canonical token; the second key is the comma-spacing variant some reports print.
+"protein,total,urine" = "protein_total_urine"
+"protein, total, urine" = "protein_total_urine"
+"prot, 24hr calculated" = "protein_24hr"
+"prot,24hr calculated" = "protein_24hr"
 
 # --- Vitamins ---
 "vitamin d" = "vitamin_d_25oh"
@@ -166,10 +220,15 @@
 # hence the full-label key below rather than a global rule.
 "kappa" = "kappa_free_light_chain"
 "free kappa light chain" = "kappa_free_light_chain"
+"kappa free light chain, serum" = "kappa_free_light_chain"
+"kappa free light chains, serum" = "kappa_free_light_chain"
 "lambda" = "lambda_free_light_chain"
 "free lambda light chain" = "lambda_free_light_chain"
+"lambda free light chain, serum" = "lambda_free_light_chain"
+"lambda free light chains, serum" = "lambda_free_light_chain"
 "k/l ratio" = "kappa_lambda_ratio"
 "kappa/lambda ratio" = "kappa_lambda_ratio"
+"kappa/lambda free light chain ratio" = "kappa_lambda_ratio"
 "m-spike" = "m_spike"
 "m-spike (spep)" = "m_spike"
 "immunoglobulin g" = "igg"
@@ -183,6 +242,12 @@
 "b2 microglobulin" = "beta2_microglobulin"
 "beta2 microglobulin" = "beta2_microglobulin"
 "beta-2 microglobulin" = "beta2_microglobulin"
+"bmg" = "beta2_microglobulin"
+# Immunofixation interpretation, urine. Two spellings that differ only by a comma vs a
+# colon — punctuation is load-bearing in lab labels (`M-Spike` vs `M-Spike, %`), so the
+# normalizer does not strip it and these are enumerated instead.
+"ife interpretation, u" = "ife_interpretation_urine"
+"ife interpretation:u" = "ife_interpretation_urine"
 
 # --- observation obs_type conventions ---
 # Four obs_type families out of the generic `observation` table. Extraction

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -310,8 +310,9 @@ in the DB: layer-2 dedup misses it and the same fact lands twice. `pemr rekey` r
 every stored key under the current dictionary (dry-run by default, `--apply` to write,
 values and provenance untouched). Two rows that recompute to one key are a **collision**,
 and the message names which of the two causes it is: *different* payloads mean the new
-synonym fuses two distinct facts (e.g. a CMP `ALB` and an SPEP `Albumin` off one draw) and
-the fix belongs in the dictionary; *identical* payloads mean one fact was filed twice, once
+synonym fuses two distinct facts (e.g. a CMP `Albumin` and an SPEP `Protein
+Electrophoresis Albumin Fraction` off one draw) and the fix belongs in the dictionary;
+*identical* payloads mean one fact was filed twice, once
 under a pre-drift key, and the fix belongs in the data.
 
 **A collision quarantines its own table, not the run** (issue #92). The record tables are

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -786,3 +786,116 @@ def test_keep_both_no_op_line_names_the_fields_it_filled(ready, capsys):
     finally:
         conn.close()
     assert (stored["reaction"], stored["criticality"]) == ("rash", "high")
+
+
+# --- issue #104: the curated lab-label synonyms, walked through the real CLI ---
+
+# (label as one document prints it, label as the other prints it) for every pair the
+# #104 curation has to converge. Same person, same draw, same value, two spellings:
+# the second document must land as a DUPLICATE, never as a second row. Some pairs
+# carry no dictionary line at all - the parenthesized ones ride identity()'s
+# redundant-alias rule and `Hemoglobin`/`hemoglobin` rides _collapse()'s casefold -
+# and they are listed here precisely so "no entry needed" stays a tested claim.
+_DICT_104_CLI_PAIRS: list[tuple[str, str]] = [
+    ("ALB", "Albumin"),
+    ("TPro", "Protein, Total (SPEP)"),
+    ("MG", "magnesium"),
+    ("BMG", "Beta-2 Microglobulin"),
+    ("BUN", "Urea Nitrogen (BUN)"),
+    ("CO2", "CO2 (Bicarbonate)"),
+    ("ALT", "ALT (SGPT)"),
+    ("AST", "AST (SGOT)"),
+    ("TSH", "TSH (Thyroid Stimulating Hormone)"),
+    ("Kappa", "Kappa Free Light Chains, Serum"),
+    ("Lambda", "Lambda Free Light Chain, Serum"),
+    ("K/L Ratio", "Kappa/Lambda Free Light Chain Ratio"),
+    ("LYM", "Lymphocytes (absolute)"),
+    ("NEU", "Neutrophils (absolute)"),
+    ("MONO", "Monocytes (absolute)"),
+    ("EO", "Eosinophils (absolute)"),
+    ("BAS", "Basophils (absolute)"),
+    ("LYM%", "Lymphocytes %"),
+    ("NEU%", "Neutrophils %"),
+    ("MON%", "Monocytes %"),
+    ("EO%", "Eosinophils %"),
+    ("BAS%", "Basophils %"),
+    ("IFE Interpretation, U", "IFE Interpretation:U"),
+    ("Hemoglobin", "hemoglobin"),
+    ("Protein,Total,Urine", "Protein, Total, Urine"),
+    ("Prot, 24hr Calculated", "Prot,24hr Calculated"),
+]
+
+# The other half of the bargain: labels off the SAME draw that the curation must leave
+# on keys of their own (issue #71's qualifier constraint plus the short codes #104
+# deliberately excluded). Every one of these has to commit as a new row.
+_DICT_104_CLI_DISTINCT: list[str] = [
+    "Albumin (SPEP)",
+    "Protein Electrophoresis Albumin Fraction",
+    "Bicarbonate",
+    "LDL cholesterol (direct)",
+    "LDL cholesterol (calculated)",
+    "estimated GFR (black)",
+    "estimated GFR (other)",
+    "M-Spike",
+    "M-Spike, %",
+    "Gran",
+    "LY",
+    "MO",
+]
+
+
+def test_curated_synonyms_dedup_across_documents_through_the_cli(ready, capsys):
+    """#104 end to end, against the shipped dictionary: one report prints the short
+    codes, the next prints the long forms, and layer-2 dedup has to see one draw
+    rather than two. A fork here is exactly the symptom the curation exists to fix -
+    rendered summaries repeating a row per spelling."""
+    tmp_path = ready
+    sources = tmp_path / "sources"
+    for i in (1, 2, 3):
+        scan = tmp_path / f"d{i}.txt"
+        scan.write_bytes(f"lab report {i}".encode())
+        assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                    "--sources", str(sources)) == 0
+    capsys.readouterr()
+
+    def _labs(names):
+        # Index-derived values, so the two documents state the SAME number for each
+        # pair (a duplicate, not a conflict) while every pair stays distinguishable.
+        return [{"test_name": name, "collected_at": "2026-01-02",
+                 "value_num": 1.0 + i, "unit": "g/dL"} for i, name in enumerate(names)]
+
+    pairs = len(_DICT_104_CLI_PAIRS)
+    short = _write_json(tmp_path, "short.json",
+                        {"lab_result": _labs([a for a, _ in _DICT_104_CLI_PAIRS])})
+    assert _run(tmp_path, "commit-extraction", "--document", "1",
+                "--json", str(short)) == 0
+    assert f"{pairs} new, 0 duplicate" in capsys.readouterr().out
+
+    spelled = _write_json(tmp_path, "spelled.json",
+                          {"lab_result": _labs([b for _, b in _DICT_104_CLI_PAIRS])})
+    assert _run(tmp_path, "commit-extraction", "--document", "2",
+                "--json", str(spelled)) == 0
+    assert f"0 new, {pairs} duplicate" in capsys.readouterr().out
+
+    # ...and nothing over-collapsed: the qualifier-distinct labels off that same draw
+    # each still key on their own, so they commit as new rows rather than deduping
+    # into their stems.
+    distinct = _write_json(tmp_path, "distinct.json",
+                           {"lab_result": _labs(_DICT_104_CLI_DISTINCT)})
+    assert _run(tmp_path, "commit-extraction", "--document", "3",
+                "--json", str(distinct)) == 0
+    assert f"{len(_DICT_104_CLI_DISTINCT)} new, 0 duplicate" in capsys.readouterr().out
+
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        rows, keys = conn.execute(
+            "SELECT COUNT(*), COUNT(DISTINCT dedup_key) FROM lab_result"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert rows == keys == pairs + len(_DICT_104_CLI_DISTINCT)
+
+    # The rows were keyed under the shipped dictionary, so `pemr rekey` (dry run) has
+    # nothing to move and no collision to report.
+    assert _run(tmp_path, "rekey") == 0
+    assert "all dedup keys already match the current dictionary" in capsys.readouterr().out

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -174,6 +174,106 @@ _CORPUS_VARIANTS = [
 ]
 
 
+# Issue #104's bucket-A abbreviation/long-form pairs. Kept OUT of _CORPUS_VARIANTS on
+# purpose: test_real_corpus_overlap_dedups_not_splits commits every entry of that list
+# on one date with an index-derived value, so a pair whose canonical token is already
+# listed there would stage a spurious conflict.
+_DICT_104_VARIANTS: list[tuple[str, str]] = [
+    ("ALB", "Albumin"),
+    ("MG", "magnesium"),
+    ("TPro", "Total Protein"),
+    ("TPro", "Protein, Total"),
+    ("TPro", "Protein, Total (SPEP)"),
+    ("TPro", "Protein Electrophoresis Total Protein"),
+    ("Kappa", "Kappa Free Light Chain, Serum"),
+    ("Kappa", "Kappa Free Light Chains, Serum"),
+    ("Lambda", "Lambda Free Light Chain, Serum"),
+    ("Lambda", "Lambda Free Light Chains, Serum"),
+    ("K/L Ratio", "Kappa/Lambda Ratio"),
+    ("K/L Ratio", "Kappa/Lambda Free Light Chain Ratio"),
+    ("BMG", "Beta-2 Microglobulin"),
+    ("BUN", "Urea Nitrogen"),
+    ("CO2", "CO2 (Bicarbonate)"),
+    ("ALT", "ALT (SGPT)"),
+    ("AST", "AST (SGOT)"),
+    ("TSH", "TSH (Thyroid Stimulating Hormone)"),
+    ("LYM", "Lymphocytes (absolute)"),
+    ("NEU", "Neutrophils (absolute)"),
+    ("MONO", "Monocytes (absolute)"),
+    ("EO", "Eosinophils (absolute)"),
+    ("BAS", "Basophils (absolute)"),
+    ("LYM%", "Lymphocytes %"),
+    ("NEU%", "Neutrophils %"),
+    ("MON%", "Monocytes %"),
+    ("EO%", "Eosinophils %"),
+    ("BAS%", "Basophils %"),
+]
+
+
+def test_synonym_additions_share_key_token():
+    """Issue #104 acceptance: every curated abbreviation/long-form pair derives ONE
+    dedup identity, so the same analyte stops rendering as two rows."""
+    d = dedup.load_dictionary(DICT_PATH)
+    for short, long in _DICT_104_VARIANTS:
+        assert dedup.key_token(short, d) == dedup.key_token(long, d), (short, long)
+
+
+def test_redundant_parenthetical_needs_no_entry():
+    """These four are NOT in the dictionary and must not be: identity() rule 2 already
+    drops a parenthetical that maps to the same canonical token as its stem, so adding
+    full-label keys for them would be dead curation."""
+    d = dedup.load_dictionary(DICT_PATH)
+    for label in ("alt (sgpt)", "ast (sgot)",
+                  "tsh (thyroid stimulating hormone)", "urea nitrogen (bun)"):
+        assert label not in d, label
+    assert dedup.key_token("ALT (SGPT)", d) == dedup.key_token("ALT", d) == "alt"
+    assert dedup.key_token("AST (SGOT)", d) == dedup.key_token("AST", d) == "ast"
+    assert dedup.key_token("TSH (Thyroid Stimulating Hormone)", d) \
+        == dedup.key_token("TSH", d) == "tsh"
+    assert dedup.key_token("Urea Nitrogen (BUN)", d) \
+        == dedup.key_token("BUN", d) == "bun"
+
+
+def test_punctuation_distinct_labels_need_an_entry():
+    """Issue #104 bucket B, both halves. Case/whitespace-only variants converge for free
+    through _collapse(); only labels differing by real punctuation need a synonym line,
+    because stripping punctuation globally would fuse meaningful pairs (`M-Spike, %`)."""
+    d = dedup.load_dictionary(DICT_PATH)
+    # (a) already-converging: no dictionary entry involved at all.
+    for a, b in (("Hemoglobin", "hemoglobin"), ("bun", "BUN"), ("WBC", "wbc"),
+                 ("Hemoglobin A1c", "hemoglobin  a1c"), ("Kappa", "kappa")):
+        assert dedup.key_token(a, {}) == dedup.key_token(b, {}), (a, b)
+        assert dedup.key_token(a, d) == dedup.key_token(b, d), (a, b)
+    # (b) punctuation-distinct: converge only *because of* the entries added here.
+    for a, b in (("IFE Interpretation, U", "IFE Interpretation:U"),
+                 ("Protein,Total,Urine", "Protein, Total, Urine"),
+                 ("Prot, 24hr Calculated", "Prot,24hr Calculated")):
+        assert dedup.key_token(a, {}) != dedup.key_token(b, {}), (a, b)
+        assert dedup.key_token(a, d) == dedup.key_token(b, d), (a, b)
+
+
+def test_synonym_additions_keep_qualifier_distinct_labels_apart():
+    """The negative half of issue #104: growing the dictionary must not collapse any
+    pair issue #71 keeps apart, and must not quietly map the excluded short codes."""
+    d = dedup.load_dictionary(DICT_PATH)
+    for a, b in (
+        ("Albumin", "Albumin (SPEP)"),
+        ("Albumin", "Protein Electrophoresis Albumin Fraction"),
+        ("Lymphocytes %", "Lymphocytes (absolute)"),
+        ("Neutrophils %", "Neutrophils (absolute)"),
+        ("LDL cholesterol (direct)", "LDL cholesterol (calculated)"),
+        ("estimated GFR (black)", "estimated GFR (other)"),
+        ("CO2 (Bicarbonate)", "Bicarbonate"),
+        ("Protein, Total", "Protein, Total, Urine"),
+        ("M-Spike", "M-Spike, %"),
+    ):
+        assert dedup.key_token(a, d) != dedup.key_token(b, d), (a, b)
+    # Excluded ambiguous short codes gain no mapping (`hgb` keeps its existing one).
+    for code in ("gran", "ly", "mo"):
+        assert code not in d, code
+    assert d["hgb"] == "hemoglobin"
+
+
 def test_corpus_naming_variants_share_canonical_token():
     d = dedup.load_dictionary(DICT_PATH)
     for report, csv in _CORPUS_VARIANTS:
@@ -705,6 +805,19 @@ def _rekey_dict(**extra):
     return d
 
 
+# The canonical "one synonym fuses two same-draw facts" setup, in one place because
+# three tests need it. The SPEP albumin *fraction* is a separately measured quantity
+# from the CMP's `Albumin` and carries no parenthetical to keep it apart, so it is
+# deliberately absent from the shipped dictionary (issue #104's Out of scope) — which
+# is what makes it a valid fuse to construct here.
+_FUSING_ALBUMIN_PAIR = {"lab_result": [
+    {"test_name": "Protein Electrophoresis Albumin Fraction",
+     "collected_at": "2026-01-02", "value_num": 4.2},
+    {"test_name": "Albumin", "collected_at": "2026-01-02", "value_num": 3.6},
+]}
+_FUSING_ALBUMIN_SYNONYM = {"protein electrophoresis albumin fraction": "albumin"}
+
+
 def test_rekey_dry_run_reports_without_writing(conn):
     doc = _make_document(conn)
     # Committed with the shipped dictionary, where "cl" has no synonym.
@@ -756,17 +869,17 @@ def test_rekey_is_idempotent(conn):
 
 
 def test_rekey_refuses_a_dictionary_that_fuses_two_facts(conn):
-    """Two methods for one analyte off one draw (CMP ALB vs SPEP Albumin) must not be
-    merged by a synonym: the colliding table keeps every stored key."""
+    """Two methods for one analyte off one draw (the SPEP albumin *fraction* vs a CMP
+    Albumin) must not be merged by a synonym: the colliding table keeps every stored
+    key. The pair doubles as a pin on that fraction label staying unmapped in the
+    shipped dictionary (issue #104) — mapping it is exactly this fuse."""
     doc = _make_document(conn)
-    dedup.commit_extraction(conn, doc, {"lab_result": [
-        {"test_name": "ALB", "collected_at": "2026-01-02", "value_num": 4.2},
-        {"test_name": "Albumin", "collected_at": "2026-01-02", "value_num": 3.6},
-    ]}, dedup.load_dictionary(DICT_PATH))
+    dedup.commit_extraction(conn, doc, _FUSING_ALBUMIN_PAIR,
+                            dedup.load_dictionary(DICT_PATH))
     before = {r["lab_result_id"]: r["dedup_key"]
               for r in conn.execute("SELECT lab_result_id, dedup_key FROM lab_result")}
 
-    report = dedup.rekey(conn, _rekey_dict(alb="albumin"), apply=True)
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM), apply=True)
 
     assert [c.kind for c in report.collisions] == ["fused"]
     assert "same dedup_key" in report.collisions[0].message
@@ -819,11 +932,9 @@ def test_rekey_dry_run_reports_every_collision_instead_of_stopping_at_the_first(
     definition, so it must enumerate all collisions in all tables rather than abort on
     the first and force a serial edit-and-rerun loop."""
     d_new = _collide_allergy_and_move_condition(conn)
-    dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
-        {"test_name": "ALB", "collected_at": "2026-01-02", "value_num": 4.2},
-        {"test_name": "Albumin", "collected_at": "2026-01-02", "value_num": 3.6},
-    ]}, dedup.load_dictionary(DICT_PATH))
-    d_new["alb"] = "albumin"
+    dedup.commit_extraction(conn, _make_document(conn), _FUSING_ALBUMIN_PAIR,
+                            dedup.load_dictionary(DICT_PATH))
+    d_new.update(_FUSING_ALBUMIN_SYNONYM)
     before = {t: _keys(conn, t, c) for t, c in
               (("allergy", "substance"), ("lab_result", "test_name"),
                ("condition", "name"))}
@@ -1070,13 +1181,12 @@ def test_rekey_names_a_doubled_fact_instead_of_blaming_the_dictionary(conn):
 
 def test_rekey_still_blames_the_dictionary_when_it_fuses_distinct_facts(conn):
     """The other cause keeps its own message: two *different* payloads recomputing onto
-    one key really is a dictionary that merges distinct facts."""
+    one key really is a dictionary that merges distinct facts (here the SPEP albumin
+    fraction fused with the CMP `Albumin` off one draw)."""
     doc = _make_document(conn)
-    dedup.commit_extraction(conn, doc, {"lab_result": [
-        {"test_name": "ALB", "collected_at": "2026-01-02", "value_num": 4.2},
-        {"test_name": "Albumin", "collected_at": "2026-01-02", "value_num": 3.6},
-    ]}, dedup.load_dictionary(DICT_PATH))
-    report = dedup.rekey(conn, _rekey_dict(alb="albumin"))
+    dedup.commit_extraction(conn, doc, _FUSING_ALBUMIN_PAIR,
+                            dedup.load_dictionary(DICT_PATH))
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM))
     assert [c.kind for c in report.collisions] == ["fused"]
     assert "two distinct facts" in report.collisions[0].message
 


### PR DESCRIPTION
## Summary

Extends `[synonyms]` in `data/dictionary.example.toml` so dedup converges on lab-label variants that currently derive distinct keys for the same analyte (abbreviation/long-form pairs, and punctuation-distinct casing variants), per the curated inventory in meridun/pemr-data#9.

- Bucket A: 28 abbreviation/long-form pairs (`ALB`/`Albumin`, `MG`/`magnesium`, the `TPro`/`Protein, Total` family, `Kappa`/`Lambda` "Free Light Chain, Serum" forms, `K/L Ratio` spellings, `BMG`, bare `Urea Nitrogen`, and the 10 CBC differential short codes with absolute/percent kept as separate canonical tokens).
- `CO2 (Bicarbonate)` added as a rule-1 full-label key mapping to `co2`, without mapping bare `bicarbonate`/`HCO3` — preserves the deliberate non-mapping documented at `data/dictionary.example.toml:118-119`.
- Bucket B: the 3 punctuation-distinct pairs (comma vs colon, comma-spacing) get real entries; casing/whitespace-only variants already converge via `_collapse()` with zero new entries — confirmed by test, not assumed.
- Verified-redundant pairs (`ALT (SGPT)`, `AST (SGOT)`, `TSH (Thyroid Stimulating Hormone)`, `Urea Nitrogen (BUN)`) deliberately get **no** entry — they already converge via `identity()` rule 2 once their stems map.
- `identity()`/`_collapse()`/`norm()` are untouched (design decision recorded on the issue thread: punctuation is meaningful in lab labels, so bucket B is entries, not a normalizer change).
- `tests/test_dedup.py`: repaired three rekey-collision fixtures that depended on `ALB`/`Albumin` being unmapped (re-pointed to `Protein Electrophoresis Albumin Fraction`/`Albumin`, which stays deliberately unmapped), plus four new tests covering bucket-A convergence, rule-2 redundancy, bucket-B punctuation vs casing, and qualifier-distinct labels staying apart.
- `tests/test_cli_phase2.py`: new end-to-end CLI spec that ingests documents under the shipped dictionary and confirms the "rendered summaries repeat rows" symptom is gone (verified it fails against the pre-change dictionary and passes after).
- `docs/Architecture.md:313`: swapped the fusing-synonym example from `ALB`/`Albumin` (now correctly fused) to the SPEP albumin fraction (still deliberately unmapped).

**Rekey required for existing stores.** This is a dictionary-only change (no schema/migration change), but any store already holding rows under the now-mapped labels will drift and `commit_extraction` will raise `DictionaryDriftError` until `pemr rekey --apply` runs (`docs/Architecture.md:307-313,333`). This repo ships no stored data, so there is nothing to migrate here. The data-repo side is tracked in meridun/pemr-data#9's resume checklist, steps 1-3 — AC 5 (`pemr rekey` dry run over the real corpus showing convergence with no new collisions outside the known allergy/condition set) is discharged there, not in this repo; verify's in-repo proxy run (a second DB committed under the pre-change dictionary, then `rekey` dry-run against the new one) found 17/48 keys move, 22 collisions, and all of them `doubled` (data-side re-filing), zero `fused` (dictionary-fault) — the strongest in-repo signal available that the dictionary itself introduces no bad fusion.

Closes #104

## Reports

- Design (implementation plan): https://github.com/meridun/pemr/issues/104#issuecomment-5224245199
- Build: https://github.com/meridun/pemr/issues/104#issuecomment-5224319002
- Verify: https://github.com/meridun/pemr/issues/104#issuecomment-5224374704
- Audit: https://github.com/meridun/pemr/issues/104#issuecomment-5224401135

🤖 Generated with agentic SDLC pipeline (run dispatch-20260808-0326-3d12-ship)