### PR TITLE
feat(curation): record human verdicts as a render-time overlay (#109)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,10 +61,13 @@ Write tools (mutate the DB; the only tools that do):
 
 Read/write separation is also declared to the client via MCP `readOnlyHint` annotations.
 
-**Deletion is never an MCP tool.** `document rm` and `record rm` (the CLI's only destructive
-verbs — the latter added by issue #107) are deliberately excluded from the tool surface above.
-This is what keeps "an agent cannot delete PHI" true: removing a document or a single record row
-is a human-at-a-terminal action only, never something an agent can reach through this server.
+**Deletion — and clinical verdicts — are never an MCP tool.** `document rm`, `record rm` (the
+CLI's destructive verbs — the latter added by issue #107), and `record annotate` (issue #109) are
+deliberately excluded from the tool surface above. This is what keeps "an agent cannot delete PHI"
+true: removing a document or a single record row is a human-at-a-terminal action only, never
+something an agent can reach through this server. `record annotate` joins them for the adjacent
+reason — a `curation` verdict is a human's clinical judgment, and writing one can drop a record
+out of every generated document without deleting a row.
 
 ## MUST rules
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -111,8 +111,10 @@ CREATE TABLE document_tombstone (
 -- Recorded human verdicts over record families (issue #109). A pure overlay: no record
 -- row is ever mutated, and a family with no row here renders exactly as before. Keyed
 -- by (record_type, dedup_base) - the stable family identity of §3 - so a verdict
--- outlives occurrence renumbering and `record rm`. Like 007 it carries no FK to the row
--- it annotates, and `pemr verify` warns (never fails) on a verdict whose family is gone.
+-- outlives occurrence renumbering and `record rm`, but NOT a dictionary-driven `rekey`
+-- that renames the family itself: that moves `dedup_base` too, and orphans the verdict
+-- exactly like a removed row would. Like 007 it carries no FK to the row it annotates,
+-- and `pemr verify` warns (never fails) on a verdict whose family is gone either way.
 -- Written only by `record annotate`; read at render time by every generated document.
 CREATE TABLE curation (
   record_type      TEXT NOT NULL,   -- one of dedup.KNOWN_TYPES; validated in Python
@@ -695,7 +697,10 @@ Every section is filtered at read time against the `curation` overlay (§2, issu
 `confirmed` renders unchanged. Both new sections are omitted entirely when empty, so a record
 with no verdicts renders byte-identically to before the overlay existed. This does not weaken
 the purity rule: the filter is a read, and output changes after a verdict because the
-*database* changed.
+*database* changed. One consequence of the read-time join: if a dictionary-driven `rekey`
+(§3) has renamed a family since its verdict was recorded, the join misses and the family
+renders as if unannotated — `pemr verify` flags the orphaned verdict, but nothing re-attaches
+it automatically.
 
 Because they regenerate from truth, they never drift. Old exports are disposable.
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -107,6 +107,23 @@ CREATE TABLE document_tombstone (
   note        TEXT,                       -- free text: the only human-recognisable label
   document_id INTEGER                     -- the id it had; forensics only, not a FK
 );
+
+-- Recorded human verdicts over record families (issue #109). A pure overlay: no record
+-- row is ever mutated, and a family with no row here renders exactly as before. Keyed
+-- by (record_type, dedup_base) - the stable family identity of §3 - so a verdict
+-- outlives occurrence renumbering and `record rm`. Like 007 it carries no FK to the row
+-- it annotates, and `pemr verify` warns (never fails) on a verdict whose family is gone.
+-- Written only by `record annotate`; read at render time by every generated document.
+CREATE TABLE curation (
+  record_type      TEXT NOT NULL,   -- one of dedup.KNOWN_TYPES; validated in Python
+  dedup_base       TEXT NOT NULL,   -- family identity: NOT dedup_key, NOT a row id
+  status           TEXT NOT NULL,   -- confirmed|superseded|erroneous-in-source|disputed|merged-into
+  note             TEXT NOT NULL,   -- required: the why, and who said so
+  merged_into_base TEXT,            -- set iff status = 'merged-into'
+  attributed_to    TEXT,
+  created_at       TEXT NOT NULL,   -- ISO8601 UTC
+  PRIMARY KEY (record_type, dedup_base)
+);
 ```
 
 High-value typed tables (each carries `document_id` provenance + a `dedup_key`; migration
@@ -590,6 +607,13 @@ pemr document rm <id> [--apply] [--purge-blob] [--tombstone [--reason ...] [--no
                                                          # --tombstone: also refuse to re-ingest this content (§3)
 pemr record rm <table> <id> [--apply]                    # delete ONE record row; its document and every
                                                          # other record it produced survive; dry run by default
+pemr record annotate <table> <base-or-id> --status <s> --note <text> [--attributed-to ...]
+                     [--merged-into <base-or-id>] [--apply]
+                                                         # record a human verdict over a record FAMILY (§2 curation):
+                                                         # confirmed|superseded|erroneous-in-source|disputed|merged-into
+                                                         # pure overlay - no record row is mutated; dry run by default
+pemr record annotate --list [<table>] [--json]           # current verdicts, newest first (orphans flagged)
+pemr record annotate <table> <base-or-id> --clear [--apply]      # lift one verdict
 pemr document tombstone list [--json]                    # recorded intentional removals, newest first
 pemr document tombstone add (--file <path> | --sha256 <hex>) [--reason ...] [--note ...]
                                                          # pre-emptive exclusion; ingests and copies nothing
@@ -638,10 +662,14 @@ annotations expose the read/write split to the client.
 `commit_extraction`/`person_add`/`person_edit`/`ingest`/`document_set_text`; always `ingest` (with `ocr_text` populated) before
 extracting; dictionary additions go through human review, never agent-direct edits.
 
-`document rm` and `record rm` (issue #107) are deliberately **absent** from `WRITE_TOOLS` — this
-is a rule, not an oversight. Deletion of PHI stays a human-at-a-terminal action; no MCP tool, and
-therefore no agent, can remove a record or a document. Any future destructive verb should default
-to the same exclusion unless a human explicitly decides otherwise.
+`document rm`, `record rm` (issue #107) and `record annotate` (issue #109) are deliberately
+**absent** from `WRITE_TOOLS` — this is a rule, not an oversight. Deletion of PHI stays a
+human-at-a-terminal action; no MCP tool, and therefore no agent, can remove a record or a
+document. `record annotate` joins them for the adjacent reason: a `curation` verdict is a
+*human's clinical judgment*, recorded with attribution, and an agent that could write one could
+make a record disappear from every generated document without deleting a row. Any future
+destructive — or render-altering — verb should default to the same exclusion unless a human
+explicitly decides otherwise.
 
 ---
 
@@ -659,6 +687,15 @@ to the same exclusion unless a human explicitly decides otherwise.
   questions. This is your "walk-in readiness" as a repeatable command.
 - **journal** — chronological event stream (documents + appointments + procedures)
   rendered as a narrative timeline.
+
+Every section is filtered at read time against the `curation` overlay (§2, issue #109):
+`superseded` / `erroneous-in-source` / `merged-into` families leave their section for a
+`## Superseded / corrected` appendix, `disputed` families render in place with a
+`[DISPUTED: <note>]` marker and reach the brief's `## Questions for the Clinician`, and
+`confirmed` renders unchanged. Both new sections are omitted entirely when empty, so a record
+with no verdicts renders byte-identically to before the overlay existed. This does not weaken
+the purity rule: the filter is a read, and output changes after a verdict because the
+*database* changed.
 
 Because they regenerate from truth, they never drift. Old exports are disposable.
 

--- a/migrations/008_curation.sql
+++ b/migrations/008_curation.sql
@@ -14,8 +14,11 @@
 --
 -- Keyed by (record_type, dedup_base), NOT by row id and NOT by dedup_key. `dedup_base`
 -- is the stable per-family identity across occurrence renumbering (Architecture.md §3),
--- so a verdict survives `pemr rekey`, a re-ingest of the same document, and the
--- occurrence shifts `record rm` (#107) produces. A row-id or dedup_key join would not.
+-- so a verdict survives a re-ingest of the same document and the occurrence shifts
+-- `record rm` (#107) produces. A row-id or dedup_key join would not. `pemr rekey` only
+-- preserves it when the family's own key fields are untouched: a dictionary edit that
+-- changes this family's canonical name moves its dedup_base too, orphaning the verdict
+-- (`pemr verify` warns; re-annotate after rekeying).
 --
 -- No FK to the row it annotates (the 007 document_tombstone precedent): the verdict has
 -- to outlive key churn and removals, including the removal of the family itself - an

--- a/migrations/008_curation.sql
+++ b/migrations/008_curation.sql
@@ -1,0 +1,44 @@
+-- 008_curation: overlay table for recorded human verdicts on record families (issue #109).
+--
+-- Some record states cannot be settled by deterministic tooling over documents: two
+-- sources that contradict each other, a row that is real in the source but known to be
+-- wrong, a diagnosis superseded by later clinical understanding, a restated fact the
+-- dedup keyer must never collapse. The engine's only durable outcomes today are
+-- keep/drop/keep-both, so a resolved human judgment has nowhere to live and the same
+-- question reopens on every re-render or re-extraction.
+--
+-- This is a pure **overlay**: no record row is ever mutated, single-provenance is
+-- untouched, and a family with no row here renders exactly as it does today. The
+-- renderer resolves verdicts at read time, so re-rendering after a verdict changes the
+-- output because the *database* changed - `render` stays a pure function of DB state.
+--
+-- Keyed by (record_type, dedup_base), NOT by row id and NOT by dedup_key. `dedup_base`
+-- is the stable per-family identity across occurrence renumbering (Architecture.md §3),
+-- so a verdict survives `pemr rekey`, a re-ingest of the same document, and the
+-- occurrence shifts `record rm` (#107) produces. A row-id or dedup_key join would not.
+--
+-- No FK to the row it annotates (the 007 document_tombstone precedent): the verdict has
+-- to outlive key churn and removals, including the removal of the family itself - an
+-- orphaned verdict is reported by `pemr verify` as a warning, not erased by the schema.
+-- No index beyond the PK: access is a PK lookup, a per-type scan, or a full list.
+--
+-- Unlike 007, this table carries CHECKs. 007 chose Python validation for better
+-- messages, and Python still raises first for every operator-facing case here. The
+-- CHECKs guard a different threat: this is the only table whose contents silently change
+-- what a clinical document renders, so a hand-edited or corrupted status/coupling would
+-- *misrender* records rather than error.
+
+CREATE TABLE curation (
+  record_type      TEXT NOT NULL,   -- one of dedup.KNOWN_TYPES; validated in Python
+  dedup_base       TEXT NOT NULL,   -- family identity: NOT dedup_key, NOT a row id
+  status           TEXT NOT NULL,
+  note             TEXT NOT NULL,   -- required: the why, and who said so
+  merged_into_base TEXT,            -- set iff status = 'merged-into'
+  attributed_to    TEXT,
+  created_at       TEXT NOT NULL,   -- ISO8601 UTC, timespec=seconds (as document.ingested_at)
+  PRIMARY KEY (record_type, dedup_base),
+  CHECK (status IN ('confirmed', 'superseded', 'erroneous-in-source', 'disputed',
+                    'merged-into')),
+  CHECK (trim(note) <> ''),
+  CHECK ((merged_into_base IS NOT NULL) = (status = 'merged-into'))
+);

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -18,8 +18,8 @@ from dataclasses import asdict
 from pathlib import Path
 
 from . import (
-    __version__, backup, db, dedup, documents, ingest, persons, query, records,
-    render, restore, study, tombstones, verify,
+    __version__, backup, curation, db, dedup, documents, ingest, persons, query,
+    records, render, restore, study, tombstones, verify,
 )
 
 # Shipped starter analyte/name dictionary (framework, not user data — see .gitignore).
@@ -411,6 +411,8 @@ def _with_document_conn(args: argparse.Namespace, work):
             documents.OcrTextPresentError,
             records.RecordNotFoundError,
             records.AnchoredConflictError,
+            curation.CurationNotFoundError,
+            curation.FamilyNotFoundError,
             persons.PersonNotFoundError,
         ) as exc:
             print(f"error: {exc}", file=sys.stderr)
@@ -887,6 +889,121 @@ def _cmd_record_rm(args: argparse.Namespace) -> int:
                 "dry run: nothing was deleted - re-run with --apply "
                 "(back up first: `pemr backup`)"
             )
+        return 0
+
+    return _with_document_conn(args, work)
+
+
+# --------------------------------------------------------------------------- #
+# recorded human verdicts (`record annotate`) - issue #109
+# --------------------------------------------------------------------------- #
+
+def _curation_row_line(row: dict) -> str:
+    """One `--list` line: identity, verdict, and whether the family still exists."""
+    orphan = "  (orphaned: no live family)" if not row["family_size"] else ""
+    return (
+        f"{row['record_type']:12}  {str(row['dedup_base'])[:12]}  "
+        f"{(row['created_at'] or '')[:10]:10}  {row['label']}  "
+        f"[{curation.describe(row)}]{orphan}"
+    )
+
+
+def _print_curation_report(report: "curation.CurationReport") -> None:
+    """The human block shared by annotate and clear, shaped like `_cmd_record_rm`'s."""
+    family = (
+        f"{report.family_size} row(s)" if report.family_size
+        else "no live rows (orphaned verdict)"
+    )
+    print(
+        f"{report.record_type}  {report.label or '(no live family)'}  "
+        f"base {report.dedup_base[:12]}  ({family})"
+    )
+    print(f"  status: {report.status}")
+    print(f"  note: {report.note}")
+    if report.attributed_to:
+        print(f"  attributed to: {report.attributed_to}")
+    if report.merged_into_base:
+        print(f"  merged into: {report.merged_into_base[:12]}")
+    if report.previous is not None and report.action != "clear":
+        print(f"  replaces: {curation.describe(report.previous)}")
+
+
+def _cmd_record_annotate(args: argparse.Namespace) -> int:
+    """`record annotate` — list, clear, or record one family's verdict.
+
+    Three modes on one subparser rather than three verbs: the positionals differ only
+    in whether they are present, and `--list`/`--clear` read as flags on the noun the
+    operator already has in hand. The handler owns the "table and target are required
+    unless --list" rule, because argparse cannot express it across `nargs='?'`.
+    """
+    parser = args.annotate_parser
+    if args.list:
+        if args.target is not None:
+            parser.error("--list takes an optional table, not a target")
+
+        def work(conn):
+            rows = curation.list_curation(conn, args.table)
+            if args.json:
+                _print_json(rows)
+                return 0
+            if not rows:
+                print("no curation verdicts recorded")
+                return 0
+            print(f"{'type':12}  {'base':12}  {'recorded':10}  label  [verdict]")
+            for row in rows:
+                print(_curation_row_line(row))
+            return 0
+
+        return _with_document_conn(args, work)
+
+    if args.table is None or args.target is None:
+        parser.error("table and target are required unless --list is given")
+
+    if args.clear:
+        def work(conn):
+            report = curation.clear_curation(
+                conn, args.table, args.target, apply=args.apply
+            )
+            if args.json:
+                _print_json(report.as_dict())
+                return 0
+            _print_curation_report(report)
+            if report.applied:
+                print(
+                    f"cleared curation verdict for {report.record_type} "
+                    f"{report.dedup_base[:12]}"
+                )
+            else:
+                print("dry run: nothing was written - re-run with --apply")
+            return 0
+
+        return _with_document_conn(args, work)
+
+    if args.status is None or args.note is None:
+        parser.error("--status and --note are required to record a verdict")
+
+    def work(conn):
+        report = curation.annotate_record(
+            conn,
+            args.table,
+            args.target,
+            status=args.status,
+            note=args.note,
+            attributed_to=args.attributed_to,
+            merged_into_base=args.merged_into,
+            apply=args.apply,
+        )
+        if args.json:
+            _print_json(report.as_dict())
+            return 0
+        _print_curation_report(report)
+        if report.applied:
+            print(
+                f"annotated {report.record_type} {report.dedup_base[:12]} "
+                f"({report.action})"
+            )
+        else:
+            print("dry run: nothing was written - re-run with --apply")
         return 0
 
     return _with_document_conn(args, work)
@@ -1890,6 +2007,41 @@ def build_parser() -> argparse.ArgumentParser:
     )
     r_rm.add_argument("--json", action="store_true", help="machine-readable output")
     r_rm.set_defaults(func=_cmd_record_rm)
+
+    # --- recorded human verdicts (curation overlay, issue #109) ---
+    r_annotate = record_sub.add_parser(
+        "annotate",
+        help="record a human verdict over a record family (dry run by default); "
+             "source rows are never mutated",
+    )
+    # Both optional so `--list` can take an optional table and no target; the handler
+    # enforces "table and target unless --list" with the usage line.
+    r_annotate.add_argument(
+        "table", nargs="?", choices=list(dedup.KNOWN_TYPES)
+    )
+    r_annotate.add_argument("target", nargs="?", metavar="BASE-OR-ID")
+    r_annotate.add_argument(
+        "--status", choices=list(curation.STATUSES), help="the verdict"
+    )
+    r_annotate.add_argument(
+        "--note", help="required: why the verdict was made, and who said so"
+    )
+    r_annotate.add_argument("--attributed-to", help="who made the call")
+    r_annotate.add_argument(
+        "--merged-into", metavar="BASE-OR-ID",
+        help="target family, required with --status merged-into",
+    )
+    r_annotate.add_argument(
+        "--list", action="store_true", help="list current verdicts and exit"
+    )
+    r_annotate.add_argument(
+        "--clear", action="store_true", help="lift the verdict on this family"
+    )
+    r_annotate.add_argument(
+        "--apply", action="store_true", help="write the verdict (default: report only)"
+    )
+    r_annotate.add_argument("--json", action="store_true", help="machine-readable output")
+    r_annotate.set_defaults(func=_cmd_record_annotate, annotate_parser=r_annotate)
 
     p_ingest = sub.add_parser(
         "ingest", help="ingest a document (hash, blob store, layer-1 dedup)"

--- a/pemr/curation.py
+++ b/pemr/curation.py
@@ -21,10 +21,13 @@ verdict changes output because the database changed, which is the point.
 
 **Keyed by ``(record_type, dedup_base)``**, not by row id and not by ``dedup_key``.
 ``dedup_base`` is the stable per-family identity across occurrence renumbering
-(Architecture.md §3), so a verdict survives `pemr rekey`, a re-ingest of the same
-document, and the occurrence shifts `record rm` (#107) leaves behind. One live verdict
-per family: re-annotating overwrites (last verdict wins), which is what "a human ruled"
-means — there is no verdict history here by design.
+(Architecture.md §3), so a verdict survives a re-ingest of the same document and the
+occurrence shifts `record rm` (#107) leaves behind. It does *not* survive every
+`pemr rekey`: a dictionary edit that changes this family's own canonical name moves its
+``dedup_base``, orphaning the verdict (`pemr verify` warns; `record annotate --clear`
+then re-annotate). One live verdict per family: re-annotating overwrites (last verdict
+wins), which is what "a human ruled" means — there is no verdict history here by
+design.
 
 The module imports :mod:`db` and :mod:`dedup` only, keeping the import graph acyclic;
 `render` and `verify` import *it*.

--- a/pemr/curation.py
+++ b/pemr/curation.py
@@ -1,0 +1,443 @@
+"""Recorded human verdicts on record families — `pemr record annotate` (issue #109).
+
+Some record states are not resolvable by deterministic tooling over documents. Two
+source documents contradict each other and the extraction is faithful to both. A row is
+real in the source but known-erroneous (a requisition coding artifact). A diagnosis
+*evolved*, so collapsing the two statements would erase real history. The engine's
+durable outcomes are keep / drop / keep-both, and none of them says "a clinician looked
+at this and ruled" — so the question reopens on every re-render and re-extraction.
+
+This module is that missing durable state: one small overlay table, and the verbs that
+write it.
+
+    annotate_record  -- record (or overwrite) one family's verdict, dry-run by default
+    list_curation    -- every verdict, newest first
+    clear_curation   -- lift one verdict, dry-run by default
+    load_verdicts    -- the whole table as a lookup, for the render/verify hot path
+
+**Pure overlay.** No record row is ever written. `render` stays a pure function of DB
+state: it just reads two tables per section instead of one, and re-rendering after a
+verdict changes output because the database changed, which is the point.
+
+**Keyed by ``(record_type, dedup_base)``**, not by row id and not by ``dedup_key``.
+``dedup_base`` is the stable per-family identity across occurrence renumbering
+(Architecture.md §3), so a verdict survives `pemr rekey`, a re-ingest of the same
+document, and the occurrence shifts `record rm` (#107) leaves behind. One live verdict
+per family: re-annotating overwrites (last verdict wins), which is what "a human ruled"
+means — there is no verdict history here by design.
+
+The module imports :mod:`db` and :mod:`dedup` only, keeping the import graph acyclic;
+`render` and `verify` import *it*.
+
+`record annotate` is **CLI-only** and deliberately absent from
+``mcp_server.WRITE_TOOLS``, matching `document rm` / `record rm`: a human's clinical
+verdict is exactly the thing the blessed-write-set boundary exists to keep an agent out
+of.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from . import db, dedup
+
+#: Every legal ``curation.status``. Also the CLI's ``choices`` — one source of truth.
+STATUSES: tuple[str, ...] = (
+    "confirmed",
+    "superseded",
+    "erroneous-in-source",
+    "disputed",
+    "merged-into",
+)
+
+#: The statuses that move a family **out** of its normal rendered section and into the
+#: "Superseded / corrected" appendix. ``confirmed`` renders exactly as today (it records
+#: agreement, it does not change the document); ``disputed`` renders in place, marked —
+#: a disputed fact that vanished from the summary would be worse than an unmarked one.
+APPENDIX_STATUSES: tuple[str, ...] = (
+    "superseded",
+    "erroneous-in-source",
+    "merged-into",
+)
+
+#: The key a rendered row carries its verdict under, when it has one.
+CURATION_FIELD = "_curation"
+
+
+class CurationNotFoundError(ValueError):
+    """Raised when a family carries no verdict (friendly rc=1 at the CLI)."""
+
+
+class FamilyNotFoundError(ValueError):
+    """Raised when a base-or-id token does not resolve to a live family."""
+
+
+@dataclass
+class CurationReport:
+    """Structured result of :func:`annotate_record` / :func:`clear_curation`.
+
+    Also the ``--json`` payload shape, so the key names here are a contract.
+    """
+
+    record_type: str
+    dedup_base: str
+    status: str = ""
+    note: str = ""
+    attributed_to: str | None = None
+    created_at: str = ""
+    merged_into_base: str | None = None
+    label: str = ""                    # which fact is being ruled on (occurrence 0)
+    family_size: int = 0
+    previous: dict | None = None       # the verdict this one replaces, if any
+    action: str = "create"             # "create" | "overwrite" | "clear"
+    applied: bool = False
+
+    def as_dict(self) -> dict:
+        return {
+            "record_type": self.record_type,
+            "dedup_base": self.dedup_base,
+            "status": self.status,
+            "note": self.note,
+            "attributed_to": self.attributed_to,
+            "created_at": self.created_at,
+            "merged_into_base": self.merged_into_base,
+            "label": self.label,
+            "family_size": self.family_size,
+            "previous": self.previous,
+            "action": self.action,
+            "applied": self.applied,
+        }
+
+
+def _now(now: str | None = None) -> str:
+    """ISO8601 UTC to the second — the stamp `document.ingested_at` carries."""
+    return now or datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _require_type(record_type: str) -> None:
+    """Guard every f-string table interpolation below (the `records.remove_record`
+    idiom): a record type reaches SQL only after matching a known key."""
+    if record_type not in dedup.FIELD_SPECS:
+        raise ValueError(
+            f"unknown record type '{record_type}' - known types: "
+            f"{', '.join(dedup.KNOWN_TYPES)}"
+        )
+
+
+def _row_view(row: sqlite3.Row) -> dict:
+    return {
+        "record_type": row["record_type"],
+        "dedup_base": row["dedup_base"],
+        "status": row["status"],
+        "note": row["note"],
+        "merged_into_base": row["merged_into_base"],
+        "attributed_to": row["attributed_to"],
+        "created_at": row["created_at"],
+    }
+
+
+def has_table(conn: sqlite3.Connection) -> bool:
+    """Whether `curation` exists — false for a database predating migration 008.
+
+    The :func:`tombstones.has_table` guard: `render` and `verify` must keep working
+    against an older snapshot rather than raising ``no such table``.
+    """
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='curation'"
+    ).fetchone()
+    return row is not None
+
+
+def get_verdict(
+    conn: sqlite3.Connection, record_type: str, base: str
+) -> dict | None:
+    """The live verdict for one family, or None."""
+    if not has_table(conn):
+        return None
+    row = conn.execute(
+        "SELECT * FROM curation WHERE record_type = ? AND dedup_base = ?",
+        (record_type, base),
+    ).fetchone()
+    return _row_view(row) if row is not None else None
+
+
+def load_verdicts(conn: sqlite3.Connection) -> dict[tuple[str, str], dict]:
+    """Every verdict as ``{(record_type, dedup_base): verdict}`` — one query.
+
+    The render/verify hot path: a document render touches every section, and a
+    per-family lookup would be one SELECT per row. Returns ``{}`` when the table is
+    absent (pre-008 snapshot), so callers need no second guard.
+    """
+    if not has_table(conn):
+        return {}
+    rows = conn.execute("SELECT * FROM curation").fetchall()
+    return {(r["record_type"], r["dedup_base"]): _row_view(r) for r in rows}
+
+
+def family_label(conn: sqlite3.Connection, record_type: str, base: str) -> tuple[str, int]:
+    """``(label, family_size)`` for one family — the label off occurrence 0.
+
+    The operator has to see *which fact* they are ruling on; a 64-character hex base
+    is not that. An empty family reports ``("", 0)`` rather than raising: `list` and
+    `verify` both need to describe an orphaned verdict.
+
+    Re-validates ``record_type`` at the boundary even though every caller already has:
+    the value can come off a *stored* `curation` row, and :func:`dedup.load_family`
+    interpolates it into a table name.
+    """
+    _require_type(record_type)
+    family = dedup.load_family(conn, record_type, base)
+    if not family:
+        return "", 0
+    return dedup._rekey_label(record_type, family[0]), len(family)
+
+
+def resolve_base(conn: sqlite3.Connection, record_type: str, token: str) -> str:
+    """Resolve a ``<base-or-id>`` token to a ``dedup_base`` in ``record_type``.
+
+    An all-digits token is a row id in ``<table>`` and resolves to that row's
+    ``dedup_base``; anything else is treated as a ``dedup_base`` literal and is
+    confirmed to name a live family. The disambiguation is safe rather than
+    heuristic: a ``dedup_base`` is a sha256 hex digest (:func:`dedup._hash_parts`),
+    so it always carries at least one non-digit character.
+
+    Accepting the row id matters more than it looks — every other verb in the repo
+    names rows by id (`pemr rekey`'s collision report, `pemr query`, `record rm`), and
+    forcing the operator to look up a base by hand between reading the collision and
+    ruling on it is where a wrong base gets pasted.
+
+    Raises :class:`FamilyNotFoundError` when the token resolves to nothing.
+    """
+    _require_type(record_type)
+    token = (token or "").strip()
+    if not token:
+        raise FamilyNotFoundError(
+            f"no {record_type} target given - pass a dedup_base or a row id"
+        )
+    if token.isdigit():
+        pk = f"{record_type}_id"
+        row = conn.execute(
+            f"SELECT dedup_base FROM {record_type} WHERE {pk} = ?", (int(token),)
+        ).fetchone()
+        if row is None:
+            raise FamilyNotFoundError(
+                f"no {record_type} with id {token} - row ids come from `pemr rekey`'s "
+                "collision report, or `pemr query`"
+            )
+        return row["dedup_base"]
+    if not dedup.load_family(conn, record_type, token):
+        raise FamilyNotFoundError(
+            f"no live {record_type} family with dedup_base {token[:12]}... - pass a "
+            "row id instead, or see `pemr record annotate --list`"
+        )
+    return token
+
+
+def annotate_record(
+    conn: sqlite3.Connection,
+    record_type: str,
+    token: str,
+    *,
+    status: str,
+    note: str,
+    attributed_to: str | None = None,
+    merged_into_base: str | None = None,
+    now: str | None = None,
+    apply: bool = False,
+) -> CurationReport:
+    """Record one family's verdict; dry-run by default (``apply=True`` writes).
+
+    Validation is deliberately front-loaded, because the write is an upsert that
+    silently replaces the previous verdict: an unknown status or a dangling
+    ``merged_into_base`` must fail *before* a good verdict is overwritten by a bad one.
+    Nothing is written on any raise.
+
+    ``note`` is required and must be non-empty after ``strip()`` — the point of the
+    table is the why and who said so, and a verdict with no reason is a verdict nobody
+    can audit later.
+
+    ``merged_into_base`` is set iff ``status='merged-into'``, must name a live family
+    of the same ``record_type``, and must not be the annotated family itself (a family
+    merged into itself would render nowhere at all).
+
+    Raises ``ValueError`` for an unknown ``record_type``/``status``/empty note or a bad
+    merge target, and :class:`FamilyNotFoundError` when the target does not resolve.
+    """
+    db.require_migrated(conn)
+    _require_type(record_type)
+    if status not in STATUSES:
+        raise ValueError(
+            f"unknown curation status '{status}' - known statuses: "
+            f"{', '.join(STATUSES)}"
+        )
+    cleaned_note = (note or "").strip()
+    if not cleaned_note:
+        raise ValueError(
+            "a curation note is required - it records why the verdict was made and "
+            "who made it; nothing was written"
+        )
+    base = resolve_base(conn, record_type, token)
+
+    merge_target = (merged_into_base or "").strip() or None
+    if status == "merged-into":
+        if merge_target is None:
+            raise ValueError(
+                "status 'merged-into' needs the family it merges into - pass "
+                "--merged-into <BASE-OR-ID>; nothing was written"
+            )
+        merge_target = resolve_base(conn, record_type, merge_target)
+        if merge_target == base:
+            raise ValueError(
+                f"cannot merge {record_type} {base[:12]}... into itself - the merged "
+                "family renders only under its target, so this would hide it "
+                "entirely; nothing was written"
+            )
+    elif merge_target is not None:
+        raise ValueError(
+            f"--merged-into is only meaningful with status 'merged-into', not "
+            f"'{status}'; nothing was written"
+        )
+
+    previous = get_verdict(conn, record_type, base)
+    label, family_size = family_label(conn, record_type, base)
+    stamp = _now(now)
+    report = CurationReport(
+        record_type=record_type,
+        dedup_base=base,
+        status=status,
+        note=cleaned_note,
+        attributed_to=(attributed_to or "").strip() or None,
+        created_at=stamp,
+        merged_into_base=merge_target,
+        label=label,
+        family_size=family_size,
+        previous=previous,
+        action="overwrite" if previous is not None else "create",
+    )
+
+    if apply:
+        # UPSERT, the `tombstones.add_tombstone` idiom: one live verdict per family,
+        # last verdict wins, and a re-run of the same command is a safe no-op-shaped
+        # write. created_at is refreshed - it stamps *this* verdict, not the first one.
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO curation
+                  (record_type, dedup_base, status, note, merged_into_base,
+                   attributed_to, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(record_type, dedup_base) DO UPDATE SET
+                  status           = excluded.status,
+                  note             = excluded.note,
+                  merged_into_base = excluded.merged_into_base,
+                  attributed_to    = excluded.attributed_to,
+                  created_at       = excluded.created_at
+                """,
+                (record_type, base, status, cleaned_note, merge_target,
+                 report.attributed_to, stamp),
+            )
+    report.applied = apply
+    return report
+
+
+def list_curation(
+    conn: sqlite3.Connection, record_type: str | None = None
+) -> list[dict]:
+    """Every verdict (optionally one record type), newest first.
+
+    Each entry carries ``label`` and ``family_size``. ``family_size == 0`` is an
+    **orphan**: the family it rules on is gone (a `record rm` of every occurrence, or a
+    restore from a snapshot that never had it). Surfaced rather than hidden, the
+    ``tombstones.list_tombstones`` ``live_document_id`` precedent — `pemr verify` warns
+    about the same state.
+    """
+    db.require_migrated(conn)
+    if record_type is not None:
+        _require_type(record_type)
+    if not has_table(conn):
+        return []
+    sql = "SELECT * FROM curation"
+    params: tuple = ()
+    if record_type is not None:
+        sql += " WHERE record_type = ?"
+        params = (record_type,)
+    sql += " ORDER BY created_at DESC, record_type, dedup_base"
+    out: list[dict] = []
+    for row in conn.execute(sql, params).fetchall():
+        view = _row_view(row)
+        if view["record_type"] in dedup.FIELD_SPECS:
+            label, size = family_label(conn, view["record_type"], view["dedup_base"])
+        else:
+            # A hand-edited row can name anything; never build a query from it.
+            label, size = "", 0
+        view["label"] = label
+        view["family_size"] = size
+        out.append(view)
+    return out
+
+
+def clear_curation(
+    conn: sqlite3.Connection,
+    record_type: str,
+    token: str,
+    *,
+    apply: bool = False,
+) -> CurationReport:
+    """Lift one family's verdict; dry-run by default.
+
+    The target is resolved leniently on purpose: a row id still needs a live row, but a
+    ``dedup_base`` literal is accepted even when the family is gone, because clearing an
+    **orphaned** verdict (the one `pemr verify` warns about) is exactly a case where no
+    live row exists to name it by.
+
+    Raises :class:`CurationNotFoundError` when there is no verdict to lift — a typo
+    must not read as success.
+    """
+    db.require_migrated(conn)
+    _require_type(record_type)
+    token = (token or "").strip()
+    if token.isdigit():
+        base = resolve_base(conn, record_type, token)
+    else:
+        base = token
+    existing = get_verdict(conn, record_type, base)
+    if existing is None:
+        raise CurationNotFoundError(
+            f"no curation verdict for {record_type} {base[:12]}... - see "
+            "`pemr record annotate --list`"
+        )
+    label, family_size = family_label(conn, record_type, base)
+    report = CurationReport(
+        record_type=record_type,
+        dedup_base=base,
+        status=existing["status"],
+        note=existing["note"],
+        attributed_to=existing["attributed_to"],
+        created_at=existing["created_at"],
+        merged_into_base=existing["merged_into_base"],
+        label=label,
+        family_size=family_size,
+        previous=existing,
+        action="clear",
+    )
+    if apply:
+        with conn:
+            conn.execute(
+                "DELETE FROM curation WHERE record_type = ? AND dedup_base = ?",
+                (record_type, base),
+            )
+    report.applied = apply
+    return report
+
+
+def describe(verdict: dict) -> str:
+    """One-line ``<status> - <note>`` summary shared by the CLI and render printers."""
+    status = verdict.get("status") or ""
+    if status == "merged-into" and verdict.get("merged_into_base"):
+        status = f"merged into {str(verdict['merged_into_base'])[:12]}..."
+    note = verdict.get("note") or ""
+    who = verdict.get("attributed_to")
+    attribution = f" ({who})" if who else ""
+    return f"{status} - {note}{attribution}"

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -178,7 +178,11 @@ def query_meds(
 
 
 def query_timeline(
-    conn: sqlite3.Connection, slug: str, since: str | None = None
+    conn: sqlite3.Connection,
+    slug: str,
+    since: str | None = None,
+    *,
+    with_identity: bool = False,
 ) -> list[dict]:
     """Merged chronological event stream across the typed tables + observations.
 
@@ -188,17 +192,38 @@ def query_timeline(
     ``condition-resolved``); family-history rows contribute none.
     Events without a usable date are omitted (they cannot be placed on a timeline).
     ``since`` (a date) drops events strictly before it. Ordered oldest first.
+
+    ``with_identity=True`` additionally stamps ``record_type`` and ``dedup_base`` on
+    every event — the family identity `render_journal` needs to apply the `curation`
+    overlay (issue #109), which the event contract otherwise has no way to express.
+    Opt-in and **default-off** on purpose: ``dedup_base`` is one of
+    :data:`dedup.INTERNAL_COLUMNS`, deliberately stripped from the CLI ``--json`` and
+    MCP read payloads, so widening the default event shape would leak an unstable key
+    into both contracts.
     """
     person_id = resolve_person_id(conn, slug)
     events: list[dict] = []
 
-    def add(when: object, etype: str, summary: str, document_id: object) -> None:
+    def add(
+        when: object,
+        etype: str,
+        summary: str,
+        row: sqlite3.Row,
+        record_type: str,
+    ) -> None:
         d = _date_part(when)
         if not d:
             return
-        events.append(
-            {"date": d, "type": etype, "summary": summary, "document_id": document_id}
-        )
+        event = {
+            "date": d,
+            "type": etype,
+            "summary": summary,
+            "document_id": row["document_id"],
+        }
+        if with_identity:
+            event["record_type"] = record_type
+            event["dedup_base"] = row["dedup_base"]
+        events.append(event)
 
     for r in conn.execute(
         "SELECT * FROM lab_result WHERE person_id = ?", (person_id,)
@@ -207,20 +232,21 @@ def query_timeline(
         unit = f" {r['unit']}" if r["unit"] else ""
         flag = f" [{r['flag']}]" if r["flag"] else ""
         val = "" if value is None else f" {value}{unit}"
-        add(r["collected_at"], "lab", f"{r['test_name']}{val}{flag}".strip(), r["document_id"])
+        add(r["collected_at"], "lab", f"{r['test_name']}{val}{flag}".strip(), r,
+            "lab_result")
 
     for r in conn.execute(
         "SELECT * FROM medication WHERE person_id = ?", (person_id,)
     ).fetchall():
         dose = f" {r['dose']}" if r["dose"] else ""
-        add(r["started_on"], "med-start", f"started {r['name']}{dose}", r["document_id"])
-        add(r["ended_on"], "med-stop", f"stopped {r['name']}", r["document_id"])
+        add(r["started_on"], "med-start", f"started {r['name']}{dose}", r, "medication")
+        add(r["ended_on"], "med-stop", f"stopped {r['name']}", r, "medication")
 
     for r in conn.execute(
         "SELECT * FROM procedure WHERE person_id = ?", (person_id,)
     ).fetchall():
         outcome = f" - {r['outcome']}" if r["outcome"] else ""
-        add(r["performed_on"], "procedure", f"{r['name']}{outcome}", r["document_id"])
+        add(r["performed_on"], "procedure", f"{r['name']}{outcome}", r, "procedure")
 
     for r in conn.execute(
         "SELECT * FROM appointment WHERE person_id = ?", (person_id,)
@@ -228,7 +254,7 @@ def query_timeline(
         who = " ".join(p for p in (r["provider"], r["specialty"]) if p)
         why = r["reason"] or r["summary"] or ""
         summary = " - ".join(p for p in (who, why) if p) or "appointment"
-        add(r["scheduled_for"], "appointment", summary, r["document_id"])
+        add(r["scheduled_for"], "appointment", summary, r, "appointment")
 
     for r in conn.execute(
         "SELECT * FROM observation WHERE person_id = ?", (person_id,)
@@ -240,7 +266,7 @@ def query_timeline(
             parts.append(str(r["key"]))
         detail = " ".join(parts)
         val = "" if value is None else f" = {value}{unit}"
-        add(r["observed_at"], "observation", f"{detail}{val}".strip(), r["document_id"])
+        add(r["observed_at"], "observation", f"{detail}{val}".strip(), r, "observation")
 
     for r in conn.execute(
         "SELECT * FROM condition WHERE person_id = ?", (person_id,)
@@ -249,14 +275,14 @@ def query_timeline(
         # family history is deliberately absent from the timeline (issue #63).
         if enum_token(r["status"]) == "family-history":
             continue
-        add(r["onset_on"], "condition", f"{r['name']} ({r['status']})", r["document_id"])
-        add(r["resolved_on"], "condition-resolved", f"resolved {r['name']}",
-            r["document_id"])
+        add(r["onset_on"], "condition", f"{r['name']} ({r['status']})", r, "condition")
+        add(r["resolved_on"], "condition-resolved", f"resolved {r['name']}", r,
+            "condition")
 
     for r in conn.execute(
         "SELECT * FROM allergy WHERE person_id = ?", (person_id,)
     ).fetchall():
-        add(r["noted_on"], "allergy", f"{r['substance']} allergy", r["document_id"])
+        add(r["noted_on"], "allergy", f"{r['substance']} allergy", r, "allergy")
 
     if since:
         cutoff = _date_part(since)

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -28,6 +28,17 @@ canonical *vital* vocabulary in ``data/dictionary.example.toml``):
     collapse disclosed on the line (issue #93) -- the stored rows keep their dates
     and stay distinct, because an order is an event, not a standing fact.
 
+**Curation overlay** (issue #109). Every section is filtered at read time against the
+``curation`` table, a pure overlay of recorded human verdicts keyed by
+``(record_type, dedup_base)``: ``superseded`` / ``erroneous-in-source`` /
+``merged-into`` families leave their section for a ``## Superseded / corrected``
+appendix, ``disputed`` families render in place with a ``[DISPUTED: ...]`` marker (and
+reach the brief's ``## Questions for the Clinician``), and ``confirmed`` renders exactly
+as before. Both new sections are **omitted entirely** when empty, so a record with no
+verdicts renders byte-identically to what it did before the overlay existed. This is
+still a pure function of DB state -- the filter is a read, and output changes after a
+verdict because the database changed.
+
 Output is **ASCII-only** (the cp1252/cp437 Windows-console lesson from phases 2-3):
 plain hyphens, never em-dashes -- a non-ASCII byte crashes a non-UTF-8 console.
 
@@ -43,7 +54,7 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime
 
-from . import db, query
+from . import curation, db, query
 from .dedup import enum_token, key_token
 
 # Observation obs_type conventions this layer reads (see module docstring).
@@ -119,11 +130,171 @@ def _ref_range(row: sqlite3.Row | dict) -> str:
 
 
 # --------------------------------------------------------------------------- #
+# Curation overlay (issue #109) -- a read-time filter, never a write
+# --------------------------------------------------------------------------- #
+
+class _CurationPass:
+    """One render's view of the `curation` overlay: the verdict map plus the two
+    out-of-band collections a render builds while filtering its sections.
+
+    One object rather than threading ``verdicts``/``appendix``/``disputed`` through
+    every read helper: a render touches ten sections and the three always travel
+    together. It is created once per render and is read-only with respect to the DB --
+    ``render`` never writes, and the overlay does not change that.
+
+    ``verdicts`` empty (the overwhelmingly common case, and every pre-008 snapshot) is
+    the fast path: :func:`_apply_curation` returns its rows untouched, no row is given a
+    ``_curation`` key, and both new sections are omitted -- which is what keeps output
+    byte-identical for unannotated data.
+    """
+
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+        self.verdicts = curation.load_verdicts(conn)
+        # Keyed by (record_type, dedup_base) so a multi-occurrence family is listed
+        # once however many of its rows a section selected. Insertion-ordered.
+        self.appendix: dict[tuple[str, str], dict] = {}
+        self.disputed: dict[tuple[str, str], dict] = {}
+
+    def _entry(self, record_type: str, base: str, verdict: dict) -> dict:
+        label, family_size = curation.family_label(self.conn, record_type, base)
+        return dict(verdict, label=label, family_size=family_size)
+
+    def record(self, record_type: str, base: str, verdict: dict) -> None:
+        """File a family under the section its status sends it to, once.
+
+        ``confirmed`` is filed nowhere on purpose: it records agreement, so it neither
+        leaves its section nor raises a question.
+        """
+        if verdict["status"] in curation.APPENDIX_STATUSES:
+            bucket = self.appendix
+        elif verdict["status"] == "disputed":
+            bucket = self.disputed
+        else:
+            return
+        key = (record_type, base)
+        if key not in bucket:
+            bucket[key] = self._entry(record_type, base, verdict)
+
+
+def _apply_curation(
+    rows: list[dict], record_type: str, cur: "_CurationPass | None"
+) -> list[dict]:
+    """Filter one section's rows through the overlay, before any grouping.
+
+    Returns the rows that still render, stamping each annotated survivor with its
+    verdict under ``_curation``; families in :data:`curation.APPENDIX_STATUSES` are
+    dropped from the section and collected for the appendix instead.
+
+    Called immediately after each section's ``SELECT`` and **before** any latest-wins,
+    grouping or top-N logic, so a superseded reading can neither win "latest" nor
+    consume a slot in a truncated list.
+    """
+    if cur is None or not cur.verdicts:
+        return rows
+    out: list[dict] = []
+    for row in rows:
+        base = row["dedup_base"]
+        verdict = cur.verdicts.get((record_type, base))
+        if verdict is None:
+            out.append(row)
+            continue
+        cur.record(record_type, base, verdict)
+        if verdict["status"] in curation.APPENDIX_STATUSES:
+            continue
+        row[curation.CURATION_FIELD] = verdict
+        out.append(row)
+    return out
+
+
+def _apply_curation_events(
+    events: list[dict], cur: "_CurationPass | None"
+) -> list[dict]:
+    """:func:`_apply_curation` for timeline events.
+
+    Same rule, different carrier: an event is a rendered sentence rather than a row, and
+    it only carries ``record_type``/``dedup_base`` when
+    :func:`query.query_timeline` was asked for them (``with_identity``). An event
+    without identity is passed through -- that is the no-verdicts fast path, where the
+    journal never asks for the extra keys in the first place.
+    """
+    if cur is None or not cur.verdicts:
+        return events
+    out: list[dict] = []
+    for event in events:
+        base = event.get("dedup_base")
+        if base is None:
+            out.append(event)
+            continue
+        record_type = event["record_type"]
+        verdict = cur.verdicts.get((record_type, base))
+        if verdict is None:
+            out.append(event)
+            continue
+        cur.record(record_type, base, verdict)
+        if verdict["status"] in curation.APPENDIX_STATUSES:
+            continue
+        event[curation.CURATION_FIELD] = verdict
+        out.append(event)
+    return out
+
+
+def _dispute_suffix(row: dict) -> str:
+    """``  [DISPUTED: <note>]`` for a disputed row, ``""`` otherwise.
+
+    A disputed fact stays in place -- silently moving it to an appendix would hide a
+    value a clinician is still acting on -- so every line builder marks it instead.
+    """
+    verdict = row.get(curation.CURATION_FIELD) if isinstance(row, dict) else None
+    if verdict is not None and verdict["status"] == "disputed":
+        return f"  [DISPUTED: {verdict['note']}]"
+    return ""
+
+
+def _appendix_section(entries: dict[tuple[str, str], dict]) -> str | None:
+    """The ``## Superseded / corrected`` section, or ``None`` when there is nothing
+    to say.
+
+    Deliberately **not** built with :func:`_section`: that helper's always-present
+    header is right for a clinical section whose emptiness is itself information, and
+    exactly wrong here -- an empty appendix on every unannotated record would break the
+    additive-only guarantee for output that has no verdicts at all.
+    """
+    if not entries:
+        return None
+    lines = []
+    for (record_type, _base), entry in entries.items():
+        label = entry["label"] or "(no live rows)"
+        lines.append(f"- {record_type}: {label}  [{curation.describe(entry)}]")
+    return _section("Superseded / corrected", lines)
+
+
+def _questions_section(entries: dict[tuple[str, str], dict]) -> str | None:
+    """The ``## Questions for the Clinician`` section, or ``None`` when empty.
+
+    A ``disputed`` verdict is a recorded "two sources disagree and a human has to
+    rule", so the brief -- the document actually handed over at the appointment --
+    surfaces it as a question rather than leaving it as an inline marker only.
+    """
+    if not entries:
+        return None
+    lines = []
+    for (record_type, _base), entry in entries.items():
+        label = entry["label"] or "(no live rows)"
+        who = f" ({entry['attributed_to']})" if entry.get("attributed_to") else ""
+        lines.append(f"- {record_type}: {label} - {entry['note']}{who}")
+    return _section("Questions for the Clinician", lines)
+
+
+# --------------------------------------------------------------------------- #
 # Read helpers (pure SELECTs; person already resolved to an id)
 # --------------------------------------------------------------------------- #
 
 def _conditions(
-    conn: sqlite3.Connection, person_id: int, statuses: tuple[str, ...] | str
+    conn: sqlite3.Connection,
+    person_id: int,
+    statuses: tuple[str, ...] | str,
+    cur: "_CurationPass | None" = None,
 ) -> list[dict]:
     """Condition rows in one status bucket, ordered by name.
 
@@ -136,10 +307,13 @@ def _conditions(
         "SELECT * FROM condition WHERE person_id = ? ORDER BY name, condition_id",
         (person_id,),
     ).fetchall()
-    return [dict(r) for r in rows if enum_token(r["status"]) in wanted]
+    rows = _apply_curation([dict(r) for r in rows], "condition", cur)
+    return [r for r in rows if enum_token(r["status"]) in wanted]
 
 
-def _allergies(conn: sqlite3.Connection, person_id: int) -> list[dict]:
+def _allergies(
+    conn: sqlite3.Connection, person_id: int, cur: "_CurationPass | None" = None
+) -> list[dict]:
     """Allergy rows, ``criticality='high'`` first then alphabetical -- the dangerous ones
     have to survive a skim of the list."""
     rows = conn.execute(
@@ -147,7 +321,8 @@ def _allergies(conn: sqlite3.Connection, person_id: int) -> list[dict]:
         (person_id,),
     ).fetchall()
     return sorted(
-        (dict(r) for r in rows), key=lambda r: enum_token(r["criticality"]) != "high"
+        _apply_curation([dict(r) for r in rows], "allergy", cur),
+        key=lambda r: enum_token(r["criticality"]) != "high",
     )
 
 
@@ -157,18 +332,21 @@ def _condition_line(row: dict, *, past: bool = False) -> str:
         f"  (resolved {row['resolved_on']})" if past and row["resolved_on"] else ""
     )
     note = f" - {row['note']}" if row["note"] else ""
-    return f"- {row['name']}{since}{resolved}{note}"
+    return f"- {row['name']}{since}{resolved}{note}{_dispute_suffix(row)}"
 
 
 def _allergy_line(row: dict) -> str:
     crit = f" [{str(row['criticality']).upper()}]" if row["criticality"] else ""
     reaction = f" - {row['reaction']}" if row["reaction"] else ""
     noted = f"  (noted {row['noted_on']})" if row["noted_on"] else ""
-    return f"- {row['substance']}{crit}{reaction}{noted}"
+    return f"- {row['substance']}{crit}{reaction}{noted}{_dispute_suffix(row)}"
 
 
 def _latest_vitals(
-    conn: sqlite3.Connection, person_id: int, dictionary: dict[str, str] | None
+    conn: sqlite3.Connection,
+    person_id: int,
+    dictionary: dict[str, str] | None,
+    cur: "_CurationPass | None" = None,
 ) -> list[dict]:
     """Most recent ``obs_type='vital'`` row per normalized ``key``. Rows are ordered so
     that, for a given key, the latest date (then highest id) wins deterministically.
@@ -181,9 +359,12 @@ def _latest_vitals(
         "ORDER BY observed_at, observation_id",
         (person_id, OBS_VITAL),
     ).fetchall()
+    # Curation runs before the latest-wins fold, so a superseded reading cannot win
+    # "latest" and hide the good one behind it.
+    kept = _apply_curation([dict(r) for r in rows], "observation", cur)
     latest: dict[str, dict] = {}
-    for r in rows:
-        latest[key_token(r["key"], dictionary)] = dict(r)  # ascending -> last wins
+    for r in kept:
+        latest[key_token(r["key"], dictionary)] = r  # ascending -> last wins
     return [latest[k] for k in sorted(latest)]
 
 
@@ -194,7 +375,10 @@ def _order_display(row: dict) -> str:
 
 
 def _grouped_orders(
-    conn: sqlite3.Connection, person_id: int, dictionary: dict[str, str] | None
+    conn: sqlite3.Connection,
+    person_id: int,
+    dictionary: dict[str, str] | None,
+    cur: "_CurationPass | None" = None,
 ) -> list[dict]:
     """``obs_type='order'`` rows folded to one entry per normalized item, newest first.
 
@@ -220,10 +404,13 @@ def _grouped_orders(
         "ORDER BY observed_at, observation_id",
         (person_id, OBS_ORDER),
     ).fetchall()
+    # Before the grouping fold: a superseded order must not become the group's
+    # "latest" row and speak for the ones behind it.
+    kept = _apply_curation([dict(r) for r in rows], "observation", cur)
     groups: dict[object, list[dict]] = {}
-    for r in rows:
+    for r in kept:
         token = key_token(r["key"], dictionary) or key_token(r["value_text"], dictionary)
-        groups.setdefault(token or ("", r["observation_id"]), []).append(dict(r))
+        groups.setdefault(token or ("", r["observation_id"]), []).append(r)
 
     out = []
     for members in groups.values():
@@ -251,10 +438,12 @@ def _order_line(row: dict) -> str:
         first = f", first {row['group_first']}" if row["group_first"] else ""
         notes.append(f"+{row['group_count'] - 1} earlier{first}")
     note = f"  ({'; '.join(notes)})" if notes else ""
-    return f"- {_order_display(row)}{detail}{note}"
+    return f"- {_order_display(row)}{detail}{note}{_dispute_suffix(row)}"
 
 
-def _abnormal_labs(conn: sqlite3.Connection, person_id: int) -> list[dict]:
+def _abnormal_labs(
+    conn: sqlite3.Connection, person_id: int, cur: "_CurationPass | None" = None
+) -> list[dict]:
     rows = conn.execute(
         # lab_result_id DESC breaks same-timestamp ties (a `--keep both` sibling shares
         # its date): newest-first ordering treats the later row id as the later point.
@@ -262,11 +451,15 @@ def _abnormal_labs(conn: sqlite3.Connection, person_id: int) -> list[dict]:
         "ORDER BY collected_at DESC, test_name, lab_result_id DESC",
         (person_id,),
     ).fetchall()
-    return [dict(r) for r in rows if _is_abnormal(r)]
+    kept = _apply_curation([dict(r) for r in rows], "lab_result", cur)
+    return [r for r in kept if _is_abnormal(r)]
 
 
 def _open_appointments(
-    conn: sqlite3.Connection, person_id: int, today: str
+    conn: sqlite3.Connection,
+    person_id: int,
+    today: str,
+    cur: "_CurationPass | None" = None,
 ) -> list[dict]:
     """Upcoming (scheduled on/after ``today``) or open (no post-visit ``summary``)
     appointments -- the ones a summary reader still needs to act on."""
@@ -276,12 +469,12 @@ def _open_appointments(
         (person_id,),
     ).fetchall()
     out: list[dict] = []
-    for r in rows:
+    for r in _apply_curation([dict(x) for x in rows], "appointment", cur):
         d = _date_part(r["scheduled_for"])
         upcoming = bool(d) and d >= today
         is_open = not (r["summary"] or "").strip()
         if upcoming or is_open:
-            out.append(dict(r))
+            out.append(r)
     return out
 
 
@@ -364,6 +557,9 @@ def render_summary(
     ).fetchone()
     today = _date_part(now or datetime.now())
     counts = _row_counts(conn, person_id)
+    # Source rows stay a count of what is *stored*: the overlay hides nothing from the
+    # database, only from the sections below.
+    cur = _CurationPass(conn)
 
     header = (
         f"# Master Summary: {person['full_name']}\n\n"
@@ -377,47 +573,52 @@ def render_summary(
         f"conditions={counts['condition']}, allergies={counts['allergy']}\n"
     )
 
-    meds = query.query_meds(conn, slug, active=True, now=now)
+    meds = _apply_curation(
+        query.query_meds(conn, slug, active=True, now=now), "medication", cur
+    )
     med_lines = []
     for m in meds:
         dose = f" {m['dose']}" if m["dose"] else ""
         freq = f" {m['frequency']}" if m["frequency"] else ""
         since = f" (since {m['started_on']})" if m["started_on"] else ""
-        med_lines.append(f"- {m['name']}{dose}{freq}{since}")
+        med_lines.append(f"- {m['name']}{dose}{freq}{since}{_dispute_suffix(m)}")
 
     active_lines = [
-        _condition_line(c) for c in _conditions(conn, person_id, CONDITION_ACTIVE)
+        _condition_line(c) for c in _conditions(conn, person_id, CONDITION_ACTIVE, cur)
     ]
     past_lines = [
         _condition_line(c, past=True)
-        for c in _conditions(conn, person_id, CONDITION_PAST)
+        for c in _conditions(conn, person_id, CONDITION_PAST, cur)
     ]
     family_lines = [
-        f"- {c['relation'] or 'family'}: {c['name']}"
-        for c in _conditions(conn, person_id, CONDITION_FAMILY)
+        f"- {c['relation'] or 'family'}: {c['name']}{_dispute_suffix(c)}"
+        for c in _conditions(conn, person_id, CONDITION_FAMILY, cur)
     ]
-    allergy_lines = [_allergy_line(a) for a in _allergies(conn, person_id)]
+    allergy_lines = [_allergy_line(a) for a in _allergies(conn, person_id, cur)]
     order_lines = [
-        _order_line(o) for o in _grouped_orders(conn, person_id, dictionary)
+        _order_line(o) for o in _grouped_orders(conn, person_id, dictionary, cur)
     ]
 
     vital_lines = []
-    for v in _latest_vitals(conn, person_id, dictionary):
+    for v in _latest_vitals(conn, person_id, dictionary, cur):
         value = v["value_num"] if v["value_num"] is not None else v["value_text"]
         unit = f" {v['unit']}" if v["unit"] else ""
         when = f"  ({_date_part(v['observed_at'])})" if v["observed_at"] else ""
-        vital_lines.append(f"- {v['key']}: {_fmt(value)}{unit}{when}")
+        vital_lines.append(
+            f"- {v['key']}: {_fmt(value)}{unit}{when}{_dispute_suffix(v)}"
+        )
 
     lab_lines = []
-    for r in _abnormal_labs(conn, person_id):
+    for r in _abnormal_labs(conn, person_id, cur):
         flag = f" [{r['flag']}]" if r["flag"] else ""
         lab_lines.append(
             f"- {_date_part(r['collected_at'])}  {r['test_name']}  "
-            f"{_lab_value(r)}{flag}{_ref_range(r)}"
+            f"{_lab_value(r)}{flag}{_ref_range(r)}{_dispute_suffix(r)}"
         )
 
     appt_lines = [
-        f"- {_appt_line(a)}" for a in _open_appointments(conn, person_id, today)
+        f"- {_appt_line(a)}{_dispute_suffix(a)}"
+        for a in _open_appointments(conn, person_id, today, cur)
     ]
 
     parts = [
@@ -435,6 +636,8 @@ def render_summary(
             "Open Conflicts", _open_conflict_lines(conn, person_id), empty="_none_"
         ),
     ]
+    # Omitted entirely when there are no verdicts -- see _appendix_section.
+    parts += [p for p in (_appendix_section(cur.appendix),) if p is not None]
     return "\n".join(parts).rstrip() + "\n"
 
 
@@ -473,6 +676,7 @@ def render_brief(
     person = conn.execute(
         "SELECT * FROM person WHERE person_id = ?", (person_id,)
     ).fetchone()
+    cur = _CurationPass(conn)
 
     header = (
         f"# Appointment Brief: {person['full_name']}\n\n"
@@ -486,12 +690,14 @@ def render_brief(
         f"- Reason: {appt['reason'] or '(none given)'}",
     ])
 
-    meds = query.query_meds(conn, person["slug"], active=True, now=now)
+    meds = _apply_curation(
+        query.query_meds(conn, person["slug"], active=True, now=now), "medication", cur
+    )
     med_lines = []
     for m in meds:
         dose = f" {m['dose']}" if m["dose"] else ""
         freq = f" {m['frequency']}" if m["frequency"] else ""
-        med_lines.append(f"- {m['name']}{dose}{freq}")
+        med_lines.append(f"- {m['name']}{dose}{freq}{_dispute_suffix(m)}")
 
     # Recency stays the primary axis, but a single draw can carry a 50+ analyte panel —
     # a flat `LIMIT N` over `collected_at DESC, test_name` then returns the
@@ -500,11 +706,17 @@ def render_brief(
     # the brief is the doc handed to a clinician, and the out-of-range values are the
     # ones that must survive truncation. Abnormality is `_is_abnormal` (flag OR
     # reference interval), which SQL can't express, so the cut happens here.
-    lab_rows = conn.execute(
-        "SELECT * FROM lab_result WHERE person_id = ? "
-        "ORDER BY collected_at DESC, test_name, lab_result_id DESC",
-        (person_id,),
-    ).fetchall()
+    lab_rows = _apply_curation(
+        [
+            dict(r) for r in conn.execute(
+                "SELECT * FROM lab_result WHERE person_id = ? "
+                "ORDER BY collected_at DESC, test_name, lab_result_id DESC",
+                (person_id,),
+            ).fetchall()
+        ],
+        "lab_result",
+        cur,
+    )
     draw_rank = {
         ts: i for i, ts in enumerate(dict.fromkeys(r["collected_at"] for r in lab_rows))
     }
@@ -519,25 +731,37 @@ def render_brief(
         abnormal = f"  [!]{_ref_range(r)}" if _is_abnormal(r) else ""
         lab_lines.append(
             f"- {_date_part(r['collected_at'])}  {r['test_name']}  "
-            f"{_lab_value(r)}{flag}{abnormal}"
+            f"{_lab_value(r)}{flag}{abnormal}{_dispute_suffix(r)}"
         )
 
-    proc_rows = conn.execute(
-        "SELECT * FROM procedure WHERE person_id = ? "
-        "ORDER BY performed_on DESC, procedure_id",
-        (person_id,),
-    ).fetchall()
-    obs_rows = conn.execute(
-        "SELECT * FROM observation WHERE person_id = ? "
-        "ORDER BY observed_at DESC, observation_id",
-        (person_id,),
-    ).fetchall()
+    proc_rows = _apply_curation(
+        [
+            dict(r) for r in conn.execute(
+                "SELECT * FROM procedure WHERE person_id = ? "
+                "ORDER BY performed_on DESC, procedure_id",
+                (person_id,),
+            ).fetchall()
+        ],
+        "procedure",
+        cur,
+    )
+    obs_rows = _apply_curation(
+        [
+            dict(r) for r in conn.execute(
+                "SELECT * FROM observation WHERE person_id = ? "
+                "ORDER BY observed_at DESC, observation_id",
+                (person_id,),
+            ).fetchall()
+        ],
+        "observation",
+        cur,
+    )
     ctx_lines = []
     for p in proc_rows:
         outcome = f" - {p['outcome']}" if p["outcome"] else ""
         ctx_lines.append(
             f"- {_date_part(p['performed_on']) or '(undated)'}  procedure: "
-            f"{p['name']}{outcome}"
+            f"{p['name']}{outcome}{_dispute_suffix(p)}"
         )
     for o in obs_rows:
         value = o["value_num"] if o["value_num"] is not None else o["value_text"]
@@ -545,11 +769,12 @@ def render_brief(
         detail = " ".join(p for p in (o["obs_type"], o["key"]) if p)
         ctx_lines.append(
             f"- {_date_part(o['observed_at']) or '(undated)'}  {detail}{val}"
+            f"{_dispute_suffix(o)}"
         )
 
-    brief_allergy_lines = [_allergy_line(a) for a in _allergies(conn, person_id)]
+    brief_allergy_lines = [_allergy_line(a) for a in _allergies(conn, person_id, cur)]
     brief_problem_lines = [
-        _condition_line(c) for c in _conditions(conn, person_id, CONDITION_ACTIVE)
+        _condition_line(c) for c in _conditions(conn, person_id, CONDITION_ACTIVE, cur)
     ]
 
     conflict_lines = _open_conflict_lines(conn, person_id)
@@ -573,8 +798,15 @@ def render_brief(
         _section("Active Problems", brief_problem_lines),
         _section("Procedures & Observations", ctx_lines),
         _section("Open Conflicts", conflict_lines, empty="_none_"),
-        interaction,
     ]
+    # Both omitted entirely when empty, so an unannotated brief is byte-identical to
+    # what it was before the overlay existed. The clinician questions sit immediately
+    # before the interaction block: the last thing read is what to ask about.
+    parts += [
+        p for p in (_appendix_section(cur.appendix), _questions_section(cur.disputed))
+        if p is not None
+    ]
+    parts.append(interaction)
     return "\n".join(parts).rstrip() + "\n"
 
 
@@ -597,14 +829,24 @@ def render_journal(
     person = conn.execute(
         "SELECT * FROM person WHERE person_id = ?", (person_id,)
     ).fetchone()
-    events = query.query_timeline(conn, slug, since=since)
+    cur = _CurationPass(conn)
+    # `with_identity` is what makes the overlay reachable from here: a timeline event
+    # is a rendered sentence, not a row, so it carries no family identity by default.
+    events = query.query_timeline(
+        conn, slug, since=since, with_identity=bool(cur.verdicts)
+    )
+    events = _apply_curation_events(events, cur)
 
     header = (
         f"# Journal: {person['full_name']}\n\n"
         f"- Generated: {_generated_at(now)} (read-only view of DB state)\n"
     )
     if not events:
-        return header + "\n_No dated events on record._\n"
+        # An appendix can outlive the events: a journal whose every dated event was
+        # superseded still has to say where they went.
+        tail = _appendix_section(cur.appendix)
+        empty = header + "\n_No dated events on record._\n"
+        return empty if tail is None else empty + "\n" + tail
 
     # Provenance footnotes: assign a stable [^n] marker per referenced document, in
     # first-appearance order, and resolve each to a one-line source description.
@@ -624,7 +866,13 @@ def render_journal(
         ref = ""
         if e["document_id"] is not None:
             ref = f" [^{footnote_num[e['document_id']]}]"
-        lines.append(f"- **{e['type']}** -- {e['summary']}{ref}")
+        lines.append(f"- **{e['type']}** -- {e['summary']}{ref}{_dispute_suffix(e)}")
+
+    # Before the footnote block: footnotes are reference apparatus for the events
+    # above them and stay last.
+    appendix = _appendix_section(cur.appendix)
+    if appendix is not None:
+        lines.append("\n" + appendix.rstrip())
 
     if footnote_order:
         lines.append("\n---\n")

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -21,7 +21,7 @@ import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from . import db, ingest
+from . import curation, db, dedup, ingest
 
 # Row counts reported, in a stable order. A table missing from the schema (a snapshot
 # predating its migration, checked before `restore` runs `migrate`) is simply omitted.
@@ -29,6 +29,7 @@ COUNTED_TABLES = (
     "person",
     "document",
     "document_tombstone",
+    "curation",
     "lab_result",
     "medication",
     "procedure",
@@ -57,6 +58,11 @@ class VerifyReport:
     blobs_mismatched: int = 0
     blobs_skipped: str | None = None  # why the blob pass was skipped, if it was
     problems: list[str] = field(default_factory=list)
+    #: Things a human should look at that are **not** failures. Until issue #109 every
+    #: string this module appended failed the report; the curation overlay introduces a
+    #: state that is worth surfacing and wrong to fail on (a verdict whose family was
+    #: legitimately removed is untidy, not corrupt), so the warn/fail split lives here.
+    warnings: list[str] = field(default_factory=list)
 
     @property
     def ok(self) -> bool:
@@ -66,6 +72,8 @@ class VerifyReport:
         integrity, an un-migrated database, a missing or mismatched blob - so that list
         is the single source of truth. A *skipped* blob pass is deliberately not a
         problem: unconfigured or mid-sync `sources/` must not fail a restore.
+        :attr:`warnings` is deliberately *not* consulted: a warning is an observation,
+        and an observation that flips the exit code is a failure wearing a softer word.
         """
         return not self.problems
 
@@ -82,6 +90,7 @@ class VerifyReport:
                 "skipped": self.blobs_skipped,
             },
             "problems": list(self.problems),
+            "warnings": list(self.warnings),
             "ok": self.ok,
         }
 
@@ -135,6 +144,40 @@ def _check_blobs(
         report.blobs_ok += 1
 
 
+def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
+    """Warn about `curation` verdicts that no longer point at anything (issue #109).
+
+    The overlay deliberately has no FK to the row it annotates - a verdict has to
+    outlive `rekey`, re-ingest and `record rm` occurrence shifts - so nothing in the
+    schema notices when the last row of an annotated family is removed. The verdict is
+    then inert: it rules on a fact no document renders. That is untidy, not corrupt,
+    and usually intentional (the human removed the row *because* they ruled on it), so
+    it warns rather than fails. `pemr record annotate --clear` lifts it.
+    """
+    if not curation.has_table(conn):
+        return
+    for (record_type, base), verdict in curation.load_verdicts(conn).items():
+        short = str(base)[:12]
+        if record_type not in dedup.FIELD_SPECS:
+            # A hand-edited row can name any table; never build a query from it.
+            report.warnings.append(
+                f"curation verdict {record_type}/{short}... names an unknown record "
+                f"type (known: {', '.join(dedup.KNOWN_TYPES)})"
+            )
+            continue
+        if not dedup.load_family(conn, record_type, base):
+            report.warnings.append(
+                f"curation verdict {record_type}/{short}... has no live family "
+                "(removed?) - lift it with `pemr record annotate --clear`"
+            )
+        target = verdict.get("merged_into_base")
+        if target and not dedup.load_family(conn, record_type, target):
+            report.warnings.append(
+                f"curation verdict {record_type}/{short}... merges into "
+                f"{str(target)[:12]}..., which has no live family"
+            )
+
+
 def verify_report(
     conn: sqlite3.Connection, sources_dir: str | Path | None = None
 ) -> VerifyReport:
@@ -156,6 +199,8 @@ def verify_report(
         report.problems.append("database has no schema applied")
 
     report.row_counts = row_counts(conn)
+    if db.is_migrated(conn):
+        _check_curation(conn, report)
 
     if sources_dir is None:
         report.blobs_skipped = "no sources dir configured"
@@ -195,6 +240,14 @@ def format_report(report: VerifyReport) -> list[str]:
         for problem in report.problems[:PROBLEM_DISPLAY_LIMIT]:
             lines.append(f"  - {problem}")
         hidden = len(report.problems) - PROBLEM_DISPLAY_LIMIT
+        if hidden > 0:
+            lines.append(f"  ... and {hidden} more (use --json for the full list)")
+    # Only when non-empty: a clean database's console output is unchanged.
+    if report.warnings:
+        lines.append(f"warnings       {len(report.warnings)}")
+        for warning in report.warnings[:PROBLEM_DISPLAY_LIMIT]:
+            lines.append(f"  - {warning}")
+        hidden = len(report.warnings) - PROBLEM_DISPLAY_LIMIT
         if hidden > 0:
             lines.append(f"  ... and {hidden} more (use --json for the full list)")
     return lines

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -148,11 +148,13 @@ def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
     """Warn about `curation` verdicts that no longer point at anything (issue #109).
 
     The overlay deliberately has no FK to the row it annotates - a verdict has to
-    outlive `rekey`, re-ingest and `record rm` occurrence shifts - so nothing in the
-    schema notices when the last row of an annotated family is removed. The verdict is
-    then inert: it rules on a fact no document renders. That is untidy, not corrupt,
-    and usually intentional (the human removed the row *because* they ruled on it), so
-    it warns rather than fails. `pemr record annotate --clear` lifts it.
+    outlive re-ingest, `record rm` occurrence shifts, and any `rekey` that leaves this
+    family's own key fields untouched - so nothing in the schema notices when the last
+    row of an annotated family is removed, or when a dictionary-driven rekey moves a
+    family onto a new `dedup_base`. Either way the verdict goes inert: it rules on a
+    fact no document renders. That is untidy, not corrupt, and often intentional (the
+    human removed the row *because* they ruled on it, or the rekey just relabeled it),
+    so it warns rather than fails. `pemr record annotate --clear` lifts it.
     """
     if not curation.has_table(conn):
         return

--- a/tests/test_cli_ascii.py
+++ b/tests/test_cli_ascii.py
@@ -168,3 +168,46 @@ def test_help_description_is_console_safe(capsys):
     out = capsys.readouterr().out
     assert "Personal EMR engine" in out
     _assert_console_safe(out)
+
+
+def test_record_annotate_output_is_console_safe(ready, capsys):
+    """Issue #109's new CLI + render surface: the verdict block, the `--list` table,
+    the `[DISPUTED: ...]` marker, the appendix heading and `verify`'s warning block."""
+    scan = ready / "scan.txt"
+    scan.write_bytes(b"visit note: glucose 95")
+    assert _run(ready, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(ready / "sources"), "--ocr-text-file", str(scan)) == 0
+    payload = ready / "extract.json"
+    payload.write_text(json.dumps({"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 95,
+         "unit": "mg/dL"},
+    ]}), encoding="utf-8")
+    assert _run(ready, "commit-extraction", "--document", "1", "--json",
+                str(payload)) == 0
+
+    capsys.readouterr()
+    assert _run(ready, "record", "annotate", "lab_result", "1", "--status",
+                "disputed", "--note", "two sources disagree", "--apply") == 0
+    _assert_console_safe(capsys.readouterr().out)
+
+    assert _run(ready, "record", "annotate", "--list") == 0
+    _assert_console_safe(capsys.readouterr().out)
+
+    assert _run(ready, "render", "summary", "--person", "jane-doe") == 0
+    _assert_console_safe(capsys.readouterr().out)
+
+    assert _run(ready, "record", "annotate", "lab_result", "1", "--status",
+                "superseded", "--note", "corrected later", "--apply") == 0
+    capsys.readouterr()
+    assert _run(ready, "render", "summary", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    assert "## Superseded / corrected" in out
+    _assert_console_safe(out)
+
+    assert _run(ready, "record", "rm", "lab_result", "1", "--apply") == 0
+    capsys.readouterr()
+    assert _run(ready, "verify") == 0
+    captured = capsys.readouterr()
+    assert "warnings" in captured.out
+    _assert_console_safe(captured.out)
+    _assert_console_safe(captured.err)

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -1,0 +1,684 @@
+"""Recorded human verdicts over record families: `pemr record annotate` (issue #109).
+
+Covers the engine module (pemr/curation.py) and its CLI wiring, in the shape
+test_records.py uses for `record rm`. The two tests that matter most are the identity
+regressions: a verdict is keyed by ``dedup_base``, so it must survive a `record rm` of
+occurrence 0 and must cover a later `--keep both` sibling — the two things a row-id or
+``dedup_key`` key would get wrong.
+
+Renderer behaviour lives in test_render.py, next to the rest of the render mechanics;
+the `verify` orphan warning lives here (it is curation's own check) and in the
+integration drill at the bottom.
+"""
+
+import json
+
+import pytest
+
+from pemr import cli, curation, db, dedup, persons, records, verify
+
+RECORDS = {
+    "lab_result": [
+        {"test_name": "HbA1c", "collected_at": "2026-01-02", "value_num": 5.7,
+         "unit": "%"},
+        {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 95,
+         "unit": "mg/dL"},
+    ],
+    "condition": [
+        {"name": "Type 2 Diabetes", "status": "active", "onset_on": "2024-01-01"},
+        {"name": "Prediabetes", "status": "history", "onset_on": "2022-01-01"},
+    ],
+}
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    conn = db.connect(tmp_path / "test.db")
+    db.migrate(conn)
+    yield conn
+    conn.close()
+
+
+def _insert_document(conn, person_id, sha):
+    cur = conn.execute(
+        """
+        INSERT INTO document
+          (sha256, person_id, doc_date, category, provider, source_path,
+           ocr_text, ingested_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (sha, person_id, "2026-03-15", "visit-note", "Dr Who",
+         f"{sha[:2]}/{sha}.pdf", "scan text", "2026-03-16T00:00:00"),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+@pytest.fixture()
+def seeded(conn):
+    """Jane owns one document holding two labs and two conditions."""
+    jane = persons.add_person(conn, "jane-doe", "Jane Doe")
+    doc_id = _insert_document(conn, jane.person_id, "aa11bb22cc33dd44")
+    dedup.commit_extraction(conn, doc_id, RECORDS)
+    return {"conn": conn, "jane": jane, "doc": doc_id}
+
+
+def _row_id(conn, record_type, column, value):
+    return int(conn.execute(
+        f"SELECT {record_type}_id FROM {record_type} WHERE {column} = ?", (value,)
+    ).fetchone()[f"{record_type}_id"])
+
+
+def _base(conn, record_type, column, value):
+    return conn.execute(
+        f"SELECT dedup_base FROM {record_type} WHERE {column} = ?", (value,)
+    ).fetchone()["dedup_base"]
+
+
+def _curation_count(conn):
+    return conn.execute("SELECT COUNT(*) AS n FROM curation").fetchone()["n"]
+
+
+def _record_counts(conn):
+    return {
+        record_type: conn.execute(
+            f"SELECT COUNT(*) AS n FROM {record_type}"
+        ).fetchone()["n"]
+        for record_type in dedup.KNOWN_TYPES
+    }
+
+
+# --- the core claim: an overlay, not a mutation ------------------------------
+
+
+def test_annotate_writes_a_verdict_and_touches_no_record_row(seeded):
+    conn = seeded["conn"]
+    before = _record_counts(conn)
+    row_id = _row_id(conn, "lab_result", "test_name", "Glucose")
+    stored = dict(conn.execute(
+        "SELECT * FROM lab_result WHERE lab_result_id = ?", (row_id,)
+    ).fetchone())
+
+    report = curation.annotate_record(
+        conn, "lab_result", str(row_id),
+        status="erroneous-in-source", note="requisition coding artifact",
+        attributed_to="Dr Who", apply=True,
+    )
+
+    assert report.applied is True
+    assert report.action == "create"
+    assert report.label == "Glucose"
+    assert report.family_size == 1
+    assert report.dedup_base == stored["dedup_base"]
+    # Not one source row moved.
+    assert _record_counts(conn) == before
+    assert dict(conn.execute(
+        "SELECT * FROM lab_result WHERE lab_result_id = ?", (row_id,)
+    ).fetchone()) == stored
+    assert curation.get_verdict(conn, "lab_result", report.dedup_base) == {
+        "record_type": "lab_result",
+        "dedup_base": report.dedup_base,
+        "status": "erroneous-in-source",
+        "note": "requisition coding artifact",
+        "merged_into_base": None,
+        "attributed_to": "Dr Who",
+        "created_at": report.created_at,
+    }
+
+
+@pytest.mark.parametrize("status", curation.STATUSES)
+def test_every_status_round_trips(seeded, status):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    target = _base(conn, "lab_result", "test_name", "HbA1c")
+    curation.annotate_record(
+        conn, "lab_result", base, status=status, note="because",
+        merged_into_base=target if status == "merged-into" else None, apply=True,
+    )
+    stored = curation.get_verdict(conn, "lab_result", base)
+    assert stored["status"] == status
+    assert stored["merged_into_base"] == (
+        target if status == "merged-into" else None
+    )
+
+
+def test_dry_run_is_the_default_and_writes_nothing(seeded):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    report = curation.annotate_record(
+        conn, "lab_result", base, status="disputed", note="two sources disagree"
+    )
+    assert report.applied is False
+    assert report.action == "create"
+    assert _curation_count(conn) == 0
+
+
+def test_re_annotating_overwrites_and_reports_the_previous_verdict(seeded):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    first = curation.annotate_record(
+        conn, "lab_result", base, status="disputed", note="two sources disagree",
+        now="2026-01-01T00:00:00+00:00", apply=True,
+    )
+    second = curation.annotate_record(
+        conn, "lab_result", base, status="superseded", note="repeat draw supersedes",
+        now="2026-02-02T00:00:00+00:00", apply=True,
+    )
+    assert second.action == "overwrite"
+    assert second.previous["status"] == "disputed"
+    assert second.previous["created_at"] == first.created_at
+    assert _curation_count(conn) == 1  # one live verdict per family
+    live = curation.get_verdict(conn, "lab_result", base)
+    assert live["status"] == "superseded"
+    assert live["created_at"] == "2026-02-02T00:00:00+00:00"
+
+
+# --- validation --------------------------------------------------------------
+
+
+@pytest.mark.parametrize("note", ["", "   ", "\t\n"])
+def test_empty_note_is_refused(seeded, note):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    with pytest.raises(ValueError, match="note is required"):
+        curation.annotate_record(
+            conn, "lab_result", base, status="disputed", note=note, apply=True
+        )
+    assert _curation_count(conn) == 0
+
+
+def test_unknown_record_type_is_refused(seeded):
+    with pytest.raises(ValueError, match="unknown record type"):
+        curation.annotate_record(
+            seeded["conn"], "family_history", "abc", status="disputed", note="x"
+        )
+
+
+def test_unknown_status_is_refused(seeded):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    with pytest.raises(ValueError, match="unknown curation status"):
+        curation.annotate_record(
+            conn, "lab_result", base, status="wrong-ish", note="x"
+        )
+
+
+def test_merged_into_is_required_for_merged_into_and_refused_otherwise(seeded):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    other = _base(conn, "lab_result", "test_name", "HbA1c")
+    with pytest.raises(ValueError, match="needs the family it merges into"):
+        curation.annotate_record(
+            conn, "lab_result", base, status="merged-into", note="x"
+        )
+    with pytest.raises(ValueError, match="only meaningful with status 'merged-into'"):
+        curation.annotate_record(
+            conn, "lab_result", base, status="disputed", note="x",
+            merged_into_base=other,
+        )
+    assert _curation_count(conn) == 0
+
+
+def test_merge_target_must_be_a_live_other_family(seeded):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    with pytest.raises(curation.FamilyNotFoundError):
+        curation.annotate_record(
+            conn, "lab_result", base, status="merged-into", note="x",
+            merged_into_base="deadbeef" * 8,
+        )
+    with pytest.raises(ValueError, match="into itself"):
+        curation.annotate_record(
+            conn, "lab_result", base, status="merged-into", note="x",
+            merged_into_base=base,
+        )
+    assert _curation_count(conn) == 0
+
+
+def test_a_bad_verdict_never_overwrites_a_good_one(seeded):
+    """Validation is front-loaded because the write is an upsert: a typo'd status must
+    not take the previous verdict down with it."""
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    curation.annotate_record(
+        conn, "lab_result", base, status="confirmed", note="clinician agreed",
+        apply=True,
+    )
+    with pytest.raises(ValueError):
+        curation.annotate_record(
+            conn, "lab_result", base, status="nonsense", note="oops", apply=True
+        )
+    assert curation.get_verdict(conn, "lab_result", base)["status"] == "confirmed"
+
+
+def test_schema_check_backstops_a_hand_edited_status(seeded):
+    """Python raises first for every operator path; the CHECK exists for the row a
+    human (or a corrupted restore) writes around it."""
+    conn = seeded["conn"]
+    with pytest.raises(Exception):
+        conn.execute(
+            "INSERT INTO curation (record_type, dedup_base, status, note, created_at) "
+            "VALUES ('lab_result', 'b', 'not-a-status', 'why', '2026-01-01T00:00:00')"
+        )
+    with pytest.raises(Exception):
+        conn.execute(
+            "INSERT INTO curation (record_type, dedup_base, status, note, created_at) "
+            "VALUES ('lab_result', 'b', 'disputed', '   ', '2026-01-01T00:00:00')"
+        )
+    with pytest.raises(Exception):
+        conn.execute(
+            "INSERT INTO curation (record_type, dedup_base, status, note, "
+            "merged_into_base, created_at) VALUES "
+            "('lab_result', 'b', 'disputed', 'why', 'other', '2026-01-01T00:00:00')"
+        )
+
+
+# --- target resolution -------------------------------------------------------
+
+
+def test_resolve_base_accepts_a_row_id_or_a_base(seeded):
+    conn = seeded["conn"]
+    row_id = _row_id(conn, "lab_result", "test_name", "Glucose")
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    assert curation.resolve_base(conn, "lab_result", str(row_id)) == base
+    assert curation.resolve_base(conn, "lab_result", base) == base
+
+
+def test_resolve_base_reports_both_not_found_cases(seeded):
+    conn = seeded["conn"]
+    with pytest.raises(curation.FamilyNotFoundError, match="no lab_result with id 9999"):
+        curation.resolve_base(conn, "lab_result", "9999")
+    with pytest.raises(curation.FamilyNotFoundError, match="no live lab_result family"):
+        curation.resolve_base(conn, "lab_result", "deadbeef" * 8)
+
+
+# --- list / clear ------------------------------------------------------------
+
+
+def test_list_curation_filters_by_type_and_flags_orphans(seeded):
+    conn = seeded["conn"]
+    lab_base = _base(conn, "lab_result", "test_name", "Glucose")
+    cond_base = _base(conn, "condition", "name", "Prediabetes")
+    curation.annotate_record(conn, "lab_result", lab_base, status="disputed",
+                            note="a", now="2026-01-01T00:00:00+00:00", apply=True)
+    curation.annotate_record(conn, "condition", cond_base, status="superseded",
+                            note="b", now="2026-02-01T00:00:00+00:00", apply=True)
+
+    rows = curation.list_curation(conn)
+    assert [r["record_type"] for r in rows] == ["condition", "lab_result"]  # newest first
+    assert rows[0]["label"] == "Prediabetes" and rows[0]["family_size"] == 1
+    assert [r["record_type"] for r in curation.list_curation(conn, "lab_result")] == [
+        "lab_result"
+    ]
+
+    records.remove_record(
+        conn, "condition", _row_id(conn, "condition", "name", "Prediabetes"), apply=True
+    )
+    orphan = [r for r in curation.list_curation(conn) if r["record_type"] == "condition"]
+    assert orphan[0]["family_size"] == 0 and orphan[0]["label"] == ""
+
+
+def test_clear_curation_dry_run_then_apply(seeded):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    curation.annotate_record(conn, "lab_result", base, status="confirmed",
+                            note="agreed", apply=True)
+
+    dry = curation.clear_curation(conn, "lab_result", base)
+    assert dry.action == "clear" and dry.applied is False
+    assert _curation_count(conn) == 1
+
+    done = curation.clear_curation(conn, "lab_result", base, apply=True)
+    assert done.applied is True
+    assert done.previous["status"] == "confirmed"
+    assert _curation_count(conn) == 0
+
+
+def test_clear_curation_without_a_verdict_is_an_error_not_a_success(seeded):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    with pytest.raises(curation.CurationNotFoundError, match="no curation verdict"):
+        curation.clear_curation(conn, "lab_result", base, apply=True)
+
+
+def test_clear_curation_can_lift_an_orphaned_verdict(seeded):
+    """The verdict `verify` warns about: its family is gone, so no row id names it."""
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    curation.annotate_record(conn, "lab_result", base, status="superseded",
+                            note="gone", apply=True)
+    records.remove_record(
+        conn, "lab_result", _row_id(conn, "lab_result", "test_name", "Glucose"),
+        apply=True,
+    )
+    report = curation.clear_curation(conn, "lab_result", base, apply=True)
+    assert report.family_size == 0
+    assert _curation_count(conn) == 0
+
+
+# --- identity: the whole reason for keying on dedup_base ---------------------
+
+
+def _second_occurrence(seeded):
+    """Re-file the same Glucose fact off a second document as occurrence 1 (the
+    `--keep both` shape), and return the family's base."""
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    doc2 = _insert_document(conn, seeded["jane"].person_id, "bb22cc33dd44ee55")
+    conn.execute(
+        "INSERT INTO lab_result (person_id, document_id, test_name, collected_at, "
+        "value_num, unit, dedup_key, dedup_base, dedup_occurrence) "
+        "VALUES (?, ?, 'Glucose', '2026-01-02', 95, 'mg/dL', ?, ?, 1)",
+        (seeded["jane"].person_id, doc2, dedup.occurrence_key(base, 1), base),
+    )
+    conn.commit()
+    return base
+
+
+def test_verdict_survives_removal_of_occurrence_zero(seeded):
+    """A row-id key would dangle here: `record rm` deliberately does not renumber, so
+    the family lives on at occurrence 1 under the same base."""
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    curation.annotate_record(conn, "lab_result", base, status="disputed",
+                            note="two sources disagree", apply=True)
+    occ0 = int(conn.execute(
+        "SELECT lab_result_id FROM lab_result WHERE dedup_base = ? AND "
+        "dedup_occurrence = 0", (base,)
+    ).fetchone()["lab_result_id"])
+
+    records.remove_record(conn, "lab_result", occ0, apply=True)
+
+    verdict = curation.get_verdict(conn, "lab_result", base)
+    assert verdict is not None and verdict["status"] == "disputed"
+    label, size = curation.family_label(conn, "lab_result", base)
+    assert (label, size) == ("Glucose", 1)  # still resolves to a live family
+
+
+def test_verdict_covers_a_later_keep_both_sibling(seeded):
+    """A `dedup_key` key would only have covered occurrence 0; the base covers the
+    whole family, which is what "one verdict per fact" means."""
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    curation.annotate_record(conn, "lab_result", base, status="superseded",
+                            note="corrected downstream", apply=True)
+    _second_occurrence(seeded)
+
+    assert curation.family_label(conn, "lab_result", base)[1] == 2
+    assert curation.load_verdicts(conn)[("lab_result", base)]["status"] == "superseded"
+
+
+def test_verdict_survives_a_no_drift_rekey(seeded):
+    """`rekey` under an unchanged dictionary is key-neutral, so the verdict still
+    resolves. (A dictionary edit that renames the canonical fact *does* move the base
+    -- that verdict orphans and `pemr verify` warns about it, by design.)"""
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    curation.annotate_record(conn, "lab_result", base, status="confirmed",
+                            note="agreed", apply=True)
+    report = dedup.rekey(conn, None, apply=True)
+    assert not report.collisions
+    assert curation.get_verdict(conn, "lab_result", base) is not None
+
+
+# --- verify integration ------------------------------------------------------
+
+
+def test_verify_warns_about_an_orphaned_verdict_without_failing(seeded):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    curation.annotate_record(conn, "lab_result", base, status="superseded",
+                            note="gone", apply=True)
+    assert verify.verify_report(conn).warnings == []
+
+    records.remove_record(
+        conn, "lab_result", _row_id(conn, "lab_result", "test_name", "Glucose"),
+        apply=True,
+    )
+    report = verify.verify_report(conn)
+    assert report.ok is True and report.problems == []
+    assert any("has no live family" in w for w in report.warnings)
+    assert "warnings" in report.as_dict()
+    assert any("warnings       1" in line for line in verify.format_report(report))
+
+
+def test_verify_is_silent_about_warnings_when_there_are_none(seeded):
+    """The console block only appears when non-empty, so a clean database's output is
+    unchanged by this feature."""
+    report = verify.verify_report(seeded["conn"])
+    assert report.warnings == []
+    assert not any(line.startswith("warnings") for line in verify.format_report(report))
+
+
+def test_verify_warns_about_a_dangling_merge_target(seeded):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    target = _base(conn, "lab_result", "test_name", "HbA1c")
+    curation.annotate_record(conn, "lab_result", base, status="merged-into",
+                            note="same draw", merged_into_base=target, apply=True)
+    records.remove_record(
+        conn, "lab_result", _row_id(conn, "lab_result", "test_name", "HbA1c"),
+        apply=True,
+    )
+    report = verify.verify_report(conn)
+    assert report.ok is True
+    assert any("merges into" in w for w in report.warnings)
+
+
+def test_verify_warns_about_a_hand_edited_unknown_record_type(seeded):
+    """A read-path re-validation: the stored type must never be interpolated into a
+    query just because it is in the table."""
+    conn = seeded["conn"]
+    conn.execute(
+        "INSERT INTO curation (record_type, dedup_base, status, note, created_at) "
+        "VALUES ('family_history', 'b', 'disputed', 'hand-edited', "
+        "'2026-01-01T00:00:00')"
+    )
+    conn.commit()
+    report = verify.verify_report(conn)
+    assert report.ok is True
+    assert any("unknown record type" in w for w in report.warnings)
+
+
+# --- CLI surface -------------------------------------------------------------
+
+
+def _run(tmp_path, *argv):
+    return cli.main(["--db", str(tmp_path / "cli.db"), *argv])
+
+
+@pytest.fixture()
+def cli_ready(tmp_path):
+    """Migrated DB, one person, one ingested+committed multi-record document."""
+    assert _run(tmp_path, "migrate", "--create") == 0
+    assert _run(tmp_path, "person", "add", "--slug", "jane-doe", "--name", "Jane") == 0
+    scan = tmp_path / "scan.txt"
+    scan.write_bytes(b"visit note: hba1c 5.7 percent, glucose 95")
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources"), "--ocr-text-file",
+                str(scan)) == 0
+    payload = tmp_path / "extract.json"
+    payload.write_text(json.dumps(RECORDS), encoding="utf-8")
+    assert _run(tmp_path, "commit-extraction", "--document", "1",
+                "--json", str(payload)) == 0
+    return tmp_path
+
+
+def _cli_conn(tmp_path):
+    return db.connect(tmp_path / "cli.db")
+
+
+def _cli_row_id(tmp_path, record_type, column, value):
+    conn = _cli_conn(tmp_path)
+    try:
+        return _row_id(conn, record_type, column, value)
+    finally:
+        conn.close()
+
+
+def _cli_curation_count(tmp_path):
+    conn = _cli_conn(tmp_path)
+    try:
+        return _curation_count(conn)
+    finally:
+        conn.close()
+
+
+def test_cli_annotate_dry_run_then_apply(cli_ready, capsys):
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "Glucose")
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
+                "--status", "disputed", "--note", "two sources disagree") == 0
+    out = capsys.readouterr().out
+    assert "lab_result  Glucose" in out
+    assert "status: disputed" in out
+    assert "note: two sources disagree" in out
+    assert "dry run: nothing was written - re-run with --apply" in out
+    assert _cli_curation_count(cli_ready) == 0
+
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
+                "--status", "disputed", "--note", "two sources disagree",
+                "--attributed-to", "Dr Who", "--apply") == 0
+    out = capsys.readouterr().out
+    assert "attributed to: Dr Who" in out
+    assert "annotated lab_result" in out and "(create)" in out
+    assert _cli_curation_count(cli_ready) == 1
+
+
+def test_cli_annotate_json_shape_is_stable(cli_ready, capsys):
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "Glucose")
+    expected = {
+        "record_type", "dedup_base", "status", "note", "attributed_to",
+        "created_at", "merged_into_base", "label", "family_size", "previous",
+        "action", "applied",
+    }
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
+                "--status", "confirmed", "--note", "agreed", "--json") == 0
+    dry = json.loads(capsys.readouterr().out)
+    assert set(dry) == expected
+    assert dry["applied"] is False and dry["action"] == "create"
+    assert dry["previous"] is None and dry["label"] == "Glucose"
+
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
+                "--status", "confirmed", "--note", "agreed", "--json",
+                "--apply") == 0
+    applied = json.loads(capsys.readouterr().out)
+    assert set(applied) == expected and applied["applied"] is True
+
+
+def test_cli_annotate_list_with_and_without_a_table_filter(cli_ready, capsys):
+    lab = _cli_row_id(cli_ready, "lab_result", "test_name", "Glucose")
+    cond = _cli_row_id(cli_ready, "condition", "name", "Prediabetes")
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(lab),
+                "--status", "disputed", "--note", "a", "--apply") == 0
+    assert _run(cli_ready, "record", "annotate", "condition", str(cond),
+                "--status", "superseded", "--note", "b", "--apply") == 0
+
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "annotate", "--list") == 0
+    out = capsys.readouterr().out
+    assert "Glucose" in out and "Prediabetes" in out
+
+    assert _run(cli_ready, "record", "annotate", "--list", "lab_result",
+                "--json") == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert [r["record_type"] for r in rows] == ["lab_result"]
+    assert rows[0]["label"] == "Glucose" and rows[0]["family_size"] == 1
+
+
+def test_cli_annotate_list_is_friendly_when_empty(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "annotate", "--list") == 0
+    assert "no curation verdicts recorded" in capsys.readouterr().out
+
+
+def test_cli_annotate_clear(cli_ready, capsys):
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "Glucose")
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
+                "--status", "confirmed", "--note", "agreed", "--apply") == 0
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
+                "--clear") == 0
+    assert "dry run: nothing was written" in capsys.readouterr().out
+    assert _cli_curation_count(cli_ready) == 1
+
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
+                "--clear", "--apply") == 0
+    assert "cleared curation verdict for lab_result" in capsys.readouterr().out
+    assert _cli_curation_count(cli_ready) == 0
+
+
+def test_cli_annotate_requires_table_and_target_unless_list(cli_ready):
+    with pytest.raises(SystemExit) as exc:
+        _run(cli_ready, "record", "annotate", "lab_result")
+    assert exc.value.code == 2
+    with pytest.raises(SystemExit) as exc:
+        _run(cli_ready, "record", "annotate", "--list", "lab_result", "1")
+    assert exc.value.code == 2
+
+
+def test_cli_annotate_requires_status_and_note(cli_ready):
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "Glucose")
+    with pytest.raises(SystemExit) as exc:
+        _run(cli_ready, "record", "annotate", "lab_result", str(target))
+    assert exc.value.code == 2
+
+
+def test_cli_annotate_unknown_target_fails_friendly(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "annotate", "lab_result", "9999",
+                "--status", "disputed", "--note", "x", "--apply") == 1
+    assert "error: no lab_result with id 9999" in capsys.readouterr().err
+    assert _cli_curation_count(cli_ready) == 0
+
+
+def test_cli_annotate_empty_note_fails_friendly(cli_ready, capsys):
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "Glucose")
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
+                "--status", "disputed", "--note", "   ", "--apply") == 1
+    assert "error: a curation note is required" in capsys.readouterr().err
+    assert _cli_curation_count(cli_ready) == 0
+
+
+def test_cli_annotate_unknown_table_is_argparse_misuse(cli_ready):
+    with pytest.raises(SystemExit) as exc:
+        _run(cli_ready, "record", "annotate", "family_history", "1",
+             "--status", "disputed", "--note", "x")
+    assert exc.value.code == 2
+
+
+def test_cli_annotate_clear_without_a_verdict_fails_friendly(cli_ready, capsys):
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "Glucose")
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
+                "--clear", "--apply") == 1
+    assert "error: no curation verdict" in capsys.readouterr().err
+
+
+# --- the integration drill from the issue ------------------------------------
+
+
+def test_cli_annotate_render_remove_verify_drill(cli_ready, capsys):
+    """annotate --apply -> render summary shows the appendix -> record rm the whole
+    family -> verify warns about the orphan and still exits ok."""
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "Glucose")
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
+                "--status", "superseded", "--note", "repeat draw supersedes it",
+                "--apply") == 0
+
+    capsys.readouterr()
+    assert _run(cli_ready, "render", "summary", "--person", "jane-doe") == 0
+    summary = capsys.readouterr().out
+    assert "## Superseded / corrected" in summary
+    assert "lab_result: Glucose" in summary
+    assert "repeat draw supersedes it" in summary
+
+    assert _run(cli_ready, "record", "rm", "lab_result", str(target), "--apply") == 0
+
+    capsys.readouterr()
+    assert _run(cli_ready, "verify") == 0
+    out = capsys.readouterr().out
+    assert "warnings       1" in out
+    assert "has no live family" in out

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -18,6 +18,7 @@ EXPECTED_TABLES = {
     "allergy",
     "conflict",
     "document_tombstone",
+    "curation",
     "schema_migrations",
 }
 
@@ -42,6 +43,7 @@ ALL_MIGRATIONS = [
     "005_dedup_occurrence.sql",
     "006_condition_allergy.sql",
     "007_document_tombstone.sql",
+    "008_curation.sql",
 ]
 
 # Every record table carries the occurrence-family columns (migration 005; 006's two
@@ -129,7 +131,8 @@ def test_migration_006_moves_condition_and_allergy_observations(conn, tmp_path):
     conn.commit()
 
     assert db.migrate(conn) == [
-        "006_condition_allergy.sql", "007_document_tombstone.sql"
+        "006_condition_allergy.sql", "007_document_tombstone.sql",
+        "008_curation.sql",
     ]
 
     a = conn.execute("SELECT * FROM allergy").fetchone()
@@ -234,3 +237,38 @@ def test_foreign_keys_enforced(conn):
             "INSERT INTO lab_result (person_id, test_name, collected_at, dedup_key)"
             " VALUES (999, 'hba1c', '2026-01-01', 'k1')"
         )
+
+
+def _migrate_through_007(conn, tmp_path):
+    """Apply every migration up to 007, leaving 008 pending (a 007-era database)."""
+    import shutil
+
+    staged = tmp_path / "pre008"
+    staged.mkdir()
+    for path in sorted(db.DEFAULT_MIGRATIONS_DIR.glob("*.sql")):
+        if path.name < "008":
+            shutil.copy(path, staged / path.name)
+    db.migrate(conn, staged)
+    return staged
+
+
+def test_migration_008_applies_on_a_007_era_database(conn, tmp_path):
+    """The upgrade path for the curation overlay (issue #109): the table is additive,
+    so an existing database gains it without touching a single record row."""
+    from pemr import curation
+
+    _migrate_through_007(conn, tmp_path)
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane', 'Jane')")
+    conn.commit()
+    assert curation.has_table(conn) is False
+    assert curation.load_verdicts(conn) == {}  # readable before the migration exists
+
+    assert db.migrate(conn) == ["008_curation.sql"]
+
+    assert curation.has_table(conn) is True
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(curation)").fetchall()}
+    assert cols == {
+        "record_type", "dedup_base", "status", "note", "merged_into_base",
+        "attributed_to", "created_at",
+    }
+    assert conn.execute("SELECT COUNT(*) AS n FROM person").fetchone()["n"] == 1

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -477,3 +477,13 @@ def test_server_info_advertises_pemr_version():
     opts = mcp_server.build_server()._mcp_server.create_initialization_options()
     assert opts.server_name == "pemr"
     assert opts.server_version == __version__
+
+
+def test_curation_verbs_are_not_on_the_mcp_surface():
+    """Trust boundary (issue #109, the `document rm` / `record rm` precedent): a
+    human's clinical verdict is CLI-only. AGENTS.md's blessed write set is
+    commit_extraction/person_add/person_edit/ingest/document_set_text, and
+    `record annotate` is deliberately not in it - read or write."""
+    surface = " ".join(mcp_server.TOOL_NAMES).lower()
+    for spelling in ("annotate", "curation", "record_rm", "record_annotate"):
+        assert spelling not in surface, spelling

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -238,6 +238,30 @@ def test_timeline_carries_provenance(seeded):
     assert any(e["document_id"] is not None for e in events)
 
 
+def test_timeline_with_identity_stamps_family_keys(seeded):
+    """Issue #109: `render_journal` needs each event's family identity to apply the
+    curation overlay, and an event otherwise carries none."""
+    plain = query.query_timeline(seeded, "jane-doe")
+    tagged = query.query_timeline(seeded, "jane-doe", with_identity=True)
+
+    assert len(tagged) == len(plain)
+    assert all({"record_type", "dedup_base"} <= set(e) for e in tagged)
+    assert all(e["dedup_base"] for e in tagged)
+    assert {e["record_type"] for e in tagged} <= set(dedup.KNOWN_TYPES)
+    # Same events, same order, same values - identity is purely additive.
+    assert [
+        {k: v for k, v in e.items() if k not in ("record_type", "dedup_base")}
+        for e in tagged
+    ] == plain
+
+
+def test_timeline_default_shape_is_unchanged(seeded):
+    """Default-off is load-bearing: `dedup_base` is an INTERNAL_COLUMN, deliberately
+    absent from the CLI `--json` and MCP payloads."""
+    for e in query.query_timeline(seeded, "jane-doe"):
+        assert set(e) == {"date", "type", "summary", "document_id"}
+
+
 def test_timeline_summaries_are_ascii_safe(seeded):
     """§4 cp1252/cp437 console lesson: human-table summaries must be ASCII-only, or
     they crash on a non-UTF-8 Windows console (regression for the em-dash bounce —

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from pemr import db, dedup, persons, query, render
+from pemr import curation, db, dedup, persons, query, render
 
 DICT_PATH = Path(__file__).resolve().parent.parent / "data" / "dictionary.example.toml"
 
@@ -539,3 +539,151 @@ def test_unknown_person_raises(seeded):
         render.render_summary(seeded, "nobody")
     with pytest.raises(query.PersonNotFoundError):
         render.render_journal(seeded, "nobody")
+
+
+# --- curation overlay (issue #109) --------------------------------------------
+#
+# The overlay is additive: with no verdicts every render is byte-identical to what it
+# was before it existed (the golden test below is the guard), and a verdict changes
+# output only through the four documented behaviours.
+
+def _annotate(conn, record_type, column, value, **kwargs):
+    """Record a verdict on the family holding one seeded row."""
+    base = conn.execute(
+        f"SELECT dedup_base FROM {record_type} WHERE {column} = ?", (value,)
+    ).fetchone()["dedup_base"]
+    kwargs.setdefault("note", "clinician ruled")
+    curation.annotate_record(conn, record_type, base, apply=True, **kwargs)
+    return base
+
+
+def _renders(conn):
+    d = dedup.load_dictionary(DICT_PATH)
+    return {
+        "summary": render.render_summary(conn, "jane-doe", dictionary=d),
+        "brief": render.render_brief(conn, _upcoming_appt_id(conn), dictionary=d),
+        "journal": render.render_journal(conn, "jane-doe"),
+    }
+
+
+def test_no_verdicts_renders_byte_identically(seeded):
+    """The load-bearing guarantee: the appendix and questions sections are *omitted*,
+    not rendered empty, so unannotated output is unchanged to the byte."""
+    before = _renders(seeded)
+    # An empty `curation` table is the state every existing database is in.
+    assert seeded.execute("SELECT COUNT(*) AS n FROM curation").fetchone()["n"] == 0
+    after = _renders(seeded)
+    assert after == before
+    for md in before.values():
+        assert "Superseded / corrected" not in md
+        assert "Questions for the Clinician" not in md
+        assert "DISPUTED" not in md
+
+
+@pytest.mark.parametrize("status", ["superseded", "erroneous-in-source"])
+def test_superseded_family_leaves_its_section_for_the_appendix(seeded, status):
+    _annotate(seeded, "condition", "name", "Appendicitis", status=status,
+              note="never actually confirmed")
+    out = _renders(seeded)
+    for name, md in out.items():
+        if name == "brief":
+            continue  # the brief has no past-medical-history section
+        assert "## Superseded / corrected" in md, name
+        assert "condition: Appendicitis" in md, name
+        assert "never actually confirmed" in md, name
+    # Gone from Past Medical History, but the row itself is untouched.
+    body = out["summary"].split("## Superseded / corrected")[0]
+    assert "Appendicitis" not in body
+    assert seeded.execute(
+        "SELECT COUNT(*) AS n FROM condition WHERE name = 'Appendicitis'"
+    ).fetchone()["n"] == 1
+
+
+def test_disputed_family_renders_in_place_with_a_marker(seeded):
+    _annotate(seeded, "allergy", "substance", "Sulfa", status="disputed",
+              note="two notes disagree on criticality")
+    out = _renders(seeded)
+    for name in ("summary", "brief"):
+        assert "- Sulfa" in out[name], name
+        assert "[DISPUTED: two notes disagree on criticality]" in out[name], name
+        assert "Superseded / corrected" not in out[name], name
+    # ... and reaches the brief's clinician questions, but not the summary's.
+    assert "## Questions for the Clinician" in out["brief"]
+    assert "allergy: Sulfa - two notes disagree on criticality" in out["brief"]
+    assert "Questions for the Clinician" not in out["summary"]
+
+
+def test_disputed_marker_reaches_the_journal(seeded):
+    _annotate(seeded, "condition", "name", "Type 2 Diabetes", status="disputed",
+              note="onset date contested")
+    md = render.render_journal(seeded, "jane-doe")
+    assert "[DISPUTED: onset date contested]" in md
+
+
+def test_merged_into_renders_only_the_target(seeded):
+    target = seeded.execute(
+        "SELECT dedup_base FROM lab_result WHERE test_name = 'LDL'"
+    ).fetchone()["dedup_base"]
+    _annotate(seeded, "lab_result", "test_name", "Glucose, fasting",
+              status="merged-into", merged_into_base=target,
+              note="same analyte, two spellings")
+    md = render.render_summary(seeded, "jane-doe",
+                               dictionary=dedup.load_dictionary(DICT_PATH))
+    body, appendix = md.split("## Superseded / corrected")
+    assert "Glucose, fasting" not in body
+    assert "LDL" in body                                     # the target still renders
+    assert "lab_result: Glucose, fasting" in appendix
+    assert f"merged into {target[:12]}..." in appendix
+
+
+def test_confirmed_changes_nothing_but_the_row_still_renders(seeded):
+    before = _renders(seeded)
+    _annotate(seeded, "allergy", "substance", "Penicillin", status="confirmed",
+              note="clinician agreed")
+    after = _renders(seeded)
+    assert after == before
+
+
+def test_superseded_vital_does_not_win_latest(seeded):
+    """Ordering guard: the curation pass runs before the latest-wins fold, so a
+    superseded reading cannot hide the good one behind it."""
+    plain = render.render_summary(seeded, "jane-doe",
+                                  dictionary=dedup.load_dictionary(DICT_PATH))
+    assert "blood_pressure: 118.0 mmHg" in plain          # 2026 reading wins today
+
+    base = seeded.execute(
+        "SELECT dedup_base FROM observation WHERE obs_type='vital' AND "
+        "key='blood_pressure' AND value_num = 118"
+    ).fetchone()["dedup_base"]
+    curation.annotate_record(seeded, "observation", base, status="superseded",
+                             note="transcription error", apply=True)
+
+    md = render.render_summary(seeded, "jane-doe",
+                               dictionary=dedup.load_dictionary(DICT_PATH))
+    body = md.split("## Superseded / corrected")[0]
+    assert "blood_pressure: 118.0 mmHg" not in body
+    assert "blood_pressure: 128.0 mmHg" in body           # the 2025 reading takes over
+
+
+def test_superseded_lab_does_not_consume_a_brief_slot(seeded):
+    """The brief's top-N cut happens after the curation pass, so a superseded lab
+    frees its slot rather than spending it."""
+    _annotate(seeded, "lab_result", "test_name", "Glucose, fasting",
+              status="erroneous-in-source", note="wrong patient's requisition")
+    md = render.render_brief(seeded, _upcoming_appt_id(seeded), recent_labs=1,
+                             dictionary=dedup.load_dictionary(DICT_PATH))
+    labs = md.split("## Recent Labs")[1].split("## ")[0]
+    assert "Glucose, fasting" not in labs
+    assert "LDL" in labs                                  # next-most-recent takes it
+
+
+def test_curated_renders_stay_ascii_and_read_only(seeded):
+    before = _row_counts(seeded)
+    _annotate(seeded, "allergy", "substance", "Sulfa", status="disputed",
+              note="two notes disagree")
+    _annotate(seeded, "condition", "name", "Chickenpox", status="superseded",
+              note="duplicate of a later note")
+    for md in _renders(seeded).values():
+        assert md.isascii(), f"non-ASCII would crash a cp437 console: {md!r}"
+        md.encode("cp437")
+    assert _row_counts(seeded) == before  # still a pure read


### PR DESCRIPTION
## Summary
- Adds a `curation` overlay table (migration `008_curation.sql`) keyed by `(record_type, dedup_base)` recording human verdicts (`confirmed | superseded | erroneous-in-source | disputed | merged-into`) on record families — no record row is ever mutated.
- New engine module `pemr/curation.py` and CLI `pemr record annotate <table> <base-or-id> --status ... --note ...` (dry-run default, `--apply`), plus list/clear verbs. `record annotate` is CLI-only, deliberately absent from `mcp_server.WRITE_TOOLS`, matching `document rm` / `record rm`.
- `render.py` filters every section against the overlay at read time: `superseded`/`erroneous-in-source`/`merged-into` families move to a `## Superseded / corrected` appendix, `disputed` renders in place with a `[DISPUTED: <note>]` marker and surfaces in the brief's `## Questions for the Clinician`.
- `pemr verify` warns (never fails) on a curation verdict whose family no longer resolves.
- **Ship docs fan-out (this commit):** the original spec's "a verdict survives `pemr rekey`" claim is false for a dictionary-driven rekey that renames the family itself (that moves `dedup_base` and orphans the verdict — `pemr verify`'s orphan warning is exactly the backstop for this). Corrected the overclaiming in-code comments in `migrations/008_curation.sql`, `pemr/curation.py`, and `pemr/verify.py`; added a one-clause caveat to `docs/Architecture.md` §2/§6; and registered `record annotate`'s MCP exclusion in `AGENTS.md` alongside `record rm`/`document rm`, matching the precedent set for #107.

Closes #109

Verify report: https://github.com/meridun/pemr/issues/109#issuecomment-5229795583
Audit report: https://github.com/meridun/pemr/issues/109#issuecomment-5229817692

🤖 Generated with [Claude Code](https://claude.com/claude-code)