### PR TITLE
feat(records): human-attested rows with no source document (#110)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,13 +61,16 @@ Write tools (mutate the DB; the only tools that do):
 
 Read/write separation is also declared to the client via MCP `readOnlyHint` annotations.
 
-**Deletion — and clinical verdicts — are never an MCP tool.** `document rm`, `record rm` (the
-CLI's destructive verbs — the latter added by issue #107), and `record annotate` (issue #109) are
-deliberately excluded from the tool surface above. This is what keeps "an agent cannot delete PHI"
-true: removing a document or a single record row is a human-at-a-terminal action only, never
-something an agent can reach through this server. `record annotate` joins them for the adjacent
-reason — a `curation` verdict is a human's clinical judgment, and writing one can drop a record
-out of every generated document without deleting a row.
+**Deletion — and clinical verdicts, and unsourced writes — are never an MCP tool.** `document rm`,
+`record rm` (the CLI's destructive verbs — the latter added by issue #107), `record annotate`
+(issue #109), and `record assert` (issue #110) are deliberately excluded from the tool surface
+above. This is what keeps "an agent cannot delete PHI" true: removing a document or a single
+record row is a human-at-a-terminal action only, never something an agent can reach through this
+server. `record annotate` joins them for the adjacent reason — a `curation` verdict is a human's
+clinical judgment, and writing one can drop a record out of every generated document without
+deleting a row. `record assert` is the sharpest case of all — it is a *write*, not a deletion, and
+the only path in the system that can put a fact into the record with no external source; only a
+human at the CLI may vouch for one.
 
 ## MUST rules
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -81,7 +81,8 @@ CREATE TABLE person (
 );
 ```
 
-Provenance — every structured row traces to a source document:
+Provenance — every structured row traces to a source document **or to a named human
+attestation** (issue #110; the three row states are spelled out below the typed tables):
 
 ```sql
 CREATE TABLE document (
@@ -238,6 +239,26 @@ CREATE TABLE observation (
 );
 ```
 
+**Attestation columns** (migration 009, issue #110). Every one of the seven typed tables
+above additionally carries `attested_by` / `attested_on` / `attested_at`, all nullable and
+all omitted from the DDL for readability. They are the second legal provenance: `document_id`
+was already nullable at the DB level, and this is what makes a NULL there *meaningful*
+rather than a bug. Written only by `record assert` (CLI-only — never an MCP tool), never
+accepted from an extraction JSON, and deliberately absent from `dedup.FIELD_SPECS`, so keys
+are bit-identical for attested and document-sourced rows alike. Unlike `curation` this is
+**not** an overlay: an attestation is the row's own provenance and dies with the row, so it
+lives in columns rather than a sibling table. Three states, all derived
+(`dedup.attestation_state`), none stored twice:
+
+| state | predicate | renders as |
+|---|---|---|
+| document-sourced | `attested_by IS NULL` | an ordinary fact |
+| live attestation | `attested_by IS NOT NULL AND document_id IS NULL` | tagged `(attested by <who> <date>; no source document)` in **every** section |
+| superseded | `attested_by IS NOT NULL AND document_id IS NOT NULL` | an ordinary fact; the attestation is retained as history |
+
+Supersession is therefore just the attested row acquiring a `document_id` — nothing is
+deleted and the attestation columns are never cleared. See §3 for when that happens.
+
 Promotion path: an `obs_type` that grows important graduates from `observation`
 into its own typed table via a migration. The generic table absorbs the long tail so
 you're never blocked waiting on schema work. `condition` and `allergy` are the worked
@@ -300,6 +321,29 @@ new/duplicate/conflict). A stated value never overwrites a stored one on that pa
 enrichment cannot launder a disagreement into a silent overwrite. The same reading governs
 `keep incoming` on these types: it writes the fields the incoming row states and leaves the
 rest as stored, so a one-field adjudication doesn't erase the row's other payload.
+
+**Document provenance outranks an attestation** (issue #110). An attested row keys exactly
+like a document-sourced one, so a later `commit-extraction` of the same fact lands in the
+same identity family and the ordinary duplicate/conflict split decides the outcome — no new
+comparison path:
+
+* **payloads agree** — the document confirms what the family attested. This is the
+  *duplicate* branch, where by construction there is nothing to adjudicate, so the row is
+  **promoted in place**: it takes the `document_id`, keeps its attestation columns as
+  history, and the commit reports it under a fifth bucket, `promoted`. Same reading as
+  enrichment above — a stored NULL under a stated incoming value is a gain, not a
+  disagreement; here the NULL is `document_id`.
+* **payloads differ** — unchanged: a conflict is staged for a human. There is no
+  justification for auto-resolving a disagreement, only for recording an agreement.
+  `keep incoming` then promotes the row (it already writes `document_id`), `keep existing`
+  leaves the attestation live, and `keep both` admits the document row as the next
+  occurrence beside it.
+
+The mirror case — `record assert` onto a family the record already holds — is **refused,
+not staged**: an equal payload reports "already recorded" and writes nothing, a differing
+one raises and names the stored row. Same reason `commit_extraction`'s pass 1 refuses two
+colliding rows of one submission: the human is at the keyboard, and a conflict staged
+against oneself has no independent provenance to adjudicate.
 
 `norm()` = lowercase, trim, collapse whitespace, drop parenthetical qualifiers, map
 synonyms via an **analyte/name dictionary** (`data/dictionary.toml`) — e.g. `A1c`,
@@ -616,6 +660,11 @@ pemr record annotate <table> <base-or-id> --status <s> --note <text> [--attribut
                                                          # pure overlay - no record row is mutated; dry run by default
 pemr record annotate --list [<table>] [--json]           # current verdicts, newest first (orphans flagged)
 pemr record annotate <table> <base-or-id> --clear [--apply]      # lift one verdict
+pemr record assert <table> --person <slug> --attributed-to <who> --date <iso>
+                   --field NAME=VALUE [--field ...] [--apply]
+                                                         # commit a fact attested by a PERSON, with no
+                                                         # source document (§2 attestation); dry run by default
+pemr record assert --list [<table>] [--all] [--json]     # attested rows still needing a source document
 pemr document tombstone list [--json]                    # recorded intentional removals, newest first
 pemr document tombstone add (--file <path> | --sha256 <hex>) [--reason ...] [--note ...]
                                                          # pre-emptive exclusion; ingests and copies nothing
@@ -664,14 +713,16 @@ annotations expose the read/write split to the client.
 `commit_extraction`/`person_add`/`person_edit`/`ingest`/`document_set_text`; always `ingest` (with `ocr_text` populated) before
 extracting; dictionary additions go through human review, never agent-direct edits.
 
-`document rm`, `record rm` (issue #107) and `record annotate` (issue #109) are deliberately
-**absent** from `WRITE_TOOLS` — this is a rule, not an oversight. Deletion of PHI stays a
-human-at-a-terminal action; no MCP tool, and therefore no agent, can remove a record or a
-document. `record annotate` joins them for the adjacent reason: a `curation` verdict is a
-*human's clinical judgment*, recorded with attribution, and an agent that could write one could
-make a record disappear from every generated document without deleting a row. Any future
-destructive — or render-altering — verb should default to the same exclusion unless a human
-explicitly decides otherwise.
+`document rm`, `record rm` (issue #107), `record annotate` (issue #109) and `record assert`
+(issue #110) are deliberately **absent** from `WRITE_TOOLS` — this is a rule, not an
+oversight. Deletion of PHI stays a human-at-a-terminal action; no MCP tool, and therefore no
+agent, can remove a record or a document. `record annotate` joins them for the adjacent
+reason: a `curation` verdict is a *human's clinical judgment*, recorded with attribution, and
+an agent that could write one could make a record disappear from every generated document
+without deleting a row. `record assert` is the sharpest case of all — it is a *write*, not a
+deletion, and the only path in the system that can put a fact into the record with no
+external source. Any future destructive — or render-altering, or unsourced — verb should
+default to the same exclusion unless a human explicitly decides otherwise.
 
 ---
 

--- a/migrations/009_record_attestation.sql
+++ b/migrations/009_record_attestation.sql
@@ -1,0 +1,70 @@
+-- 009_record_attestation: human attestation as row provenance (issue #110).
+--
+-- Sometimes a fact is known to the family - a medication the operator personally manages -
+-- but the document that would prove it lives in a portal nobody has pulled yet. Today the
+-- only choices are to omit it (a summary that is wrong at the appointment) or to fabricate
+-- provenance (forbidden). This migration adds the third representation: "human-attested,
+-- source pending".
+--
+-- **Columns, not a sibling table** - the opposite of 008_curation's shape, deliberately.
+-- A curation verdict is a family-level judgment that must outlive the rows it rules on, so
+-- it belongs in an overlay keyed by (record_type, dedup_base). An attestation is the row's
+-- *own provenance*: it is what stands in for document_id, it means nothing without the row,
+-- and it dies with the row. So it lives beside document_id, on the row.
+--
+-- Every typed table's document_id is already nullable (migrations 001/006: a plain
+-- REFERENCES with no NOT NULL); only the Python write path insisted on a live document.
+-- Three row states, all derivable - no stored-and-derivable duplication:
+--
+--   document-sourced   attested_by IS NULL                              (today's only state)
+--   live attestation   attested_by IS NOT NULL AND document_id IS NULL  ("needs source")
+--   superseded         attested_by IS NOT NULL AND document_id IS NOT NULL
+--
+-- Supersession is therefore just the attested row acquiring a document_id: the row is never
+-- deleted and the attestation columns are never cleared, so "X said so on D before the
+-- document arrived" is retained as history on the fact itself. An explicit
+-- superseded_at/superseded_by pair was rejected - both are derivable from document_id, and a
+-- second source of truth for provenance is exactly what layer-2 cannot afford.
+--
+-- No CHECK and no FK: SQLite's ALTER TABLE ADD COLUMN can add neither, and the invariants are
+-- Python-side (pemr/attestations.py), which is also 007's stated choice. No index: access is a
+-- per-table `WHERE attested_by IS NOT NULL` scan over tables `rekey` and `verify` already scan
+-- whole.
+--
+-- The columns are absent from dedup.FIELD_SPECS, so dedup_key/dedup_base/rekey are
+-- bit-identical for every stored row, attested or not - "attested rows dedup normally" holds
+-- by construction rather than by a parallel code path.
+--
+-- Semantics:
+--   attested_by  the `--attributed-to` value, verbatim; mandatory, no anonymous attestation
+--   attested_on  the operator's `--date`: the date the attestation is MADE, not the clinical
+--                date (clinical dates stay in the payload columns)
+--   attested_at  engine-set ISO8601 UTC, timespec=seconds (as document.ingested_at)
+
+ALTER TABLE lab_result  ADD COLUMN attested_by TEXT;
+ALTER TABLE lab_result  ADD COLUMN attested_on TEXT;
+ALTER TABLE lab_result  ADD COLUMN attested_at TEXT;
+
+ALTER TABLE medication  ADD COLUMN attested_by TEXT;
+ALTER TABLE medication  ADD COLUMN attested_on TEXT;
+ALTER TABLE medication  ADD COLUMN attested_at TEXT;
+
+ALTER TABLE procedure   ADD COLUMN attested_by TEXT;
+ALTER TABLE procedure   ADD COLUMN attested_on TEXT;
+ALTER TABLE procedure   ADD COLUMN attested_at TEXT;
+
+ALTER TABLE appointment ADD COLUMN attested_by TEXT;
+ALTER TABLE appointment ADD COLUMN attested_on TEXT;
+ALTER TABLE appointment ADD COLUMN attested_at TEXT;
+
+ALTER TABLE observation ADD COLUMN attested_by TEXT;
+ALTER TABLE observation ADD COLUMN attested_on TEXT;
+ALTER TABLE observation ADD COLUMN attested_at TEXT;
+
+ALTER TABLE allergy     ADD COLUMN attested_by TEXT;
+ALTER TABLE allergy     ADD COLUMN attested_on TEXT;
+ALTER TABLE allergy     ADD COLUMN attested_at TEXT;
+
+ALTER TABLE condition   ADD COLUMN attested_by TEXT;
+ALTER TABLE condition   ADD COLUMN attested_on TEXT;
+ALTER TABLE condition   ADD COLUMN attested_at TEXT;

--- a/pemr/attestations.py
+++ b/pemr/attestations.py
@@ -1,0 +1,312 @@
+"""Human-attested records — `pemr record assert` (issue #110).
+
+A fact can be known to the family and still have no document behind it: a medication the
+operator personally manages, whose renewal note is sitting in a portal nobody has pulled.
+Until now the record had exactly two options, and both were wrong — omit the fact (and
+hand a clinician a summary that is missing a live drug) or invent a source (forbidden).
+This module is the third: **attestation**, provenance that is a named person rather than a
+document.
+
+    assert_record  -- commit one attested row, dry-run by default
+    list_attested  -- the "needs source" queue: live attestations, oldest first
+
+**Provenance on the row, not an overlay.** The curation overlay (#109) is keyed by
+``(record_type, dedup_base)`` because a verdict is a family-level judgment that must
+outlive the rows it rules on. An attestation is the opposite: it is what stands in for
+``document_id``, it means nothing without its row, and it dies with the row. So it lives in
+columns beside ``document_id`` (migration 009), and the three row states are derived, never
+stored twice — see :func:`dedup.attestation_state`.
+
+**Supersession is promotion.** When a later `commit-extraction` lands a document-sourced
+row on the same ``dedup_base``, document provenance wins: the attested row acquires the
+``document_id`` and keeps its attestation columns as history
+(:func:`dedup._promote_attestation`). Nothing is deleted, and the row stops rendering as
+unsourced the moment a real source backs it. A document that *disagrees* on the payload
+stages an ordinary conflict instead — there is no justification for auto-resolving a
+disagreement, only for recording an agreement.
+
+**Refuse, don't stage.** The mirror case — asserting a fact the record already holds —
+never stages a conflict. An equal payload reports ``duplicate`` and writes nothing; a
+differing one raises :class:`AttestationCollisionError` naming the stored row. Precedent:
+``commit_extraction``'s pass 1 already refuses two colliding rows of one submission,
+because the human is at the keyboard and a conflict staged against oneself has no
+independent provenance to adjudicate. A conflict would also have to carry
+``document_id = NULL``, which every resolution path treats as a document write.
+
+`record assert` is **CLI-only** and deliberately absent from ``mcp_server.WRITE_TOOLS`` and
+``TOOL_NAMES``, matching `document rm` / `record rm` / `record annotate`. It is the one
+path that can put a fact in the record with no external source, which is precisely the
+thing the blessed-write-set boundary exists to keep an agent out of.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from . import db, dedup, query
+
+
+class AttestationCollisionError(ValueError):
+    """Refused: the identity is already stored with a *different* payload.
+
+    Not a staged conflict — see the module docstring. Friendly rc=1 at the CLI.
+    """
+
+
+@dataclass
+class AttestReport:
+    """Structured result of :func:`assert_record`; also the ``--json`` payload shape, so
+    the key names in :meth:`as_dict` are a contract (the `record rm` / `record annotate`
+    rule)."""
+
+    record_type: str
+    person_id: int
+    person_slug: str
+    attributed_to: str
+    attested_on: str
+    attested_at: str
+    label: str = ""
+    fields: dict = field(default_factory=dict)
+    dedup_key: str = ""
+    dedup_base: str = ""
+    dedup_occurrence: int = 0
+    outcome: str = "new"                  # "new" | "duplicate"
+    row_id: int | None = None             # the row written (apply + new) or matched
+    existing_provenance: str = ""         # "document #N" | "attestation" | ""
+    applied: bool = False
+
+    def as_dict(self) -> dict:
+        return {
+            "record_type": self.record_type,
+            "person": self.person_slug,
+            "person_id": self.person_id,
+            "attributed_to": self.attributed_to,
+            "attested_on": self.attested_on,
+            "attested_at": self.attested_at,
+            "label": self.label,
+            "fields": self.fields,
+            "dedup_key": self.dedup_key,
+            "dedup_base": self.dedup_base,
+            "dedup_occurrence": self.dedup_occurrence,
+            "outcome": self.outcome,
+            "row_id": self.row_id,
+            "existing_provenance": self.existing_provenance,
+            "applied": self.applied,
+        }
+
+
+def _now(now: str | None = None) -> str:
+    """ISO8601 UTC to the second — the stamp `document.ingested_at` carries."""
+    return now or datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _require_type(record_type: str) -> None:
+    """Guard every f-string table interpolation below (the `records.remove_record`
+    idiom): a record type reaches SQL only after matching a known key."""
+    if record_type not in dedup.FIELD_SPECS:
+        raise ValueError(
+            f"unknown record type '{record_type}' - known types: "
+            f"{', '.join(dedup.KNOWN_TYPES)}"
+        )
+
+
+def has_columns(conn: sqlite3.Connection, record_type: str = "lab_result") -> bool:
+    """Whether the attestation columns exist — false for a database predating migration
+    009.
+
+    The :func:`curation.has_table` guard, one migration later: a snapshot restored from
+    before 009 must give an empty list rather than ``no such column``. Every other read
+    here goes through :func:`dedup.attestation_state`, which reads a row mapping and so
+    needs no guard of its own.
+    """
+    _require_type(record_type)
+    cols = {
+        row["name"] for row in conn.execute(f"PRAGMA table_info({record_type})").fetchall()
+    }
+    return "attested_by" in cols
+
+
+def _provenance(row: sqlite3.Row | dict) -> str:
+    """How a stored row got here, in one phrase for an error message or a report."""
+    row_map = dict(row)
+    if row_map.get("document_id") is not None:
+        return f"document #{row_map['document_id']}"
+    return "attestation"
+
+
+def assert_record(
+    conn: sqlite3.Connection,
+    record_type: str,
+    person_slug: str,
+    payload: dict,
+    *,
+    attributed_to: str,
+    attested_on: str,
+    dictionary: dict[str, str] | None = None,
+    now: str | None = None,
+    apply: bool = False,
+) -> AttestReport:
+    """Commit one row whose provenance is a person; dry-run by default.
+
+    The row goes through the *same* three gates ``commit_extraction`` uses —
+    :func:`dedup.validate_row`, :func:`dedup._assert_no_key_drift`,
+    :func:`dedup._insert_record` — so "attestations use the validated write path" is true
+    by construction rather than by convention, and the derived ``dedup_key`` /
+    ``dedup_base`` are byte-identical to what a document-sourced commit of the same
+    payload would produce.
+
+    Validation is front-loaded and nothing is written on any raise. The dry run *is* the
+    safety mechanism (the `record rm` lesson), so the report states which branch it took
+    and, for ``duplicate``, the stored row's id and provenance — otherwise an operator
+    cannot tell "nothing to do" from "about to write".
+
+    Raises ``ValueError`` for an unknown type / bad payload / non-ISO or empty attestation
+    metadata, :class:`query.PersonNotFoundError` for an unknown slug,
+    :class:`dedup.DictionaryDriftError` when a stored row of this identity is on a stale
+    key, and :class:`AttestationCollisionError` when the identity is already stored with a
+    different payload.
+    """
+    db.require_migrated(conn)
+    _require_type(record_type)
+    if not has_columns(conn, record_type):
+        raise ValueError(
+            "this database predates migration 009 and has nowhere to record an "
+            "attestation - run `pemr migrate` first; nothing was written"
+        )
+
+    person_id = query.resolve_person_id(conn, person_slug)
+    dedup.validate_row(record_type, payload)
+
+    who = (attributed_to or "").strip()
+    if not who:
+        raise ValueError(
+            "an attestation needs someone to attribute it to - pass "
+            "--attributed-to '<who>'; there is no anonymous attestation, because the "
+            "attribution is the only provenance this row will have; nothing was written"
+        )
+    when = (attested_on or "").strip()
+    if not when:
+        raise ValueError(
+            "an attestation needs the date it was made - pass --date YYYY-MM-DD; "
+            "nothing was written"
+        )
+    if not dedup._is_iso_date(when):
+        raise ValueError(
+            f"--date: expected ISO date at year (YYYY), month (YYYY-MM) or full "
+            f"(YYYY-MM-DD) precision, got {when!r}; nothing was written"
+        )
+
+    # Same guard as an ingest: a stored row of this identity sitting on a stale key would
+    # be missed below, filing the fact a second time instead of colliding with it.
+    dedup._assert_no_key_drift(conn, record_type, [payload], person_id, dictionary)
+
+    base = dedup.dedup_key(record_type, payload, person_id, dictionary)
+    family = dedup.load_family(conn, record_type, base)
+    stamp = _now(now)
+    report = AttestReport(
+        record_type=record_type,
+        person_id=person_id,
+        person_slug=person_slug.strip().lower(),
+        attributed_to=who,
+        attested_on=when,
+        attested_at=stamp,
+        # `_rekey_label` reads every column its type names, so it is given a fully
+        # keyed view; `fields` stays the sparse, operator-facing payload.
+        label=dedup._rekey_label(
+            record_type,
+            {name: payload.get(name) for name in dedup.FIELD_SPECS[record_type]},
+        ),
+        fields={
+            name: payload[name]
+            for name in dedup.FIELD_SPECS[record_type]
+            if payload.get(name) is not None
+        },
+        dedup_key=base,
+        dedup_base=base,
+    )
+
+    if family:
+        twin = next(
+            (f for f in family if dedup._rows_equal(record_type, f, payload)), None
+        )
+        pk = f"{record_type}_id"
+        if twin is None:
+            stored = family[0]
+            raise AttestationCollisionError(
+                f"{record_type} {stored[pk]} "
+                f"({dedup._rekey_label(record_type, stored)!r}, "
+                f"{_provenance(stored)}) already holds this identity with a different "
+                "value. An attestation is refused rather than staged as a conflict - "
+                "there is no second source to adjudicate against, only you. Correct the "
+                f"stored row (`pemr record rm {record_type} {stored[pk]}`, or "
+                "`pemr record annotate` to rule on it) and retry; nothing was written"
+            )
+        report.outcome = "duplicate"
+        report.row_id = int(twin[pk])
+        report.label = dedup._rekey_label(record_type, twin)
+        report.dedup_key = twin["dedup_key"]
+        report.dedup_occurrence = int(twin["dedup_occurrence"] or 0)
+        report.existing_provenance = _provenance(twin)
+        report.applied = apply
+        return report
+
+    if apply:
+        with conn:
+            report.row_id = dedup._insert_record(
+                conn, record_type, payload, person_id, None, base,
+                attestation=(who, when, stamp),
+            )
+    report.applied = apply
+    return report
+
+
+def list_attested(
+    conn: sqlite3.Connection,
+    record_type: str | None = None,
+    *,
+    include_superseded: bool = False,
+) -> list[dict]:
+    """Attested rows as plain dicts, oldest attestation first.
+
+    Live attestations only by default — that set *is* the "needs source" queue, and it is
+    the queryable surface a future `pemr review list` verb (the #109/#110 follow-up)
+    consumes without needing another schema change. ``include_superseded=True`` adds the
+    rows a document has since backed, which is how an operator confirms a source landed.
+
+    Returns dicts rather than ``sqlite3.Row``s deliberately: the caller is a report or a
+    ``--json`` payload, not a further query.
+    """
+    db.require_migrated(conn)
+    if record_type is not None:
+        _require_type(record_type)
+    if not has_columns(conn):
+        return []
+    types = (record_type,) if record_type is not None else dedup.KNOWN_TYPES
+
+    out: list[dict] = []
+    for rtype in types:
+        pk = f"{rtype}_id"
+        sql = (
+            f"SELECT {rtype}.*, person.slug AS person FROM {rtype} "
+            f"LEFT JOIN person ON person.person_id = {rtype}.person_id "
+            "WHERE attested_by IS NOT NULL"
+        )
+        if not include_superseded:
+            sql += " AND document_id IS NULL"
+        for row in conn.execute(sql).fetchall():
+            out.append({
+                "record_type": rtype,
+                "row_id": int(row[pk]),
+                "person": row["person"],
+                "label": dedup._rekey_label(rtype, row),
+                "attested_by": row["attested_by"],
+                "attested_on": row["attested_on"],
+                "attested_at": row["attested_at"],
+                "document_id": row["document_id"],
+                "needs_source": row["document_id"] is None,
+                "dedup_base": row["dedup_base"],
+            })
+    out.sort(key=lambda r: (r["attested_at"] or "", r["record_type"], r["row_id"]))
+    return out

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -18,8 +18,8 @@ from dataclasses import asdict
 from pathlib import Path
 
 from . import (
-    __version__, backup, curation, db, dedup, documents, ingest, persons, query,
-    records, render, restore, study, tombstones, verify,
+    __version__, attestations, backup, curation, db, dedup, documents, ingest, persons,
+    query, records, render, restore, study, tombstones, verify,
 )
 
 # Shipped starter analyte/name dictionary (framework, not user data — see .gitignore).
@@ -413,6 +413,7 @@ def _with_document_conn(args: argparse.Namespace, work):
             records.AnchoredConflictError,
             curation.CurationNotFoundError,
             curation.FamilyNotFoundError,
+            attestations.AttestationCollisionError,
             persons.PersonNotFoundError,
         ) as exc:
             print(f"error: {exc}", file=sys.stderr)
@@ -1009,6 +1010,149 @@ def _cmd_record_annotate(args: argparse.Namespace) -> int:
     return _with_document_conn(args, work)
 
 
+# --------------------------------------------------------------------------- #
+# human-attested records (`record assert`) - issue #110
+# --------------------------------------------------------------------------- #
+
+def _parse_field_args(
+    parser: argparse.ArgumentParser, table: str, raw: list[str] | None
+) -> dict:
+    """``--field NAME=VALUE`` repeats -> a payload dict for :mod:`dedup`.
+
+    Splits on the **first** ``=`` so a value may contain more (``--field
+    value_text=ratio=1.2``). Unknown and duplicated names are argparse misuse (rc=2 with
+    the usage line) rather than engine errors: they are typos in the command, and the
+    operator needs the field list right there. Numeric-spec fields are coerced, because
+    argparse hands everything over as text and ``value_num`` must not land as a string; a
+    value that will not coerce is passed through untouched so
+    :func:`dedup.validate_row` produces the type message instead of a worse one here.
+    """
+    spec = dedup.FIELD_SPECS[table]
+    payload: dict = {}
+    for item in raw or []:
+        name, sep, value = item.partition("=")
+        name = name.strip()
+        if not sep or not name:
+            parser.error(f"--field expects NAME=VALUE, got {item!r}")
+        if name not in spec:
+            parser.error(
+                f"unknown {table} field '{name}' - known fields: "
+                f"{', '.join(spec)}"
+            )
+        if name in payload:
+            parser.error(f"--field {name} given twice")
+        types = spec[name][0]
+        if isinstance(types, tuple) and int in types:
+            try:
+                payload[name] = int(value)
+            except ValueError:
+                try:
+                    payload[name] = float(value)
+                except ValueError:
+                    payload[name] = value
+        else:
+            payload[name] = value
+    return payload
+
+
+def _attested_row_line(row: dict) -> str:
+    """One `--list` line: what was attested, by whom, and whether a source arrived."""
+    state = "needs source" if row["needs_source"] else f"document #{row['document_id']}"
+    return (
+        f"{row['record_type']:12}  #{row['row_id']:<6}  {_fmt(row['person']):12}  "
+        f"{(row['attested_on'] or '')[:10]:10}  {row['label']}  "
+        f"[{row['attested_by']}]  ({state})"
+    )
+
+
+def _print_attest_report(report: "attestations.AttestReport") -> None:
+    """The human block, shaped like `_cmd_record_rm`'s: the fact, then its provenance."""
+    label = report.label or report.record_type
+    print(f"{report.record_type}  {_fmt(report.person_slug)}  {label}")
+    for name, value in report.fields.items():
+        print(f"  {name}: {value}")
+    print(
+        f"  attested by {report.attributed_to} on {report.attested_on} "
+        "(no source document)"
+    )
+    if report.outcome == "duplicate":
+        print(
+            f"  already recorded: {report.record_type} #{report.row_id} "
+            f"({report.existing_provenance}) holds this exact fact"
+        )
+
+
+def _cmd_record_assert(args: argparse.Namespace) -> int:
+    """`record assert` — list attested rows, or commit one attested fact.
+
+    Two modes on one subparser, the `_cmd_record_annotate` shape: `--list` takes an
+    optional table and no payload; otherwise the table and at least one `--field` are
+    required. The handler owns the rules argparse cannot express across ``nargs='?'``.
+    """
+    parser = args.assert_parser
+    if args.list:
+        def work(conn):
+            rows = attestations.list_attested(
+                conn, args.table, include_superseded=args.all
+            )
+            if args.json:
+                _print_json(rows)
+                return 0
+            if not rows:
+                print("no attested records")
+                return 0
+            print(
+                f"{'type':12}  {'row':7}  {'person':12}  {'attested':10}  label  "
+                "[who]  (source)"
+            )
+            for row in rows:
+                print(_attested_row_line(row))
+            return 0
+
+        return _with_document_conn(args, work)
+
+    if args.table is None:
+        parser.error("a table is required unless --list is given")
+    if not args.field:
+        parser.error(
+            "at least one --field NAME=VALUE is required - the fact being attested"
+        )
+    if not args.person:
+        parser.error("--person is required")
+    if not args.attributed_to:
+        parser.error("--attributed-to is required: who is attesting this fact")
+    if not args.date:
+        parser.error("--date is required: when the attestation was made")
+
+    payload = _parse_field_args(parser, args.table, args.field)
+    dictionary = dedup.load_dictionary(_resolve_dictionary_path(args))
+
+    def work(conn):
+        report = attestations.assert_record(
+            conn,
+            args.table,
+            args.person,
+            payload,
+            attributed_to=args.attributed_to,
+            attested_on=args.date,
+            dictionary=dictionary,
+            apply=args.apply,
+        )
+        if args.json:
+            _print_json(report.as_dict())
+            return 0
+        _print_attest_report(report)
+        if report.outcome == "duplicate":
+            print("nothing to do: the fact is already on record")
+        elif report.applied:
+            print(f"wrote {report.record_type} #{report.row_id}")
+        else:
+            print("dry run: nothing was written - re-run with --apply")
+        return 0
+
+    return _with_document_conn(args, work)
+
+
 def _report_owner_check(
     check: "ingest.OwnerCheck | None", person_slug: str, document_id: int
 ) -> None:
@@ -1176,6 +1320,13 @@ def _cmd_commit_extraction(args: argparse.Namespace) -> int:
         f"committed: {c['new']} new, {c['duplicate']} duplicate, "
         f"{c['enriched']} enriched, {c['conflict']} conflict"
     )
+    # Only when it happened, so an unattested commit's output is byte-identical to what
+    # it was before issue #110 (the additive-only rule).
+    if summary.promoted:
+        print(
+            f"note: {c['promoted']} attested record(s) now backed by this document - "
+            "the attestation is kept as history"
+        )
     if summary.conflict:
         print(
             f"note: {c['conflict']} conflict(s) staged - resolve with "
@@ -1353,7 +1504,12 @@ _HIDDEN_FIELDS = dedup.INTERNAL_COLUMNS
 
 
 def _clean(row: dict) -> dict:
-    return {k: v for k, v in row.items() if k not in _HIDDEN_FIELDS}
+    """Strip a record row down to its ``--json`` contract (:func:`dedup.public_row`).
+
+    Kept as a local alias because it reads at every call site; the rule itself lives in
+    `dedup` so the MCP read payload cannot drift from this one (issue #110).
+    """
+    return dedup.public_row(row)
 
 
 def _print_json(payload: object) -> None:
@@ -2042,6 +2198,43 @@ def build_parser() -> argparse.ArgumentParser:
     )
     r_annotate.add_argument("--json", action="store_true", help="machine-readable output")
     r_annotate.set_defaults(func=_cmd_record_annotate, annotate_parser=r_annotate)
+
+    # --- human-attested records (issue #110) ---
+    r_assert = record_sub.add_parser(
+        "assert",
+        help="record a fact attested by a person, with no source document yet "
+             "(dry run by default); CLI-only, never an agent write",
+    )
+    # Optional so `--list` can take an optional table and no payload; the handler
+    # enforces "table and --field unless --list" with the usage line.
+    r_assert.add_argument("table", nargs="?", choices=list(dedup.KNOWN_TYPES))
+    r_assert.add_argument("--person", help="owner slug, e.g. jane-doe")
+    r_assert.add_argument(
+        "--attributed-to", help="required: who is attesting this fact"
+    )
+    r_assert.add_argument(
+        "--date", help="required: when the attestation was made (ISO date)"
+    )
+    r_assert.add_argument(
+        "--field", action="append", metavar="NAME=VALUE",
+        help="one payload field; repeat for each (e.g. --field name=Metformin)",
+    )
+    r_assert.add_argument(
+        "--list", action="store_true",
+        help="list attested rows still needing a source document, and exit",
+    )
+    r_assert.add_argument(
+        "--all", action="store_true",
+        help="with --list: include attestations a document has since backed",
+    )
+    r_assert.add_argument(
+        "--apply", action="store_true", help="write the row (default: report only)"
+    )
+    r_assert.add_argument(
+        "--dictionary", help="synonym dictionary TOML (overrides default)"
+    )
+    r_assert.add_argument("--json", action="store_true", help="machine-readable output")
+    r_assert.set_defaults(func=_cmd_record_assert, assert_parser=r_assert)
 
     p_ingest = sub.add_parser(
         "ingest", help="ingest a document (hash, blob store, layer-1 dedup)"

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -109,6 +109,14 @@ KNOWN_TYPES = tuple(FIELD_SPECS)
 # CLI `--json` and MCP read payloads (unstable, not part of either contract).
 INTERNAL_COLUMNS = ("dedup_key", "dedup_base", "dedup_occurrence")
 
+# Human-attestation provenance columns on every record table (migration 009, issue #110).
+# Deliberately NOT in :data:`INTERNAL_COLUMNS` — those are stripped from `--json`/MCP
+# payloads, and provenance is the one thing that must stay visible. Equally deliberately
+# NOT in :data:`FIELD_SPECS`: like ``document_id`` they are never accepted from an agent's
+# extraction JSON, and their absence from the specs is what keeps every dedup key
+# bit-identical for attested and document-sourced rows alike.
+ATTESTATION_COLUMNS = ("attested_by", "attested_on", "attested_at")
+
 # Date-typed fields per record type. These feed timeline sort / trends date math and
 # the dedup_key (via _date_only), all of which assume a lexically-sortable ISO date —
 # so validate_row enforces ISO on them, not just the base `str` type. A partial
@@ -526,6 +534,57 @@ def _type_names(types: object) -> str:
 
 
 # --------------------------------------------------------------------------- #
+# Attestation provenance (issue #110)
+# --------------------------------------------------------------------------- #
+
+def attestation_state(row: sqlite3.Row | dict) -> str:
+    """Which of the three provenance states a stored row is in (migration 009):
+
+        ``""``            document-sourced — the only state before this feature;
+        ``"attested"``    a live human attestation, still needing a source document;
+        ``"superseded"``  attested, and since backed by a real document.
+
+    The single place the predicates are written down, so nothing else has to re-derive
+    "is this row unsourced" from two nullable columns. A pre-009 row (a snapshot restored
+    from before the migration) has no attestation columns at all and reads as
+    document-sourced, which is exactly what it is.
+    """
+    row_map = dict(row)
+    if not (row_map.get("attested_by") or "").strip():
+        return ""
+    return "superseded" if row_map.get("document_id") is not None else "attested"
+
+
+def is_attested(row: sqlite3.Row | dict) -> bool:
+    """True for a **live** attestation — attested and not yet backed by a document.
+
+    This is the render/query predicate: a superseded row has real document provenance
+    now, so it renders as an ordinary fact (its attestation survives as history on the
+    row, not as a marker on the page).
+    """
+    return attestation_state(row) == "attested"
+
+
+def public_row(row: sqlite3.Row | dict) -> dict:
+    """A record row reduced to its published read contract (CLI ``--json`` / MCP).
+
+    :data:`INTERNAL_COLUMNS` always go — unstable key machinery, never part of either
+    contract. The attestation columns go only when they are **NULL**: a document-sourced
+    row keeps the exact key set it had before migration 009 (the additive-only
+    guarantee), while an attested row carries its provenance, which is the whole point of
+    the feature and must never be quietly stripped.
+
+    One function rather than one rule per front door: a payload that discloses provenance
+    at the CLI but not over MCP is the drift this feature can least afford.
+    """
+    return {
+        name: value for name, value in dict(row).items()
+        if name not in INTERNAL_COLUMNS
+        and not (name in ATTESTATION_COLUMNS and value is None)
+    }
+
+
+# --------------------------------------------------------------------------- #
 # Commit extraction (new / duplicate / conflict split)
 # --------------------------------------------------------------------------- #
 
@@ -535,6 +594,8 @@ class CommitSummary:
     duplicate: list[tuple[str, str]] = field(default_factory=list)    # (type, dedup_key)
     enriched: list[tuple[str, int]] = field(default_factory=list)     # (type, row_id)
     conflict: list[tuple[str, int]] = field(default_factory=list)     # (type, conflict_id)
+    # Live attestations this commit backed with a real document (issue #110).
+    promoted: list[tuple[str, int]] = field(default_factory=list)     # (type, row_id)
 
     @property
     def counts(self) -> dict[str, int]:
@@ -543,6 +604,7 @@ class CommitSummary:
             "duplicate": len(self.duplicate),
             "enriched": len(self.enriched),
             "conflict": len(self.conflict),
+            "promoted": len(self.promoted),
         }
 
 
@@ -807,16 +869,30 @@ def commit_extraction(
                     (f for f in family if _rows_equal(record_type, f, row)), None
                 )
                 if twin is not None:
+                    twin_id = int(twin[f"{record_type}_id"])
+                    # The document confirms a fact the family attested before it had a
+                    # source (issue #110). Payloads agree, so by construction there is
+                    # nothing to adjudicate: this is the duplicate path, and the stored
+                    # NULL being filled happens to be `document_id`. Framed exactly as
+                    # #63 framed enrichment — a stored NULL under a stated incoming value
+                    # is a GAIN, not a disagreement. A *differing* payload never reaches
+                    # here; it stages a conflict below, which is the honest handling of
+                    # "the document contradicts what we were told".
+                    promoted = is_attested(twin)
+                    if promoted:
+                        _promote_attestation(conn, record_type, twin_id, document_id)
+                        summary.promoted.append((record_type, twin_id))
                     # A standing fact whose stored row lacks a field this document
                     # states is not a duplicate to drop — fill the NULL in place
                     # (issue #63). Nothing to adjudicate, so no conflict is staged,
                     # but the write is reported rather than being invisible.
                     gains = _sparse_gains(record_type, twin, row)
-                    twin_id = int(twin[f"{record_type}_id"])
                     if gains:
                         _enrich_record(conn, record_type, twin_id, gains)
                         summary.enriched.append((record_type, twin_id))
-                    else:
+                    elif not promoted:
+                        # `duplicate` means "nothing was written". A promotion writes, so
+                        # it is reported under its own bucket instead of both.
                         summary.duplicate.append((record_type, twin["dedup_key"]))
                 else:
                     # Stage against occurrence 0: it is the row the conflict's
@@ -908,11 +984,19 @@ def _insert_record(
     document_id: int | None,
     base: str,
     occurrence: int = 0,
+    *,
+    attestation: tuple[str, str, str] | None = None,
 ) -> int:
+    """Insert one validated row. ``attestation`` is ``(by, on, at)`` for a row whose
+    provenance is a person rather than a document (issue #110); every other caller leaves
+    it ``None`` and the columns stay NULL, exactly as before migration 009."""
     columns = ["person_id", "document_id", "dedup_key", "dedup_base", "dedup_occurrence"]
     values: list[object] = [
         person_id, document_id, occurrence_key(base, occurrence), base, occurrence,
     ]
+    if attestation is not None:
+        columns.extend(ATTESTATION_COLUMNS)
+        values.extend(attestation)
     for name in FIELD_SPECS[record_type]:
         if name in row and row[name] is not None:
             columns.append(name)
@@ -923,6 +1007,36 @@ def _insert_record(
         values,
     )
     return int(cur.lastrowid)
+
+
+def _promote_attestation(
+    conn: sqlite3.Connection, record_type: str, row_id: int, document_id: int
+) -> None:
+    """Back a live attestation with the document that just confirmed it (issue #110).
+
+    Sets ``document_id`` on the attested row and touches nothing else — not the payload,
+    not the keys, not the attestation columns, which stay as the history of what the
+    record knew before the document arrived. The row simply stops being renderable as
+    unsourced.
+
+    Confined to ``NULL -> id`` on a row that carries ``attested_by``: this is the only
+    path outside conflict resolution that writes ``document_id`` onto a stored row, and it
+    can never overwrite an existing one. The complement of :func:`_enrich_record`, which
+    deliberately leaves provenance alone because there the NULL is a payload column; here
+    provenance *is* the NULL being filled. A rowcount other than 1 is an error, never a
+    silent success (the :func:`_overwrite_record` guard idiom).
+    """
+    cur = conn.execute(
+        f"UPDATE {record_type} SET document_id = ? "
+        f"WHERE {record_type}_id = ? AND document_id IS NULL "
+        "AND attested_by IS NOT NULL",
+        (document_id, row_id),
+    )
+    if cur.rowcount != 1:
+        raise ValidationError(
+            f"promoting {record_type} row {row_id} to document {document_id} matched no "
+            "live attestation - refusing to record the promotion"
+        )
 
 
 def _stage_conflict(
@@ -1437,6 +1551,11 @@ def _overwrite_record(
     didn't say", so a single-field adjudication ("criticality: low, not high") must not
     also erase the reaction and noted_on the incoming document simply didn't repeat
     (issue #63). Fields it *does* state win, which is what keep-incoming means.
+
+    When the anchor is a live attestation, writing ``document_id`` here **is** the
+    conflict-flow supersession (issue #110): the human ruled for the document, so the row
+    takes both its payload and its provenance, and the attestation columns stay behind as
+    history. No extra code path — the assignment was already unconditional.
     """
     sparse = record_type in _SPARSE_TYPES
     assignments = ["document_id = ?"]

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -403,10 +403,9 @@ def query(
             raise ToolError(f"unknown query kind '{kind}' (known: labs, meds, timeline)")
     except (db.NotMigratedError, _query.PersonNotFoundError) as exc:
         raise _friendly(exc) from exc
-    return [
-        {k: v for k, v in r.items() if k not in _dedup.INTERNAL_COLUMNS}
-        for r in rows
-    ]
+    # Same read contract the CLI's `--json` emits: internal key columns stripped, and
+    # attestation provenance carried only when the row actually has it (issue #110).
+    return [_dedup.public_row(r) for r in rows]
 
 
 def find(

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -193,6 +193,10 @@ def query_timeline(
     Events without a usable date are omitted (they cannot be placed on a timeline).
     ``since`` (a date) drops events strictly before it. Ordered oldest first.
 
+    An event off a **human-attested** row (issue #110) additionally carries
+    ``attested_by``/``attested_on``; a document-sourced event carries neither key, so an
+    unattested record's event shape is unchanged.
+
     ``with_identity=True`` additionally stamps ``record_type`` and ``dedup_base`` on
     every event — the family identity `render_journal` needs to apply the `curation`
     overlay (issue #109), which the event contract otherwise has no way to express.
@@ -220,6 +224,15 @@ def query_timeline(
             "summary": summary,
             "document_id": row["document_id"],
         }
+        # Attestation provenance (issue #110) travels with the event, but only when the
+        # row actually carries it: an unattested database's timeline JSON keeps its exact
+        # key set, which is the additive-only guarantee. Unlike `dedup_base` this needs no
+        # opt-in flag - provenance is part of the public event contract, and an event that
+        # silently dropped "no source document" would be the one failure this feature
+        # cannot have.
+        if _row_get(row, "attested_by"):
+            event["attested_by"] = row["attested_by"]
+            event["attested_on"] = _row_get(row, "attested_on")
         if with_identity:
             event["record_type"] = record_type
             event["dedup_base"] = row["dedup_base"]

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -39,6 +39,12 @@ verdicts renders byte-identically to what it did before the overlay existed. Thi
 still a pure function of DB state -- the filter is a read, and output changes after a
 verdict because the database changed.
 
+**Attested rows** (issue #110). A row whose provenance is a named human rather than a
+document (`pemr record assert`) is tagged wherever it renders, by :func:`_attest_suffix` at
+every line builder: ``(attested by <who> <date>; no source document)``. It must never read
+as a document-sourced fact. Once a document backs it the row is promoted and renders
+unmarked, like any other sourced fact.
+
 Output is **ASCII-only** (the cp1252/cp437 Windows-console lesson from phases 2-3):
 plain hyphens, never em-dashes -- a non-ASCII byte crashes a non-UTF-8 console.
 
@@ -55,7 +61,7 @@ import sqlite3
 from datetime import datetime
 
 from . import curation, db, query
-from .dedup import enum_token, key_token
+from .dedup import enum_token, is_attested, key_token
 
 # Observation obs_type conventions this layer reads (see module docstring).
 OBS_VITAL = "vital"
@@ -251,6 +257,27 @@ def _dispute_suffix(row: dict) -> str:
     return ""
 
 
+def _attest_suffix(row: dict) -> str:
+    """``  (attested by <who> <date>; no source document)`` for a live attestation,
+    ``""`` otherwise (issue #110).
+
+    The single most important failure mode this feature can have is an unsourced fact
+    rendering identically to a document-sourced one, so the mitigation is structural: one
+    predicate (:func:`dedup.is_attested`), one suffix builder, appended at **every** line
+    builder that renders a typed-table row. A *superseded* attestation is deliberately
+    unmarked - a real document backs it now, and its attestation survives as history on
+    the row, not as a caveat on the page.
+
+    Placed after :func:`_dispute_suffix` wherever both apply: the verdict is about the
+    fact, provenance is about where the fact came from, and provenance reads last.
+    """
+    if not isinstance(row, dict) or not is_attested(row):
+        return ""
+    when = str(row.get("attested_on") or "").strip()
+    stamp = f" {when}" if when else ""
+    return f"  (attested by {row['attested_by']}{stamp}; no source document)"
+
+
 def _appendix_section(entries: dict[tuple[str, str], dict]) -> str | None:
     """The ``## Superseded / corrected`` section, or ``None`` when there is nothing
     to say.
@@ -332,14 +359,20 @@ def _condition_line(row: dict, *, past: bool = False) -> str:
         f"  (resolved {row['resolved_on']})" if past and row["resolved_on"] else ""
     )
     note = f" - {row['note']}" if row["note"] else ""
-    return f"- {row['name']}{since}{resolved}{note}{_dispute_suffix(row)}"
+    return (
+        f"- {row['name']}{since}{resolved}{note}"
+        f"{_dispute_suffix(row)}{_attest_suffix(row)}"
+    )
 
 
 def _allergy_line(row: dict) -> str:
     crit = f" [{str(row['criticality']).upper()}]" if row["criticality"] else ""
     reaction = f" - {row['reaction']}" if row["reaction"] else ""
     noted = f"  (noted {row['noted_on']})" if row["noted_on"] else ""
-    return f"- {row['substance']}{crit}{reaction}{noted}{_dispute_suffix(row)}"
+    return (
+        f"- {row['substance']}{crit}{reaction}{noted}"
+        f"{_dispute_suffix(row)}{_attest_suffix(row)}"
+    )
 
 
 def _latest_vitals(
@@ -438,7 +471,12 @@ def _order_line(row: dict) -> str:
         first = f", first {row['group_first']}" if row["group_first"] else ""
         notes.append(f"+{row['group_count'] - 1} earlier{first}")
     note = f"  ({'; '.join(notes)})" if notes else ""
-    return f"- {_order_display(row)}{detail}{note}{_dispute_suffix(row)}"
+    # `_grouped_orders` folds a group to its newest member, so the suffix describes the
+    # displayed row - the same rule `_dispute_suffix` already follows here.
+    return (
+        f"- {_order_display(row)}{detail}{note}"
+        f"{_dispute_suffix(row)}{_attest_suffix(row)}"
+    )
 
 
 def _abnormal_labs(
@@ -581,7 +619,9 @@ def render_summary(
         dose = f" {m['dose']}" if m["dose"] else ""
         freq = f" {m['frequency']}" if m["frequency"] else ""
         since = f" (since {m['started_on']})" if m["started_on"] else ""
-        med_lines.append(f"- {m['name']}{dose}{freq}{since}{_dispute_suffix(m)}")
+        med_lines.append(
+            f"- {m['name']}{dose}{freq}{since}{_dispute_suffix(m)}{_attest_suffix(m)}"
+        )
 
     active_lines = [
         _condition_line(c) for c in _conditions(conn, person_id, CONDITION_ACTIVE, cur)
@@ -591,7 +631,8 @@ def render_summary(
         for c in _conditions(conn, person_id, CONDITION_PAST, cur)
     ]
     family_lines = [
-        f"- {c['relation'] or 'family'}: {c['name']}{_dispute_suffix(c)}"
+        f"- {c['relation'] or 'family'}: {c['name']}"
+        f"{_dispute_suffix(c)}{_attest_suffix(c)}"
         for c in _conditions(conn, person_id, CONDITION_FAMILY, cur)
     ]
     allergy_lines = [_allergy_line(a) for a in _allergies(conn, person_id, cur)]
@@ -605,7 +646,8 @@ def render_summary(
         unit = f" {v['unit']}" if v["unit"] else ""
         when = f"  ({_date_part(v['observed_at'])})" if v["observed_at"] else ""
         vital_lines.append(
-            f"- {v['key']}: {_fmt(value)}{unit}{when}{_dispute_suffix(v)}"
+            f"- {v['key']}: {_fmt(value)}{unit}{when}"
+            f"{_dispute_suffix(v)}{_attest_suffix(v)}"
         )
 
     lab_lines = []
@@ -613,11 +655,12 @@ def render_summary(
         flag = f" [{r['flag']}]" if r["flag"] else ""
         lab_lines.append(
             f"- {_date_part(r['collected_at'])}  {r['test_name']}  "
-            f"{_lab_value(r)}{flag}{_ref_range(r)}{_dispute_suffix(r)}"
+            f"{_lab_value(r)}{flag}{_ref_range(r)}"
+            f"{_dispute_suffix(r)}{_attest_suffix(r)}"
         )
 
     appt_lines = [
-        f"- {_appt_line(a)}{_dispute_suffix(a)}"
+        f"- {_appt_line(a)}{_dispute_suffix(a)}{_attest_suffix(a)}"
         for a in _open_appointments(conn, person_id, today, cur)
     ]
 
@@ -697,7 +740,9 @@ def render_brief(
     for m in meds:
         dose = f" {m['dose']}" if m["dose"] else ""
         freq = f" {m['frequency']}" if m["frequency"] else ""
-        med_lines.append(f"- {m['name']}{dose}{freq}{_dispute_suffix(m)}")
+        med_lines.append(
+            f"- {m['name']}{dose}{freq}{_dispute_suffix(m)}{_attest_suffix(m)}"
+        )
 
     # Recency stays the primary axis, but a single draw can carry a 50+ analyte panel —
     # a flat `LIMIT N` over `collected_at DESC, test_name` then returns the
@@ -731,7 +776,7 @@ def render_brief(
         abnormal = f"  [!]{_ref_range(r)}" if _is_abnormal(r) else ""
         lab_lines.append(
             f"- {_date_part(r['collected_at'])}  {r['test_name']}  "
-            f"{_lab_value(r)}{flag}{abnormal}{_dispute_suffix(r)}"
+            f"{_lab_value(r)}{flag}{abnormal}{_dispute_suffix(r)}{_attest_suffix(r)}"
         )
 
     proc_rows = _apply_curation(
@@ -761,7 +806,7 @@ def render_brief(
         outcome = f" - {p['outcome']}" if p["outcome"] else ""
         ctx_lines.append(
             f"- {_date_part(p['performed_on']) or '(undated)'}  procedure: "
-            f"{p['name']}{outcome}{_dispute_suffix(p)}"
+            f"{p['name']}{outcome}{_dispute_suffix(p)}{_attest_suffix(p)}"
         )
     for o in obs_rows:
         value = o["value_num"] if o["value_num"] is not None else o["value_text"]
@@ -769,7 +814,7 @@ def render_brief(
         detail = " ".join(p for p in (o["obs_type"], o["key"]) if p)
         ctx_lines.append(
             f"- {_date_part(o['observed_at']) or '(undated)'}  {detail}{val}"
-            f"{_dispute_suffix(o)}"
+            f"{_dispute_suffix(o)}{_attest_suffix(o)}"
         )
 
     brief_allergy_lines = [_allergy_line(a) for a in _allergies(conn, person_id, cur)]
@@ -866,7 +911,12 @@ def render_journal(
         ref = ""
         if e["document_id"] is not None:
             ref = f" [^{footnote_num[e['document_id']]}]"
-        lines.append(f"- **{e['type']}** -- {e['summary']}{ref}{_dispute_suffix(e)}")
+        # An attested event has no document_id, so it takes no [^n] footnote marker and
+        # the suffix is the only thing that says where the fact came from (issue #110).
+        lines.append(
+            f"- **{e['type']}** -- {e['summary']}{ref}"
+            f"{_dispute_suffix(e)}{_attest_suffix(e)}"
+        )
 
     # Before the footnote block: footnotes are reference apparatus for the events
     # above them and stay last.

--- a/tests/test_attestations.py
+++ b/tests/test_attestations.py
@@ -1,0 +1,428 @@
+"""Human-attested records: `pemr record assert` (issue #110).
+
+Covers the module surface (pemr/attestations.py) and the CLI wiring, in the shape
+test_records.py uses for `record rm`. The two things this feature cannot get wrong get
+their own tests: an attested row must key exactly like a document-sourced one, and it must
+never be indistinguishable from a sourced fact.
+"""
+
+import json
+
+import pytest
+
+from pemr import attestations, cli, db, dedup, persons, query
+
+MED = {"name": "Metformin", "dose": "500 mg", "started_on": "2025-06-01"}
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    conn = db.connect(tmp_path / "test.db")
+    db.migrate(conn)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture()
+def jane(conn):
+    return persons.add_person(conn, "jane-doe", "Jane Doe")
+
+
+def _document(conn, person_id, sha="aa11bb22"):
+    cur = conn.execute(
+        "INSERT INTO document (sha256, person_id, source_path, ingested_at) "
+        "VALUES (?, ?, ?, '2026-01-01T00:00:00')",
+        (sha, person_id, f"{sha[:2]}/{sha}.pdf"),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+def _assert_med(conn, payload=None, **kwargs):
+    return attestations.assert_record(
+        conn, "medication", "jane-doe", dict(payload or MED),
+        attributed_to=kwargs.pop("attributed_to", "Mom"),
+        attested_on=kwargs.pop("attested_on", "2026-08-09"),
+        **kwargs,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# assert_record: dry run, write, and the derived identity
+# --------------------------------------------------------------------------- #
+
+def test_dry_run_writes_nothing_and_reports_the_branch(conn, jane):
+    report = _assert_med(conn)
+    assert report.outcome == "new"
+    assert report.applied is False
+    assert report.row_id is None
+    assert report.label == "Metformin"
+    assert report.fields == MED
+    assert report.dedup_key == report.dedup_base
+    assert conn.execute("SELECT COUNT(*) AS n FROM medication").fetchone()["n"] == 0
+
+
+def test_apply_inserts_one_unsourced_row_with_the_attestation(conn, jane):
+    report = _assert_med(conn, apply=True)
+    assert report.applied is True
+    row = conn.execute("SELECT * FROM medication").fetchone()
+    assert int(row["medication_id"]) == report.row_id
+    assert row["document_id"] is None
+    assert row["attested_by"] == "Mom"
+    assert row["attested_on"] == "2026-08-09"
+    assert row["attested_at"] == report.attested_at
+    assert row["name"] == "Metformin"
+    assert dedup.attestation_state(row) == "attested"
+    assert dedup.is_attested(row) is True
+
+
+def test_attested_row_keys_exactly_like_a_document_sourced_one(conn, jane):
+    """The AC that makes "attested rows dedup normally" mean something: the key is
+    derived from the payload and the person, and provenance is not part of it."""
+    report = _assert_med(conn, apply=True)
+    expected = dedup.dedup_key("medication", MED, jane.person_id)
+    row = conn.execute("SELECT * FROM medication").fetchone()
+    assert row["dedup_key"] == expected
+    assert row["dedup_base"] == expected
+    assert report.dedup_base == expected
+    assert int(row["dedup_occurrence"]) == 0
+
+
+def test_attested_row_is_indexed_for_find_like_any_other(conn, jane):
+    """The FTS triggers are provenance-blind, so an unsourced fact is still findable."""
+    _assert_med(conn, apply=True)
+    hits = query.find(conn, "jane-doe", "Metformin")
+    assert [h["source_table"] for h in hits] == ["medication"]
+    assert hits[0]["document_id"] is None
+
+
+# --------------------------------------------------------------------------- #
+# Validation — every refusal writes nothing
+# --------------------------------------------------------------------------- #
+
+def _nothing_written(conn):
+    return conn.execute("SELECT COUNT(*) AS n FROM medication").fetchone()["n"] == 0
+
+
+def test_unknown_record_type_is_refused(conn, jane):
+    with pytest.raises(ValueError, match="unknown record type"):
+        attestations.assert_record(
+            conn, "family_history", "jane-doe", {}, attributed_to="Mom",
+            attested_on="2026-08-09", apply=True,
+        )
+
+
+def test_unknown_person_is_refused(conn, jane):
+    with pytest.raises(query.PersonNotFoundError):
+        attestations.assert_record(
+            conn, "medication", "nobody", dict(MED), attributed_to="Mom",
+            attested_on="2026-08-09", apply=True,
+        )
+    assert _nothing_written(conn)
+
+
+def test_unknown_field_is_refused(conn, jane):
+    with pytest.raises(dedup.ValidationError, match="unknown field"):
+        _assert_med(conn, payload=MED | {"nope": "x"}, apply=True)
+    assert _nothing_written(conn)
+
+
+def test_missing_required_field_is_refused(conn, jane):
+    with pytest.raises(dedup.ValidationError, match="missing required field"):
+        _assert_med(conn, payload={"dose": "500 mg"}, apply=True)
+    assert _nothing_written(conn)
+
+
+def test_bad_payload_type_is_refused(conn, jane):
+    with pytest.raises(dedup.ValidationError, match="expected str"):
+        attestations.assert_record(
+            conn, "lab_result", "jane-doe",
+            {"test_name": "HbA1c", "collected_at": "2026-01-02", "unit": 5},
+            attributed_to="Mom", attested_on="2026-08-09", apply=True,
+        )
+
+
+def test_non_iso_attestation_date_is_refused(conn, jane):
+    with pytest.raises(ValueError, match="--date"):
+        _assert_med(conn, attested_on="08/09/2026", apply=True)
+    assert _nothing_written(conn)
+
+
+def test_empty_attribution_is_refused(conn, jane):
+    with pytest.raises(ValueError, match="attributed-to"):
+        _assert_med(conn, attributed_to="   ", apply=True)
+    assert _nothing_written(conn)
+
+
+def test_key_drift_still_refuses_an_assert(conn, jane):
+    """`_assert_no_key_drift` is one of the three gates an assert shares with an ingest:
+    a stored row on a stale key would be forked rather than collided with."""
+    doc = _document(conn, jane.person_id)
+    dedup.commit_extraction(conn, doc, {"medication": [MED]})
+    conn.execute("UPDATE medication SET dedup_key = 'stale', dedup_base = 'stale'")
+    conn.commit()
+    with pytest.raises(dedup.DictionaryDriftError, match="pemr rekey"):
+        _assert_med(conn, apply=True)
+
+
+# --------------------------------------------------------------------------- #
+# Collision — refused, never staged
+# --------------------------------------------------------------------------- #
+
+def test_asserting_a_fact_already_on_record_reports_duplicate(conn, jane):
+    doc = _document(conn, jane.person_id)
+    dedup.commit_extraction(conn, doc, {"medication": [MED]})
+    report = _assert_med(conn, apply=True)
+    assert report.outcome == "duplicate"
+    assert report.existing_provenance == f"document #{doc}"
+    assert report.row_id == 1
+    assert conn.execute("SELECT COUNT(*) AS n FROM medication").fetchone()["n"] == 1
+    assert conn.execute(
+        "SELECT COUNT(*) AS n FROM medication WHERE attested_by IS NOT NULL"
+    ).fetchone()["n"] == 0
+
+
+def test_asserting_a_differing_payload_is_refused_not_staged(conn, jane):
+    doc = _document(conn, jane.person_id)
+    dedup.commit_extraction(conn, doc, {"medication": [MED | {"frequency": "BID"}]})
+    with pytest.raises(attestations.AttestationCollisionError) as exc:
+        _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+    assert "medication 1" in str(exc.value)
+    assert "document #1" in str(exc.value)
+    # Refused, not staged: no conflict row, and the stored value is untouched.
+    assert conn.execute("SELECT COUNT(*) AS n FROM conflict").fetchone()["n"] == 0
+    assert conn.execute(
+        "SELECT frequency FROM medication"
+    ).fetchone()["frequency"] == "BID"
+
+
+def test_the_collision_message_names_an_attestation_as_such(conn, jane):
+    _assert_med(conn, apply=True)
+    with pytest.raises(attestations.AttestationCollisionError, match="attestation"):
+        _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+
+
+# --------------------------------------------------------------------------- #
+# list_attested — the "needs source" queue
+# --------------------------------------------------------------------------- #
+
+def test_list_attested_reports_only_live_attestations_by_default(conn, jane):
+    doc = _document(conn, jane.person_id)
+    dedup.commit_extraction(conn, doc, {
+        "lab_result": [{"test_name": "HbA1c", "collected_at": "2026-01-02"}]
+    })
+    _assert_med(conn, apply=True)
+    rows = attestations.list_attested(conn)
+    assert [(r["record_type"], r["label"], r["needs_source"]) for r in rows] == [
+        ("medication", "Metformin", True)
+    ]
+    assert rows[0]["person"] == "jane-doe"
+    assert rows[0]["attested_by"] == "Mom"
+    assert rows[0]["document_id"] is None
+
+
+def test_list_attested_can_include_superseded_rows(conn, jane):
+    _assert_med(conn, apply=True)
+    doc = _document(conn, jane.person_id)
+    dedup.commit_extraction(conn, doc, {"medication": [MED]})
+    assert attestations.list_attested(conn) == []
+    rows = attestations.list_attested(conn, include_superseded=True)
+    assert [(r["needs_source"], r["document_id"]) for r in rows] == [(False, doc)]
+
+
+def test_list_attested_filters_by_record_type(conn, jane):
+    _assert_med(conn, apply=True)
+    attestations.assert_record(
+        conn, "allergy", "jane-doe", {"substance": "Penicillin"},
+        attributed_to="Mom", attested_on="2026-08-09", apply=True,
+    )
+    assert [r["record_type"] for r in attestations.list_attested(conn, "allergy")] == [
+        "allergy"
+    ]
+    with pytest.raises(ValueError, match="unknown record type"):
+        attestations.list_attested(conn, "family_history")
+
+
+# --------------------------------------------------------------------------- #
+# CLI wiring
+# --------------------------------------------------------------------------- #
+
+def _run(tmp_path, *argv):
+    return cli.main(["--db", str(tmp_path / "cli.db"), *argv])
+
+
+@pytest.fixture()
+def cli_ready(tmp_path):
+    assert _run(tmp_path, "migrate", "--create") == 0
+    assert _run(tmp_path, "person", "add", "--slug", "jane-doe", "--name", "Jane") == 0
+    return tmp_path
+
+
+_ASSERT_ARGV = (
+    "record", "assert", "medication", "--person", "jane-doe",
+    "--attributed-to", "Mom", "--date", "2026-08-09",
+    "--field", "name=Metformin", "--field", "dose=500 mg",
+    "--field", "started_on=2025-06-01",
+)
+
+
+def test_cli_assert_dry_run(cli_ready, capsys):
+    assert _run(cli_ready, *_ASSERT_ARGV) == 0
+    out = capsys.readouterr().out
+    assert "attested by Mom on 2026-08-09 (no source document)" in out
+    assert "dry run: nothing was written" in out
+    assert _run(cli_ready, "record", "assert", "--list") == 0
+    assert "no attested records" in capsys.readouterr().out
+
+
+def test_cli_assert_apply_then_list(cli_ready, capsys):
+    assert _run(cli_ready, *_ASSERT_ARGV, "--apply") == 0
+    assert "wrote medication #1" in capsys.readouterr().out
+    assert _run(cli_ready, "record", "assert", "--list") == 0
+    out = capsys.readouterr().out
+    assert "Metformin" in out and "needs source" in out and "Mom" in out
+
+
+def test_cli_assert_json_shape_is_stable(cli_ready, capsys):
+    assert _run(cli_ready, *_ASSERT_ARGV, "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == {
+        "record_type", "person", "person_id", "attributed_to", "attested_on",
+        "attested_at", "label", "fields", "dedup_key", "dedup_base",
+        "dedup_occurrence", "outcome", "row_id", "existing_provenance", "applied",
+    }
+    assert payload["outcome"] == "new"
+    assert payload["applied"] is False
+    assert payload["fields"]["name"] == "Metformin"
+
+    assert _run(cli_ready, *_ASSERT_ARGV, "--apply", "--json") == 0
+    written = json.loads(capsys.readouterr().out)
+    assert written["applied"] is True and written["row_id"] == 1
+
+    assert _run(cli_ready, "record", "assert", "--list", "--json") == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert set(rows[0]) == {
+        "record_type", "row_id", "person", "label", "attested_by", "attested_on",
+        "attested_at", "document_id", "needs_source", "dedup_base",
+    }
+
+
+def test_cli_assert_numeric_fields_are_coerced(cli_ready, capsys):
+    assert _run(
+        cli_ready, "record", "assert", "lab_result", "--person", "jane-doe",
+        "--attributed-to", "Mom", "--date", "2026-08-09",
+        "--field", "test_name=HbA1c", "--field", "collected_at=2026-01-02",
+        "--field", "value_num=5.7", "--field", "unit=%", "--apply", "--json",
+    ) == 0
+    assert json.loads(capsys.readouterr().out)["fields"]["value_num"] == 5.7
+
+
+def test_cli_assert_unknown_field_is_argparse_misuse(cli_ready):
+    with pytest.raises(SystemExit) as exc:
+        _run(cli_ready, "record", "assert", "medication", "--person", "jane-doe",
+             "--attributed-to", "Mom", "--date", "2026-08-09", "--field", "nope=1")
+    assert exc.value.code == 2
+
+
+def test_cli_assert_requires_a_payload(cli_ready):
+    with pytest.raises(SystemExit) as exc:
+        _run(cli_ready, "record", "assert", "medication", "--person", "jane-doe",
+             "--attributed-to", "Mom", "--date", "2026-08-09")
+    assert exc.value.code == 2
+
+
+def test_cli_assert_requires_attribution(cli_ready):
+    with pytest.raises(SystemExit) as exc:
+        _run(cli_ready, "record", "assert", "medication", "--person", "jane-doe",
+             "--date", "2026-08-09", "--field", "name=Metformin")
+    assert exc.value.code == 2
+
+
+def test_cli_assert_bad_date_fails_friendly(cli_ready, capsys):
+    assert _run(
+        cli_ready, "record", "assert", "medication", "--person", "jane-doe",
+        "--attributed-to", "Mom", "--date", "08/09/2026",
+        "--field", "name=Metformin", "--apply",
+    ) == 1
+    assert "error:" in capsys.readouterr().err
+
+
+def test_cli_assert_collision_fails_friendly(cli_ready, capsys):
+    assert _run(cli_ready, *_ASSERT_ARGV, "--apply") == 0
+    capsys.readouterr()
+    assert _run(cli_ready, *_ASSERT_ARGV, "--field", "frequency=BID", "--apply") == 1
+    assert "already holds this identity" in capsys.readouterr().err
+
+
+def test_cli_walk_from_attestation_to_a_source_document(cli_ready, capsys):
+    """The whole point, end to end: attest a fact with no document, see it flagged as
+    needing a source, then ingest the document that proves it and watch the row be
+    promoted rather than duplicated."""
+    assert _run(cli_ready, *_ASSERT_ARGV, "--apply") == 0
+    capsys.readouterr()
+
+    scan = cli_ready / "note.txt"
+    scan.write_bytes(b"metformin 500 mg daily")
+    assert _run(cli_ready, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(cli_ready / "sources")) == 0
+    payload = cli_ready / "extract.json"
+    payload.write_text(json.dumps({"medication": [MED]}), encoding="utf-8")
+    capsys.readouterr()
+    assert _run(cli_ready, "commit-extraction", "--document", "1",
+                "--json", str(payload)) == 0
+    out = capsys.readouterr().out
+    assert "0 new, 0 duplicate" in out
+    assert "now backed by this document" in out
+
+    # Off the needs-source queue, still on record as an attestation.
+    assert _run(cli_ready, "record", "assert", "--list") == 0
+    assert "no attested records" in capsys.readouterr().out
+    assert _run(cli_ready, "record", "assert", "--list", "--all", "--json") == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert [(r["needs_source"], r["document_id"], r["attested_by"]) for r in rows] == [
+        (False, 1, "Mom")
+    ]
+
+
+def test_cli_assert_on_an_unmigrated_db_is_friendly(tmp_path, capsys, unmigrated_db):
+    unmigrated_db(tmp_path / "cli.db")
+    assert _run(tmp_path, *_ASSERT_ARGV, "--apply") == 1
+    assert "error:" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# One read contract, two front doors
+# --------------------------------------------------------------------------- #
+
+def test_public_row_keeps_an_unattested_payload_byte_identical(conn, jane):
+    """The additive-only AC for the read contract: three NULL columns must not appear on
+    every row of every query just because the schema grew."""
+    doc = _document(conn, jane.person_id)
+    dedup.commit_extraction(conn, doc, {"medication": [MED]})
+    row = conn.execute("SELECT * FROM medication").fetchone()
+    payload = dedup.public_row(row)
+    assert not set(payload) & set(dedup.ATTESTATION_COLUMNS)
+    assert not set(payload) & set(dedup.INTERNAL_COLUMNS)
+    assert payload["document_id"] == doc
+
+
+def test_public_row_discloses_provenance_on_an_attested_row(conn, jane):
+    _assert_med(conn, apply=True)
+    payload = dedup.public_row(conn.execute("SELECT * FROM medication").fetchone())
+    assert payload["attested_by"] == "Mom"
+    assert payload["attested_on"] == "2026-08-09"
+    assert payload["document_id"] is None
+
+
+def test_the_mcp_read_payload_uses_the_same_rule(conn, jane):
+    """A payload that discloses provenance at the CLI but not over MCP would be the one
+    drift this feature cannot afford."""
+    from pemr import mcp_server
+
+    _assert_med(conn, apply=True)
+    over_mcp = mcp_server.query(conn, kind="meds", person="jane-doe")
+    from pemr import cli as _cli
+
+    at_cli = [_cli._clean(r) for r in query.query_meds(conn, "jane-doe")]
+    assert over_mcp == at_cli
+    assert over_mcp[0]["attested_by"] == "Mom"

--- a/tests/test_cli_ascii.py
+++ b/tests/test_cli_ascii.py
@@ -211,3 +211,39 @@ def test_record_annotate_output_is_console_safe(ready, capsys):
     assert "warnings" in captured.out
     _assert_console_safe(captured.out)
     _assert_console_safe(captured.err)
+
+
+def test_record_assert_output_is_console_safe(ready, capsys):
+    """Issue #110's new CLI + render surface: the report block, the `--list` table, the
+    collision refusal, and the `(attested by ...)` marker in every render."""
+    with pytest.raises(SystemExit):
+        _run(ready, "record", "assert", "--help")
+    _assert_console_safe(capsys.readouterr().out)
+
+    argv = ("record", "assert", "medication", "--person", "jane-doe",
+            "--attributed-to", "Mom", "--date", "2026-08-09",
+            "--field", "name=Metformin", "--field", "dose=500 mg")
+    capsys.readouterr()
+    assert _run(ready, *argv) == 0
+    _assert_console_safe(capsys.readouterr().out)
+
+    assert _run(ready, *argv, "--apply") == 0
+    _assert_console_safe(capsys.readouterr().out)
+
+    assert _run(ready, "record", "assert", "--list") == 0
+    out = capsys.readouterr().out
+    assert "needs source" in out
+    _assert_console_safe(out)
+
+    assert _run(ready, "render", "summary", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    assert "no source document" in out
+    _assert_console_safe(out)
+
+    assert _run(ready, "render", "journal", "--person", "jane-doe") == 0
+    _assert_console_safe(capsys.readouterr().out)
+
+    assert _run(ready, *argv, "--field", "frequency=BID", "--apply") == 1
+    err = capsys.readouterr().err
+    assert "already holds this identity" in err
+    _assert_console_safe(err)

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -114,7 +114,7 @@ def repeat_draw(conn):
         conn, _doc(conn, "draw-2"),
         {"lab_result": [_glucose(148, "2-hour post-prandial draw")]},
     )
-    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1, "promoted": 0}
     return dedup.list_conflicts(conn)[0]["conflict_id"]
 
 
@@ -169,7 +169,7 @@ def test_recommit_of_an_admitted_draw_dedups_instead_of_forking(conn, repeat_dra
         conn, _doc(conn, "draw-3"),
         {"lab_result": [_glucose(148, "2-hour post-prandial draw")]},
     )
-    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0, "promoted": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
     # It deduped against the sibling, not against occurrence 0.
     sibling_key = conn.execute(
@@ -186,7 +186,7 @@ def test_a_changed_value_on_an_admitted_identity_restages_a_conflict(conn, repea
         conn, _doc(conn, "draw-4"),
         {"lab_result": [_glucose(210, "third draw")]},
     )
-    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1, "promoted": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
 
 
@@ -277,7 +277,7 @@ def orphaned_family(conn, repeat_draw):
     summary = dedup.commit_extraction(
         conn, _doc(conn, "draw-5"), {"lab_result": [_glucose(210, "third draw")]}
     )
-    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1, "promoted": 0}
     conflict = dedup.list_conflicts(conn)[0]
     survivor = conn.execute("SELECT * FROM lab_result").fetchone()
     # The premise of the regression: key-targeted writes cannot find this row.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -44,6 +44,7 @@ ALL_MIGRATIONS = [
     "006_condition_allergy.sql",
     "007_document_tombstone.sql",
     "008_curation.sql",
+    "009_record_attestation.sql",
 ]
 
 # Every record table carries the occurrence-family columns (migration 005; 006's two
@@ -132,7 +133,7 @@ def test_migration_006_moves_condition_and_allergy_observations(conn, tmp_path):
 
     assert db.migrate(conn) == [
         "006_condition_allergy.sql", "007_document_tombstone.sql",
-        "008_curation.sql",
+        "008_curation.sql", "009_record_attestation.sql",
     ]
 
     a = conn.execute("SELECT * FROM allergy").fetchone()
@@ -263,7 +264,9 @@ def test_migration_008_applies_on_a_007_era_database(conn, tmp_path):
     assert curation.has_table(conn) is False
     assert curation.load_verdicts(conn) == {}  # readable before the migration exists
 
-    assert db.migrate(conn) == ["008_curation.sql"]
+    assert db.migrate(conn) == [
+        "008_curation.sql", "009_record_attestation.sql",
+    ]
 
     assert curation.has_table(conn) is True
     cols = {row[1] for row in conn.execute("PRAGMA table_info(curation)").fetchall()}
@@ -272,3 +275,64 @@ def test_migration_008_applies_on_a_007_era_database(conn, tmp_path):
         "attributed_to", "created_at",
     }
     assert conn.execute("SELECT COUNT(*) AS n FROM person").fetchone()["n"] == 1
+
+
+def _migrate_through_008(conn, tmp_path):
+    """Apply every migration up to 008, leaving 009 pending (a 008-era database)."""
+    import shutil
+
+    staged = tmp_path / "pre009"
+    staged.mkdir()
+    for path in sorted(db.DEFAULT_MIGRATIONS_DIR.glob("*.sql")):
+        if path.name < "009":
+            shutil.copy(path, staged / path.name)
+    db.migrate(conn, staged)
+    return staged
+
+
+def test_migration_009_adds_attestation_columns_to_every_record_table(conn):
+    """Issue #110: provenance lives on the row, so all seven typed tables gain the same
+    three nullable columns - a per-table check, because a table missed here is a table
+    whose attested rows could never be recorded."""
+    db.migrate(conn)
+    for table in RECORD_TABLES:
+        cols = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+        assert {"attested_by", "attested_on", "attested_at"} <= cols, table
+
+
+def test_migration_009_applies_on_an_008_era_database(conn, tmp_path):
+    """The upgrade path: additive columns, so an existing database gains them without
+    touching a record row."""
+    from pemr import attestations
+
+    _migrate_through_008(conn, tmp_path)
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane', 'Jane')")
+    conn.execute(
+        "INSERT INTO lab_result (person_id, test_name, collected_at, dedup_key, "
+        "dedup_base) VALUES (1, 'HbA1c', '2026-01-01', 'k1', 'k1')"
+    )
+    conn.commit()
+    assert attestations.has_columns(conn) is False
+    assert attestations.list_attested(conn) == []   # readable before the migration
+
+    assert db.migrate(conn) == ["009_record_attestation.sql"]
+
+    assert attestations.has_columns(conn) is True
+    row = conn.execute("SELECT * FROM lab_result").fetchone()
+    assert row["test_name"] == "HbA1c"
+    # A pre-009 row is document-sourced by construction: the new columns default to NULL.
+    assert (row["attested_by"], row["attested_on"], row["attested_at"]) == (
+        None, None, None
+    )
+
+
+def test_a_bare_insert_leaves_the_attestation_columns_null(conn):
+    db.migrate(conn)
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane', 'Jane')")
+    conn.execute(
+        "INSERT INTO medication (person_id, name, dedup_key, dedup_base) "
+        "VALUES (1, 'Metformin', 'k1', 'k1')"
+    )
+    conn.commit()
+    row = conn.execute("SELECT * FROM medication").fetchone()
+    assert row["attested_by"] is None and row["attested_at"] is None

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -453,7 +453,7 @@ def test_commit_inserts_new_rows(conn):
     doc = _make_document(conn)
     d = dedup.load_dictionary(DICT_PATH)
     summary = dedup.commit_extraction(conn, doc, {"lab_result": [_lab(5.7)]}, d)
-    assert summary.counts == {"new": 1, "duplicate": 0, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 1, "duplicate": 0, "enriched": 0, "conflict": 0, "promoted": 0}
     row = conn.execute("SELECT * FROM lab_result").fetchone()
     assert row["test_name"] == "HbA1c" and row["value_num"] == 5.7
 
@@ -482,7 +482,7 @@ def test_differing_value_stages_conflict(conn):
     # same person/analyte/date (the dedup key) but a corrected value -> conflict.
     # The value is no longer in the key, so this fires regardless of magnitude.
     summary = dedup.commit_extraction(conn, doc2, {"lab_result": [_lab(6.2)]}, d)
-    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1, "promoted": 0}
     # original row untouched, no second lab row inserted
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
     assert conn.execute("SELECT value_num FROM lab_result").fetchone()["value_num"] == 5.7
@@ -501,7 +501,7 @@ def test_unit_casing_difference_is_duplicate_not_conflict(conn):
           "unit": "mg/dL"}
     dedup.commit_extraction(conn, doc1, {"lab_result": [r1]}, d)
     summary = dedup.commit_extraction(conn, doc2, {"lab_result": [r2]}, d)
-    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0, "promoted": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
 
 
@@ -528,10 +528,10 @@ def test_real_corpus_overlap_dedups_not_splits(conn):
     ]
     s1 = dedup.commit_extraction(conn, doc_report, {"lab_result": report_rows}, d)
     assert s1.counts == {
-        "new": len(_CORPUS_VARIANTS), "duplicate": 0, "enriched": 0, "conflict": 0}
+        "new": len(_CORPUS_VARIANTS), "duplicate": 0, "enriched": 0, "conflict": 0, "promoted": 0}
     s2 = dedup.commit_extraction(conn, doc_csv, {"lab_result": csv_rows}, d)
     assert s2.counts == {
-        "new": 0, "duplicate": len(_CORPUS_VARIANTS), "enriched": 0, "conflict": 0}
+        "new": 0, "duplicate": len(_CORPUS_VARIANTS), "enriched": 0, "conflict": 0, "promoted": 0}
     # One row per analyte, not two — the split-series / double-count damage is gone.
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] \
         == len(_CORPUS_VARIANTS)
@@ -554,7 +554,7 @@ def test_distinct_assays_of_one_analyte_both_land_as_new(conn):
     keys = {dedup.dedup_key("lab_result", r, 1, d) for r in rows}
     assert len(keys) == 2
     summary = dedup.commit_extraction(conn, doc, {"lab_result": rows}, d)
-    assert summary.counts == {"new": 2, "duplicate": 0, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 2, "duplicate": 0, "enriched": 0, "conflict": 0, "promoted": 0}
     stored = {r["test_name"]: r["value_num"] for r in
               conn.execute("SELECT test_name, value_num FROM lab_result")}
     assert stored == {"Albumin": 4.1, "Albumin (SPEP)": 3.8}
@@ -570,7 +570,7 @@ def test_qualified_observation_keys_are_distinct_rows(conn):
          "observed_at": "2026-01-05", "value_text": "112/70"},
     ]
     summary = dedup.commit_extraction(conn, doc, {"observation": rows})
-    assert summary.counts == {"new": 2, "duplicate": 0, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 2, "duplicate": 0, "enriched": 0, "conflict": 0, "promoted": 0}
 
 
 def test_corrected_value_still_conflicts_after_normalization(conn):
@@ -584,7 +584,7 @@ def test_corrected_value_still_conflicts_after_normalization(conn):
           "value_num": 13.4, "unit": "G/DL"}  # same draw, corrected value
     dedup.commit_extraction(conn, doc1, {"lab_result": [r1]}, d)
     summary = dedup.commit_extraction(conn, doc2, {"lab_result": [r2]}, d)
-    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1, "promoted": 0}
 
 
 def test_far_apart_correction_conflicts_not_duplicates(conn):
@@ -600,7 +600,7 @@ def test_far_apart_correction_conflicts_not_duplicates(conn):
           "unit": "mg/dL"}  # OCR re-read of the *same* draw, wildly different value
     dedup.commit_extraction(conn, doc1, {"lab_result": [r1]}, d)
     summary = dedup.commit_extraction(conn, doc2, {"lab_result": [r2]}, d)
-    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1, "promoted": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
 
 
@@ -616,7 +616,7 @@ def test_serial_same_day_draws_are_distinct_rows(conn):
          "unit": "mg/dL"},
     ]
     summary = dedup.commit_extraction(conn, doc, {"lab_result": rows}, d)
-    assert summary.counts == {"new": 2, "duplicate": 0, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 2, "duplicate": 0, "enriched": 0, "conflict": 0, "promoted": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
 
 
@@ -632,7 +632,7 @@ def test_observation_correction_conflicts_not_duplicates(conn):
           "value_num": 155}  # re-read of the same measurement, corrected value
     dedup.commit_extraction(conn, doc1, {"observation": [o1]}, d)
     summary = dedup.commit_extraction(conn, doc2, {"observation": [o2]}, d)
-    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1, "promoted": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 1
 
 
@@ -647,7 +647,7 @@ def test_serial_same_day_observations_are_distinct_rows(conn):
          "value_num": 138},
     ]
     summary = dedup.commit_extraction(conn, doc, {"observation": rows}, d)
-    assert summary.counts == {"new": 2, "duplicate": 0, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 2, "duplicate": 0, "enriched": 0, "conflict": 0, "promoted": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 2
 
 
@@ -679,7 +679,7 @@ def test_intra_payload_identical_rows_still_report_duplicate(conn):
     doc = _make_document(conn)
     row = {"test_name": "Glucose", "collected_at": "2024-04-01", "value_num": 95}
     summary = dedup.commit_extraction(conn, doc, {"lab_result": [dict(row), dict(row)]})
-    assert summary.counts == {"new": 1, "duplicate": 1, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 1, "duplicate": 1, "enriched": 0, "conflict": 0, "promoted": 0}
 
 
 def test_intra_payload_collision_checked_per_record_type(conn):
@@ -748,7 +748,7 @@ def test_migration_005_preserves_pre_existing_keys(tmp_path):
         # And the pre-005 row still dedups against a fresh commit of the same fact.
         doc = _make_document(conn)
         summary = dedup.commit_extraction(conn, doc, {"lab_result": [row]})
-        assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
+        assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0, "promoted": 0}
     finally:
         conn.close()
 
@@ -858,7 +858,7 @@ def test_rekey_apply_restores_dedup_for_a_renamed_analyte(conn):
 
     doc2 = _make_document(conn)
     summary = dedup.commit_extraction(conn, doc2, {"lab_result": [row]}, d_new)
-    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0, "promoted": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
 
 
@@ -1088,7 +1088,7 @@ def test_rekey_migrates_a_row_stored_under_a_stripped_key(conn):
     doc = _make_document(conn)
     summary = dedup.commit_extraction(conn, doc, {"lab_result": [
         {"test_name": "Albumin", "collected_at": "2026-01-05", "value_num": 4.2}]}, d)
-    assert summary.counts == {"new": 1, "duplicate": 0, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 1, "duplicate": 0, "enriched": 0, "conflict": 0, "promoted": 0}
     assert conn.execute(
         "SELECT dedup_key FROM lab_result WHERE test_name = 'Albumin'"
     ).fetchone()["dedup_key"] == legacy_key
@@ -1129,7 +1129,7 @@ def test_commit_refuses_an_ingest_against_a_drifted_key(conn):
     summary = dedup.commit_extraction(
         conn, _make_document(conn), {"lab_result": [row]}, d_new
     )
-    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0, "promoted": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
 
 
@@ -1143,7 +1143,7 @@ def test_commit_drift_guard_ignores_an_unrelated_drifted_row(conn):
 
     summary = dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
         {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 95}]}, d_new)
-    assert summary.counts == {"new": 1, "duplicate": 0, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 1, "duplicate": 0, "enriched": 0, "conflict": 0, "promoted": 0}
 
 
 def test_commit_drift_guard_accepts_a_keep_both_sibling(conn):
@@ -1158,7 +1158,7 @@ def test_commit_drift_guard_accepts_a_keep_both_sibling(conn):
 
     summary = dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
         {"test_name": "Glucose", "collected_at": "2024-04-01", "value_num": 148}]}, d)
-    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0, "promoted": 0}
 
 
 def test_rekey_names_a_doubled_fact_instead_of_blaming_the_dictionary(conn):
@@ -1210,7 +1210,7 @@ def test_allergy_key_is_date_free(conn):
         {"substance": "Penicillin", "reaction": "rash", "noted_on": "2010-01-01"}]})
     summary = _commit(conn, {"allergy": [
         {"substance": "penicillin", "reaction": "rash", "noted_on": "2021-06-01"}]})
-    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1, "promoted": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM allergy").fetchone()["n"] == 1
 
 
@@ -1222,7 +1222,7 @@ def test_condition_family_history_does_not_collide_with_the_patients_own(conn):
         {"name": "Type 2 Diabetes", "status": "family-history", "relation": "mother"},
         {"name": "Type 2 Diabetes", "status": "family-history", "relation": "father"},
     ]})
-    assert summary.counts == {"new": 3, "duplicate": 0, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 3, "duplicate": 0, "enriched": 0, "conflict": 0, "promoted": 0}
 
 
 def test_condition_lifecycle_change_stages_a_conflict(conn):
@@ -1231,7 +1231,7 @@ def test_condition_lifecycle_change_stages_a_conflict(conn):
     _commit(conn, {"condition": [{"name": "Anemia", "status": "active"}]})
     summary = _commit(conn, {"condition": [
         {"name": "Anemia", "status": "resolved", "resolved_on": "2025-09-01"}]})
-    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1, "promoted": 0}
 
     conflict_id = dedup.list_conflicts(conn)[0]["conflict_id"]
     dedup.resolve_conflict(conn, conflict_id, keep="incoming")
@@ -1245,11 +1245,11 @@ def test_sparse_types_do_not_conflict_on_an_omitted_field(conn):
     _commit(conn, {"allergy": [
         {"substance": "Sulfa", "reaction": "hives", "criticality": "high"}]})
     summary = _commit(conn, {"allergy": [{"substance": "Sulfa"}]})
-    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0, "promoted": 0}
     # ... but a stated disagreement still conflicts.
     summary = _commit(conn, {"allergy": [
         {"substance": "Sulfa", "reaction": "anaphylaxis"}]})
-    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1, "promoted": 0}
 
 
 def test_a_stated_field_over_a_stored_null_enriches_rather_than_dedups(conn):
@@ -1260,7 +1260,7 @@ def test_a_stated_field_over_a_stored_null_enriches_rather_than_dedups(conn):
     summary = _commit(conn, {"allergy": [
         {"substance": "Bee sting", "criticality": "high", "reaction": "anaphylaxis",
          "noted_on": "2024-07-07"}]})
-    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 1, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 1, "conflict": 0, "promoted": 0}
     row = conn.execute("SELECT * FROM allergy").fetchone()
     assert (row["criticality"], row["reaction"], row["noted_on"]) == (
         "high", "anaphylaxis", "2024-07-07")
@@ -1278,7 +1278,7 @@ def test_enrichment_fills_only_nulls_and_never_launders_a_disagreement(conn):
     _commit(conn, {"condition": [{"name": "Chickenpox", "status": "history"}]})
     summary = _commit(conn, {"condition": [
         {"name": "Chickenpox", "status": "active", "onset_on": "1988-03-01"}]})
-    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1}
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1, "promoted": 0}
     row = conn.execute("SELECT * FROM condition").fetchone()
     assert (row["status"], row["onset_on"]) == ("history", None)
 
@@ -1292,7 +1292,7 @@ def test_a_terser_row_later_in_one_submission_does_not_undo_an_enrichment(conn):
          "onset_on": "2019-02-01"},
         {"name": "Anemia", "status": "active"},
     ]})
-    assert summary.counts == {"new": 1, "duplicate": 1, "enriched": 1, "conflict": 0}
+    assert summary.counts == {"new": 1, "duplicate": 1, "enriched": 1, "conflict": 0, "promoted": 0}
     row = conn.execute("SELECT * FROM condition").fetchone()
     assert (row["note"], row["onset_on"]) == ("iron deficiency", "2019-02-01")
 
@@ -1422,4 +1422,104 @@ def test_rekey_rederives_a_carried_forward_migration_key(conn):
     assert row["dedup_key"] == change.new_key and row["dedup_base"] == change.new_key
     # ... and now a fresh commit of the same allergy dedups instead of forking.
     summary = _commit(conn, {"allergy": [{"substance": "Penicillin", "reaction": "rash"}]})
-    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0, "promoted": 0}
+
+
+# --- attested rows meet the document that proves them (issue #110) ------------
+
+_ATTEST_MED = {"name": "Metformin", "dose": "500 mg", "started_on": "2025-06-01"}
+
+
+def _attest(conn, record_type="medication", payload=None, **kwargs):
+    from pemr import attestations
+
+    return attestations.assert_record(
+        conn, record_type, "jane-doe", dict(payload or _ATTEST_MED),
+        attributed_to=kwargs.pop("attributed_to", "Mom"),
+        attested_on=kwargs.pop("attested_on", "2026-08-09"),
+        apply=True, **kwargs,
+    )
+
+
+def test_a_commit_with_no_attestation_in_play_still_reports_promoted_zero(conn):
+    summary = _commit(conn, {"medication": [_ATTEST_MED]})
+    assert summary.counts == {
+        "new": 1, "duplicate": 0, "enriched": 0, "conflict": 0, "promoted": 0}
+    assert summary.promoted == []
+
+
+def test_an_agreeing_document_promotes_the_attestation_in_place(conn):
+    """Document provenance outranks an attestation, and the agreeing case has nothing
+    to adjudicate: the row acquires the document_id, keeps its attestation as history,
+    and no second row is filed."""
+    report = _attest(conn)
+    summary = _commit(conn, {"medication": [_ATTEST_MED]})
+    assert summary.counts == {
+        "new": 0, "duplicate": 0, "enriched": 0, "conflict": 0, "promoted": 1}
+    assert summary.promoted == [("medication", report.row_id)]
+
+    rows = conn.execute("SELECT * FROM medication").fetchall()
+    assert len(rows) == 1                       # promoted, not duplicated
+    assert rows[0]["document_id"] is not None
+    assert (rows[0]["attested_by"], rows[0]["attested_on"]) == ("Mom", "2026-08-09")
+    assert dedup.attestation_state(rows[0]) == "superseded"
+    assert dedup.is_attested(rows[0]) is False
+
+
+def test_a_promoted_row_is_an_ordinary_duplicate_on_the_next_commit(conn):
+    _attest(conn)
+    _commit(conn, {"medication": [_ATTEST_MED]})
+    summary = _commit(conn, {"medication": [_ATTEST_MED]})
+    assert summary.counts["promoted"] == 0 and summary.counts["duplicate"] == 1
+
+
+def test_a_disagreeing_document_stages_a_conflict_and_leaves_the_attestation(conn):
+    """No silent auto-resolution for a differing payload: it takes the same
+    human-adjudicated path every other dedup disagreement takes."""
+    _attest(conn, payload=_ATTEST_MED | {"frequency": "BID"})
+    summary = _commit(conn, {"medication": [_ATTEST_MED | {"frequency": "daily"}]})
+    assert summary.counts == {
+        "new": 0, "duplicate": 0, "enriched": 0, "conflict": 1, "promoted": 0}
+    row = conn.execute("SELECT * FROM medication").fetchone()
+    assert row["document_id"] is None and row["frequency"] == "BID"
+    assert dedup.is_attested(row) is True
+
+
+def test_keep_incoming_on_an_attested_anchor_is_the_conflict_flow_supersession(conn):
+    _attest(conn, payload=_ATTEST_MED | {"frequency": "BID"})
+    summary = _commit(conn, {"medication": [_ATTEST_MED | {"frequency": "daily"}]})
+    dedup.resolve_conflict(conn, summary.conflict[0][1], keep="incoming")
+    row = conn.execute("SELECT * FROM medication").fetchone()
+    assert row["document_id"] is not None and row["frequency"] == "daily"
+    assert row["attested_by"] == "Mom"          # history, never cleared
+    assert dedup.attestation_state(row) == "superseded"
+
+
+def test_keep_existing_leaves_the_attestation_live(conn):
+    _attest(conn, payload=_ATTEST_MED | {"frequency": "BID"})
+    summary = _commit(conn, {"medication": [_ATTEST_MED | {"frequency": "daily"}]})
+    dedup.resolve_conflict(conn, summary.conflict[0][1], keep="existing")
+    row = conn.execute("SELECT * FROM medication").fetchone()
+    assert row["document_id"] is None and dedup.is_attested(row) is True
+
+
+def test_keep_both_admits_the_document_row_beside_the_attestation(conn):
+    _attest(conn, payload=_ATTEST_MED | {"frequency": "BID"})
+    summary = _commit(conn, {"medication": [_ATTEST_MED | {"frequency": "daily"}]})
+    dedup.resolve_conflict(conn, summary.conflict[0][1], keep="both")
+    rows = conn.execute(
+        "SELECT * FROM medication ORDER BY dedup_occurrence"
+    ).fetchall()
+    assert [int(r["dedup_occurrence"]) for r in rows] == [0, 1]
+    assert dedup.is_attested(rows[0]) is True          # still needs a source
+    assert rows[1]["document_id"] is not None
+    assert rows[1]["attested_by"] is None
+
+
+def test_rekey_is_blind_to_the_attestation_columns(conn):
+    """The columns are absent from FIELD_SPECS, so keys are bit-identical for attested
+    and document-sourced rows and `rekey` has nothing to move."""
+    _attest(conn)
+    _attest(conn, "allergy", {"substance": "Penicillin", "reaction": "rash"})
+    report = dedup.rekey(conn, None)
+    assert report.changes == [] and report.collisions == []

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -541,7 +541,7 @@ def test_reassign_moves_a_keep_both_family_intact(seeded):
     summary = dedup.commit_extraction(
         conn, seeded["doc"], {"lab_result": [draw | {"value_num": 148}]}
     )
-    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0}
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0, "promoted": 0}
 
 
 def test_reassign_refused_on_dictionary_drift(seeded):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -487,3 +487,14 @@ def test_curation_verbs_are_not_on_the_mcp_surface():
     surface = " ".join(mcp_server.TOOL_NAMES).lower()
     for spelling in ("annotate", "curation", "record_rm", "record_annotate"):
         assert spelling not in surface, spelling
+
+
+def test_record_assert_is_not_on_the_mcp_surface():
+    """Trust boundary (issue #110): `record assert` is the one path that can put a fact
+    in the record with no external source, so it is CLI-only - the same standing as
+    `document rm` / `record rm` / `record annotate`. AGENTS.md's blessed write set is
+    commit_extraction/person_add/person_edit/ingest/document_set_text."""
+    surface = " ".join(mcp_server.TOOL_NAMES).lower()
+    for spelling in ("assert", "attest", "record_assert", "attestation"):
+        assert spelling not in surface, spelling
+    assert "record_assert" not in mcp_server.WRITE_TOOLS

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -238,6 +238,30 @@ def test_timeline_carries_provenance(seeded):
     assert any(e["document_id"] is not None for e in events)
 
 
+def test_timeline_stamps_attestation_only_on_attested_events(seeded):
+    """Issue #110: provenance travels with the event, but only when the row carries it -
+    a document-sourced record's event shape is unchanged, key for key."""
+    from pemr import attestations
+
+    before = query.query_timeline(seeded, "jane-doe")
+    assert all(
+        "attested_by" not in e and "attested_on" not in e for e in before
+    )
+
+    attestations.assert_record(
+        seeded, "medication", "jane-doe",
+        {"name": "Amlodipine", "started_on": "2026-03-01"},
+        attributed_to="Aunt Ada", attested_on="2026-03-02", apply=True,
+    )
+    after = query.query_timeline(seeded, "jane-doe")
+    attested = [e for e in after if "attested_by" in e]
+    assert [(e["attested_by"], e["attested_on"], e["document_id"]) for e in attested] == [
+        ("Aunt Ada", "2026-03-02", None)
+    ]
+    # Every pre-existing event is untouched.
+    assert [e for e in after if "attested_by" not in e] == before
+
+
 def test_timeline_with_identity_stamps_family_keys(seeded):
     """Issue #109: `render_journal` needs each event's family identity to apply the
     curation overlay, and an event otherwise carries none."""

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -687,3 +687,147 @@ def test_curated_renders_stay_ascii_and_read_only(seeded):
         assert md.isascii(), f"non-ASCII would crash a cp437 console: {md!r}"
         md.encode("cp437")
     assert _row_counts(seeded) == before  # still a pure read
+
+
+# --- attested rows are never mistaken for document-sourced facts (issue #110) --
+
+_ATTESTED = {
+    "medication": {"name": "Amlodipine", "dose": "5 mg", "started_on": "2026-03-01"},
+    "condition": {"name": "Migraine", "status": "active", "onset_on": "2026-03-01"},
+    "allergy": {"substance": "Shellfish", "reaction": "hives"},
+    "lab_result": {"test_name": "Potassium", "collected_at": "2026-03-01",
+                   "value_num": 6.2, "unit": "mmol/L", "ref_high": 5.2},
+    "procedure": {"name": "Wisdom tooth extraction", "performed_on": "2026-03-01"},
+    "appointment": {"scheduled_for": "2099-06-01", "provider": "Dr. Attested",
+                    "specialty": "Neurology", "reason": "headaches"},
+    "observation": {"obs_type": "vital", "key": "pulse", "observed_at": "2026-03-01",
+                    "value_num": 72, "unit": "bpm"},
+}
+_ATTEST_MARKER = "(attested by Aunt Ada 2026-03-02; no source document)"
+
+
+def _attest_all(conn, slug="jane-doe"):
+    """One live attestation per typed table, plus one attested order row."""
+    from pemr import attestations
+
+    for record_type, payload in _ATTESTED.items():
+        attestations.assert_record(
+            conn, record_type, slug, dict(payload), attributed_to="Aunt Ada",
+            attested_on="2026-03-02", dictionary=dedup.load_dictionary(DICT_PATH),
+            apply=True,
+        )
+    attestations.assert_record(
+        conn, "observation", slug,
+        {"obs_type": "order", "key": "sleep study", "observed_at": "2026-03-01"},
+        attributed_to="Aunt Ada", attested_on="2026-03-02",
+        dictionary=dedup.load_dictionary(DICT_PATH), apply=True,
+    )
+
+
+def test_unattested_renders_are_byte_identical_to_today(seeded):
+    """The additive-only AC: a database with no attested rows renders exactly as it did
+    before migration 009. Captured before/after seeding attestations for *john*, whose
+    record stays untouched."""
+    d = dedup.load_dictionary(DICT_PATH)
+    before = (
+        render.render_summary(seeded, "john-doe", dictionary=d,
+                              now=datetime(2026, 6, 1)),
+        render.render_journal(seeded, "john-doe", now=datetime(2026, 6, 1)),
+    )
+    _attest_all(seeded)
+    after = (
+        render.render_summary(seeded, "john-doe", dictionary=d,
+                              now=datetime(2026, 6, 1)),
+        render.render_journal(seeded, "john-doe", now=datetime(2026, 6, 1)),
+    )
+    assert before == after
+    assert "attested" not in before[0] and "attested" not in before[1]
+
+
+def test_summary_marks_an_attested_row_in_every_section(seeded):
+    _attest_all(seeded)
+    md = render.render_summary(
+        seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH),
+        now=datetime(2026, 6, 1),
+    )
+    marked = {
+        line.split("  ")[0].lstrip("- ")
+        for line in md.splitlines() if _ATTEST_MARKER in line
+    }
+    # Meds, active problems, allergies, orders, vitals, abnormal labs, appointments:
+    # every section that can show an attested row does, so none can render it bare.
+    for token in ("Amlodipine", "Migraine", "Shellfish", "sleep study", "pulse",
+                  "Potassium", "Dr. Attested"):
+        assert any(
+            token in line and _ATTEST_MARKER in line for line in md.splitlines()
+        ), token
+    assert marked  # sanity: the marker really is on rendered lines
+
+
+def test_brief_marks_an_attested_row_in_every_section(seeded):
+    _attest_all(seeded)
+    md = render.render_brief(
+        seeded, _upcoming_appt_id(seeded), dictionary=dedup.load_dictionary(DICT_PATH),
+        recent_labs=50, now=datetime(2026, 6, 1),
+    )
+    for token in ("Amlodipine", "Potassium", "Shellfish", "Migraine",
+                  "Wisdom tooth extraction", "pulse"):
+        assert any(
+            token in line and _ATTEST_MARKER in line for line in md.splitlines()
+        ), token
+
+
+def test_journal_marks_an_attested_event_and_gives_it_no_footnote(seeded):
+    _attest_all(seeded)
+    md = render.render_journal(seeded, "jane-doe", now=datetime(2026, 6, 1))
+    line = next(l for l in md.splitlines() if "Amlodipine" in l)
+    assert _ATTEST_MARKER in line
+    assert "[^" not in line          # no document to cite
+
+
+def test_a_promoted_row_renders_without_the_marker(seeded):
+    """Once a document backs the fact it is an ordinary sourced row again; the
+    attestation survives on the row as history, not as a caveat on the page."""
+    _attest_all(seeded)
+    doc = _doc(seeded, "jane-doe")
+    summary = dedup.commit_extraction(
+        seeded, doc, {"medication": [dict(_ATTESTED["medication"])]},
+        dedup.load_dictionary(DICT_PATH),
+    )
+    assert summary.counts["promoted"] == 1
+    md = render.render_summary(
+        seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH),
+        now=datetime(2026, 6, 1),
+    )
+    line = next(l for l in md.splitlines() if "Amlodipine" in l)
+    assert _ATTEST_MARKER not in line
+    assert "Migraine" in md and _ATTEST_MARKER in md      # the others are still marked
+
+
+def test_attested_marker_is_ascii(seeded):
+    _attest_all(seeded)
+    md = render.render_summary(
+        seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH),
+        now=datetime(2026, 6, 1),
+    )
+    assert md.isascii()
+    md.encode("cp437")
+
+
+def test_a_disputed_attested_row_carries_both_markers(seeded):
+    """Provenance reads last: the verdict is about the fact, the suffix about where it
+    came from."""
+    from pemr import attestations, curation as _curation
+
+    _attest_all(seeded)
+    row_id = attestations.list_attested(seeded, "medication")[0]["row_id"]
+    _curation.annotate_record(
+        seeded, "medication", str(row_id), status="disputed",
+        note="pharmacy has no record", apply=True,
+    )
+    md = render.render_summary(
+        seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH),
+        now=datetime(2026, 6, 1),
+    )
+    line = next(l for l in md.splitlines() if "Amlodipine" in l)
+    assert line.index("[DISPUTED:") < line.index("(attested by")


### PR DESCRIPTION
## Summary

Adds a second legal provenance path alongside document-sourced extraction: `pemr record assert`
lets a human commit a record row backed by their own attestation (who + when) instead of a source
document, for facts known to the family whose supporting document hasn't been ingested yet (e.g.
a currently-managed medication).

- **`migrations/009_record_attestation.sql`** — nullable `attested_by` / `attested_on` /
  `attested_at` on all seven `dedup.KNOWN_TYPES` tables.
- **`pemr/attestations.py`** (new) — `assert_record`, `list_attested`, `AttestReport`, and the
  collision/pre-migration guards, wired into the existing `record` CLI verb group as
  `pemr record assert` (dry-run by default, `--apply`, `--json`).
- **`pemr/dedup.py`** — attested rows key identically to document-sourced rows (attestation
  columns are outside `FIELD_SPECS`), and `commit_extraction` promotes an attestation in place
  when a later document-sourced commit lands on the same dedup base with an equal payload;
  a differing payload stages a conflict instead of auto-resolving, consistent with every other
  dedup-collision case.
- **`pemr/render.py`** — every renderer visibly tags an attested row (attributed-to + date, "no
  source document") so it can never be mistaken for document-sourced.
- **Trust boundary** — `record assert` is CLI-only, never exposed as an MCP tool, matching the
  standing of `document rm` / `record rm` / `record annotate`. `AGENTS.md` and
  `docs/Architecture.md` §5 both now carry the exclusion rule.

## Follow-up (not in this PR)

Audit advisories A2/A3 (`pemr trends`/`pemr find` don't disclose attestation; a defensive
`TRIM(attested_by) <> ''` guard in `list_attested`) are natural content for the deferred
`pemr review list` aggregation verb tracked against a follow-up spanning #109 and #110 — no
GitHub issue filed for it yet; flagging here so it isn't lost.

## Test plan
- [x] `pytest` — full suite, 883 passed
- [x] `npm test` (planner) — 130 passed
- [x] `npm run check:meta-drift` — pass
- Real-run smoke over live SQLite DB (migrations 001-009), all seven `KNOWN_TYPES` tables — see
  verify report
- `npm run sync:claude-config:check` fails on this branch — **pre-existing on `origin/dev`**
  (7 stale `.claude/agents/` mirrors), confirmed unrelated by verify (checked out on dev directly)

Closes #110

Verify report: https://github.com/meridun/pemr/issues/110#issuecomment-5230046480
Audit report: https://github.com/meridun/pemr/issues/110#issuecomment-5230067538

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>