### PR TITLE
record annotate: row-scoped verdicts for multi-row dedup families

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -109,24 +109,36 @@ CREATE TABLE document_tombstone (
   document_id INTEGER                     -- the id it had; forensics only, not a FK
 );
 
--- Recorded human verdicts over record families (issue #109). A pure overlay: no record
--- row is ever mutated, and a family with no row here renders exactly as before. Keyed
--- by (record_type, dedup_base) - the stable family identity of §3 - so a verdict
--- outlives occurrence renumbering and `record rm`, but NOT a dictionary-driven `rekey`
--- that renames the family itself: that moves `dedup_base` too, and orphans the verdict
--- exactly like a removed row would. Like 007 it carries no FK to the row it annotates,
--- and `pemr verify` warns (never fails) on a verdict whose family is gone either way.
--- Written only by `record annotate`; read at render time by every generated document.
+-- Recorded human verdicts over records (issues #109, #114). A pure overlay: no record
+-- row is ever mutated, and a record with no row here renders exactly as before. A
+-- verdict is scoped either to a whole dedup FAMILY (record_id = 0, keyed by the stable
+-- family identity of §3) or to a single ROW (record_id > 0). Family scope outlives
+-- occurrence renumbering and `record rm` but NOT a dictionary-driven `rekey` that
+-- renames the family: that moves `dedup_base` and orphans the verdict. Row scope
+-- resolves by (record_type, record_id) alone and therefore DOES survive that rekey -
+-- `rekey` never renumbers a row id - so its stored dedup_base is a breadcrumb only,
+-- never a resolution key. Row scope exists for the `--keep both` family holding two
+-- live rows, where a family verdict would hide the occurrence it says should win. Row
+-- wins over family for its own row. Like 007 the table carries no FK to what it
+-- annotates, and `pemr verify` warns (never fails) on a verdict whose family - or row -
+-- is gone. Written only by `record annotate`; read at render time by every generated
+-- document.
 CREATE TABLE curation (
   record_type      TEXT NOT NULL,   -- one of dedup.KNOWN_TYPES; validated in Python
-  dedup_base       TEXT NOT NULL,   -- family identity: NOT dedup_key, NOT a row id
+  dedup_base       TEXT NOT NULL,   -- family identity; a breadcrumb when record_id <> 0
+  record_id        INTEGER NOT NULL DEFAULT 0,  -- 0 = family scope; else <record_type>_id
   status           TEXT NOT NULL,   -- confirmed|superseded|erroneous-in-source|disputed|merged-into
   note             TEXT NOT NULL,   -- required: the why, and who said so
-  merged_into_base TEXT,            -- set iff status = 'merged-into'
+  merged_into_base TEXT,            -- set iff status = 'merged-into'; always a FAMILY
   attributed_to    TEXT,
   created_at       TEXT NOT NULL,   -- ISO8601 UTC
-  PRIMARY KEY (record_type, dedup_base)
+  PRIMARY KEY (record_type, dedup_base, record_id)
 );
+-- One live verdict per row, whatever base it was recorded under (the PK cannot say this:
+-- its dedup_base member is a breadcrumb). 0 rather than NULL for family scope because
+-- SQLite treats NULLs as distinct in a unique index.
+CREATE UNIQUE INDEX idx_curation_row ON curation(record_type, record_id)
+  WHERE record_id <> 0;
 ```
 
 High-value typed tables (each carries `document_id` provenance + a `dedup_key`; migration
@@ -654,12 +666,14 @@ pemr document rm <id> [--apply] [--purge-blob] [--tombstone [--reason ...] [--no
 pemr record rm <table> <id> [--apply]                    # delete ONE record row; its document and every
                                                          # other record it produced survive; dry run by default
 pemr record annotate <table> <base-or-id> --status <s> --note <text> [--attributed-to ...]
-                     [--merged-into <base-or-id>] [--apply]
+                     [--merged-into <base-or-id>] [--row] [--apply]
                                                          # record a human verdict over a record FAMILY (§2 curation):
                                                          # confirmed|superseded|erroneous-in-source|disputed|merged-into
+                                                         # --row: scope it to that ROW only (a keep-both family holds
+                                                         #        two live rows; row scope beats family scope there)
                                                          # pure overlay - no record row is mutated; dry run by default
-pemr record annotate --list [<table>] [--json]           # current verdicts, newest first (orphans flagged)
-pemr record annotate <table> <base-or-id> --clear [--apply]      # lift one verdict
+pemr record annotate --list [<table>] [--json]           # current verdicts, newest first (scope + orphans flagged)
+pemr record annotate <table> <base-or-id> [--row] --clear [--apply]   # lift one verdict, in the named scope
 pemr record assert <table> --person <slug> --attributed-to <who> --date <iso>
                    --field NAME=VALUE [--field ...] [--apply]
                                                          # commit a fact attested by a PERSON, with no
@@ -741,17 +755,20 @@ default to the same exclusion unless a human explicitly decides otherwise.
 - **journal** — chronological event stream (documents + appointments + procedures)
   rendered as a narrative timeline.
 
-Every section is filtered at read time against the `curation` overlay (§2, issue #109):
-`superseded` / `erroneous-in-source` / `merged-into` families leave their section for a
-`## Superseded / corrected` appendix, `disputed` families render in place with a
-`[DISPUTED: <note>]` marker and reach the brief's `## Questions for the Clinician`, and
+Every section is filtered at read time against the `curation` overlay (§2, issues #109 and
+#114): `superseded` / `erroneous-in-source` / `merged-into` leave their section for a
+`## Superseded / corrected` appendix, `disputed` renders in place with a
+`[DISPUTED: <note>]` marker and reaches the brief's `## Questions for the Clinician`, and
 `confirmed` renders unchanged. Both new sections are omitted entirely when empty, so a record
 with no verdicts renders byte-identically to before the overlay existed. This does not weaken
 the purity rule: the filter is a read, and output changes after a verdict because the
-*database* changed. One consequence of the read-time join: if a dictionary-driven `rekey`
-(§3) has renamed a family since its verdict was recorded, the join misses and the family
-renders as if unannotated — `pemr verify` flags the orphaned verdict, but nothing re-attaches
-it automatically.
+*database* changed. Resolution is **per row**: a row-scoped verdict affects only its own
+occurrence — the sibling of a `--keep both` pair renders untouched — and beats the family
+verdict for that row. One consequence of the read-time join: if a dictionary-driven `rekey`
+(§3) has renamed a family since its verdict was recorded, a *family*-scoped verdict's join
+misses and the family renders as if unannotated (`pemr verify` flags the orphan; nothing
+re-attaches it automatically). A *row*-scoped verdict is immune — it joins on the row id,
+which `rekey` never renumbers — and is orphaned only by the removal of its row.
 
 Because they regenerate from truth, they never drift. Old exports are disposable.
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -770,6 +770,17 @@ misses and the family renders as if unannotated (`pemr verify` flags the orphan;
 re-attaches it automatically). A *row*-scoped verdict is immune — it joins on the row id,
 which `rekey` never renumbers — and is orphaned only by the removal of its row.
 
+That immunity has a price, and it is a rule rather than a caveat: **a row-scoped verdict is
+identified by a reusable row id, so removing the row must retire the verdict.** Record ids
+are plain rowid aliases (no `AUTOINCREMENT`), so deleting the highest-id row frees that id
+for the next insert, and a verdict left behind would re-attach to an unrelated new record —
+pulling a live clinical fact into the superseded appendix under a note about a different one,
+with `verify`'s orphan warning silent because the id resolves again. Both write paths that
+delete a record row (`record rm`, `document rm`) therefore name any row-scoped verdict on the
+doomed rows in their dry run and lift it in the same transaction as the delete. Family scope
+needs no such rule: `dedup_base` is content-derived, so re-attaching to a re-ingest of the
+same fact is the intended behaviour.
+
 Because they regenerate from truth, they never drift. Old exports are disposable.
 
 ---

--- a/migrations/010_curation_row_scope.sql
+++ b/migrations/010_curation_row_scope.sql
@@ -1,0 +1,70 @@
+-- 010_curation_row_scope: a verdict may name one ROW, not only a family (issue #114).
+--
+-- 008 keyed every verdict by (record_type, dedup_base) - the whole dedup family. That is
+-- right for the common case (one fact, however many occurrences of it were filed) and
+-- wrong for the family that a `--keep both` conflict resolution left holding two *live*
+-- rows: superseding the loser hid the winner too, because both share the base. Applying a
+-- real curation ledger hit exactly that, and the verdict had to be withdrawn.
+--
+-- So scope becomes an explicit second dimension of the key:
+--
+--   record_id = 0  -> FAMILY scope: today's verdict, over every row sharing dedup_base.
+--   record_id > 0  -> ROW scope: this one <record_type>_id, and no sibling of it.
+--
+-- A row-scoped verdict resolves by (record_type, record_id) *alone*. The dedup_base stored
+-- alongside it is a breadcrumb - which family it ruled in, at annotate time - never a
+-- resolution key: `pemr rekey` rewrites dedup_key/dedup_base but never renumbers a row id
+-- (dedup.rekey: "Values, provenance and row ids are untouched"), so a row-scoped verdict
+-- genuinely survives the dictionary-driven rekey that orphans a family-scoped one. The
+-- breadcrumb may go stale after such a rekey; every reader re-reads the live base off the
+-- row instead, and re-annotating deletes by (record_type, record_id) so the stale copy
+-- collapses.
+--
+-- 0 rather than NULL for family scope, deliberately: SQLite treats NULLs as *distinct* in a
+-- unique index, so a nullable scope column would silently permit duplicate family verdicts
+-- on one base - the one thing 008's PK exists to forbid.
+--
+-- This is a table REBUILD, not ADD COLUMN: SQLite's ALTER TABLE ADD COLUMN can add neither
+-- a PK member nor a CHECK, and 008's PK (record_type, dedup_base) forbids exactly the states
+-- this issue needs - a family verdict and a row verdict coexisting on one family, and two
+-- row verdicts inside one family. `curation` has no FK in or out and no dependent view or
+-- trigger, so the rebuild is safe under foreign_keys=ON, and db.migrate wraps the whole
+-- script in one BEGIN/COMMIT. Every 008-era verdict is family-scoped by definition, so the
+-- backfill (record_id = 0) is lossless and nothing needs re-annotating.
+--
+-- 008's three CHECKs are carried verbatim; the orphan story is unchanged (no FK, `pemr
+-- verify` warns rather than the schema erasing), and now covers "names no live row" too.
+
+CREATE TABLE curation_new (
+  record_type      TEXT NOT NULL,   -- one of dedup.KNOWN_TYPES; validated in Python
+  dedup_base       TEXT NOT NULL,   -- family identity; a BREADCRUMB when record_id <> 0
+  record_id        INTEGER NOT NULL DEFAULT 0,  -- 0 = family scope; else <record_type>_id
+  status           TEXT NOT NULL,
+  note             TEXT NOT NULL,   -- required: the why, and who said so
+  merged_into_base TEXT,            -- set iff status = 'merged-into'; always a FAMILY
+  attributed_to    TEXT,
+  created_at       TEXT NOT NULL,   -- ISO8601 UTC, timespec=seconds (as document.ingested_at)
+  PRIMARY KEY (record_type, dedup_base, record_id),
+  CHECK (record_id >= 0),
+  CHECK (status IN ('confirmed', 'superseded', 'erroneous-in-source', 'disputed',
+                    'merged-into')),
+  CHECK (trim(note) <> ''),
+  CHECK ((merged_into_base IS NOT NULL) = (status = 'merged-into'))
+);
+
+INSERT INTO curation_new
+  (record_type, dedup_base, record_id, status, note, merged_into_base, attributed_to,
+   created_at)
+SELECT record_type, dedup_base, 0, status, note, merged_into_base, attributed_to,
+       created_at
+FROM curation;
+
+DROP TABLE curation;
+
+ALTER TABLE curation_new RENAME TO curation;
+
+-- The real uniqueness rule for row scope, which the PK cannot state (its dedup_base member
+-- is a breadcrumb): one live verdict per row, whatever base it was recorded under. Also the
+-- guard against a second copy of a row verdict appearing under a new base after a rekey.
+CREATE UNIQUE INDEX idx_curation_row ON curation(record_type, record_id)
+  WHERE record_id <> 0;

--- a/migrations/010_curation_row_scope.sql
+++ b/migrations/010_curation_row_scope.sql
@@ -32,8 +32,19 @@
 -- script in one BEGIN/COMMIT. Every 008-era verdict is family-scoped by definition, so the
 -- backfill (record_id = 0) is lossless and nothing needs re-annotating.
 --
+-- Still no FK to the row (the 007 document_tombstone precedent), but row scope needs a
+-- guarantee family scope never did: a record id is a plain rowid alias (INTEGER PRIMARY
+-- KEY, no AUTOINCREMENT - migrations 001/006), so deleting the highest-id row frees that id
+-- for the next insert. A row-scoped verdict left behind would silently re-target an
+-- unrelated new record, and `pemr verify`'s orphan warning goes quiet exactly then. So the
+-- two write paths that delete a record row - records.remove_record and
+-- documents.remove_document - retire the row-scoped verdicts naming those rows, in the same
+-- transaction as the delete. Family scope has no such hazard: dedup_base is content-derived,
+-- so re-attaching to a re-ingested identical fact is intentional.
+--
 -- 008's three CHECKs are carried verbatim; the orphan story is unchanged (no FK, `pemr
--- verify` warns rather than the schema erasing), and now covers "names no live row" too.
+-- verify` warns rather than the schema erasing), and now covers "names no live row" too -
+-- the backstop for a verdict orphaned some way other than those two write paths.
 
 CREATE TABLE curation_new (
   record_type      TEXT NOT NULL,   -- one of dedup.KNOWN_TYPES; validated in Python

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -687,6 +687,8 @@ def _cmd_document_rm(args: argparse.Namespace) -> int:
                 "conflicts_deleted": report.conflicts_deleted,
                 "conflicts_anchored": report.conflicts_anchored,
                 "conflicts_detached": report.conflicts_detached,
+                # Appended, never inserted: the --json key set is a contract.
+                "curation_retired": report.curation_retired,
                 "blob_path": report.blob_path,
                 "blob_purged": report.blob_purged,
                 "tombstoned": report.tombstoned,
@@ -713,6 +715,14 @@ def _cmd_document_rm(args: argparse.Namespace) -> int:
             )
         if report.conflicts_detached:
             print(f"  conflicts detached (resolved): {report.conflicts_detached}")
+        for verdict in report.curation_retired:
+            # Row-scoped verdicts on the doomed rows (issue #114) - named rather than
+            # counted, for the same reason `record rm` names its one.
+            lifted = "lifted" if report.applied else "would be lifted"
+            print(
+                f"  curation verdict (row scope) {lifted}: {verdict['record_type']} "
+                f"#{verdict['record_id']}  {curation.describe(verdict)}"
+            )
         if not args.purge_blob:
             print(f"  blob kept: {report.blob_path}")
         elif report.blob_purged:
@@ -858,6 +868,8 @@ def _cmd_record_rm(args: argparse.Namespace) -> int:
                 "family_size": report.family_size,
                 "family_remaining": report.family_remaining,
                 "conflicts_reanchored": report.conflicts_reanchored,
+                # Appended, never inserted: the --json key set is a contract.
+                "curation_retired": report.curation_retired,
                 "applied": report.applied,
             })
             return 0
@@ -883,6 +895,14 @@ def _cmd_record_rm(args: argparse.Namespace) -> int:
             print(
                 f"  open conflict(s) {ids} re-anchor to the lowest surviving "
                 "occurrence"
+            )
+        for verdict in report.curation_retired:
+            # Named, not counted: a row-scoped verdict is a recorded human ruling, and
+            # the dry run is the only chance to notice it is going away (issue #114).
+            lifted = "lifted" if report.applied else "would be lifted"
+            print(
+                f"  curation verdict (row scope) {lifted}: "
+                f"{curation.describe(verdict)}"
             )
         if report.applied:
             print(f"removed {report.record_type} #{report.row_id}")

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -413,6 +413,7 @@ def _with_document_conn(args: argparse.Namespace, work):
             records.AnchoredConflictError,
             curation.CurationNotFoundError,
             curation.FamilyNotFoundError,
+            curation.RowNotFoundError,
             attestations.AttestationCollisionError,
             persons.PersonNotFoundError,
         ) as exc:
@@ -899,26 +900,47 @@ def _cmd_record_rm(args: argparse.Namespace) -> int:
 # recorded human verdicts (`record annotate`) - issue #109
 # --------------------------------------------------------------------------- #
 
+def _curation_scope(row: dict) -> str:
+    """`family` or `row #<id>` — the scope column shared by `--list` and the report."""
+    record_id = row.get("record_id") or 0
+    return f"row #{record_id}" if record_id else curation.SCOPE_FAMILY
+
+
 def _curation_row_line(row: dict) -> str:
-    """One `--list` line: identity, verdict, and whether the family still exists."""
-    orphan = "  (orphaned: no live family)" if not row["family_size"] else ""
+    """One `--list` line: identity, scope, verdict, and whether the target still exists.
+
+    The scope column is not cosmetic (issue #114): a family verdict and a row verdict on
+    the same family are two different rulings, and `--clear` needs `--row` for exactly
+    one of them.
+    """
+    if not row["family_size"]:
+        orphan = (
+            "  (orphaned: no live row)" if row.get("record_id")
+            else "  (orphaned: no live family)"
+        )
+    else:
+        orphan = ""
     return (
         f"{row['record_type']:12}  {str(row['dedup_base'])[:12]}  "
-        f"{(row['created_at'] or '')[:10]:10}  {row['label']}  "
-        f"[{curation.describe(row)}]{orphan}"
+        f"{_curation_scope(row):10}  {(row['created_at'] or '')[:10]:10}  "
+        f"{row['label']}  [{curation.describe(row)}]{orphan}"
     )
 
 
 def _print_curation_report(report: "curation.CurationReport") -> None:
     """The human block shared by annotate and clear, shaped like `_cmd_record_rm`'s."""
-    family = (
-        f"{report.family_size} row(s)" if report.family_size
-        else "no live rows (orphaned verdict)"
-    )
+    if report.family_size:
+        family = f"{report.family_size} row(s)"
+    elif report.record_id:
+        family = "no live row (orphaned verdict)"
+    else:
+        family = "no live rows (orphaned verdict)"
+    gone = "(no live row)" if report.record_id else "(no live family)"
     print(
-        f"{report.record_type}  {report.label or '(no live family)'}  "
+        f"{report.record_type}  {report.label or gone}  "
         f"base {report.dedup_base[:12]}  ({family})"
     )
+    print(f"  scope: {_curation_scope(report.as_dict())}")
     print(f"  status: {report.status}")
     print(f"  note: {report.note}")
     if report.attributed_to:
@@ -930,17 +952,23 @@ def _print_curation_report(report: "curation.CurationReport") -> None:
 
 
 def _cmd_record_annotate(args: argparse.Namespace) -> int:
-    """`record annotate` — list, clear, or record one family's verdict.
+    """`record annotate` — list, clear, or record one verdict (family- or row-scoped).
 
     Three modes on one subparser rather than three verbs: the positionals differ only
     in whether they are present, and `--list`/`--clear` read as flags on the noun the
     operator already has in hand. The handler owns the "table and target are required
     unless --list" rule, because argparse cannot express it across `nargs='?'`.
+
+    `--row` (issue #114) narrows both the write and the clear to one row; without it
+    every path behaves exactly as it did under #109, which is why row scope is opt-in
+    rather than inferred from a digit-shaped target.
     """
     parser = args.annotate_parser
     if args.list:
         if args.target is not None:
             parser.error("--list takes an optional table, not a target")
+        if args.row:
+            parser.error("--row scopes a verdict to one row; it has no meaning with --list")
 
         def work(conn):
             rows = curation.list_curation(conn, args.table)
@@ -950,7 +978,10 @@ def _cmd_record_annotate(args: argparse.Namespace) -> int:
             if not rows:
                 print("no curation verdicts recorded")
                 return 0
-            print(f"{'type':12}  {'base':12}  {'recorded':10}  label  [verdict]")
+            print(
+                f"{'type':12}  {'base':12}  {'scope':10}  {'recorded':10}  "
+                "label  [verdict]"
+            )
             for row in rows:
                 print(_curation_row_line(row))
             return 0
@@ -963,16 +994,19 @@ def _cmd_record_annotate(args: argparse.Namespace) -> int:
     if args.clear:
         def work(conn):
             report = curation.clear_curation(
-                conn, args.table, args.target, apply=args.apply
+                conn, args.table, args.target, row=args.row, apply=args.apply
             )
             if args.json:
                 _print_json(report.as_dict())
                 return 0
             _print_curation_report(report)
             if report.applied:
+                target = (
+                    f"row #{report.record_id}" if report.record_id
+                    else report.dedup_base[:12]
+                )
                 print(
-                    f"cleared curation verdict for {report.record_type} "
-                    f"{report.dedup_base[:12]}"
+                    f"cleared curation verdict for {report.record_type} {target}"
                 )
             else:
                 print("dry run: nothing was written - re-run with --apply")
@@ -992,6 +1026,7 @@ def _cmd_record_annotate(args: argparse.Namespace) -> int:
             note=args.note,
             attributed_to=args.attributed_to,
             merged_into_base=args.merged_into,
+            row=args.row,
             apply=args.apply,
         )
         if args.json:
@@ -999,9 +1034,12 @@ def _cmd_record_annotate(args: argparse.Namespace) -> int:
             return 0
         _print_curation_report(report)
         if report.applied:
+            target = (
+                f"row #{report.record_id}" if report.record_id
+                else report.dedup_base[:12]
+            )
             print(
-                f"annotated {report.record_type} {report.dedup_base[:12]} "
-                f"({report.action})"
+                f"annotated {report.record_type} {target} ({report.action})"
             )
         else:
             print("dry run: nothing was written - re-run with --apply")
@@ -2191,7 +2229,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--list", action="store_true", help="list current verdicts and exit"
     )
     r_annotate.add_argument(
-        "--clear", action="store_true", help="lift the verdict on this family"
+        "--clear", action="store_true", help="lift the verdict on this target"
+    )
+    r_annotate.add_argument(
+        "--row", action="store_true",
+        help="scope the verdict to this ROW only, not its whole dedup family "
+             "(target must be a row id); also selects a row verdict for --clear",
     )
     r_annotate.add_argument(
         "--apply", action="store_true", help="write the verdict (default: report only)"

--- a/pemr/curation.py
+++ b/pemr/curation.py
@@ -1,4 +1,4 @@
-"""Recorded human verdicts on record families — `pemr record annotate` (issue #109).
+"""Recorded human verdicts on records — `pemr record annotate` (issues #109, #114).
 
 Some record states are not resolvable by deterministic tooling over documents. Two
 source documents contradict each other and the extraction is faithful to both. A row is
@@ -10,7 +10,7 @@ at this and ruled" — so the question reopens on every re-render and re-extract
 This module is that missing durable state: one small overlay table, and the verbs that
 write it.
 
-    annotate_record  -- record (or overwrite) one family's verdict, dry-run by default
+    annotate_record  -- record (or overwrite) one verdict, dry-run by default
     list_curation    -- every verdict, newest first
     clear_curation   -- lift one verdict, dry-run by default
     load_verdicts    -- the whole table as a lookup, for the render/verify hot path
@@ -19,15 +19,39 @@ write it.
 state: it just reads two tables per section instead of one, and re-rendering after a
 verdict changes output because the database changed, which is the point.
 
-**Keyed by ``(record_type, dedup_base)``**, not by row id and not by ``dedup_key``.
+**Two scopes** (issue #114). A verdict names either a whole dedup **family** or a
+single **row**:
+
+*Family scope* — keyed by ``(record_type, dedup_base)``, stored with ``record_id = 0``.
 ``dedup_base`` is the stable per-family identity across occurrence renumbering
-(Architecture.md §3), so a verdict survives a re-ingest of the same document and the
+(Architecture.md §3), so the verdict survives a re-ingest of the same document and the
 occurrence shifts `record rm` (#107) leaves behind. It does *not* survive every
 `pemr rekey`: a dictionary edit that changes this family's own canonical name moves its
 ``dedup_base``, orphaning the verdict (`pemr verify` warns; `record annotate --clear`
-then re-annotate). One live verdict per family: re-annotating overwrites (last verdict
-wins), which is what "a human ruled" means — there is no verdict history here by
-design.
+then re-annotate).
+
+*Row scope* — ``--row``, keyed by ``(record_type, record_id)`` **alone**. It exists for
+the family a ``--keep both`` conflict resolution left holding two *live* rows: a
+family-scoped ``superseded`` there hides the winner along with the loser. A row-scoped
+verdict affects only its own occurrence; siblings render as if unannotated unless they
+carry their own verdict. `rekey` rewrites ``dedup_key``/``dedup_base`` but never
+renumbers a row id (:func:`dedup.rekey`: "Values, provenance and row ids are
+untouched"), so a row-scoped verdict genuinely **survives** the dictionary-driven rekey
+that orphans a family-scoped one; it is orphaned only by the removal of its row. The
+``dedup_base`` stored beside it is a *breadcrumb* — which family it ruled in, at
+annotate time — that may go stale after such a rekey and is never consulted for
+resolution: every reader re-reads the live base off the row.
+
+**Precedence**: a row-scoped verdict wins over its family's verdict, for that row only —
+resolved in exactly one place, :meth:`VerdictMap.for_row`, so render, journal and verify
+cannot drift apart.
+
+Row scope is **opt-in** and never inferred from the token's shape: :func:`resolve_base`
+has accepted a bare row id as "the family containing this row" since #109, and flipping
+that would silently change the meaning of commands already recorded in a curation ledger.
+
+One live verdict per target: re-annotating overwrites (last verdict wins), which is what
+"a human ruled" means — there is no verdict history here by design.
 
 The module imports :mod:`db` and :mod:`dedup` only, keeping the import graph acyclic;
 `render` and `verify` import *it*.
@@ -41,7 +65,7 @@ of.
 from __future__ import annotations
 
 import sqlite3
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
 from . import db, dedup
@@ -68,13 +92,31 @@ APPENDIX_STATUSES: tuple[str, ...] = (
 #: The key a rendered row carries its verdict under, when it has one.
 CURATION_FIELD = "_curation"
 
+#: ``curation.record_id`` for a family-scoped verdict (migration 010). A sentinel rather
+#: than NULL: SQLite treats NULLs as distinct in a unique index, so a nullable scope
+#: column would silently permit duplicate family verdicts on one base.
+FAMILY_SCOPE = 0
+
+#: The scope vocabulary — `--list` / `--json` / the report block all speak it, and like
+#: :data:`STATUSES` it has exactly one source of truth.
+SCOPE_FAMILY = "family"
+SCOPE_ROW = "row"
+
 
 class CurationNotFoundError(ValueError):
-    """Raised when a family carries no verdict (friendly rc=1 at the CLI)."""
+    """Raised when the named target carries no verdict (friendly rc=1 at the CLI)."""
 
 
 class FamilyNotFoundError(ValueError):
     """Raised when a base-or-id token does not resolve to a live family."""
+
+
+class RowNotFoundError(ValueError):
+    """Raised when a ``--row`` token does not name a live row.
+
+    Distinct from :class:`FamilyNotFoundError` so the CLI can say "drop ``--row`` to
+    annotate the whole family" — the two failures have different fixes.
+    """
 
 
 @dataclass
@@ -91,11 +133,13 @@ class CurationReport:
     attributed_to: str | None = None
     created_at: str = ""
     merged_into_base: str | None = None
-    label: str = ""                    # which fact is being ruled on (occurrence 0)
+    label: str = ""                    # which fact is being ruled on
     family_size: int = 0
     previous: dict | None = None       # the verdict this one replaces, if any
     action: str = "create"             # "create" | "overwrite" | "clear"
     applied: bool = False
+    record_id: int = FAMILY_SCOPE      # 0 = family scope; else the annotated row
+    scope: str = SCOPE_FAMILY          # SCOPE_FAMILY | SCOPE_ROW (derived from record_id)
 
     def as_dict(self) -> dict:
         return {
@@ -111,7 +155,55 @@ class CurationReport:
             "previous": self.previous,
             "action": self.action,
             "applied": self.applied,
+            # Appended, never inserted: the --json key set is a contract, and #114 may
+            # only widen it (Architecture.md's additive-only rule).
+            "record_id": self.record_id,
+            "scope": self.scope,
         }
+
+
+@dataclass
+class VerdictMap:
+    """Every stored verdict, partitioned by scope — the render/verify lookup.
+
+    Replaces #109's bare ``{(record_type, dedup_base): verdict}`` dict, which had no way
+    to express "this row but not its sibling". Still **one query**: the partition happens
+    in Python, because a per-row SELECT is exactly what this map exists to avoid.
+
+    Falsy when empty, so render's no-verdicts fast path (and its
+    ``with_identity=bool(...)`` journal call) keeps working unchanged.
+    """
+
+    family: dict[tuple[str, str], dict] = field(default_factory=dict)
+    rows: dict[tuple[str, int], dict] = field(default_factory=dict)
+
+    def for_row(
+        self, record_type: str, base: str | None, record_id: int | None
+    ) -> dict | None:
+        """The verdict that applies to one row: **row scope wins over family scope**.
+
+        The single precedence site (issue #114). Render, journal and verify all resolve
+        through here, so the rule cannot drift between them. ``record_id`` may be None
+        (a carrier without row identity — an event from a ``with_identity=False``
+        timeline), in which case only the family verdict can apply.
+        """
+        if record_id:
+            hit = self.rows.get((record_type, int(record_id)))
+            if hit is not None:
+                return hit
+        if base is None:
+            return None
+        return self.family.get((record_type, base))
+
+    def all(self) -> list[dict]:
+        """Every verdict, both scopes — for `verify` and `--list`."""
+        return [*self.family.values(), *self.rows.values()]
+
+    def __bool__(self) -> bool:
+        return bool(self.family or self.rows)
+
+    def __len__(self) -> int:
+        return len(self.family) + len(self.rows)
 
 
 def _now(now: str | None = None) -> str:
@@ -130,9 +222,15 @@ def _require_type(record_type: str) -> None:
 
 
 def _row_view(row: sqlite3.Row) -> dict:
+    # `record_id` is read defensively rather than by subscript: `render`/`verify` must
+    # keep working against a pre-010 snapshot (the `has_table` precedent), where the
+    # column does not exist and every verdict is family-scoped by definition.
+    record_id = int(row["record_id"]) if "record_id" in row.keys() else FAMILY_SCOPE
     return {
         "record_type": row["record_type"],
         "dedup_base": row["dedup_base"],
+        "record_id": record_id,
+        "scope": SCOPE_ROW if record_id else SCOPE_FAMILY,
         "status": row["status"],
         "note": row["note"],
         "merged_into_base": row["merged_into_base"],
@@ -154,29 +252,51 @@ def has_table(conn: sqlite3.Connection) -> bool:
 
 
 def get_verdict(
-    conn: sqlite3.Connection, record_type: str, base: str
+    conn: sqlite3.Connection,
+    record_type: str,
+    base: str,
+    *,
+    record_id: int = FAMILY_SCOPE,
 ) -> dict | None:
-    """The live verdict for one family, or None."""
+    """The live verdict for one family (default) or one row, or None.
+
+    With ``record_id > 0`` the ``base`` argument is deliberately **ignored**: a
+    row-scoped verdict resolves by row id alone, and its stored base is a breadcrumb
+    that a `rekey` may have left stale.
+    """
     if not has_table(conn):
         return None
-    row = conn.execute(
-        "SELECT * FROM curation WHERE record_type = ? AND dedup_base = ?",
-        (record_type, base),
-    ).fetchone()
+    if record_id:
+        row = conn.execute(
+            "SELECT * FROM curation WHERE record_type = ? AND record_id = ?",
+            (record_type, int(record_id)),
+        ).fetchone()
+    else:
+        row = conn.execute(
+            "SELECT * FROM curation WHERE record_type = ? AND dedup_base = ? "
+            "AND record_id = 0",
+            (record_type, base),
+        ).fetchone()
     return _row_view(row) if row is not None else None
 
 
-def load_verdicts(conn: sqlite3.Connection) -> dict[tuple[str, str], dict]:
-    """Every verdict as ``{(record_type, dedup_base): verdict}`` — one query.
+def load_verdicts(conn: sqlite3.Connection) -> VerdictMap:
+    """Every verdict as a :class:`VerdictMap` — one query, both scopes.
 
     The render/verify hot path: a document render touches every section, and a
-    per-family lookup would be one SELECT per row. Returns ``{}`` when the table is
-    absent (pre-008 snapshot), so callers need no second guard.
+    per-row lookup would be one SELECT per row. Returns an empty (falsy) map when the
+    table is absent (pre-008 snapshot), so callers need no second guard.
     """
+    out = VerdictMap()
     if not has_table(conn):
-        return {}
-    rows = conn.execute("SELECT * FROM curation").fetchall()
-    return {(r["record_type"], r["dedup_base"]): _row_view(r) for r in rows}
+        return out
+    for r in conn.execute("SELECT * FROM curation").fetchall():
+        view = _row_view(r)
+        if view["record_id"]:
+            out.rows[(view["record_type"], view["record_id"])] = view
+        else:
+            out.family[(view["record_type"], view["dedup_base"])] = view
+    return out
 
 
 def family_label(conn: sqlite3.Connection, record_type: str, base: str) -> tuple[str, int]:
@@ -195,6 +315,34 @@ def family_label(conn: sqlite3.Connection, record_type: str, base: str) -> tuple
     if not family:
         return "", 0
     return dedup._rekey_label(record_type, family[0]), len(family)
+
+
+def row_label(
+    conn: sqlite3.Connection, record_type: str, record_id: int
+) -> tuple[str, str, int]:
+    """``(label, live_base, family_size)`` for one row — :func:`family_label`'s row twin.
+
+    The label comes off the annotated row itself, not off occurrence 0: the whole point
+    of row scope is that the siblings are different facts. ``live_base`` is re-read here
+    rather than taken from the verdict, because a `rekey` may have moved the family since
+    the verdict was recorded and the stored base is only a breadcrumb.
+
+    A removed row reports ``("", "", 0)`` rather than raising — the orphan case `list`
+    and `verify` both have to describe.
+    """
+    _require_type(record_type)
+    pk = f"{record_type}_id"
+    row = conn.execute(
+        f"SELECT * FROM {record_type} WHERE {pk} = ?", (int(record_id),)
+    ).fetchone()
+    if row is None:
+        return "", "", 0
+    base = row["dedup_base"]
+    return (
+        dedup._rekey_label(record_type, row),
+        base,
+        len(dedup.load_family(conn, record_type, base)),
+    )
 
 
 def resolve_base(conn: sqlite3.Connection, record_type: str, token: str) -> str:
@@ -238,6 +386,42 @@ def resolve_base(conn: sqlite3.Connection, record_type: str, token: str) -> str:
     return token
 
 
+def resolve_row(
+    conn: sqlite3.Connection, record_type: str, token: str
+) -> tuple[int, str]:
+    """Resolve a ``--row`` token to ``(record_id, live dedup_base)``.
+
+    Only a row id will do here: a ``dedup_base`` literal names a family, and silently
+    row-scoping it would rule on whichever occurrence happened to be first. The base is
+    returned alongside because the write stores it as a breadcrumb (which family this
+    verdict ruled in), never as a resolution key.
+
+    Raises :class:`RowNotFoundError` when the id names no live row, ``ValueError`` when
+    the token is not a row id at all.
+    """
+    _require_type(record_type)
+    token = (token or "").strip()
+    if not token:
+        raise RowNotFoundError(
+            f"no {record_type} target given - pass a row id with --row"
+        )
+    if not token.isdigit():
+        raise ValueError(
+            f"--row needs a {record_type} row id, not a dedup_base "
+            f"({token[:12]}...) - a base names a whole family; drop --row to annotate it"
+        )
+    pk = f"{record_type}_id"
+    row = conn.execute(
+        f"SELECT dedup_base FROM {record_type} WHERE {pk} = ?", (int(token),)
+    ).fetchone()
+    if row is None:
+        raise RowNotFoundError(
+            f"no {record_type} with id {token} - row ids come from `pemr rekey`'s "
+            "collision report, or `pemr query`"
+        )
+    return int(token), row["dedup_base"]
+
+
 def annotate_record(
     conn: sqlite3.Connection,
     record_type: str,
@@ -247,10 +431,15 @@ def annotate_record(
     note: str,
     attributed_to: str | None = None,
     merged_into_base: str | None = None,
+    row: bool = False,
     now: str | None = None,
     apply: bool = False,
 ) -> CurationReport:
-    """Record one family's verdict; dry-run by default (``apply=True`` writes).
+    """Record one verdict; dry-run by default (``apply=True`` writes).
+
+    ``row=True`` scopes the verdict to the single row ``token`` names, instead of to its
+    whole dedup family (issue #114). Opt-in on purpose: without it the behaviour — and
+    the stored row — is bit-identical to #109's.
 
     Validation is deliberately front-loaded, because the write is an upsert that
     silently replaces the previous verdict: an unknown status or a dangling
@@ -266,7 +455,8 @@ def annotate_record(
     merged into itself would render nowhere at all).
 
     Raises ``ValueError`` for an unknown ``record_type``/``status``/empty note or a bad
-    merge target, and :class:`FamilyNotFoundError` when the target does not resolve.
+    merge target, :class:`FamilyNotFoundError` when a family target does not resolve, and
+    :class:`RowNotFoundError` when a ``--row`` target does not.
     """
     db.require_migrated(conn)
     _require_type(record_type)
@@ -281,7 +471,10 @@ def annotate_record(
             "a curation note is required - it records why the verdict was made and "
             "who made it; nothing was written"
         )
-    base = resolve_base(conn, record_type, token)
+    if row:
+        record_id, base = resolve_row(conn, record_type, token)
+    else:
+        record_id, base = FAMILY_SCOPE, resolve_base(conn, record_type, token)
 
     merge_target = (merged_into_base or "").strip() or None
     if status == "merged-into":
@@ -303,12 +496,17 @@ def annotate_record(
             f"'{status}'; nothing was written"
         )
 
-    previous = get_verdict(conn, record_type, base)
-    label, family_size = family_label(conn, record_type, base)
+    previous = get_verdict(conn, record_type, base, record_id=record_id)
+    if record_id:
+        label, _live_base, family_size = row_label(conn, record_type, record_id)
+    else:
+        label, family_size = family_label(conn, record_type, base)
     stamp = _now(now)
     report = CurationReport(
         record_type=record_type,
         dedup_base=base,
+        record_id=record_id,
+        scope=SCOPE_ROW if record_id else SCOPE_FAMILY,
         status=status,
         note=cleaned_note,
         attributed_to=(attributed_to or "").strip() or None,
@@ -321,24 +519,33 @@ def annotate_record(
     )
 
     if apply:
-        # UPSERT, the `tombstones.add_tombstone` idiom: one live verdict per family,
-        # last verdict wins, and a re-run of the same command is a safe no-op-shaped
-        # write. created_at is refreshed - it stamps *this* verdict, not the first one.
+        # DELETE-by-scope then INSERT, where #109 upserted: since 010 there are two
+        # disjoint uniqueness rules - the PK for family scope, the partial index for row
+        # scope - and one ON CONFLICT target cannot name both. (A row-scoped
+        # re-annotate after a rekey can collide with both at once: same row id, new
+        # base.) The observable semantics are unchanged - one live verdict per target,
+        # last verdict wins - and the delete additionally collapses a stale-base copy.
+        # created_at is refreshed: it stamps *this* verdict, not the first one.
         with conn:
+            if record_id:
+                conn.execute(
+                    "DELETE FROM curation WHERE record_type = ? AND record_id = ?",
+                    (record_type, record_id),
+                )
+            else:
+                conn.execute(
+                    "DELETE FROM curation WHERE record_type = ? AND dedup_base = ? "
+                    "AND record_id = 0",
+                    (record_type, base),
+                )
             conn.execute(
                 """
                 INSERT INTO curation
-                  (record_type, dedup_base, status, note, merged_into_base,
+                  (record_type, dedup_base, record_id, status, note, merged_into_base,
                    attributed_to, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(record_type, dedup_base) DO UPDATE SET
-                  status           = excluded.status,
-                  note             = excluded.note,
-                  merged_into_base = excluded.merged_into_base,
-                  attributed_to    = excluded.attributed_to,
-                  created_at       = excluded.created_at
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                (record_type, base, status, cleaned_note, merge_target,
+                (record_type, base, record_id, status, cleaned_note, merge_target,
                  report.attributed_to, stamp),
             )
     report.applied = apply
@@ -350,11 +557,15 @@ def list_curation(
 ) -> list[dict]:
     """Every verdict (optionally one record type), newest first.
 
-    Each entry carries ``label`` and ``family_size``. ``family_size == 0`` is an
-    **orphan**: the family it rules on is gone (a `record rm` of every occurrence, or a
-    restore from a snapshot that never had it). Surfaced rather than hidden, the
-    ``tombstones.list_tombstones`` ``live_document_id`` precedent — `pemr verify` warns
-    about the same state.
+    Each entry carries ``scope``, ``record_id``, ``label`` and ``family_size``.
+    ``family_size == 0`` is an **orphan**: the target it rules on is gone — the whole
+    family for a family-scoped verdict, the single row for a row-scoped one. Surfaced
+    rather than hidden, the ``tombstones.list_tombstones`` ``live_document_id``
+    precedent — `pemr verify` warns about the same state.
+
+    A row-scoped entry is labelled from its **row**, whose live ``dedup_base`` is re-read
+    here: after a `rekey` the stored base is stale, and resolving on it would make a
+    perfectly live row verdict look orphaned.
     """
     db.require_migrated(conn)
     if record_type is not None:
@@ -366,15 +577,19 @@ def list_curation(
     if record_type is not None:
         sql += " WHERE record_type = ?"
         params = (record_type,)
-    sql += " ORDER BY created_at DESC, record_type, dedup_base"
+    sql += " ORDER BY created_at DESC, record_type, dedup_base, record_id"
     out: list[dict] = []
     for row in conn.execute(sql, params).fetchall():
         view = _row_view(row)
-        if view["record_type"] in dedup.FIELD_SPECS:
-            label, size = family_label(conn, view["record_type"], view["dedup_base"])
-        else:
+        if view["record_type"] not in dedup.FIELD_SPECS:
             # A hand-edited row can name anything; never build a query from it.
             label, size = "", 0
+        elif view["record_id"]:
+            label, _live_base, size = row_label(
+                conn, view["record_type"], view["record_id"]
+            )
+        else:
+            label, size = family_label(conn, view["record_type"], view["dedup_base"])
         view["label"] = label
         view["family_size"] = size
         out.append(view)
@@ -386,14 +601,21 @@ def clear_curation(
     record_type: str,
     token: str,
     *,
+    row: bool = False,
     apply: bool = False,
 ) -> CurationReport:
-    """Lift one family's verdict; dry-run by default.
+    """Lift one verdict — a family's, or with ``row=True`` a single row's; dry-run by
+    default.
 
-    The target is resolved leniently on purpose: a row id still needs a live row, but a
-    ``dedup_base`` literal is accepted even when the family is gone, because clearing an
-    **orphaned** verdict (the one `pemr verify` warns about) is exactly a case where no
-    live row exists to name it by.
+    Targeting mirrors :func:`annotate_record`, and clearing one scope never touches the
+    other: a family verdict and a row verdict may legitimately coexist on the same
+    family (that is the precedence case), so a `--clear` that took both would silently
+    lift a ruling the operator never named.
+
+    The target is resolved leniently on purpose, in both scopes: a ``dedup_base``
+    literal is accepted even when the family is gone, and a ``--row`` id even when the
+    row is gone, because clearing an **orphaned** verdict (the one `pemr verify` warns
+    about) is exactly a case where nothing live names it.
 
     Raises :class:`CurationNotFoundError` when there is no verdict to lift — a typo
     must not read as success.
@@ -401,20 +623,36 @@ def clear_curation(
     db.require_migrated(conn)
     _require_type(record_type)
     token = (token or "").strip()
-    if token.isdigit():
-        base = resolve_base(conn, record_type, token)
+    if row:
+        if not token.isdigit():
+            raise ValueError(
+                f"--row needs a {record_type} row id, not a dedup_base "
+                f"({token[:12]}...) - drop --row to clear the family's verdict"
+            )
+        record_id = int(token)
+        existing = get_verdict(conn, record_type, "", record_id=record_id)
+        if existing is None:
+            raise CurationNotFoundError(
+                f"no row-scoped curation verdict for {record_type} row #{record_id} - "
+                "see `pemr record annotate --list`"
+            )
+        base = existing["dedup_base"]
+        label, _live_base, family_size = row_label(conn, record_type, record_id)
     else:
-        base = token
-    existing = get_verdict(conn, record_type, base)
-    if existing is None:
-        raise CurationNotFoundError(
-            f"no curation verdict for {record_type} {base[:12]}... - see "
-            "`pemr record annotate --list`"
-        )
-    label, family_size = family_label(conn, record_type, base)
+        record_id = FAMILY_SCOPE
+        base = resolve_base(conn, record_type, token) if token.isdigit() else token
+        existing = get_verdict(conn, record_type, base)
+        if existing is None:
+            raise CurationNotFoundError(
+                f"no curation verdict for {record_type} {base[:12]}... - see "
+                "`pemr record annotate --list`"
+            )
+        label, family_size = family_label(conn, record_type, base)
     report = CurationReport(
         record_type=record_type,
         dedup_base=base,
+        record_id=record_id,
+        scope=SCOPE_ROW if record_id else SCOPE_FAMILY,
         status=existing["status"],
         note=existing["note"],
         attributed_to=existing["attributed_to"],
@@ -427,10 +665,17 @@ def clear_curation(
     )
     if apply:
         with conn:
-            conn.execute(
-                "DELETE FROM curation WHERE record_type = ? AND dedup_base = ?",
-                (record_type, base),
-            )
+            if record_id:
+                conn.execute(
+                    "DELETE FROM curation WHERE record_type = ? AND record_id = ?",
+                    (record_type, record_id),
+                )
+            else:
+                conn.execute(
+                    "DELETE FROM curation WHERE record_type = ? AND dedup_base = ? "
+                    "AND record_id = 0",
+                    (record_type, base),
+                )
     report.applied = apply
     return report
 

--- a/pemr/curation.py
+++ b/pemr/curation.py
@@ -10,10 +10,12 @@ at this and ruled" — so the question reopens on every re-render and re-extract
 This module is that missing durable state: one small overlay table, and the verbs that
 write it.
 
-    annotate_record  -- record (or overwrite) one verdict, dry-run by default
-    list_curation    -- every verdict, newest first
-    clear_curation   -- lift one verdict, dry-run by default
-    load_verdicts    -- the whole table as a lookup, for the render/verify hot path
+    annotate_record      -- record (or overwrite) one verdict, dry-run by default
+    list_curation        -- every verdict, newest first
+    clear_curation       -- lift one verdict, dry-run by default
+    load_verdicts        -- the whole table as a lookup, for the render/verify hot path
+    row_verdicts_for     -- the row-scoped verdicts naming a set of rows
+    retire_row_verdicts  -- ... and drop them, for the row-removal write paths
 
 **Pure overlay.** No record row is ever written. `render` stays a pure function of DB
 state: it just reads two tables per section instead of one, and re-rendering after a
@@ -42,6 +44,19 @@ that orphans a family-scoped one; it is orphaned only by the removal of its row.
 annotate time — that may go stale after such a rekey and is never consulted for
 resolution: every reader re-reads the live base off the row.
 
+**Removing the row retires the verdict.** A ``dedup_base`` is content-derived, so a
+family verdict re-attaching to a re-ingested identical fact is correct. A row id is not:
+every record table is ``INTEGER PRIMARY KEY`` without ``AUTOINCREMENT``, so deleting the
+highest-id row frees that id for the **next insert** — a surviving row-scoped verdict
+would silently re-target an unrelated new record, filing a live clinical fact under a
+note about a different one, and `pemr verify`'s orphan warning goes quiet the moment the
+id is reused. So the two write paths that can delete a record row —
+:func:`records.remove_record` and :func:`documents.remove_document` — disclose any
+row-scoped verdict naming a doomed row in their dry run and lift it, in the same
+transaction as the delete (:func:`row_verdicts_for`, :func:`retire_row_verdicts`). The
+window is closed where it opens; `verify`'s warning stays as the backstop for a verdict
+orphaned some other way.
+
 **Precedence**: a row-scoped verdict wins over its family's verdict, for that row only —
 resolved in exactly one place, :meth:`VerdictMap.for_row`, so render, journal and verify
 cannot drift apart.
@@ -65,6 +80,7 @@ of.
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
@@ -297,6 +313,53 @@ def load_verdicts(conn: sqlite3.Connection) -> VerdictMap:
         else:
             out.family[(view["record_type"], view["dedup_base"])] = view
     return out
+
+
+def row_verdicts_for(
+    conn: sqlite3.Connection, record_type: str, record_ids: Iterable[int]
+) -> list[dict]:
+    """The **row-scoped** verdicts naming any of ``record_ids``, newest first.
+
+    What a row-removal write path has to disclose before it deletes: those rows' ids are
+    about to become free for reuse, so the verdicts naming them are about to become
+    hazardous (see the module docstring). Family-scoped verdicts are deliberately not
+    returned — ``dedup_base`` is content-derived and survives the removal legitimately.
+
+    One query, intersected in Python: `curation` holds one row per human ruling, so it is
+    always the small side, while ``record_ids`` can be every row of a large document.
+    """
+    _require_type(record_type)
+    wanted = {int(rid) for rid in record_ids if int(rid)}
+    if not wanted or not has_table(conn):
+        return []
+    rows = conn.execute(
+        "SELECT * FROM curation WHERE record_type = ? AND record_id <> 0 "
+        "ORDER BY created_at DESC, record_id",
+        (record_type,),
+    ).fetchall()
+    return [v for v in (_row_view(r) for r in rows) if v["record_id"] in wanted]
+
+
+def retire_row_verdicts(
+    conn: sqlite3.Connection, record_type: str, record_ids: Iterable[int]
+) -> list[dict]:
+    """Lift the row-scoped verdicts naming ``record_ids``; return what was lifted.
+
+    **Caller-managed transaction** (the :func:`tombstones.add_tombstone`
+    ``conn_managed`` precedent): the caller is deleting the rows themselves, and a
+    delete that commits without retiring the verdict is the exact failure this closes,
+    so both must land in one ``with conn:``.
+
+    Deletes by ``(record_type, record_id)`` — never by ``dedup_base``, which is a
+    breadcrumb a `rekey` may have left stale — and touches no family-scoped verdict.
+    """
+    doomed = row_verdicts_for(conn, record_type, record_ids)
+    for verdict in doomed:
+        conn.execute(
+            "DELETE FROM curation WHERE record_type = ? AND record_id = ?",
+            (record_type, verdict["record_id"]),
+        )
+    return doomed
 
 
 def family_label(conn: sqlite3.Connection, record_type: str, base: str) -> tuple[str, int]:

--- a/pemr/documents.py
+++ b/pemr/documents.py
@@ -42,7 +42,7 @@ import unicodedata
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from . import db, dedup, tombstones
+from . import curation, db, dedup, tombstones
 from .persons import PersonNotFoundError, get_person
 
 
@@ -161,6 +161,29 @@ def _record_counts(conn: sqlite3.Connection, document_id: int) -> dict[str, int]
         ).fetchone()
         counts[record_type] = int(row["n"])
     return counts
+
+
+def _doomed_row_verdicts(
+    conn: sqlite3.Connection, document_id: int
+) -> list[dict]:
+    """Row-scoped curation verdicts naming a row this document owns (issue #114).
+
+    The cascade frees every one of those row ids for reuse, so the verdicts have to go
+    with the rows — same reason `record rm` retires its one row's verdict, at document
+    scale. Family-scoped verdicts are untouched: ``dedup_base`` is content-derived, so a
+    re-ingest of the same document legitimately re-attaches them.
+    """
+    doomed: list[dict] = []
+    for record_type in dedup.KNOWN_TYPES:
+        pk = f"{record_type}_id"
+        ids = [
+            int(r[pk])
+            for r in conn.execute(
+                f"SELECT {pk} FROM {record_type} WHERE document_id = ?", (document_id,)
+            ).fetchall()
+        ]
+        doomed.extend(curation.row_verdicts_for(conn, record_type, ids))
+    return doomed
 
 
 def _conflicts_cited_by(conn: sqlite3.Connection, document_id: int) -> list[int]:
@@ -553,6 +576,8 @@ class RemoveReport:
     conflicts_deleted: int = 0      # open conflicts raised by this document
     conflicts_anchored: int = 0     # open conflicts staged against its rows (also deleted)
     conflicts_detached: int = 0     # resolved conflicts, document_id nulled
+    # Row-scoped curation verdicts on the doomed rows - lifted with them (issue #114).
+    curation_retired: list[dict] = field(default_factory=list)
     # Absolute when a ``sources_dir`` was passed, else the store-relative
     # `sources/<shard>/<sha><ext>` form `pemr ingest` echoes. The CLI only resolves a
     # sources dir for `--purge-blob`, so its `blob kept:` line is always the latter.
@@ -597,8 +622,12 @@ def remove_document(
     owns (:func:`_conflicts_anchored_to`) are deleted too and counted separately — the
     row they were staged against is going away, so leaving them would strand a conflict
     whose only remaining resolution is `keep both` (`keep incoming` refuses loudly once
-    the family is empty — :func:`dedup._anchor_row`). Every count is in the dry-run
-    report: the blast radius is the safety
+    the family is empty — :func:`dedup._anchor_row`). Row-scoped curation verdicts
+    (`record annotate --row`, issue #114) naming a doomed row are lifted with it, because
+    the row id becomes reusable the moment the row is gone and a surviving verdict would
+    re-attach to whatever lands on it; family-scoped verdicts are kept, since
+    ``dedup_base`` is content-derived and re-attaches to a re-ingest on purpose. Every
+    count is in the dry-run report: the blast radius is the safety
     mechanism here, so it has to be truthful.
 
     The scan under ``sources_dir`` is **kept** unless ``purge_blob`` is set — it is the
@@ -646,6 +675,9 @@ def remove_document(
         "SELECT COUNT(*) AS n FROM conflict WHERE document_id = ? AND status != 'open'",
         (document_id,),
     ).fetchone()["n"])
+    # Every row this document owns is about to be deleted, freeing its id for reuse, so
+    # the row-scoped verdicts naming those rows go with them (issue #114).
+    report.curation_retired = _doomed_row_verdicts(conn, document_id)
     report.tombstoned = tombstone
     report.tombstone_reason = reason
     report.tombstone_note = note
@@ -671,6 +703,17 @@ def remove_document(
                 (document_id,),
             )
             for record_type in dedup.KNOWN_TYPES:
+                # Verdicts first, while their rows are still there to be matched - and
+                # in this same transaction, because a cascade that commits without
+                # retiring them leaves ids free to be reused under a stale ruling.
+                curation.retire_row_verdicts(
+                    conn,
+                    record_type,
+                    [
+                        v["record_id"] for v in report.curation_retired
+                        if v["record_type"] == record_type
+                    ],
+                )
                 conn.execute(
                     f"DELETE FROM {record_type} WHERE document_id = ?", (document_id,)
                 )

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -197,9 +197,11 @@ def query_timeline(
     ``attested_by``/``attested_on``; a document-sourced event carries neither key, so an
     unattested record's event shape is unchanged.
 
-    ``with_identity=True`` additionally stamps ``record_type`` and ``dedup_base`` on
-    every event — the family identity `render_journal` needs to apply the `curation`
-    overlay (issue #109), which the event contract otherwise has no way to express.
+    ``with_identity=True`` additionally stamps ``record_type``, ``dedup_base`` and
+    ``record_id`` on every event — the family identity `render_journal` needs to apply
+    the `curation` overlay (issue #109), plus the row identity a **row-scoped** verdict
+    resolves by (issue #114); without the row id the journal could only ever apply the
+    family verdict, and would hide a sibling the operator deliberately left alone.
     Opt-in and **default-off** on purpose: ``dedup_base`` is one of
     :data:`dedup.INTERNAL_COLUMNS`, deliberately stripped from the CLI ``--json`` and
     MCP read payloads, so widening the default event shape would leak an unstable key
@@ -236,6 +238,7 @@ def query_timeline(
         if with_identity:
             event["record_type"] = record_type
             event["dedup_base"] = row["dedup_base"]
+            event["record_id"] = row[f"{record_type}_id"]
         events.append(event)
 
     for r in conn.execute(

--- a/pemr/records.py
+++ b/pemr/records.py
@@ -29,6 +29,14 @@ resolution and the conflict's ``incoming_json`` is still worth something — no 
 run could undo destroying it. So: removal is refused when it would empty the
 conflict's identity family, and allowed (with the conflict re-anchoring itself to
 the lowest surviving occurrence) when a sibling remains.
+
+**Row-scoped curation verdicts are retired with the row** (issue #114). A record
+id is a plain rowid alias — no ``AUTOINCREMENT`` on any record table — so removing
+the highest-id row frees that id for the next insert, and a `record annotate --row`
+verdict left behind would re-attach to whatever unrelated record lands on it. The
+dry run names the verdict; ``apply`` lifts it in the same transaction as the delete
+(:func:`curation.retire_row_verdicts`). Family-scoped verdicts are untouched:
+``dedup_base`` is content-derived, so re-attachment there is intentional.
 """
 
 from __future__ import annotations
@@ -36,7 +44,7 @@ from __future__ import annotations
 import sqlite3
 from dataclasses import dataclass, field
 
-from . import db, dedup
+from . import curation, db, dedup
 
 
 class RecordNotFoundError(ValueError):
@@ -66,6 +74,9 @@ class RecordRemoveReport:
     family_size: int = 0          # rows sharing this dedup_base, including this one
     family_remaining: int = 0     # ... after the removal
     conflicts_reanchored: list[int] = field(default_factory=list)
+    # Row-scoped curation verdicts naming this row - lifted with it (issue #114), and
+    # named in the dry run because a recorded clinical judgment is going away.
+    curation_retired: list[dict] = field(default_factory=list)
     applied: bool = False
 
 
@@ -91,13 +102,16 @@ def remove_record(
     Dry-run by default: pass ``apply=True`` to write. The dry run *is* the safety
     mechanism (there is no undo and no tombstone — a record row has no content
     hash to key one on), so the report has to be truthful about the blast radius:
-    the row's payload, its position in its identity family, and any open conflict
-    the removal re-anchors.
+    the row's payload, its position in its identity family, any open conflict
+    the removal re-anchors, and any row-scoped curation verdict it retires.
 
-    Deliberately narrow. It touches exactly one row: the document survives with
-    every other record it produced, ``dedup_key``s are neither recomputed nor
+    Deliberately narrow. It touches exactly one record row: the document survives
+    with every other record it produced, ``dedup_key``s are neither recomputed nor
     renumbered (deletion is key-neutral), and the ``conflict`` table is never
-    written. That makes it composable with the collision it exists to resolve —
+    written. The one thing outside the row it does write is the row's own
+    ``curation`` verdict, and only the row-scoped one (issue #114 — see the module
+    docstring: the id becomes reusable, the verdict must not outlive it). That makes
+    it composable with the collision it exists to resolve —
     `pemr rekey` names the two row ids, `pemr record rm` drops the degraded one,
     `pemr rekey --apply` then runs clean.
 
@@ -156,6 +170,9 @@ def remove_record(
     # occurrence on its next resolution (`dedup._anchor_row`) - allowed, but the
     # report says so out loud because the anchor moving is not obvious.
     report.conflicts_reanchored = anchored
+    # The row id is about to become reusable, so any row-scoped verdict naming it is
+    # about to become a mis-render waiting for the next insert (issue #114).
+    report.curation_retired = curation.row_verdicts_for(conn, record_type, [row_id])
 
     if apply:
         # record_fts follows via the per-table AFTER DELETE triggers (migrations
@@ -167,5 +184,8 @@ def remove_record(
                 raise RecordNotFoundError(
                     f"no {record_type} with id {row_id} - nothing was deleted"
                 )
+            # Same transaction as the delete: a commit that dropped the row but kept
+            # its verdict is exactly the state that mis-renders once the id is reused.
+            curation.retire_row_verdicts(conn, record_type, [row_id])
     report.applied = apply
     return report

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -28,11 +28,12 @@ canonical *vital* vocabulary in ``data/dictionary.example.toml``):
     collapse disclosed on the line (issue #93) -- the stored rows keep their dates
     and stay distinct, because an order is an event, not a standing fact.
 
-**Curation overlay** (issue #109). Every section is filtered at read time against the
-``curation`` table, a pure overlay of recorded human verdicts keyed by
-``(record_type, dedup_base)``: ``superseded`` / ``erroneous-in-source`` /
-``merged-into`` families leave their section for a ``## Superseded / corrected``
-appendix, ``disputed`` families render in place with a ``[DISPUTED: ...]`` marker (and
+**Curation overlay** (issues #109, #114). Every section is filtered at read time against
+the ``curation`` table, a pure overlay of recorded human verdicts scoped to a whole dedup
+family or to a **single row** (:meth:`curation.VerdictMap.for_row` resolves per row, row
+scope winning over family scope): ``superseded`` / ``erroneous-in-source`` /
+``merged-into`` leave their section for a ``## Superseded / corrected``
+appendix, ``disputed`` renders in place with a ``[DISPUTED: ...]`` marker (and
 reach the brief's ``## Questions for the Clinician``), and ``confirmed`` renders exactly
 as before. Both new sections are **omitted entirely** when empty, so a record with no
 verdicts renders byte-identically to what it did before the overlay existed. This is
@@ -157,17 +158,32 @@ class _CurationPass:
     def __init__(self, conn: sqlite3.Connection):
         self.conn = conn
         self.verdicts = curation.load_verdicts(conn)
-        # Keyed by (record_type, dedup_base) so a multi-occurrence family is listed
-        # once however many of its rows a section selected. Insertion-ordered.
-        self.appendix: dict[tuple[str, str], dict] = {}
-        self.disputed: dict[tuple[str, str], dict] = {}
+        # Keyed by (record_type, dedup_base, record_id) so a multi-occurrence family is
+        # listed once however many of its rows a section selected -- while two rows of
+        # one family carrying *different* row-scoped verdicts (issue #114) are two
+        # entries rather than one swallowing the other. Insertion-ordered.
+        self.appendix: dict[tuple[str, str, int], dict] = {}
+        self.disputed: dict[tuple[str, str, int], dict] = {}
 
-    def _entry(self, record_type: str, base: str, verdict: dict) -> dict:
-        label, family_size = curation.family_label(self.conn, record_type, base)
+    def _entry(self, verdict: dict) -> dict:
+        record_type = verdict["record_type"]
+        if verdict["record_id"]:
+            label, _live_base, family_size = curation.row_label(
+                self.conn, record_type, verdict["record_id"]
+            )
+        else:
+            label, family_size = curation.family_label(
+                self.conn, record_type, verdict["dedup_base"]
+            )
         return dict(verdict, label=label, family_size=family_size)
 
-    def record(self, record_type: str, base: str, verdict: dict) -> None:
-        """File a family under the section its status sends it to, once.
+    def record(self, verdict: dict) -> None:
+        """File a verdict under the section its status sends it to, once.
+
+        Identity comes off the verdict itself rather than off the row that matched it:
+        the key must be the verdict's *scope* (family or this one row), and passing the
+        matching row's id alongside a family-scoped verdict would split one family into
+        an appendix line per occurrence.
 
         ``confirmed`` is filed nowhere on purpose: it records agreement, so it neither
         leaves its section nor raises a question.
@@ -178,9 +194,9 @@ class _CurationPass:
             bucket = self.disputed
         else:
             return
-        key = (record_type, base)
+        key = (verdict["record_type"], verdict["dedup_base"], verdict["record_id"])
         if key not in bucket:
-            bucket[key] = self._entry(record_type, base, verdict)
+            bucket[key] = self._entry(verdict)
 
 
 def _apply_curation(
@@ -189,8 +205,14 @@ def _apply_curation(
     """Filter one section's rows through the overlay, before any grouping.
 
     Returns the rows that still render, stamping each annotated survivor with its
-    verdict under ``_curation``; families in :data:`curation.APPENDIX_STATUSES` are
-    dropped from the section and collected for the appendix instead.
+    verdict under ``_curation``; rows whose verdict is in
+    :data:`curation.APPENDIX_STATUSES` are dropped from the section and collected for the
+    appendix instead.
+
+    Resolution is **per row**, not per family (issue #114): a row-scoped verdict applies
+    to its own occurrence and a family-scoped one to every row that has no verdict of its
+    own, all decided in :meth:`curation.VerdictMap.for_row`. Every section selects
+    ``SELECT *``, so the row id needed for that is already in hand.
 
     Called immediately after each section's ``SELECT`` and **before** any latest-wins,
     grouping or top-N logic, so a superseded reading can neither win "latest" nor
@@ -200,12 +222,13 @@ def _apply_curation(
         return rows
     out: list[dict] = []
     for row in rows:
-        base = row["dedup_base"]
-        verdict = cur.verdicts.get((record_type, base))
+        verdict = cur.verdicts.for_row(
+            record_type, row["dedup_base"], row.get(f"{record_type}_id")
+        )
         if verdict is None:
             out.append(row)
             continue
-        cur.record(record_type, base, verdict)
+        cur.record(verdict)
         if verdict["status"] in curation.APPENDIX_STATUSES:
             continue
         row[curation.CURATION_FIELD] = verdict
@@ -219,7 +242,7 @@ def _apply_curation_events(
     """:func:`_apply_curation` for timeline events.
 
     Same rule, different carrier: an event is a rendered sentence rather than a row, and
-    it only carries ``record_type``/``dedup_base`` when
+    it only carries ``record_type``/``dedup_base``/``record_id`` when
     :func:`query.query_timeline` was asked for them (``with_identity``). An event
     without identity is passed through -- that is the no-verdicts fast path, where the
     journal never asks for the extra keys in the first place.
@@ -233,11 +256,11 @@ def _apply_curation_events(
             out.append(event)
             continue
         record_type = event["record_type"]
-        verdict = cur.verdicts.get((record_type, base))
+        verdict = cur.verdicts.for_row(record_type, base, event.get("record_id"))
         if verdict is None:
             out.append(event)
             continue
-        cur.record(record_type, base, verdict)
+        cur.record(verdict)
         if verdict["status"] in curation.APPENDIX_STATUSES:
             continue
         event[curation.CURATION_FIELD] = verdict
@@ -278,7 +301,7 @@ def _attest_suffix(row: dict) -> str:
     return f"  (attested by {row['attested_by']}{stamp}; no source document)"
 
 
-def _appendix_section(entries: dict[tuple[str, str], dict]) -> str | None:
+def _appendix_section(entries: dict[tuple[str, str, int], dict]) -> str | None:
     """The ``## Superseded / corrected`` section, or ``None`` when there is nothing
     to say.
 
@@ -290,13 +313,13 @@ def _appendix_section(entries: dict[tuple[str, str], dict]) -> str | None:
     if not entries:
         return None
     lines = []
-    for (record_type, _base), entry in entries.items():
+    for (record_type, _base, _record_id), entry in entries.items():
         label = entry["label"] or "(no live rows)"
         lines.append(f"- {record_type}: {label}  [{curation.describe(entry)}]")
     return _section("Superseded / corrected", lines)
 
 
-def _questions_section(entries: dict[tuple[str, str], dict]) -> str | None:
+def _questions_section(entries: dict[tuple[str, str, int], dict]) -> str | None:
     """The ``## Questions for the Clinician`` section, or ``None`` when empty.
 
     A ``disputed`` verdict is a recorded "two sources disagree and a human has to
@@ -306,7 +329,7 @@ def _questions_section(entries: dict[tuple[str, str], dict]) -> str | None:
     if not entries:
         return None
     lines = []
-    for (record_type, _base), entry in entries.items():
+    for (record_type, _base, _record_id), entry in entries.items():
         label = entry["label"] or "(no live rows)"
         who = f" ({entry['attributed_to']})" if entry.get("attributed_to") else ""
         lines.append(f"- {record_type}: {label} - {entry['note']}{who}")

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -145,7 +145,7 @@ def _check_blobs(
 
 
 def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
-    """Warn about `curation` verdicts that no longer point at anything (issue #109).
+    """Warn about `curation` verdicts that no longer point at anything (issues #109, #114).
 
     The overlay deliberately has no FK to the row it annotates - a verdict has to
     outlive re-ingest, `record rm` occurrence shifts, and any `rekey` that leaves this
@@ -155,10 +155,18 @@ def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
     fact no document renders. That is untidy, not corrupt, and often intentional (the
     human removed the row *because* they ruled on it, or the rekey just relabeled it),
     so it warns rather than fails. `pemr record annotate --clear` lifts it.
+
+    A **row-scoped** verdict (#114) is checked against its row, not its family: it
+    resolves by row id, so a rekey no longer orphans it - only the row's removal does.
+    Its stored `dedup_base` is a breadcrumb that may legitimately be stale, so the family
+    check is deliberately skipped for it.
     """
     if not curation.has_table(conn):
         return
-    for (record_type, base), verdict in curation.load_verdicts(conn).items():
+    for verdict in curation.load_verdicts(conn).all():
+        record_type = verdict["record_type"]
+        base = verdict["dedup_base"]
+        record_id = verdict["record_id"]
         short = str(base)[:12]
         if record_type not in dedup.FIELD_SPECS:
             # A hand-edited row can name any table; never build a query from it.
@@ -167,15 +175,31 @@ def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
                 f"type (known: {', '.join(dedup.KNOWN_TYPES)})"
             )
             continue
-        if not dedup.load_family(conn, record_type, base):
+        if record_id:
+            pk = f"{record_type}_id"
+            live = conn.execute(
+                f"SELECT 1 FROM {record_type} WHERE {pk} = ?", (record_id,)
+            ).fetchone()
+            if live is None:
+                report.warnings.append(
+                    f"curation verdict {record_type} row #{record_id} names no live "
+                    "row (removed?) - lift it with `pemr record annotate --clear --row`"
+                )
+        elif not dedup.load_family(conn, record_type, base):
             report.warnings.append(
                 f"curation verdict {record_type}/{short}... has no live family "
                 "(removed?) - lift it with `pemr record annotate --clear`"
             )
         target = verdict.get("merged_into_base")
         if target and not dedup.load_family(conn, record_type, target):
+            # The merge target is always a family, in either scope (`--merged-into`
+            # names a `dedup_base`), so this check is scope-independent.
+            ident = (
+                f"{record_type} row #{record_id}" if record_id
+                else f"{record_type}/{short}..."
+            )
             report.warnings.append(
-                f"curation verdict {record_type}/{short}... merges into "
+                f"curation verdict {ident} merges into "
                 f"{str(target)[:12]}..., which has no live family"
             )
 

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -15,7 +15,7 @@ import json
 
 import pytest
 
-from pemr import cli, curation, db, dedup, persons, records, verify
+from pemr import cli, curation, db, dedup, documents, persons, records, verify
 
 RECORDS = {
     "lab_result": [
@@ -662,9 +662,13 @@ def test_verify_is_silent_about_warnings_when_there_are_none(seeded):
 
 
 def test_verify_warns_about_an_orphaned_row_scoped_verdict(seeded):
-    """AC 7: the row-scope twin of the family orphan warning. Only the row's removal
-    can orphan a row-scoped verdict, so that is the state `verify` has to name - and it
-    names the row, because `--clear` needs `--row` to lift it."""
+    """AC 7: the row-scope twin of the family orphan warning - the **backstop**.
+
+    Since the row-id-reuse fix, the two write paths that delete a record row retire the
+    verdict themselves, so this state can only be reached some other way (a hand-edited
+    or restored database). It still has to be named, and named by row, because `--clear`
+    needs `--row` to lift it.
+    """
     conn = seeded["conn"]
     base = _second_occurrence(seeded)
     _occ0, occ1 = _occurrence_ids(conn, base)
@@ -672,7 +676,9 @@ def test_verify_warns_about_an_orphaned_row_scoped_verdict(seeded):
                             note="loser", row=True, apply=True)
     assert verify.verify_report(conn).warnings == []
 
-    records.remove_record(conn, "lab_result", occ1, apply=True)
+    # Straight to the table, behind the write paths' backs - the only way here now.
+    conn.execute("DELETE FROM lab_result WHERE lab_result_id = ?", (occ1,))
+    conn.commit()
 
     report = verify.verify_report(conn)
     assert report.ok is True and report.problems == []
@@ -682,6 +688,105 @@ def test_verify_warns_about_an_orphaned_row_scoped_verdict(seeded):
     # And the orphan is liftable without a live row to name it by.
     curation.clear_curation(conn, "lab_result", str(occ1), row=True, apply=True)
     assert _curation_count(conn) == 0
+
+
+# --- row ids are reusable, so removing the row retires its verdict (issue #114) ---
+
+
+def _max_row_id(conn, record_type):
+    return int(conn.execute(
+        f"SELECT MAX({record_type}_id) AS n FROM {record_type}"
+    ).fetchone()["n"])
+
+
+def test_record_rm_retires_the_row_verdict_and_keeps_the_family_one(seeded):
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    _occ0, occ1 = _occurrence_ids(conn, base)
+    curation.annotate_record(conn, "lab_result", base, status="disputed",
+                            note="two sources disagree", apply=True)
+    curation.annotate_record(conn, "lab_result", str(occ1), row=True,
+                            status="superseded", note="the keep-both loser", apply=True)
+
+    report = records.remove_record(conn, "lab_result", occ1, apply=True)
+
+    assert [v["record_id"] for v in report.curation_retired] == [occ1]
+    assert curation.get_verdict(conn, "lab_result", "", record_id=occ1) is None
+    # The family verdict survives on purpose: dedup_base is content-derived, so it has
+    # no reuse hazard and occurrence 0 is still there for it to rule on.
+    family = curation.get_verdict(conn, "lab_result", base)
+    assert family is not None and family["status"] == "disputed"
+    assert verify.verify_report(conn).warnings == []
+
+
+def test_record_rm_dry_run_names_the_verdict_it_would_lift(seeded):
+    """The dry run is `record rm`'s whole safety mechanism, and a recorded clinical
+    ruling going away is part of the blast radius it promises to be truthful about."""
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    _occ0, occ1 = _occurrence_ids(conn, base)
+    curation.annotate_record(conn, "lab_result", str(occ1), row=True,
+                            status="superseded", note="the keep-both loser", apply=True)
+
+    report = records.remove_record(conn, "lab_result", occ1)
+
+    assert report.applied is False
+    assert [v["note"] for v in report.curation_retired] == ["the keep-both loser"]
+    assert curation.get_verdict(conn, "lab_result", "", record_id=occ1) is not None
+
+
+def test_a_reused_row_id_does_not_inherit_the_removed_rows_verdict(seeded):
+    """The regression this whole retirement rule exists for.
+
+    Record ids are plain rowid aliases (INTEGER PRIMARY KEY, no AUTOINCREMENT), so
+    deleting the highest-id row hands that id to the next insert. Before the fix, the
+    stale row-scoped verdict re-attached to the new, unrelated record - and `verify`
+    went *quiet* about it, because the id resolved again.
+    """
+    conn = seeded["conn"]
+    glucose = _row_id(conn, "lab_result", "test_name", "Glucose")
+    assert glucose == _max_row_id(conn, "lab_result")   # the reuse precondition
+    curation.annotate_record(conn, "lab_result", str(glucose), row=True,
+                            status="superseded", note="loser of a keep-both", apply=True)
+
+    records.remove_record(conn, "lab_result", glucose, apply=True)
+    doc2 = _insert_document(conn, seeded["jane"].person_id, "cc33dd44ee55ff66")
+    dedup.commit_extraction(conn, doc2, {"lab_result": [
+        {"test_name": "Creatinine", "collected_at": "2026-02-02", "value_num": 0.9,
+         "unit": "mg/dL"},
+    ]})
+    recycled = _row_id(conn, "lab_result", "test_name", "Creatinine")
+    assert recycled == glucose          # SQLite handed the id straight back
+
+    verdicts = curation.load_verdicts(conn)
+    base = _base(conn, "lab_result", "test_name", "Creatinine")
+    assert verdicts.for_row("lab_result", base, recycled) is None
+    assert _curation_count(conn) == 0
+    assert not any("curation" in w for w in verify.verify_report(conn).warnings)
+
+
+def test_document_rm_retires_the_row_verdicts_of_the_rows_it_deletes(seeded):
+    """`document rm` cascades to every row the document produced, freeing every one of
+    those ids - the same hazard as `record rm`, at document scale."""
+    conn = seeded["conn"]
+    glucose = _row_id(conn, "lab_result", "test_name", "Glucose")
+    cond_base = _base(conn, "condition", "name", "Type 2 Diabetes")
+    curation.annotate_record(conn, "lab_result", str(glucose), row=True,
+                            status="superseded", note="row scope", apply=True)
+    curation.annotate_record(conn, "condition", cond_base, status="disputed",
+                            note="family scope", apply=True)
+
+    dry = documents.remove_document(conn, seeded["doc"])
+    assert [v["record_id"] for v in dry.curation_retired] == [glucose]
+    assert curation.get_verdict(conn, "lab_result", "", record_id=glucose) is not None
+
+    report = documents.remove_document(conn, seeded["doc"], apply=True)
+
+    assert [v["record_id"] for v in report.curation_retired] == [glucose]
+    assert curation.get_verdict(conn, "lab_result", "", record_id=glucose) is None
+    # The family verdict outlives the cascade: `dedup_base` is content-derived, so a
+    # re-ingest of the same document re-attaches it, which is the point of family scope.
+    assert curation.get_verdict(conn, "condition", cond_base) is not None
 
 
 def test_verify_warns_about_a_dangling_merge_target(seeded):
@@ -993,6 +1098,66 @@ def test_cli_annotate_row_misuse_is_friendly(cli_ready, capsys):
                 "--status", "disputed", "--note", "x", "--apply") == 1
     assert "no lab_result with id 9999" in capsys.readouterr().err
     assert _cli_curation_count(cli_ready) == 0
+
+
+def test_cli_record_rm_names_and_lifts_the_row_verdict(cli_ready, capsys):
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "Glucose")
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(target), "--row",
+                "--status", "superseded", "--note", "loser of a keep-both",
+                "--apply") == 0
+    capsys.readouterr()
+
+    assert _run(cli_ready, "record", "rm", "lab_result", str(target)) == 0
+    out = capsys.readouterr().out
+    assert "curation verdict (row scope) would be lifted" in out
+    assert "loser of a keep-both" in out
+    assert _cli_curation_count(cli_ready) == 1        # dry run wrote nothing
+
+    assert _run(cli_ready, "record", "rm", "lab_result", str(target), "--apply") == 0
+    assert "curation verdict (row scope) lifted" in capsys.readouterr().out
+    assert _cli_curation_count(cli_ready) == 0
+
+
+def test_cli_a_reused_row_id_is_not_filed_under_the_superseded_appendix(
+    cli_ready, capsys
+):
+    """The end-to-end shape of the regression: annotate the highest-id row, remove it,
+    ingest something else onto the recycled id, and the new fact must render in its own
+    section rather than under a stranger's verdict."""
+    target = _cli_row_id(cli_ready, "condition", "name", "Prediabetes")
+    assert _run(cli_ready, "record", "annotate", "condition", str(target), "--row",
+                "--status", "superseded", "--note", "loser of a keep-both",
+                "--apply") == 0
+    assert _run(cli_ready, "record", "rm", "condition", str(target), "--apply") == 0
+
+    scan2 = cli_ready / "scan2.txt"
+    scan2.write_bytes(b"visit note: anaphylaxis, epinephrine plan in place")
+    assert _run(cli_ready, "ingest", str(scan2), "--person", "jane-doe",
+                "--sources", str(cli_ready / "sources"), "--ocr-text-file",
+                str(scan2)) == 0
+    payload = cli_ready / "extract2.json"
+    payload.write_text(json.dumps({"condition": [
+        {"name": "Anaphylaxis - epinephrine plan", "status": "active",
+         "onset_on": "2025-05-05"},
+    ]}), encoding="utf-8")
+    assert _run(cli_ready, "commit-extraction", "--document", "2",
+                "--json", str(payload)) == 0
+    recycled = _cli_row_id(cli_ready, "condition", "name",
+                           "Anaphylaxis - epinephrine plan")
+    assert recycled == target       # SQLite handed the id straight back
+
+    capsys.readouterr()
+    assert _run(cli_ready, "render", "summary", "--person", "jane-doe") == 0
+    summary = capsys.readouterr().out
+    assert "Anaphylaxis - epinephrine plan" in summary
+    assert "## Superseded / corrected" not in summary
+    assert "loser of a keep-both" not in summary
+
+    capsys.readouterr()
+    assert _run(cli_ready, "verify") == 0
+    out = capsys.readouterr().out
+    assert "names no live row" not in out
+    assert not any(line.startswith("warnings") for line in out.splitlines())
 
 
 # --- the integration drill from the issue ------------------------------------

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -767,23 +767,46 @@ def test_a_reused_row_id_does_not_inherit_the_removed_rows_verdict(seeded):
 
 def test_document_rm_retires_the_row_verdicts_of_the_rows_it_deletes(seeded):
     """`document rm` cascades to every row the document produced, freeing every one of
-    those ids - the same hazard as `record rm`, at document scale."""
+    those ids - the same hazard as `record rm`, at document scale.
+
+    Two *different* record types carry a row verdict here on purpose:
+    :func:`documents._doomed_row_verdicts` sweeps ``dedup.KNOWN_TYPES``, and a sweep
+    narrowed to one type would leave the freed ids of every other type unguarded while
+    still passing a single-type assertion.
+    """
     conn = seeded["conn"]
     glucose = _row_id(conn, "lab_result", "test_name", "Glucose")
+    prediabetes = _row_id(conn, "condition", "name", "Prediabetes")
     cond_base = _base(conn, "condition", "name", "Type 2 Diabetes")
     curation.annotate_record(conn, "lab_result", str(glucose), row=True,
                             status="superseded", note="row scope", apply=True)
+    curation.annotate_record(conn, "condition", str(prediabetes), row=True,
+                            status="erroneous-in-source", note="row scope, other type",
+                            apply=True)
     curation.annotate_record(conn, "condition", cond_base, status="disputed",
                             note="family scope", apply=True)
 
+    def _retired(report):
+        return sorted(
+            (v["record_type"], v["record_id"]) for v in report.curation_retired
+        )
+
+    expected = sorted(
+        [("lab_result", glucose), ("condition", prediabetes)]
+    )
+
     dry = documents.remove_document(conn, seeded["doc"])
-    assert [v["record_id"] for v in dry.curation_retired] == [glucose]
+    assert _retired(dry) == expected
     assert curation.get_verdict(conn, "lab_result", "", record_id=glucose) is not None
+    assert curation.get_verdict(
+        conn, "condition", "", record_id=prediabetes
+    ) is not None
 
     report = documents.remove_document(conn, seeded["doc"], apply=True)
 
-    assert [v["record_id"] for v in report.curation_retired] == [glucose]
+    assert _retired(report) == expected
     assert curation.get_verdict(conn, "lab_result", "", record_id=glucose) is None
+    assert curation.get_verdict(conn, "condition", "", record_id=prediabetes) is None
     # The family verdict outlives the cascade: `dedup_base` is content-derived, so a
     # re-ingest of the same document re-attaches it, which is the point of family scope.
     assert curation.get_verdict(conn, "condition", cond_base) is not None

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -118,6 +118,8 @@ def test_annotate_writes_a_verdict_and_touches_no_record_row(seeded):
     assert curation.get_verdict(conn, "lab_result", report.dedup_base) == {
         "record_type": "lab_result",
         "dedup_base": report.dedup_base,
+        "record_id": 0,
+        "scope": "family",
         "status": "erroneous-in-source",
         "note": "requisition coding artifact",
         "merged_into_base": None,
@@ -405,7 +407,10 @@ def test_verdict_covers_a_later_keep_both_sibling(seeded):
     _second_occurrence(seeded)
 
     assert curation.family_label(conn, "lab_result", base)[1] == 2
-    assert curation.load_verdicts(conn)[("lab_result", base)]["status"] == "superseded"
+    assert (
+        curation.load_verdicts(conn).family[("lab_result", base)]["status"]
+        == "superseded"
+    )
 
 
 def test_verdict_survives_a_no_drift_rekey(seeded):
@@ -419,6 +424,212 @@ def test_verdict_survives_a_no_drift_rekey(seeded):
     report = dedup.rekey(conn, None, apply=True)
     assert not report.collisions
     assert curation.get_verdict(conn, "lab_result", base) is not None
+
+
+# --- row scope: one occurrence of a multi-row family (issue #114) -------------
+
+
+def _occurrence_ids(conn, base):
+    """``(occurrence 0 id, occurrence 1 id)`` for a two-row lab_result family."""
+    rows = conn.execute(
+        "SELECT lab_result_id FROM lab_result WHERE dedup_base = ? "
+        "ORDER BY dedup_occurrence", (base,)
+    ).fetchall()
+    return tuple(int(r["lab_result_id"]) for r in rows)
+
+
+def test_annotate_row_scopes_the_verdict_to_a_single_row(seeded):
+    """The case that forced #114: a `--keep both` family holds two *live* rows, and a
+    family-scoped verdict on the loser hides the winner too."""
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    _occ0, occ1 = _occurrence_ids(conn, base)
+
+    report = curation.annotate_record(
+        conn, "lab_result", str(occ1), status="superseded",
+        note="loser of an earlier keep-both", row=True, apply=True,
+    )
+
+    assert report.scope == curation.SCOPE_ROW and report.record_id == occ1
+    assert report.dedup_base == base       # stored as the breadcrumb
+    assert report.label == "Glucose" and report.family_size == 2
+    stored = curation.get_verdict(conn, "lab_result", base, record_id=occ1)
+    assert stored["scope"] == "row" and stored["record_id"] == occ1
+    # No family verdict was created as a side effect: the sibling is untouched.
+    assert curation.get_verdict(conn, "lab_result", base) is None
+    assert _curation_count(conn) == 1
+
+
+def test_family_scope_is_unchanged_and_stores_the_sentinel(seeded):
+    """AC 3, the backward-compatibility pin: with no `row=True` anywhere, storage is
+    bit-identical to #109's - one row, `record_id = 0`, resolvable by base."""
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    report = curation.annotate_record(
+        conn, "lab_result", base, status="superseded", note="whole family", apply=True
+    )
+    assert report.scope == curation.SCOPE_FAMILY
+    assert report.record_id == curation.FAMILY_SCOPE
+    stored = conn.execute("SELECT * FROM curation").fetchone()
+    assert stored["record_id"] == 0 and stored["dedup_base"] == base
+    verdicts = curation.load_verdicts(conn)
+    assert verdicts.rows == {} and set(verdicts.family) == {("lab_result", base)}
+    # Every row of the family sees it.
+    for record_id in _occurrence_ids(conn, base):
+        assert verdicts.for_row("lab_result", base, record_id)["note"] == "whole family"
+
+
+def test_a_row_verdict_wins_over_its_family_verdict_for_that_row_only(seeded):
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    occ0, occ1 = _occurrence_ids(conn, base)
+    curation.annotate_record(conn, "lab_result", base, status="disputed",
+                            note="the family is contested", apply=True)
+    curation.annotate_record(conn, "lab_result", str(occ1), status="superseded",
+                            note="this occurrence lost", row=True, apply=True)
+
+    verdicts = curation.load_verdicts(conn)
+    assert len(verdicts) == 2                       # both scopes coexist
+    assert verdicts.for_row("lab_result", base, occ1)["status"] == "superseded"
+    assert verdicts.for_row("lab_result", base, occ0)["status"] == "disputed"
+    # A carrier with no row identity can still only see the family verdict.
+    assert verdicts.for_row("lab_result", base, None)["status"] == "disputed"
+
+
+def test_re_annotating_a_row_overwrites_only_that_row(seeded):
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    _occ0, occ1 = _occurrence_ids(conn, base)
+    curation.annotate_record(conn, "lab_result", str(occ1), status="disputed",
+                            note="first", row=True, now="2026-01-01T00:00:00+00:00",
+                            apply=True)
+    second = curation.annotate_record(
+        conn, "lab_result", str(occ1), status="superseded", note="second", row=True,
+        now="2026-02-02T00:00:00+00:00", apply=True,
+    )
+    assert second.action == "overwrite" and second.previous["note"] == "first"
+    assert _curation_count(conn) == 1
+    live = curation.get_verdict(conn, "lab_result", base, record_id=occ1)
+    assert live["status"] == "superseded"
+    assert live["created_at"] == "2026-02-02T00:00:00+00:00"
+
+
+def test_resolve_row_requires_a_live_row_id(seeded):
+    conn = seeded["conn"]
+    row_id = _row_id(conn, "lab_result", "test_name", "Glucose")
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    assert curation.resolve_row(conn, "lab_result", str(row_id)) == (row_id, base)
+    with pytest.raises(curation.RowNotFoundError, match="no lab_result with id 9999"):
+        curation.resolve_row(conn, "lab_result", "9999")
+    with pytest.raises(ValueError, match="drop --row"):
+        curation.resolve_row(conn, "lab_result", base)
+
+
+def test_row_and_family_verdicts_are_cleared_independently(seeded):
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    _occ0, occ1 = _occurrence_ids(conn, base)
+    curation.annotate_record(conn, "lab_result", base, status="disputed",
+                            note="family", apply=True)
+    curation.annotate_record(conn, "lab_result", str(occ1), status="superseded",
+                            note="row", row=True, apply=True)
+
+    cleared = curation.clear_curation(conn, "lab_result", str(occ1), row=True,
+                                      apply=True)
+    assert cleared.scope == "row" and cleared.record_id == occ1
+    assert curation.get_verdict(conn, "lab_result", base, record_id=occ1) is None
+    assert curation.get_verdict(conn, "lab_result", base)["note"] == "family"
+
+    curation.annotate_record(conn, "lab_result", str(occ1), status="superseded",
+                            note="row again", row=True, apply=True)
+    curation.clear_curation(conn, "lab_result", base, apply=True)
+    assert curation.get_verdict(conn, "lab_result", base) is None
+    assert curation.get_verdict(
+        conn, "lab_result", base, record_id=occ1
+    )["note"] == "row again"
+
+
+def test_clearing_an_empty_scope_is_an_error_not_a_success(seeded):
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    _occ0, occ1 = _occurrence_ids(conn, base)
+    curation.annotate_record(conn, "lab_result", base, status="disputed",
+                            note="family only", apply=True)
+    with pytest.raises(curation.CurationNotFoundError, match="row-scoped"):
+        curation.clear_curation(conn, "lab_result", str(occ1), row=True, apply=True)
+    with pytest.raises(ValueError, match="drop --row"):
+        curation.clear_curation(conn, "lab_result", base, row=True, apply=True)
+    assert _curation_count(conn) == 1
+
+
+def test_list_curation_reports_scope_for_both_kinds(seeded):
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    _occ0, occ1 = _occurrence_ids(conn, base)
+    curation.annotate_record(conn, "lab_result", base, status="disputed", note="fam",
+                            now="2026-01-01T00:00:00+00:00", apply=True)
+    curation.annotate_record(conn, "lab_result", str(occ1), status="superseded",
+                            note="row", row=True, now="2026-02-01T00:00:00+00:00",
+                            apply=True)
+
+    rows = curation.list_curation(conn)
+    assert [r["scope"] for r in rows] == ["row", "family"]     # newest first
+    assert rows[0]["record_id"] == occ1 and rows[1]["record_id"] == 0
+    assert all(r["label"] == "Glucose" and r["family_size"] == 2 for r in rows)
+
+
+def test_a_row_verdict_survives_the_rekey_that_orphans_a_family_verdict(seeded):
+    """The rekey answer AC 8 asks to *document*, pinned as behaviour: `rekey` rewrites
+    dedup_key/dedup_base but never renumbers a row id, so a row-scoped verdict follows
+    its row while the family-scoped one on the same family goes inert."""
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    _occ0, occ1 = _occurrence_ids(conn, base)
+    curation.annotate_record(conn, "lab_result", base, status="disputed",
+                            note="family", apply=True)
+    curation.annotate_record(conn, "lab_result", str(occ1), status="superseded",
+                            note="row", row=True, apply=True)
+
+    report = dedup.rekey(conn, {"glucose": "blood-sugar"}, apply=True)
+    assert not report.collisions and report.changes
+
+    new_base = _base(conn, "lab_result", "test_name", "Glucose")
+    assert new_base != base
+    # The family verdict is orphaned - its base names nothing live.
+    assert curation.family_label(conn, "lab_result", base) == ("", 0)
+    # The row verdict still resolves, by row id; its stored base is now a stale
+    # breadcrumb that nothing resolves on.
+    live = curation.get_verdict(conn, "lab_result", "", record_id=occ1)
+    assert live["status"] == "superseded" and live["dedup_base"] == base
+    assert curation.load_verdicts(conn).for_row(
+        "lab_result", new_base, occ1
+    )["status"] == "superseded"
+    # `--list` re-reads the live base off the row, so it is not reported as an orphan.
+    entry = next(r for r in curation.list_curation(conn) if r["record_id"] == occ1)
+    assert entry["label"] == "Glucose" and entry["family_size"] == 2
+
+    warnings = verify.verify_report(conn).warnings
+    assert any("has no live family" in w for w in warnings)
+    assert not any("names no live row" in w for w in warnings)
+
+
+def test_re_annotating_a_row_after_a_rekey_collapses_the_stale_breadcrumb(seeded):
+    """The delete-by-(record_type, record_id) write path: the second verdict carries the
+    new base, and the row must still hold exactly one."""
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    _occ0, occ1 = _occurrence_ids(conn, base)
+    curation.annotate_record(conn, "lab_result", str(occ1), status="disputed",
+                            note="before", row=True, apply=True)
+    dedup.rekey(conn, {"glucose": "blood-sugar"}, apply=True)
+    new_base = _base(conn, "lab_result", "test_name", "Glucose")
+
+    curation.annotate_record(conn, "lab_result", str(occ1), status="superseded",
+                            note="after", row=True, apply=True)
+
+    assert _curation_count(conn) == 1
+    live = curation.get_verdict(conn, "lab_result", "", record_id=occ1)
+    assert live["dedup_base"] == new_base and live["note"] == "after"
 
 
 # --- verify integration ------------------------------------------------------
@@ -448,6 +659,29 @@ def test_verify_is_silent_about_warnings_when_there_are_none(seeded):
     report = verify.verify_report(seeded["conn"])
     assert report.warnings == []
     assert not any(line.startswith("warnings") for line in verify.format_report(report))
+
+
+def test_verify_warns_about_an_orphaned_row_scoped_verdict(seeded):
+    """AC 7: the row-scope twin of the family orphan warning. Only the row's removal
+    can orphan a row-scoped verdict, so that is the state `verify` has to name - and it
+    names the row, because `--clear` needs `--row` to lift it."""
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    _occ0, occ1 = _occurrence_ids(conn, base)
+    curation.annotate_record(conn, "lab_result", str(occ1), status="superseded",
+                            note="loser", row=True, apply=True)
+    assert verify.verify_report(conn).warnings == []
+
+    records.remove_record(conn, "lab_result", occ1, apply=True)
+
+    report = verify.verify_report(conn)
+    assert report.ok is True and report.problems == []
+    assert any("row #" in w and "names no live row" in w for w in report.warnings)
+    # The sibling family is still live, so the *family* warning must not fire.
+    assert not any("has no live family" in w for w in report.warnings)
+    # And the orphan is liftable without a live row to name it by.
+    curation.clear_curation(conn, "lab_result", str(occ1), row=True, apply=True)
+    assert _curation_count(conn) == 0
 
 
 def test_verify_warns_about_a_dangling_merge_target(seeded):
@@ -550,7 +784,7 @@ def test_cli_annotate_json_shape_is_stable(cli_ready, capsys):
     expected = {
         "record_type", "dedup_base", "status", "note", "attributed_to",
         "created_at", "merged_into_base", "label", "family_size", "previous",
-        "action", "applied",
+        "action", "applied", "record_id", "scope",
     }
     capsys.readouterr()
     assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
@@ -655,6 +889,110 @@ def test_cli_annotate_clear_without_a_verdict_fails_friendly(cli_ready, capsys):
     assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
                 "--clear", "--apply") == 1
     assert "error: no curation verdict" in capsys.readouterr().err
+
+
+# --- CLI surface: row scope (issue #114) -------------------------------------
+
+
+def _cli_second_occurrence(tmp_path):
+    """Re-file the CLI fixture's Glucose fact as occurrence 1, and return
+    ``(base, occurrence 0 id, occurrence 1 id)`` — the keep-both shape."""
+    conn = _cli_conn(tmp_path)
+    try:
+        base = _base(conn, "lab_result", "test_name", "Glucose")
+        person_id = int(conn.execute(
+            "SELECT person_id FROM lab_result WHERE dedup_base = ?", (base,)
+        ).fetchone()["person_id"])
+        doc2 = _insert_document(conn, person_id, "bb22cc33dd44ee55")
+        conn.execute(
+            "INSERT INTO lab_result (person_id, document_id, test_name, collected_at, "
+            "value_num, unit, dedup_key, dedup_base, dedup_occurrence) "
+            "VALUES (?, ?, 'Glucose', '2026-01-02', 95, 'mg/dL', ?, ?, 1)",
+            (person_id, doc2, dedup.occurrence_key(base, 1), base),
+        )
+        conn.commit()
+        return (base, *_occurrence_ids(conn, base))
+    finally:
+        conn.close()
+
+
+def test_cli_annotate_row_dry_run_then_apply(cli_ready, capsys):
+    _base_hex, _occ0, occ1 = _cli_second_occurrence(cli_ready)
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(occ1), "--row",
+                "--status", "superseded", "--note", "loser of a keep-both") == 0
+    out = capsys.readouterr().out
+    assert f"scope: row #{occ1}" in out
+    assert "dry run: nothing was written - re-run with --apply" in out
+    assert _cli_curation_count(cli_ready) == 0
+
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(occ1), "--row",
+                "--status", "superseded", "--note", "loser of a keep-both",
+                "--apply") == 0
+    out = capsys.readouterr().out
+    assert f"annotated lab_result row #{occ1} (create)" in out
+    assert _cli_curation_count(cli_ready) == 1
+
+
+def test_cli_annotate_row_json_carries_scope(cli_ready, capsys):
+    _base_hex, _occ0, occ1 = _cli_second_occurrence(cli_ready)
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(occ1), "--row",
+                "--status", "disputed", "--note", "one occurrence only", "--json",
+                "--apply") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["scope"] == "row" and payload["record_id"] == occ1
+
+    assert _run(cli_ready, "record", "annotate", "--list", "--json") == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert [(r["scope"], r["record_id"]) for r in rows] == [("row", occ1)]
+
+
+def test_cli_annotate_list_shows_the_scope_column(cli_ready, capsys):
+    _base_hex, _occ0, occ1 = _cli_second_occurrence(cli_ready)
+    cond = _cli_row_id(cli_ready, "condition", "name", "Prediabetes")
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(occ1), "--row",
+                "--status", "superseded", "--note", "a", "--apply") == 0
+    assert _run(cli_ready, "record", "annotate", "condition", str(cond),
+                "--status", "disputed", "--note", "b", "--apply") == 0
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "annotate", "--list") == 0
+    out = capsys.readouterr().out
+    assert "scope" in out.splitlines()[0]
+    assert f"row #{occ1}" in out and "family" in out
+
+
+def test_cli_annotate_clear_row_leaves_the_family_verdict(cli_ready, capsys):
+    base, _occ0, occ1 = _cli_second_occurrence(cli_ready)
+    assert _run(cli_ready, "record", "annotate", "lab_result", base,
+                "--status", "disputed", "--note", "family", "--apply") == 0
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(occ1), "--row",
+                "--status", "superseded", "--note", "row", "--apply") == 0
+    capsys.readouterr()
+
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(occ1), "--row",
+                "--clear", "--apply") == 0
+    assert f"cleared curation verdict for lab_result row #{occ1}" in (
+        capsys.readouterr().out
+    )
+    assert _cli_curation_count(cli_ready) == 1
+
+
+def test_cli_annotate_row_misuse_is_friendly(cli_ready, capsys):
+    base, _occ0, _occ1 = _cli_second_occurrence(cli_ready)
+    with pytest.raises(SystemExit) as exc:
+        _run(cli_ready, "record", "annotate", "--list", "--row")
+    assert exc.value.code == 2
+
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "annotate", "lab_result", base, "--row",
+                "--status", "disputed", "--note", "x", "--apply") == 1
+    assert "drop --row" in capsys.readouterr().err
+
+    assert _run(cli_ready, "record", "annotate", "lab_result", "9999", "--row",
+                "--status", "disputed", "--note", "x", "--apply") == 1
+    assert "no lab_result with id 9999" in capsys.readouterr().err
+    assert _cli_curation_count(cli_ready) == 0
 
 
 # --- the integration drill from the issue ------------------------------------

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -45,6 +45,7 @@ ALL_MIGRATIONS = [
     "007_document_tombstone.sql",
     "008_curation.sql",
     "009_record_attestation.sql",
+    "010_curation_row_scope.sql",
 ]
 
 # Every record table carries the occurrence-family columns (migration 005; 006's two
@@ -134,6 +135,7 @@ def test_migration_006_moves_condition_and_allergy_observations(conn, tmp_path):
     assert db.migrate(conn) == [
         "006_condition_allergy.sql", "007_document_tombstone.sql",
         "008_curation.sql", "009_record_attestation.sql",
+        "010_curation_row_scope.sql",
     ]
 
     a = conn.execute("SELECT * FROM allergy").fetchone()
@@ -262,17 +264,18 @@ def test_migration_008_applies_on_a_007_era_database(conn, tmp_path):
     conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane', 'Jane')")
     conn.commit()
     assert curation.has_table(conn) is False
-    assert curation.load_verdicts(conn) == {}  # readable before the migration exists
+    assert not curation.load_verdicts(conn)  # readable before the migration exists
 
     assert db.migrate(conn) == [
         "008_curation.sql", "009_record_attestation.sql",
+        "010_curation_row_scope.sql",
     ]
 
     assert curation.has_table(conn) is True
     cols = {row[1] for row in conn.execute("PRAGMA table_info(curation)").fetchall()}
     assert cols == {
-        "record_type", "dedup_base", "status", "note", "merged_into_base",
-        "attributed_to", "created_at",
+        "record_type", "dedup_base", "record_id", "status", "note",
+        "merged_into_base", "attributed_to", "created_at",
     }
     assert conn.execute("SELECT COUNT(*) AS n FROM person").fetchone()["n"] == 1
 
@@ -315,7 +318,9 @@ def test_migration_009_applies_on_an_008_era_database(conn, tmp_path):
     assert attestations.has_columns(conn) is False
     assert attestations.list_attested(conn) == []   # readable before the migration
 
-    assert db.migrate(conn) == ["009_record_attestation.sql"]
+    assert db.migrate(conn) == [
+        "009_record_attestation.sql", "010_curation_row_scope.sql",
+    ]
 
     assert attestations.has_columns(conn) is True
     row = conn.execute("SELECT * FROM lab_result").fetchone()
@@ -324,6 +329,87 @@ def test_migration_009_applies_on_an_008_era_database(conn, tmp_path):
     assert (row["attested_by"], row["attested_on"], row["attested_at"]) == (
         None, None, None
     )
+
+
+def _migrate_through_009(conn, tmp_path):
+    """Apply every migration up to 009, leaving 010 pending (a 009-era database)."""
+    import shutil
+
+    staged = tmp_path / "pre010"
+    staged.mkdir()
+    for path in sorted(db.DEFAULT_MIGRATIONS_DIR.glob("*.sql")):
+        if path.name < "010":
+            shutil.copy(path, staged / path.name)
+    db.migrate(conn, staged)
+    return staged
+
+
+def test_migration_010_rebuilds_curation_and_preserves_every_verdict(conn, tmp_path):
+    """Issue #114's table rebuild is the only destructive-shaped DDL in this repo's
+    history (001-009 are pure CREATE / ADD COLUMN), so the round trip is the test: every
+    009-era verdict must come out the other side byte-for-byte, `created_at` included,
+    and family-scoped by definition."""
+    from pemr import curation
+
+    _migrate_through_009(conn, tmp_path)
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane', 'Jane')")
+    conn.execute(
+        "INSERT INTO curation (record_type, dedup_base, status, note, attributed_to, "
+        "created_at) VALUES ('lab_result', 'base-a', 'disputed', 'two sources', "
+        "'Dr Who', '2026-01-01T00:00:00+00:00')"
+    )
+    conn.execute(
+        "INSERT INTO curation (record_type, dedup_base, status, note, "
+        "merged_into_base, created_at) VALUES ('condition', 'base-b', 'merged-into', "
+        "'same episode', 'base-c', '2026-02-02T00:00:00+00:00')"
+    )
+    conn.commit()
+    before = [dict(r) for r in conn.execute(
+        "SELECT * FROM curation ORDER BY dedup_base"
+    ).fetchall()]
+
+    assert db.migrate(conn) == ["010_curation_row_scope.sql"]
+
+    after = [dict(r) for r in conn.execute(
+        "SELECT * FROM curation ORDER BY dedup_base"
+    ).fetchall()]
+    assert [{k: v for k, v in r.items() if k != "record_id"} for r in after] == before
+    assert [r["record_id"] for r in after] == [0, 0]   # 008 verdicts were family-scoped
+    verdicts = curation.load_verdicts(conn)
+    assert len(verdicts.family) == 2 and verdicts.rows == {}
+
+
+def test_migration_010_lets_scopes_coexist_but_pins_one_verdict_per_row(conn):
+    """The two uniqueness rules #114 needs, which 008's PK could not express: a family
+    verdict and a row verdict may share a base (that is the precedence case), and two
+    rows may be annotated inside one family - but a row may carry only one verdict,
+    whatever base it was recorded under (the partial index, which also collapses the
+    stale-breadcrumb duplicate a rekey could otherwise produce)."""
+    db.migrate(conn)
+    for record_type, base, record_id in [
+        ("lab_result", "base-a", 0),   # family scope
+        ("lab_result", "base-a", 7),   # a row inside it
+        ("lab_result", "base-a", 8),   # its sibling, ruled separately
+    ]:
+        conn.execute(
+            "INSERT INTO curation (record_type, dedup_base, record_id, status, note, "
+            "created_at) VALUES (?, ?, ?, 'disputed', 'why', '2026-01-01T00:00:00')",
+            (record_type, base, record_id),
+        )
+    conn.commit()
+
+    with pytest.raises(sqlite3.IntegrityError):   # same row, a different base
+        conn.execute(
+            "INSERT INTO curation (record_type, dedup_base, record_id, status, note, "
+            "created_at) VALUES ('lab_result', 'base-z', 7, 'disputed', 'why', "
+            "'2026-01-01T00:00:00')"
+        )
+    with pytest.raises(sqlite3.IntegrityError):   # negative scope sentinel
+        conn.execute(
+            "INSERT INTO curation (record_type, dedup_base, record_id, status, note, "
+            "created_at) VALUES ('lab_result', 'base-a', -1, 'disputed', 'why', "
+            "'2026-01-01T00:00:00')"
+        )
 
 
 def test_a_bare_insert_leaves_the_attestation_columns_null(conn):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -262,19 +262,22 @@ def test_timeline_stamps_attestation_only_on_attested_events(seeded):
     assert [e for e in after if "attested_by" not in e] == before
 
 
-def test_timeline_with_identity_stamps_family_keys(seeded):
-    """Issue #109: `render_journal` needs each event's family identity to apply the
-    curation overlay, and an event otherwise carries none."""
+def test_timeline_with_identity_stamps_family_and_row_keys(seeded):
+    """Issues #109/#114: `render_journal` needs each event's family identity to apply
+    the curation overlay and its **row** id to apply a row-scoped verdict; an event
+    otherwise carries neither."""
     plain = query.query_timeline(seeded, "jane-doe")
     tagged = query.query_timeline(seeded, "jane-doe", with_identity=True)
 
     assert len(tagged) == len(plain)
-    assert all({"record_type", "dedup_base"} <= set(e) for e in tagged)
+    assert all({"record_type", "dedup_base", "record_id"} <= set(e) for e in tagged)
     assert all(e["dedup_base"] for e in tagged)
+    assert all(isinstance(e["record_id"], int) and e["record_id"] > 0 for e in tagged)
     assert {e["record_type"] for e in tagged} <= set(dedup.KNOWN_TYPES)
     # Same events, same order, same values - identity is purely additive.
+    identity = ("record_type", "dedup_base", "record_id")
     assert [
-        {k: v for k, v in e.items() if k not in ("record_type", "dedup_base")}
+        {k: v for k, v in e.items() if k not in identity}
         for e in tagged
     ] == plain
 

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -418,6 +418,9 @@ def test_cli_record_rm_json_shape_is_stable(cli_ready, capsys):
         "record_type", "row_id", "person", "document_id", "label", "fields",
         "dedup_key", "dedup_base", "dedup_occurrence", "family_size",
         "family_remaining", "conflicts_reanchored", "applied",
+        # Appended by #114: the row-scoped curation verdicts retired with the row.
+        # Appended, never inserted - the --json key set is a contract.
+        "curation_retired",
     }
     capsys.readouterr()
     assert _run(cli_ready, "record", "rm", "lab_result", str(target), "--json") == 0

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -689,6 +689,93 @@ def test_curated_renders_stay_ascii_and_read_only(seeded):
     assert _row_counts(seeded) == before  # still a pure read
 
 
+# --- row-scoped verdicts over a multi-row family (issue #114) ------------------
+
+
+def _keep_both_sibling(conn, value_num=205.0):
+    """File a second *live* occurrence of Jane's fasting glucose — the shape an earlier
+    `--keep both` conflict resolution leaves behind — and return
+    ``(base, occurrence 0 id, occurrence 1 id)``."""
+    row = conn.execute(
+        "SELECT lab_result_id, person_id, document_id, dedup_base FROM lab_result "
+        "WHERE test_name = 'Glucose, fasting'"
+    ).fetchone()
+    base = row["dedup_base"]
+    cur = conn.execute(
+        "INSERT INTO lab_result (person_id, document_id, test_name, collected_at, "
+        "value_num, unit, ref_high, dedup_key, dedup_base, dedup_occurrence) "
+        "VALUES (?, ?, 'Glucose, fasting', '2026-01-01', ?, 'mg/dL', 100, ?, ?, 1)",
+        (row["person_id"], row["document_id"], value_num,
+         dedup.occurrence_key(base, 1), base),
+    )
+    conn.commit()
+    return base, int(row["lab_result_id"]), int(cur.lastrowid)
+
+
+def test_a_row_scoped_verdict_hides_one_occurrence_and_spares_its_sibling(seeded):
+    """The bug that forced #114: a family-scoped `superseded` on a keep-both family
+    removes the row the verdict says should *win*. Row scope is the fix, and the
+    family-scoped contrast below is why it had to exist."""
+    base, _occ0, occ1 = _keep_both_sibling(seeded)
+    curation.annotate_record(seeded, "lab_result", str(occ1), status="superseded",
+                             note="loser of an earlier keep-both", row=True, apply=True)
+
+    md = render.render_summary(seeded, "jane-doe",
+                               dictionary=dedup.load_dictionary(DICT_PATH))
+    body, appendix = md.split("## Superseded / corrected")
+    assert "200.0" in body                  # the sibling renders normally
+    assert "205.0" not in body              # the annotated occurrence does not
+    # Listed once, not once per row of the family.
+    assert appendix.count("lab_result: Glucose, fasting") == 1
+    assert "loser of an earlier keep-both" in appendix
+
+    # The contrast: the same verdict at family scope takes both rows with it.
+    curation.clear_curation(seeded, "lab_result", str(occ1), row=True, apply=True)
+    curation.annotate_record(seeded, "lab_result", base, status="superseded",
+                             note="the whole family", apply=True)
+    body = render.render_summary(
+        seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH)
+    ).split("## Superseded / corrected")[0]
+    assert "200.0" not in body and "205.0" not in body
+
+
+def test_a_row_verdict_overrides_its_family_verdict_at_render_time(seeded):
+    """Precedence, end to end: the family is disputed, one occurrence is superseded.
+    The superseded row leaves for the appendix; its sibling renders in place, marked."""
+    base, _occ0, occ1 = _keep_both_sibling(seeded)
+    curation.annotate_record(seeded, "lab_result", base, status="disputed",
+                             note="two sources disagree", apply=True)
+    curation.annotate_record(seeded, "lab_result", str(occ1), status="superseded",
+                             note="this one is the transcription error", row=True,
+                             apply=True)
+
+    md = render.render_summary(seeded, "jane-doe",
+                               dictionary=dedup.load_dictionary(DICT_PATH))
+    body, appendix = md.split("## Superseded / corrected")
+    assert "200.0" in body
+    assert "[DISPUTED: two sources disagree]" in body
+    assert "205.0" not in body
+    assert "this one is the transcription error" in appendix
+    # One appendix line: the row verdict's, not one per row of the family.
+    assert appendix.count("lab_result: Glucose, fasting") == 1
+
+
+def test_a_row_scoped_verdict_filters_only_its_own_journal_event(seeded):
+    """The journal resolves per row too, via the `record_id` `with_identity` now
+    stamps: without it a row verdict could only ever be applied family-wide."""
+    _base, _occ0, occ1 = _keep_both_sibling(seeded)
+    before = render.render_journal(seeded, "jane-doe")
+    assert before.count("Glucose, fasting") == 2
+
+    curation.annotate_record(seeded, "lab_result", str(occ1), status="superseded",
+                             note="loser", row=True, apply=True)
+
+    md = render.render_journal(seeded, "jane-doe")
+    timeline = md.split("## Superseded / corrected")[0]
+    assert timeline.count("Glucose, fasting") == 1
+    assert "205.0" not in timeline and "200.0" in timeline
+
+
 # --- attested rows are never mistaken for document-sourced facts (issue #110) --
 
 _ATTESTED = {


### PR DESCRIPTION
## Summary

`record annotate` (#109) scoped every curation verdict to a dedup **family** (`dedup_base`). A
family that holds more than one live row — the shape a `keep both` conflict resolution leaves
behind — had no way to carry a verdict naming one occurrence without hiding every row that shares
its base. This landed in practice applying a curation ledger verdict: superseding one row of a
two-row keep-both family hid the winner too.

This PR adds an opt-in `--row` scope alongside the existing family scope:

- `migrations/010_curation_row_scope.sql` rebuilds `curation` with a `record_id` column
  (`0` = family scope, `>0` = row scope), a `PRIMARY KEY (record_type, dedup_base, record_id)`,
  and a partial unique index enforcing one live verdict per row. Backfill is lossless — every
  008-era verdict becomes family-scoped.
- `pemr/curation.py` grows `resolve_row`, `row_label`, a `VerdictMap` (`for_row()` is the single
  precedence site: row verdict wins over family verdict for that row), and a
  delete-then-insert write path (family/row scopes have disjoint uniqueness rules, so one
  `ON CONFLICT` target can't express both).
- `pemr/render.py` / `pemr/verify.py` resolve verdicts per-row instead of per-family, so a
  row-scoped verdict affects only its own row; siblings render/verify normally.
- `pemr/records.py` / `pemr/documents.py`: removing a record (`record rm`) or a document
  (`document rm`) now retires any row-scoped verdict on the rows it deletes — a row id is a plain
  rowid alias and can be reused by a later insert, so a stale row verdict could otherwise silently
  re-target an unrelated new record.
- `pemr/cli.py` gains `--row` on `record annotate --status/--clear/--list`; `--list` now shows
  each verdict's scope.
- `record annotate` remains CLI-only and excluded from `mcp_server.WRITE_TOOLS` — confirmed
  unchanged, no `AGENTS.md` boundary change.
- Docs: `docs/Architecture.md` §6, the migration 010 header, and the `curation.py` /
  `records.py` / `documents.py` module docstrings all describe the new scoping and the verified
  rekey behavior (a row-scoped verdict resolves by row id alone, so it survives a dictionary-driven
  `rekey` that would orphan a family-scoped verdict).

Backward compatible: with no `--row` anywhere, storage and rendered output are bit-identical to
today (regression-tested).

## Reports

- Verify: https://github.com/meridun/pemr/issues/114#issuecomment-5241063164 (910 passed)
- Audit (re-audit, clean): https://github.com/meridun/pemr/issues/114#issuecomment-5241207335

## Known environment artifact

`npm run sync:claude-config:check` fails inside this worktree due to CRLF line endings; it passes
on `dev`. Not a defect introduced by this branch — `.claude/` is untouched here.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)