### PR TITLE
fix(dictionary): stop fusing SPEP bare labels with CMP codes (#106)

### DIFF
--- a/data/dictionary.example.toml
+++ b/data/dictionary.example.toml
@@ -107,7 +107,11 @@
 "lym" = "lymphocytes_abs"
 "lymphocytes (absolute)" = "lymphocytes_abs"
 "neu" = "neutrophils_abs"
-"neutrophils (absolute)" = "neutrophils_abs"
+# `Neutrophils (absolute)` is deliberately NOT mapped to `neutrophils_abs` yet: the
+# corpus holds a payload-degraded duplicate of one NEU row (a visit note quoting the
+# same-day lab), and fusing the labels collides them with no row-level removal verb to
+# resolve it (issue #107). Restore this mapping once #107 lands and the doubled row is
+# dropped.
 "mono" = "monocytes_abs"
 "monocytes (absolute)" = "monocytes_abs"
 "eo" = "eosinophils_abs"
@@ -179,23 +183,26 @@
 
 # --- Serum protein ---
 # A CMP and an SPEP run off the SAME draw both report total protein (`TPro` /
-# `Protein, Total`) and albumin (`ALB` / `Albumin`) — different methods, slightly
-# different numbers, same person + same collected_at. Mapping `alb`->`albumin` used to
-# be unsafe for exactly that reason; issue #71's method-aware key fixed it, since the
-# SPEP row's `Albumin (SPEP)` label keys as `albumin (spep)`, distinct from the CMP's
-# bare `albumin`.
+# `Protein, Total`) and albumin (`ALB` / `Albumin`) — different methods, different
+# numbers, different reference intervals, same person + same collected_at. Issue #71's
+# method-aware key only protects the case where the SPEP row carries a `(SPEP)`
+# qualifier; the real corpus prints the BARE labels (`Albumin`, `Protein, Total`) on
+# SPEP renderings, so fusing them with the CMP codes collides two assays off one draw
+# (issue #106). Over-splitting is the safe direction, so:
 #
-# Total protein IS deliberately fused across the two methods (the SPEP carries the CMP
-# total protein forward — same-draw same-value evidence), whereas the separately
-# measured SPEP fraction labels (`Protein Electrophoresis Albumin Fraction`, the
-# globulin fractions) stay unmapped so they keep keys of their own.
-"alb" = "albumin"
-"albumin" = "albumin"
+#   * `alb` is NOT mapped to `albumin`: the bare `albumin` label is ambiguous — some
+#     renderings use it for the CMP assay, others for the SPEP fraction — so the CMP
+#     code keeps its own token and the bare label keys on itself.
+#   * The SPEP total-protein spellings get their own token; only the unambiguous CMP
+#     spellings share `protein_total`.
+#
+# The separately measured SPEP fraction labels (`Protein Electrophoresis Albumin
+# Fraction`, the globulin fractions) stay unmapped so they keep keys of their own.
 "tpro" = "protein_total"
 "total protein" = "protein_total"
-"protein, total" = "protein_total"
-"protein, total (spep)" = "protein_total"
-"protein electrophoresis total protein" = "protein_total"
+"protein, total" = "protein_total_spep"
+"protein, total (spep)" = "protein_total_spep"
+"protein electrophoresis total protein" = "protein_total_spep"
 # Urine total protein is a different analyte from the serum one, so it keeps its own
 # canonical token; the second key is the comma-spacing variant some reports print.
 "protein,total,urine" = "protein_total_urine"

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -797,8 +797,8 @@ def test_keep_both_no_op_line_names_the_fields_it_filled(ready, capsys):
 # redundant-alias rule and `Hemoglobin`/`hemoglobin` rides _collapse()'s casefold -
 # and they are listed here precisely so "no entry needed" stays a tested claim.
 _DICT_104_CLI_PAIRS: list[tuple[str, str]] = [
-    ("ALB", "Albumin"),
-    ("TPro", "Protein, Total (SPEP)"),
+    ("TPro", "Total Protein"),
+    ("Protein, Total (SPEP)", "Protein Electrophoresis Total Protein"),
     ("MG", "magnesium"),
     ("BMG", "Beta-2 Microglobulin"),
     ("BUN", "Urea Nitrogen (BUN)"),
@@ -810,7 +810,6 @@ _DICT_104_CLI_PAIRS: list[tuple[str, str]] = [
     ("Lambda", "Lambda Free Light Chain, Serum"),
     ("K/L Ratio", "Kappa/Lambda Free Light Chain Ratio"),
     ("LYM", "Lymphocytes (absolute)"),
-    ("NEU", "Neutrophils (absolute)"),
     ("MONO", "Monocytes (absolute)"),
     ("EO", "Eosinophils (absolute)"),
     ("BAS", "Basophils (absolute)"),
@@ -829,6 +828,12 @@ _DICT_104_CLI_PAIRS: list[tuple[str, str]] = [
 # on keys of their own (issue #71's qualifier constraint plus the short codes #104
 # deliberately excluded). Every one of these has to commit as a new row.
 _DICT_104_CLI_DISTINCT: list[str] = [
+    # Issue #106: SPEP renderings print bare labels, so the CMP codes and the bare
+    # forms must stay apart; `Neutrophils (absolute)` is unmapped pending #107.
+    "ALB",
+    "Albumin",
+    "NEU",
+    "Neutrophils (absolute)",
     "Albumin (SPEP)",
     "Protein Electrophoresis Albumin Fraction",
     "Bicarbonate",

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -179,12 +179,10 @@ _CORPUS_VARIANTS = [
 # on one date with an index-derived value, so a pair whose canonical token is already
 # listed there would stage a spurious conflict.
 _DICT_104_VARIANTS: list[tuple[str, str]] = [
-    ("ALB", "Albumin"),
     ("MG", "magnesium"),
     ("TPro", "Total Protein"),
-    ("TPro", "Protein, Total"),
-    ("TPro", "Protein, Total (SPEP)"),
-    ("TPro", "Protein Electrophoresis Total Protein"),
+    ("Protein, Total", "Protein, Total (SPEP)"),
+    ("Protein, Total", "Protein Electrophoresis Total Protein"),
     ("Kappa", "Kappa Free Light Chain, Serum"),
     ("Kappa", "Kappa Free Light Chains, Serum"),
     ("Lambda", "Lambda Free Light Chain, Serum"),
@@ -198,7 +196,6 @@ _DICT_104_VARIANTS: list[tuple[str, str]] = [
     ("AST", "AST (SGOT)"),
     ("TSH", "TSH (Thyroid Stimulating Hormone)"),
     ("LYM", "Lymphocytes (absolute)"),
-    ("NEU", "Neutrophils (absolute)"),
     ("MONO", "Monocytes (absolute)"),
     ("EO", "Eosinophils (absolute)"),
     ("BAS", "Basophils (absolute)"),
@@ -259,6 +256,12 @@ def test_synonym_additions_keep_qualifier_distinct_labels_apart():
     for a, b in (
         ("Albumin", "Albumin (SPEP)"),
         ("Albumin", "Protein Electrophoresis Albumin Fraction"),
+        # Issue #106: SPEP renderings print the BARE labels, so the CMP short codes
+        # must not fuse with them, and `Neutrophils (absolute)` stays unmapped until
+        # the doubled corpus row can be dropped (issue #107).
+        ("ALB", "Albumin"),
+        ("TPro", "Protein, Total"),
+        ("NEU", "Neutrophils (absolute)"),
         ("Lymphocytes %", "Lymphocytes (absolute)"),
         ("Neutrophils %", "Neutrophils (absolute)"),
         ("LDL cholesterol (direct)", "LDL cholesterol (calculated)"),


### PR DESCRIPTION
Closes #106.

Rekey against the real corpus showed the #104 albumin/total-protein merges colliding: SPEP renderings print the bare labels (`Albumin`, `Protein, Total`) with different values and reference intervals than the same-draw CMP `ALB`/`TPro`, and no `(SPEP)` qualifier for the #71 method-aware key to catch.

- SPEP total-protein spellings (`Protein, Total`, `Protein, Total (SPEP)`, `Protein Electrophoresis Total Protein`) move to their own token `protein_total_spep`; the unambiguous CMP spellings (`TPro`, `Total Protein`) keep `protein_total`.
- `alb` no longer maps to `albumin` — the bare label is method-ambiguous across renderings, so the CMP code keys on itself.
- `Neutrophils (absolute)` is withheld from `neutrophils_abs` until #107 provides row-level removal for the doubled corpus row.
- Tests updated accordingly: the moved pairs are now asserted distinct.

Full suite passes (754 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)