### PR TITLE
feat(rekey): let a recorded verdict resolve a dedup-key collision

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -426,14 +426,23 @@ of its clinical section (a `merged-into` on one spelling of an allergy taking th
 canonical spelling out of `## Allergies`). So the authorizing family verdict is **narrowed
 to row scope** instead, pinned to exactly the rows whose stored `dedup_base` was its own,
 in the same transaction as the keys: the ruling keeps precisely the extension it had when
-it was made, the merged-in row keeps rendering where it was, and nothing is orphaned.
-Criticality-blind by construction — no live row silently leaves its rendered section,
-whatever it records. The conversion is announced, never silent: `resolved` names the pinned
-rows in both output modes, and `pemr verify` notices a row verdict whose family breadcrumb
-a rekey left stale, pointing at `pemr record annotate --row` to re-affirm or re-rule. A
-recorded human ruling is only ever re-pointed or scope-narrowed within its original
-extension here — never overwritten, deleted, or auto-cleared; a row that already carries
-its own row-scoped verdict is skipped for the same reason.
+it was made, the merged-in row keeps rendering where it was, and the verdict that *resolved*
+the collision is never orphaned. That guarantee is scoped to the resolving verdict only: a
+clash covered by verdicts on **both** colliding families still resolves through exactly one
+of them (`covering()` returns a single verdict — row scope over family scope), and the
+*other* family's verdict is not carried anywhere. Its rows move out from under it the same
+way an unrelated dictionary-driven rekey has always been able to orphan a family verdict
+(documented since migration 008) — `rekey`'s own output says nothing about it, and `pemr
+verify` is the only signal (`curation verdict ... has no live family (removed?)`). The
+direction is over-reporting, not data loss: no fact disappears, but a row a human had ruled
+out of its clinical section can be promoted back into it until the operator re-rules or
+clears the stale verdict. Criticality-blind by construction — no live row silently leaves
+its rendered section, whatever it records. The conversion is announced, never silent:
+`resolved` names the pinned rows in both output modes, and `pemr verify` notices a row
+verdict whose family breadcrumb a rekey left stale, pointing at `pemr record annotate --row`
+to re-affirm or re-rule. A recorded human ruling is only ever re-pointed or scope-narrowed
+within its original extension here — never overwritten, deleted, or auto-cleared; a row that
+already carries its own row-scoped verdict is skipped for the same reason.
 
 That re-affirm has to be *runnable*, which is why `--merged-into` may name the annotated
 row's own family at **row** scope. A `merged-into` narrowing is the common shape, and the

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -435,6 +435,15 @@ recorded human ruling is only ever re-pointed or scope-narrowed within its origi
 extension here — never overwritten, deleted, or auto-cleared; a row that already carries
 its own row-scoped verdict is skipped for the same reason.
 
+That re-affirm has to be *runnable*, which is why `--merged-into` may name the annotated
+row's own family at **row** scope. A `merged-into` narrowing is the common shape, and the
+same rekey that narrows the ruling also moves its row into the merge target — so by the
+time the operator answers the notice there is no third family left to name. At row scope
+the pointer still means something (this occurrence is absorbed into the family it sits in;
+it moves to the appendix while its siblings keep rendering live), so it is accepted. At
+**family** scope a self-merge would leave the fact rendering nowhere at all, and stays
+refused.
+
 **Ingesting against drifted keys is refused, not silently forked.** Until the rekey is
 applied, a stored row's frozen key is invisible to layer-2 dedup, so re-filing that same
 fact would land a *second* row reported as `new` — no duplicate, no conflict, no signal at

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -409,18 +409,31 @@ stuck on. So `rekey` consults the overlay — through an injected resolver, beca
 `curation` imports `dedup` and not the reverse — and a clash covered by such a verdict on
 **either** row at **either** scope stops being blocking. The clash row is filed as the
 next free *occurrence* of the surviving family (the `--keep both` shape; leaving it on its
-stored key would strand it permanently drifted while `rekey` itself reported clean), and
-the verdict that authorized this follows its family onto the surviving `dedup_base` in the
-same transaction as the keys, so `pemr verify` gains no orphan warning. Only
+stored key would strand it permanently drifted while `rekey` itself reported clean). Only
 `merged-into`/`superseded` resolve — `confirmed`, `disputed` and `erroneous-in-source`
 rule on a row's content, not on its identity against another row — and a table holding any
-*unresolved* collision still withholds every change in it, resolved pairs included. Both
+*unresolved* collision still withholds every change in it, resolved pairs included (its
+resolutions say exactly that, rather than describing a write that did not happen). Both
 output modes distinguish the two: a resolved pair is a `note:` line and an entry in
 `--json`'s `resolved` list, a blocked one stays `error:` plus `skipped`. A run whose every
-collision was verdict-resolved therefore exits **0**. If the surviving base already carries
-its own family verdict, the incumbent wins and the moved-off verdict is left exactly where
-it is and named in the output — a recorded human ruling is never overwritten, deleted, or
-auto-cleared here.
+collision was verdict-resolved therefore exits **0**.
+
+**A verdict's scope never widens across that merge.** Resolution joins a judged family to
+an unjudged one, so the surviving family is *larger* than the one the human ruled on.
+Carrying the family verdict over wholesale would silently extend the ruling to a row nobody
+judged — and for the appendix statuses that resolve collisions, that pulls a live row out
+of its clinical section (a `merged-into` on one spelling of an allergy taking the other,
+canonical spelling out of `## Allergies`). So the authorizing family verdict is **narrowed
+to row scope** instead, pinned to exactly the rows whose stored `dedup_base` was its own,
+in the same transaction as the keys: the ruling keeps precisely the extension it had when
+it was made, the merged-in row keeps rendering where it was, and nothing is orphaned.
+Criticality-blind by construction — no live row silently leaves its rendered section,
+whatever it records. The conversion is announced, never silent: `resolved` names the pinned
+rows in both output modes, and `pemr verify` notices a row verdict whose family breadcrumb
+a rekey left stale, pointing at `pemr record annotate --row` to re-affirm or re-rule. A
+recorded human ruling is only ever re-pointed or scope-narrowed within its original
+extension here — never overwritten, deleted, or auto-cleared; a row that already carries
+its own row-scoped verdict is skipped for the same reason.
 
 **Ingesting against drifted keys is refused, not silently forked.** Until the rekey is
 applied, a stored row's frozen key is invisible to layer-2 dedup, so re-filing that same

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -399,8 +399,28 @@ stored keys, and names them (`skipped: collision` per table, plus a `skipped` li
 `--json`). `--json`'s `changed` list is every key the scan computed as moving, not only
 the ones written — a row in a skipped table still shows up there, so a consumer must
 cross-reference `skipped` to tell written from withheld. Exit code is 1 whenever any
-collision was found, in both output modes: partial progress is fine, silent partial
-progress is not.
+**blocking** collision was found, in both output modes: partial progress is fine, silent
+partial progress is not.
+
+**A collision a human already ruled on is settled, not blocking** (issue #116). Many
+collisions are exactly the pair the curation overlay exists to answer: a `merged-into` or
+`superseded` verdict says "these two are one fact", which is the question the guard is
+stuck on. So `rekey` consults the overlay — through an injected resolver, because
+`curation` imports `dedup` and not the reverse — and a clash covered by such a verdict on
+**either** row at **either** scope stops being blocking. The clash row is filed as the
+next free *occurrence* of the surviving family (the `--keep both` shape; leaving it on its
+stored key would strand it permanently drifted while `rekey` itself reported clean), and
+the verdict that authorized this follows its family onto the surviving `dedup_base` in the
+same transaction as the keys, so `pemr verify` gains no orphan warning. Only
+`merged-into`/`superseded` resolve — `confirmed`, `disputed` and `erroneous-in-source`
+rule on a row's content, not on its identity against another row — and a table holding any
+*unresolved* collision still withholds every change in it, resolved pairs included. Both
+output modes distinguish the two: a resolved pair is a `note:` line and an entry in
+`--json`'s `resolved` list, a blocked one stays `error:` plus `skipped`. A run whose every
+collision was verdict-resolved therefore exits **0**. If the surviving base already carries
+its own family verdict, the incumbent wins and the moved-off verdict is left exactly where
+it is and named in the output — a recorded human ruling is never overwritten, deleted, or
+auto-cleared here.
 
 **Ingesting against drifted keys is refused, not silently forked.** Until the rekey is
 applied, a stored row's frozen key is invisible to layer-2 dedup, so re-filing that same
@@ -441,7 +461,11 @@ documents is three stored rows that all recompute onto the single date-free key 
 type — the legacy shape behind #86's apparently duplicated condition bullets, correct storage
 under the old identity and a three-way fusion under the new one. A collision quarantines its own
 table only (above), so the clean tables are still written and the fusion is settled in the
-dictionary or the data before a re-run.
+dictionary or the data before a re-run — or, where a `merged-into`/`superseded` verdict has
+already been recorded on the pair, it is settled by that verdict and the table writes
+(above, issue #116). That is the common case for this migration's collisions: the rows are
+the *same* standing fact restated by several documents, which is precisely what those two
+statuses record.
 
 The **measured value is deliberately *not* in the key** — temporal identity carries the
 draw instead. `collected_at`/`observed_at` are used at full precision (timestamp when the

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -1398,7 +1398,13 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
     try:
         dictionary = dedup.load_dictionary(_resolve_dictionary_path(args))
         try:
-            report = dedup.rekey(conn, dictionary, apply=args.apply)
+            # The curation overlay is injected, never imported by `dedup` (issue #116):
+            # a collision the human already ruled on with a merged-into/superseded
+            # verdict is settled, not blocking.
+            report = dedup.rekey(
+                conn, dictionary, apply=args.apply,
+                resolver=curation.collision_resolver(conn),
+            )
         except db.NotMigratedError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 1
@@ -1408,6 +1414,8 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
     # A collision blocks its own table only (issue #92), so it is a partial failure:
     # the clean tables are reported (and, under --apply, written) and the exit code
     # still says something was left undone. Same rc in --json mode as in text mode.
+    # `collisions` is now the *blocking* ones only, so a run whose every collision was
+    # verdict-resolved exits 0 - there is nothing left for the operator to fix.
     writable = report.writable()
     rc = 1 if report.collisions else 0
 
@@ -1440,6 +1448,27 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
                 }
                 for c in report.collisions
             ],
+            # Appended, never inserted (the additive-only contract rule): the collisions
+            # a recorded verdict settled, which `collisions` and `skipped` deliberately
+            # no longer carry.
+            "resolved": [
+                {
+                    "record_type": r.record_type,
+                    "row_id": r.row_id,
+                    "label": r.label,
+                    "clash_row_id": r.clash_row_id,
+                    "clash_label": r.clash_label,
+                    "kind": r.kind,
+                    "status": r.status,
+                    "scope": r.scope,
+                    "record_id": r.record_id,
+                    "new_base": r.new_base,
+                    "new_occurrence": r.new_occurrence,
+                    "verdict_action": r.verdict_action,
+                    "message": r.message,
+                }
+                for r in report.resolved
+            ],
         })
         return rc
 
@@ -1449,6 +1478,21 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
         print(f"{record_type}: {changed}/{count} key(s) change{blocked}")
     for c in report.changes:
         print(f"  {c.record_type} #{c.row_id}  {c.label}")
+
+    # A note, not an error: the operator has nothing to fix here, but they do need to
+    # see why a table that holds a collision was written anyway.
+    for resolution in report.resolved:
+        print(f"note: {resolution.message}")
+        if resolution.verdict_action == "kept":
+            print(
+                f"note: {resolution.record_type} "
+                f"{resolution.new_base[:12]}... already carried its own family verdict, "
+                f"so the resolving one stayed on {resolution.verdict_base[:12]}... - "
+                "lift it with `pemr record annotate --clear "
+                f"{resolution.record_type} {resolution.verdict_base}` if it is now stale"
+            )
+    if report.resolved:
+        print(f"{len(report.resolved)} collision(s) resolved by verdict")
 
     for collision in report.collisions:
         print(f"error: {collision.message}", file=sys.stderr)
@@ -1460,7 +1504,7 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
-    if not report.changes and not report.collisions:
+    if not report.changes and not report.collisions and not report.resolved:
         print("all dedup keys already match the current dictionary")
     elif report.applied:
         print(f"rekeyed {len(writable)} row(s)")

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -1464,7 +1464,9 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
                     "record_id": r.record_id,
                     "new_base": r.new_base,
                     "new_occurrence": r.new_occurrence,
+                    "covered_row_ids": r.covered_row_ids,
                     "verdict_action": r.verdict_action,
+                    "narrowed_row_ids": r.narrowed_row_ids,
                     "message": r.message,
                 }
                 for r in report.resolved
@@ -1480,16 +1482,20 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
         print(f"  {c.record_type} #{c.row_id}  {c.label}")
 
     # A note, not an error: the operator has nothing to fix here, but they do need to
-    # see why a table that holds a collision was written anyway.
+    # see why a table that holds a collision was written anyway - and, when a ruling's
+    # scope was narrowed to keep it off a row it never judged, they need to be told
+    # loudly enough to re-affirm or re-rule it.
     for resolution in report.resolved:
         print(f"note: {resolution.message}")
-        if resolution.verdict_action == "kept":
+        if resolution.verdict_action == "narrowed":
+            rows = ", ".join(str(r) for r in resolution.narrowed_row_ids)
             print(
-                f"note: {resolution.record_type} "
-                f"{resolution.new_base[:12]}... already carried its own family verdict, "
-                f"so the resolving one stayed on {resolution.verdict_base[:12]}... - "
-                "lift it with `pemr record annotate --clear "
-                f"{resolution.record_type} {resolution.verdict_base}` if it is now stale"
+                f"note: the family verdict on {resolution.verdict_base[:12]}... was "
+                f"narrowed to row scope on {resolution.record_type} "
+                f"{'rows' if len(resolution.narrowed_row_ids) > 1 else 'row'} {rows} - "
+                "the rows it already covered - so it does not extend over the rest of "
+                f"{resolution.new_base[:12]}...; re-affirm or re-rule it with "
+                f"`pemr record annotate --row {resolution.record_type} <id>`"
             )
     if report.resolved:
         print(f"{len(report.resolved)} collision(s) resolved by verdict")

--- a/pemr/curation.py
+++ b/pemr/curation.py
@@ -536,9 +536,16 @@ def annotate_record(
     table is the why and who said so, and a verdict with no reason is a verdict nobody
     can audit later.
 
-    ``merged_into_base`` is set iff ``status='merged-into'``, must name a live family
-    of the same ``record_type``, and must not be the annotated family itself (a family
-    merged into itself would render nowhere at all).
+    ``merged_into_base`` is set iff ``status='merged-into'``, and must name a live family
+    of the same ``record_type``. At **family** scope it must not be the annotated family
+    itself: a family merged into itself would render nowhere at all. At **row** scope it
+    may be — "this occurrence is absorbed into the family it sits in" is a coherent
+    ruling (the row moves to the appendix, its siblings keep rendering live), and it is
+    exactly the state :meth:`CollisionResolver.narrow` produces when it pins a
+    collision-resolving ``merged-into`` family verdict to its rows (#116): the same rekey
+    that narrows the verdict also moves those rows into the merge target. Refusing it
+    here would make `pemr verify`'s "re-affirm it" notice impossible to follow for the
+    one status that most often carries it.
 
     Raises ``ValueError`` for an unknown ``record_type``/``status``/empty note or a bad
     merge target, :class:`FamilyNotFoundError` when a family target does not resolve, and
@@ -570,7 +577,7 @@ def annotate_record(
                 "--merged-into <BASE-OR-ID>; nothing was written"
             )
         merge_target = resolve_base(conn, record_type, merge_target)
-        if merge_target == base:
+        if merge_target == base and not record_id:
             raise ValueError(
                 f"cannot merge {record_type} {base[:12]}... into itself - the merged "
                 "family renders only under its target, so this would hide it "

--- a/pemr/curation.py
+++ b/pemr/curation.py
@@ -30,7 +30,10 @@ single **row**:
 occurrence shifts `record rm` (#107) leaves behind. It does *not* survive every
 `pemr rekey`: a dictionary edit that changes this family's own canonical name moves its
 ``dedup_base``, orphaning the verdict (`pemr verify` warns; `record annotate --clear`
-then re-annotate).
+then re-annotate). The one exception is the verdict that *resolved* a rekey collision
+(issue #116, :class:`CollisionResolver`): it follows its family onto the surviving base
+in the same transaction as the keys it authorized, because a committed rekey whose
+authorizing ruling was left orphaned is a worse state than the one it fixed.
 
 *Row scope* — ``--row``, keyed by ``(record_type, record_id)`` **alone**. It exists for
 the family a ``--keep both`` conflict resolution left holding two *live* rows: a
@@ -103,6 +106,17 @@ APPENDIX_STATUSES: tuple[str, ...] = (
     "superseded",
     "erroneous-in-source",
     "merged-into",
+)
+
+#: The statuses that say "a human settled *which fact this is*" — and therefore the only
+#: ones that may resolve a `pemr rekey` collision (issue #116). ``confirmed`` records
+#: agreement with the row as filed, ``disputed`` records that the question is still open,
+#: and ``erroneous-in-source`` rules on the *content* of one row without saying anything
+#: about its identity relative to another — none of the three settles "these two rows are
+#: one fact", which is the question a collision asks.
+RESOLVING_STATUSES: tuple[str, ...] = (
+    "merged-into",
+    "superseded",
 )
 
 #: The key a rendered row carries its verdict under, when it has one.
@@ -741,6 +755,101 @@ def clear_curation(
                 )
     report.applied = apply
     return report
+
+
+# --------------------------------------------------------------------------- #
+# The `pemr rekey` collision seam (issue #116)
+# --------------------------------------------------------------------------- #
+
+class CollisionResolver:
+    """The overlay half of :class:`dedup.CollisionResolver` — the seam `rekey` asks
+    "did a human already settle this pair?" through.
+
+    Injected rather than imported: this module imports :mod:`dedup`, so ``dedup`` cannot
+    import it back. ``dedup`` declares the shape as a ``Protocol`` and the CLI builds the
+    implementation, which keeps every `curation`-table SQL statement here (the
+    :func:`retire_row_verdicts` precedent) and keeps the import graph acyclic.
+    """
+
+    def __init__(self, verdicts: VerdictMap) -> None:
+        self._verdicts = verdicts
+
+    def covering(
+        self, record_type: str, row: sqlite3.Row, clash: sqlite3.Row
+    ) -> dict | None:
+        """The verdict that settles a collision between two rows, or None.
+
+        Either row, either scope: the operator annotated whichever of the pair they were
+        looking at, and a family verdict on one is as much a ruling on the pair as a row
+        verdict on the other. Resolution runs through :meth:`VerdictMap.for_row`, so the
+        row-over-family precedence rule stays defined in exactly one place.
+
+        The **stored** ``dedup_base`` is the lookup key, not the recomputed one: the
+        human ruled on the family as it exists today, before this rekey moves it.
+        """
+        pk = f"{record_type}_id"
+        for candidate in (row, clash):
+            verdict = self._verdicts.for_row(
+                record_type, candidate["dedup_base"], candidate[pk]
+            )
+            if verdict is not None and verdict["status"] in RESOLVING_STATUSES:
+                return verdict
+        return None
+
+    def rebase(
+        self,
+        conn: sqlite3.Connection,
+        record_type: str,
+        verdict: dict,
+        new_base: str,
+        base_map: dict[str, str],
+    ) -> str:
+        """Keep a collision-resolving verdict attached to the family that survived.
+
+        Returns ``"unchanged"`` | ``"rebased"`` | ``"kept"``. **Caller-managed
+        transaction** (the :func:`retire_row_verdicts` precedent): `rekey` writes the keys
+        and this re-base in one ``with conn:``, because a committed rekey whose
+        authorizing verdict was left orphaned is the exact failure the seam exists to
+        avoid.
+
+        A *row-scoped* verdict needs nothing: it resolves by row id, which `rekey` never
+        renumbers, and its stored base is a breadcrumb deliberately left stale (migration
+        010). A *family-scoped* one follows its family onto ``new_base``, and follows its
+        ``merged_into_base`` through ``base_map`` when the merge target moved in this same
+        run.
+
+        Only ever an ``UPDATE`` of the two identity pointers, so ``status``, ``note``,
+        ``attributed_to`` and ``created_at`` survive verbatim — this is the same human
+        ruling, not a new one. And if the surviving base already carries a family verdict,
+        the incumbent wins and this one is left exactly where it is (``"kept"``): a
+        verdict is a human's, and nothing here may overwrite or delete one.
+        """
+        if verdict["record_id"]:
+            return "unchanged"
+        base = verdict["dedup_base"]
+        target = verdict["merged_into_base"]
+        new_target = base_map.get(target, target) if target else target
+        if base == new_base and new_target == target:
+            return "unchanged"
+        if base != new_base and get_verdict(conn, record_type, new_base) is not None:
+            return "kept"
+        conn.execute(
+            "UPDATE curation SET dedup_base = ?, merged_into_base = ? "
+            "WHERE record_type = ? AND dedup_base = ? AND record_id = 0",
+            (new_base, new_target, record_type, base),
+        )
+        return "rebased"
+
+
+def collision_resolver(conn: sqlite3.Connection) -> CollisionResolver:
+    """Build the resolver `pemr rekey` adjudicates its collisions through.
+
+    One :func:`load_verdicts` query up front (the render/verify hot-path idiom) — a rekey
+    scans every row of every table, and a per-collision SELECT would be the wrong shape.
+    A pre-008 snapshot yields an empty map, hence a resolver that resolves nothing, which
+    is exactly today's behaviour.
+    """
+    return CollisionResolver(load_verdicts(conn))
 
 
 def describe(verdict: dict) -> str:

--- a/pemr/curation.py
+++ b/pemr/curation.py
@@ -31,9 +31,14 @@ occurrence shifts `record rm` (#107) leaves behind. It does *not* survive every
 `pemr rekey`: a dictionary edit that changes this family's own canonical name moves its
 ``dedup_base``, orphaning the verdict (`pemr verify` warns; `record annotate --clear`
 then re-annotate). The one exception is the verdict that *resolved* a rekey collision
-(issue #116, :class:`CollisionResolver`): it follows its family onto the surviving base
-in the same transaction as the keys it authorized, because a committed rekey whose
-authorizing ruling was left orphaned is a worse state than the one it fixed.
+(issue #116, :class:`CollisionResolver`): rather than being left orphaned, it is
+**narrowed to row scope** — pinned to exactly the rows it covered when it was made — in
+the same transaction as the keys it authorized. It is narrowed rather than re-pointed
+because the surviving family is *larger* than the one the human ruled on: re-pointing
+would silently extend the ruling over a row nobody judged, and a ``superseded`` verdict
+reaching a previously-live row drops that row out of its clinical section. A ruling's
+judgment is never destroyed or reinterpreted; re-pointing and scope-narrowing that
+preserve its original extension are what this module permits.
 
 *Row scope* — ``--row``, keyed by ``(record_type, record_id)`` **alone**. It exists for
 the family a ``--keep both`` conflict resolution left holding two *live* rows: a
@@ -45,7 +50,11 @@ untouched"), so a row-scoped verdict genuinely **survives** the dictionary-drive
 that orphans a family-scoped one; it is orphaned only by the removal of its row. The
 ``dedup_base`` stored beside it is a *breadcrumb* — which family it ruled in, at
 annotate time — that may go stale after such a rekey and is never consulted for
-resolution: every reader re-reads the live base off the row.
+resolution: every reader re-reads the live base off the row. A stale breadcrumb is not
+an error, but it *is* reported: `pemr verify` notices that a rekey moved the row out of
+the family the ruling was made in, so the human can re-affirm (re-annotating collapses
+the breadcrumb) or re-rule. That notice is what makes a collision-resolving narrowing
+loud rather than silent.
 
 **Removing the row retires the verdict.** A ``dedup_base`` is content-derived, so a
 family verdict re-attaching to a re-ingested identical fact is correct. A row id is not:
@@ -796,49 +805,85 @@ class CollisionResolver:
                 return verdict
         return None
 
-    def rebase(
+    def narrow(
         self,
         conn: sqlite3.Connection,
         record_type: str,
         verdict: dict,
-        new_base: str,
+        covered_row_ids: Iterable[int],
         base_map: dict[str, str],
-    ) -> str:
-        """Keep a collision-resolving verdict attached to the family that survived.
+    ) -> tuple[str, list[int]]:
+        """Pin a collision-resolving family verdict to the rows it actually ruled on.
 
-        Returns ``"unchanged"`` | ``"rebased"`` | ``"kept"``. **Caller-managed
-        transaction** (the :func:`retire_row_verdicts` precedent): `rekey` writes the keys
-        and this re-base in one ``with conn:``, because a committed rekey whose
-        authorizing verdict was left orphaned is the exact failure the seam exists to
-        avoid.
+        Returns ``(action, row_ids)`` where ``action`` is ``"unchanged"`` or
+        ``"narrowed"``. **Caller-managed transaction** (the
+        :func:`retire_row_verdicts` precedent): `rekey` writes the keys and this
+        conversion in one ``with conn:``, because a committed rekey whose authorizing
+        verdict was left orphaned is the exact failure the seam exists to avoid.
 
-        A *row-scoped* verdict needs nothing: it resolves by row id, which `rekey` never
-        renumbers, and its stored base is a breadcrumb deliberately left stale (migration
-        010). A *family-scoped* one follows its family onto ``new_base``, and follows its
-        ``merged_into_base`` through ``base_map`` when the merge target moved in this same
-        run.
+        A *row-scoped* verdict needs nothing (``"unchanged"``): it already names exactly
+        one row, `rekey` never renumbers a row id, and its stored base is a breadcrumb
+        (migration 010).
 
-        Only ever an ``UPDATE`` of the two identity pointers, so ``status``, ``note``,
-        ``attributed_to`` and ``created_at`` survive verbatim — this is the same human
-        ruling, not a new one. And if the surviving base already carries a family verdict,
-        the incumbent wins and this one is left exactly where it is (``"kept"``): a
-        verdict is a human's, and nothing here may overwrite or delete one.
+        A *family-scoped* one may **not** simply follow its family onto the surviving
+        base. Resolution merges a judged family with an unjudged one, so the surviving
+        family is larger than the one the human ruled on: a verdict that moved wholesale
+        would silently extend over a row nobody judged, and — for the
+        :data:`APPENDIX_STATUSES` that resolve collisions — would drop that previously
+        live row out of its clinical section. Criticality-blind by design: no live row
+        ever silently leaves its rendered section, whatever it records. So the verdict is
+        narrowed instead, to row-scoped verdicts on ``covered_row_ids`` — the rows whose
+        *stored* ``dedup_base`` was the verdict's, i.e. its extension at ruling time.
+
+        ``status``, ``note``, ``attributed_to`` and ``created_at`` are carried verbatim
+        onto each pinned row (the first by ``UPDATE``, so the original ledger row itself
+        survives), and ``merged_into_base`` follows ``base_map`` when the merge target
+        moved in this same run. The breadcrumb ``dedup_base`` deliberately stays the
+        family the ruling was made in — which is what `pemr verify` notices, so the
+        narrowing is announced rather than silent.
+
+        A row that already carries its **own** row-scoped verdict is skipped: that
+        verdict already wins over the family one for that row (:meth:`VerdictMap.for_row`),
+        so the family verdict never applied there and narrowing must not overwrite a
+        second human ruling. If that skip leaves nothing to pin — defensive; the verdict
+        was reached *through* a row that had none — nothing is written at all
+        (``"unchanged"``): a verdict is a human's, and nothing here deletes one outright.
         """
         if verdict["record_id"]:
-            return "unchanged"
+            return ("unchanged", [])
+        _require_type(record_type)
         base = verdict["dedup_base"]
         target = verdict["merged_into_base"]
         new_target = base_map.get(target, target) if target else target
-        if base == new_base and new_target == target:
-            return "unchanged"
-        if base != new_base and get_verdict(conn, record_type, new_base) is not None:
-            return "kept"
-        conn.execute(
-            "UPDATE curation SET dedup_base = ?, merged_into_base = ? "
-            "WHERE record_type = ? AND dedup_base = ? AND record_id = 0",
-            (new_base, new_target, record_type, base),
+        taken = {
+            int(r["record_id"])
+            for r in conn.execute(
+                "SELECT record_id FROM curation "
+                "WHERE record_type = ? AND record_id <> 0",
+                (record_type,),
+            ).fetchall()
+        }
+        pinned = sorted(
+            {int(rid) for rid in covered_row_ids if int(rid)} - taken
         )
-        return "rebased"
+        if not pinned:
+            return ("unchanged", [])
+        conn.execute(
+            "UPDATE curation SET record_id = ?, merged_into_base = ? "
+            "WHERE record_type = ? AND dedup_base = ? AND record_id = 0",
+            (pinned[0], new_target, record_type, base),
+        )
+        for row_id in pinned[1:]:
+            # The same ruling, restated on a sibling it already covered - not a new
+            # verdict, hence the verbatim note/attribution/timestamp.
+            conn.execute(
+                "INSERT INTO curation (record_type, dedup_base, record_id, status, "
+                "note, merged_into_base, attributed_to, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (record_type, base, row_id, verdict["status"], verdict["note"],
+                 new_target, verdict["attributed_to"], verdict["created_at"]),
+            )
+        return ("narrowed", pinned)
 
 
 def collision_resolver(conn: sqlite3.Connection) -> CollisionResolver:

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -32,6 +32,7 @@ import tomllib
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from pathlib import Path
+from typing import Protocol
 
 from . import db
 
@@ -1365,6 +1366,33 @@ def _rekey_label(record_type: str, row: sqlite3.Row) -> str:
     return " ".join(p for p in (row["obs_type"], row["key"]) if p)  # observation
 
 
+class CollisionResolver(Protocol):
+    """How :func:`rekey` asks the curation overlay whether a human already settled a
+    collision (issue #116) — a structural type, deliberately not an import.
+
+    ``curation`` imports *this* module, so the dependency can only run one way: the
+    implementation lives in :class:`curation.CollisionResolver`, the CLI builds it, and
+    `rekey` takes it as an argument. A lazy ``import curation`` inside `rekey` would
+    silently reintroduce the cycle this seam exists to prevent.
+    """
+
+    def covering(
+        self, record_type: str, row: sqlite3.Row, clash: sqlite3.Row
+    ) -> dict | None:
+        """The verdict settling this pair's identity, or None if none does."""
+
+    def rebase(
+        self,
+        conn: sqlite3.Connection,
+        record_type: str,
+        verdict: dict,
+        new_base: str,
+        base_map: dict[str, str],
+    ) -> str:
+        """Keep ``verdict`` attached to the surviving family; caller-managed
+        transaction. Returns ``"unchanged"`` | ``"rebased"`` | ``"kept"``."""
+
+
 @dataclass
 class RekeyChange:
     record_type: str
@@ -1373,6 +1401,39 @@ class RekeyChange:
     old_key: str
     new_key: str
     new_base: str = ""      # recomputed dedup_base (new_key == new_base at occurrence 0)
+    # Set only for a row whose collision a verdict resolved (issue #116): it moves onto
+    # the surviving family as a new occurrence. None -- every other change -- means the
+    # stored occurrence is kept, which is what `rekey` has always done.
+    new_occurrence: int | None = None
+
+
+@dataclass
+class RekeyResolution:
+    """A collision a recorded human verdict settled, instead of blocking on (issue #116).
+
+    The pair still recomputes onto one identity; what the verdict supplies is the answer
+    `rekey` cannot derive — that a human already ruled these two rows are one fact. The
+    clash row is then filed as the next free **occurrence** of the surviving family, the
+    shape a ``--keep both`` conflict resolution produces, rather than left on its stored
+    key: a row left behind would stay permanently drifted, and
+    :func:`_assert_no_key_drift` would refuse the next ingest deriving that identity
+    while this very command reported clean.
+    """
+    record_type: str
+    row_id: int
+    label: str
+    clash_row_id: int
+    clash_label: str
+    kind: str               # "fused" | "doubled", as RekeyCollision — diagnostic only
+    status: str             # the verdict's status (one of curation.RESOLVING_STATUSES)
+    scope: str              # "family" | "row"
+    record_id: int          # the verdict's row id; 0 for family scope
+    verdict_base: str       # dedup_base the verdict is stored under
+    new_base: str           # the surviving family both rows land in
+    new_occurrence: int     # occurrence the clash row takes under new_base
+    message: str            # full account, ready to print
+    # "unchanged" | "rebased" | "kept", filled in by the write; "" on a dry run.
+    verdict_action: str = ""
 
 
 @dataclass
@@ -1397,6 +1458,9 @@ class RekeyReport:
     scanned: dict[str, int] = field(default_factory=dict)      # type -> rows examined
     changes: list[RekeyChange] = field(default_factory=list)
     collisions: list[RekeyCollision] = field(default_factory=list)
+    # Collisions a human verdict settled (issue #116). Deliberately NOT part of
+    # `blocked`/`writable()`: a resolved pair does not quarantine its table.
+    resolved: list[RekeyResolution] = field(default_factory=list)
     applied: bool = False
 
     @property
@@ -1411,11 +1475,28 @@ class RekeyReport:
         return [c for c in self.changes if c.record_type not in blocked]
 
 
+@dataclass
+class _RekeyEntry:
+    """One scanned row plus what the current dictionary makes of it.
+
+    Mutable on purpose: adjudicating a verdict-resolved collision moves the entry to a
+    new occurrence, and the *next* clash in the same family has to see that move when it
+    picks its own free occurrence.
+    """
+    row: sqlite3.Row
+    row_id: int
+    payload: dict
+    base: str               # recomputed dedup_base
+    occurrence: int
+    key: str                # occurrence_key(base, occurrence)
+
+
 def rekey(
     conn: sqlite3.Connection,
     dictionary: dict[str, str] | None = None,
     *,
     apply: bool = False,
+    resolver: CollisionResolver | None = None,
 ) -> RekeyReport:
     """Recompute every stored ``dedup_key`` under the *current* dictionary.
 
@@ -1423,7 +1504,9 @@ def rekey(
     ``chloride``) changes the key a future commit computes for a fact already in the
     DB: layer-2 dedup misses and the same fact lands twice. This walks the record
     tables and re-derives each key, so stored rows keep deduping after a dictionary
-    edit. Values, provenance and row ids are untouched — only ``dedup_key`` moves.
+    edit. Values, provenance and row ids are untouched — only the key-machinery columns
+    move (``dedup_occurrence`` among them, but for a verdict-resolved row only; see
+    ``resolver`` below).
 
     Dry-run by default: pass ``apply=True`` to write. Two rows in one table that
     recompute to the same key are a **collision**, and each one names which of the two
@@ -1445,66 +1528,123 @@ def rekey(
     leaving the colliding tables on their stored keys and naming them in
     :attr:`RekeyReport.blocked`. Callers surface a non-empty ``collisions`` as a failure;
     partial progress with an explicit account of what was skipped beats all-or-nothing.
+
+    ``resolver`` is the optional curation-overlay seam (issue #116). Many collisions are
+    exactly the pair a human already ruled on — since migrations 008/010 a
+    ``merged-into`` or ``superseded`` verdict says "these are one fact", which is the
+    very question the guard is stuck on. With a resolver injected, a clash whose pair
+    carries such a verdict (either row, either scope) is **not** blocking: the clash row
+    is filed as the next free occurrence of the surviving family — the shape a
+    ``--keep both`` conflict resolution produces — and reported in
+    :attr:`RekeyReport.resolved` instead of :attr:`RekeyReport.collisions`, so the table
+    still writes. Under ``apply=True`` the verdict that authorized it follows its family
+    onto the surviving ``dedup_base`` in the *same* transaction as the keys. With
+    ``resolver=None`` (the default) every collision blocks, exactly as before.
     """
     db.require_migrated(conn)
     report = RekeyReport(applied=False)
+    # Stored dedup_base -> recomputed base, per table: how a family verdict's merge
+    # target is followed when the target family moved in this same run.
+    base_maps: dict[str, dict[str, str]] = {}
+    # (record_type, verdict, surviving base, resolution) — the re-bases the write block
+    # owes. Kept beside the report rather than inside it so RekeyResolution stays a
+    # plain, serializable account of what happened.
+    pending_rebases: list[tuple[str, dict, str, RekeyResolution]] = []
 
     for record_type in KNOWN_TYPES:
         pk = f"{record_type}_id"
-        rows = conn.execute(f"SELECT * FROM {record_type}").fetchall()
+        # ORDER BY the primary key: incumbency now decides which row of a resolved pair
+        # keeps its occurrence, so the scan order has to be stable rather than whatever
+        # the table happens to yield.
+        rows = conn.execute(f"SELECT * FROM {record_type} ORDER BY {pk}").fetchall()
         report.scanned[record_type] = len(rows)
-        seen: dict[str, sqlite3.Row] = {}
+
+        # Pass 1 (scan): what the current dictionary makes of every row. Collected in
+        # full before anything is adjudicated, because giving a verdict-resolved clash a
+        # free occurrence needs its whole recomputed family in hand.
+        entries: list[_RekeyEntry] = []
+        by_base: dict[str, list[_RekeyEntry]] = {}
+        base_map: dict[str, str] = {}
         for row in rows:
             payload = {name: row[name] for name in FIELD_SPECS[record_type]}
             # The occurrence is a stored column, so an admitted repeat (`--keep both`)
             # recomputes to its own key rather than colliding with its sibling.
             occurrence = int(row["dedup_occurrence"] or 0)
             base = dedup_key(record_type, payload, row["person_id"], dictionary)
-            key = occurrence_key(base, occurrence)
-            clash = seen.get(key)
-            if clash is not None:
-                label, clash_label = (_rekey_label(record_type, row),
-                                      _rekey_label(record_type, clash))
-                if _rows_equal(record_type, clash, payload):
-                    # Same payload, two keys: not a dictionary fault at all - one fact
-                    # was filed twice, once under a pre-drift key and once under the
-                    # current one. Say so, because "fix the dictionary" is exactly the
-                    # wrong advice here (`_assert_no_key_drift` now stops new ingests
-                    # from reaching this state).
-                    kind, message = "doubled", (
-                        f"{record_type}: {pk} {row[pk]} and {pk} {clash[pk]} "
-                        f"({label!r}) hold the SAME fact "
-                        "under two dedup_keys - it was filed a second time by an "
-                        "ingest that ran against drifted keys before this rekey. The "
-                        "dictionary is fine; the data is doubled. Drop whichever row "
-                        "is the degraded copy with "
-                        f"`pemr record rm {record_type} {row[pk]}` (or "
-                        f"`... {clash[pk]}`) - dry run first, then --apply - and "
-                        "re-run; `pemr document rm` is the whole-document option when "
-                        "the re-filing document holds nothing else worth keeping; "
-                        f"{record_type} was not written"
-                    )
-                else:
-                    kind, message = "fused", (
-                        f"{record_type}: {pk} {row[pk]} ({label!r}) and "
-                        f"{pk} {clash[pk]} ({clash_label!r}) recompute to the same "
-                        "dedup_key - the dictionary maps two distinct facts onto one "
-                        f"canonical name; {record_type} was not written"
-                    )
-                report.collisions.append(RekeyCollision(
-                    record_type, row[pk], label, clash[pk], clash_label, kind, message,
-                ))
-                # Keep scanning: report-only mode is a survey, so the run must find
-                # every collision in every table rather than stop at the first. The
-                # first-seen row stays the incumbent for this key, so a third row on it
-                # is reported against the same anchor instead of chaining.
+            entry = _RekeyEntry(
+                row=row, row_id=row[pk], payload=payload, base=base,
+                occurrence=occurrence, key=occurrence_key(base, occurrence),
+            )
+            entries.append(entry)
+            by_base.setdefault(base, []).append(entry)
+            base_map[row["dedup_base"]] = base
+        base_maps[record_type] = base_map
+
+        # Pass 2 (adjudicate): first-seen wins the key; anything landing on a taken one
+        # is either settled by a human verdict or a blocking collision.
+        seen: dict[str, _RekeyEntry] = {}
+        for entry in entries:
+            clash = seen.get(entry.key)
+            if clash is None:
+                seen[entry.key] = entry
+                if entry.key != entry.row["dedup_key"]:
+                    report.changes.append(RekeyChange(
+                        record_type, entry.row_id,
+                        _rekey_label(record_type, entry.row),
+                        entry.row["dedup_key"], entry.key, entry.base,
+                    ))
                 continue
-            seen[key] = row
-            if key != row["dedup_key"]:
-                report.changes.append(RekeyChange(
-                    record_type, row[pk], _rekey_label(record_type, row),
-                    row["dedup_key"], key, base,
-                ))
+
+            label, clash_label = (_rekey_label(record_type, entry.row),
+                                  _rekey_label(record_type, clash.row))
+            kind = ("doubled" if _rows_equal(record_type, clash.row, entry.payload)
+                    else "fused")
+            verdict = (None if resolver is None
+                       else resolver.covering(record_type, entry.row, clash.row))
+            if verdict is not None:
+                resolution = _resolve_clash(
+                    report, record_type, pk, entry, clash, kind, verdict,
+                    by_base[entry.base], seen, label, clash_label,
+                )
+                pending_rebases.append(
+                    (record_type, verdict, entry.base, resolution)
+                )
+                continue
+
+            if kind == "doubled":
+                # Same payload, two keys: not a dictionary fault at all - one fact
+                # was filed twice, once under a pre-drift key and once under the
+                # current one. Say so, because "fix the dictionary" is exactly the
+                # wrong advice here (`_assert_no_key_drift` now stops new ingests
+                # from reaching this state).
+                message = (
+                    f"{record_type}: {pk} {entry.row_id} and {pk} {clash.row_id} "
+                    f"({label!r}) hold the SAME fact "
+                    "under two dedup_keys - it was filed a second time by an "
+                    "ingest that ran against drifted keys before this rekey. The "
+                    "dictionary is fine; the data is doubled. Drop whichever row "
+                    "is the degraded copy with "
+                    f"`pemr record rm {record_type} {entry.row_id}` (or "
+                    f"`... {clash.row_id}`) - dry run first, then --apply - and "
+                    "re-run; `pemr document rm` is the whole-document option when "
+                    "the re-filing document holds nothing else worth keeping; "
+                    f"{record_type} was not written"
+                )
+            else:
+                message = (
+                    f"{record_type}: {pk} {entry.row_id} ({label!r}) and "
+                    f"{pk} {clash.row_id} ({clash_label!r}) recompute to the same "
+                    "dedup_key - the dictionary maps two distinct facts onto one "
+                    f"canonical name; {record_type} was not written"
+                )
+            report.collisions.append(RekeyCollision(
+                record_type, entry.row_id, label, clash.row_id, clash_label,
+                kind, message,
+            ))
+            # Keep scanning: report-only mode is a survey, so the run must find
+            # every collision in every table rather than stop at the first. The
+            # first-seen row stays the incumbent for this key, so a third row on it
+            # is reported against the same anchor instead of chaining.
 
     writable = report.writable()
     if apply and writable:
@@ -1512,6 +1652,7 @@ def rekey(
         # because `UNIQUE(dedup_key)` is enforced per statement: if two rows swap keys
         # (or one takes a key another is about to vacate) a single-pass update trips
         # the index mid-flight. Park every moving row on a unique placeholder first.
+        blocked = set(report.blocked)
         with conn:
             for change in writable:
                 conn.execute(
@@ -1523,13 +1664,87 @@ def rekey(
             for change in writable:
                 # dedup_base moves with the key: base and key are injective in each
                 # other for a fixed occurrence, so a changed key means a changed base.
+                columns = "dedup_key = ?, dedup_base = ?"
+                values: list[object] = [change.new_key, change.new_base]
+                if change.new_occurrence is not None:
+                    # A verdict-resolved row joins the surviving family as a sibling.
+                    # The occurrence is a stored column, so it has to move with the key
+                    # or `_assert_no_key_drift` would read the row as drifted forever.
+                    columns += ", dedup_occurrence = ?"
+                    values.append(change.new_occurrence)
+                values.append(change.row_id)
                 conn.execute(
-                    f"UPDATE {change.record_type} SET dedup_key = ?, dedup_base = ? "
+                    f"UPDATE {change.record_type} SET {columns} "
                     f"WHERE {change.record_type}_id = ?",
-                    (change.new_key, change.new_base, change.row_id),
+                    values,
+                )
+            # Same transaction as the keys they authorized: a committed rekey whose
+            # authorizing verdict was left orphaned is the failure this seam exists to
+            # avoid. Skipped for a blocked table, whose changes were withheld anyway.
+            for rec_type, verdict, new_base, resolution in pending_rebases:
+                if rec_type in blocked:
+                    continue
+                resolution.verdict_action = resolver.rebase(
+                    conn, rec_type, verdict, new_base, base_maps[rec_type],
                 )
     report.applied = apply
     return report
+
+
+def _resolve_clash(
+    report: RekeyReport,
+    record_type: str,
+    pk: str,
+    entry: _RekeyEntry,
+    clash: _RekeyEntry,
+    kind: str,
+    verdict: dict,
+    family: list[_RekeyEntry],
+    seen: dict[str, _RekeyEntry],
+    label: str,
+    clash_label: str,
+) -> RekeyResolution:
+    """File a verdict-settled clash as the next free occurrence of its family.
+
+    ``dedup_key`` is ``UNIQUE`` per table, so "both rows carry this identity" has exactly
+    one representation available — occurrence numbering (migration 005). The incumbent
+    keeps its occurrence and the later row takes the next free one, which is the state a
+    ``--keep both`` conflict resolution leaves behind and exactly what row-scoped
+    curation (issue #114) exists to annotate.
+
+    Mutates ``entry`` and ``seen`` so a *third* row landing on this family sees the
+    occupancy this one just created, and appends to ``report``.
+    """
+    occurrence = 1 + max(sibling.occurrence for sibling in family)
+    # Defensive: the family's occupancy is derived from recomputed bases, so a stored
+    # row that recomputes elsewhere could still be sitting on the key that number implies.
+    while occurrence_key(entry.base, occurrence) in seen:
+        occurrence += 1
+    entry.occurrence = occurrence
+    entry.key = occurrence_key(entry.base, occurrence)
+    seen[entry.key] = entry
+
+    scope = "row" if verdict["record_id"] else "family"
+    message = (
+        f"{record_type}: {pk} {entry.row_id} ({label!r}) and {pk} {clash.row_id} "
+        f"({clash_label!r}) recompute to the same dedup_key ({kind}), but a "
+        f"{scope}-scoped '{verdict['status']}' verdict already settles the pair - "
+        f"{pk} {entry.row_id} was filed as occurrence {occurrence} of "
+        f"{entry.base[:12]}..., the surviving family"
+    )
+    report.changes.append(RekeyChange(
+        record_type, entry.row_id, label, entry.row["dedup_key"], entry.key,
+        entry.base, new_occurrence=occurrence,
+    ))
+    resolution = RekeyResolution(
+        record_type=record_type, row_id=entry.row_id, label=label,
+        clash_row_id=clash.row_id, clash_label=clash_label, kind=kind,
+        status=verdict["status"], scope=scope, record_id=verdict["record_id"],
+        verdict_base=verdict["dedup_base"], new_base=entry.base,
+        new_occurrence=occurrence, message=message,
+    )
+    report.resolved.append(resolution)
+    return resolution
 
 
 def _overwrite_record(

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -29,6 +29,7 @@ import json
 import re
 import sqlite3
 import tomllib
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -1381,16 +1382,17 @@ class CollisionResolver(Protocol):
     ) -> dict | None:
         """The verdict settling this pair's identity, or None if none does."""
 
-    def rebase(
+    def narrow(
         self,
         conn: sqlite3.Connection,
         record_type: str,
         verdict: dict,
-        new_base: str,
+        covered_row_ids: Iterable[int],
         base_map: dict[str, str],
-    ) -> str:
-        """Keep ``verdict`` attached to the surviving family; caller-managed
-        transaction. Returns ``"unchanged"`` | ``"rebased"`` | ``"kept"``."""
+    ) -> tuple[str, list[int]]:
+        """Pin ``verdict`` to the rows it already covered, so resolution cannot widen
+        it over the row that survived; caller-managed transaction. Returns
+        ``(action, pinned_row_ids)`` with action ``"unchanged"`` | ``"narrowed"``."""
 
 
 @dataclass
@@ -1418,6 +1420,12 @@ class RekeyResolution:
     key: a row left behind would stay permanently drifted, and
     :func:`_assert_no_key_drift` would refuse the next ingest deriving that identity
     while this very command reported clean.
+
+    Resolution merges a judged family into a larger one, so the authorizing verdict is
+    **narrowed** to the rows it already covered rather than moved onto the surviving
+    base: a ruling keeps exactly the extension it had when it was made, and the row that
+    was never judged stays live in its own section. ``covered_row_ids`` is that
+    extension; ``narrowed_row_ids`` is what the write actually pinned.
     """
     record_type: str
     row_id: int
@@ -1432,8 +1440,14 @@ class RekeyResolution:
     new_base: str           # the surviving family both rows land in
     new_occurrence: int     # occurrence the clash row takes under new_base
     message: str            # full account, ready to print
-    # "unchanged" | "rebased" | "kept", filled in by the write; "" on a dry run.
+    # Rows the verdict covered before this rekey — its extension at ruling time. For a
+    # row-scoped verdict, the one row it names.
+    covered_row_ids: list[int] = field(default_factory=list)
+    # "unchanged" | "narrowed" | "withheld", filled in by the write; "" on a dry run,
+    # which writes nothing.
     verdict_action: str = ""
+    # The rows a "narrowed" write pinned the verdict to (empty for every other action).
+    narrowed_row_ids: list[int] = field(default_factory=list)
 
 
 @dataclass
@@ -1537,8 +1551,11 @@ def rekey(
     is filed as the next free occurrence of the surviving family — the shape a
     ``--keep both`` conflict resolution produces — and reported in
     :attr:`RekeyReport.resolved` instead of :attr:`RekeyReport.collisions`, so the table
-    still writes. Under ``apply=True`` the verdict that authorized it follows its family
-    onto the surviving ``dedup_base`` in the *same* transaction as the keys. With
+    still writes. Under ``apply=True`` the authorizing verdict is **narrowed to row
+    scope** in the *same* transaction as the keys, pinned to exactly the rows it covered
+    before the merge: the surviving family is bigger than the one the human ruled on, so
+    a verdict carried over wholesale would extend a ruling over a row nobody judged and
+    (for the appendix statuses) pull that live row out of its rendered section. With
     ``resolver=None`` (the default) every collision blocks, exactly as before.
     """
     db.require_migrated(conn)
@@ -1546,10 +1563,10 @@ def rekey(
     # Stored dedup_base -> recomputed base, per table: how a family verdict's merge
     # target is followed when the target family moved in this same run.
     base_maps: dict[str, dict[str, str]] = {}
-    # (record_type, verdict, surviving base, resolution) — the re-bases the write block
-    # owes. Kept beside the report rather than inside it so RekeyResolution stays a
-    # plain, serializable account of what happened.
-    pending_rebases: list[tuple[str, dict, str, RekeyResolution]] = []
+    # (record_type, verdict, resolution) — the narrowings the write block owes. Kept
+    # beside the report rather than inside it so RekeyResolution stays a plain,
+    # serializable account of what happened (the raw verdict dict is not part of it).
+    pending_narrowings: list[tuple[str, dict, RekeyResolution]] = []
 
     for record_type in KNOWN_TYPES:
         pk = f"{record_type}_id"
@@ -1565,6 +1582,10 @@ def rekey(
         entries: list[_RekeyEntry] = []
         by_base: dict[str, list[_RekeyEntry]] = {}
         base_map: dict[str, str] = {}
+        # Stored dedup_base -> the row ids filed under it *before* this rekey: a
+        # family-scoped verdict's extension at ruling time, which is what a resolution
+        # narrows it to rather than widening it over the family that survives.
+        stored_family: dict[str, list[int]] = {}
         for row in rows:
             payload = {name: row[name] for name in FIELD_SPECS[record_type]}
             # The occurrence is a stored column, so an admitted repeat (`--keep both`)
@@ -1578,6 +1599,7 @@ def rekey(
             entries.append(entry)
             by_base.setdefault(base, []).append(entry)
             base_map[row["dedup_base"]] = base
+            stored_family.setdefault(row["dedup_base"], []).append(entry.row_id)
         base_maps[record_type] = base_map
 
         # Pass 2 (adjudicate): first-seen wins the key; anything landing on a taken one
@@ -1602,13 +1624,13 @@ def rekey(
             verdict = (None if resolver is None
                        else resolver.covering(record_type, entry.row, clash.row))
             if verdict is not None:
+                covered = ([int(verdict["record_id"])] if verdict["record_id"]
+                           else stored_family.get(verdict["dedup_base"], []))
                 resolution = _resolve_clash(
                     report, record_type, pk, entry, clash, kind, verdict,
-                    by_base[entry.base], seen, label, clash_label,
+                    by_base[entry.base], seen, label, clash_label, covered,
                 )
-                pending_rebases.append(
-                    (record_type, verdict, entry.base, resolution)
-                )
+                pending_narrowings.append((record_type, verdict, resolution))
                 continue
 
             if kind == "doubled":
@@ -1646,13 +1668,28 @@ def rekey(
             # first-seen row stays the incumbent for this key, so a third row on it
             # is reported against the same anchor instead of chaining.
 
+    # A resolved pair in a table that *also* holds an unresolved collision is withheld
+    # with the rest of that table (`writable()` is per-table, not per-row). The account
+    # has to say so: the adjudication message alone would describe a write that never
+    # happened.
+    blocked = set(report.blocked)
+    for resolution in report.resolved:
+        if resolution.record_type in blocked:
+            resolution.message += (
+                f" - withheld: {resolution.record_type} still holds an unresolved "
+                "collision, so nothing in this table was written"
+            )
+            # Recorded here, not in the write block: a fully blocked run has nothing
+            # writable and never enters it, and the account must still say why.
+            if apply:
+                resolution.verdict_action = "withheld"
+
     writable = report.writable()
     if apply and writable:
         # One transaction: a half-rekeyed table dedups inconsistently. Two passes,
         # because `UNIQUE(dedup_key)` is enforced per statement: if two rows swap keys
         # (or one takes a key another is about to vacate) a single-pass update trips
         # the index mid-flight. Park every moving row on a unique placeholder first.
-        blocked = set(report.blocked)
         with conn:
             for change in writable:
                 conn.execute(
@@ -1679,14 +1716,24 @@ def rekey(
                     values,
                 )
             # Same transaction as the keys they authorized: a committed rekey whose
-            # authorizing verdict was left orphaned is the failure this seam exists to
-            # avoid. Skipped for a blocked table, whose changes were withheld anyway.
-            for rec_type, verdict, new_base, resolution in pending_rebases:
-                if rec_type in blocked:
+            # authorizing verdict was left in the wrong shape is the failure this seam
+            # exists to avoid. Skipped for a blocked table, whose changes were withheld
+            # anyway - recorded as "withheld" so the account never implies otherwise.
+            # One verdict may settle several clashes at once (two occurrences of a
+            # judged family landing on two occurrences of the surviving one), so the
+            # narrowing is done once per verdict and reported on every resolution it
+            # authorized - narrowing twice would find its own first pass and no-op.
+            done: dict[tuple[str, str, int], tuple[str, list[int]]] = {}
+            for rec_type, verdict, resolution in pending_narrowings:
+                if rec_type in blocked:      # already recorded as "withheld" above
                     continue
-                resolution.verdict_action = resolver.rebase(
-                    conn, rec_type, verdict, new_base, base_maps[rec_type],
-                )
+                ident = (rec_type, verdict["dedup_base"], verdict["record_id"])
+                if ident not in done:
+                    done[ident] = resolver.narrow(
+                        conn, rec_type, verdict, resolution.covered_row_ids,
+                        base_maps[rec_type],
+                    )
+                resolution.verdict_action, resolution.narrowed_row_ids = done[ident]
     report.applied = apply
     return report
 
@@ -1703,6 +1750,7 @@ def _resolve_clash(
     seen: dict[str, _RekeyEntry],
     label: str,
     clash_label: str,
+    covered_row_ids: list[int],
 ) -> RekeyResolution:
     """File a verdict-settled clash as the next free occurrence of its family.
 
@@ -1725,11 +1773,13 @@ def _resolve_clash(
     seen[entry.key] = entry
 
     scope = "row" if verdict["record_id"] else "family"
+    # Present tense, not past: whether this actually lands depends on `apply` and on the
+    # rest of the table coming out clean, and the caller appends that verdict.
     message = (
         f"{record_type}: {pk} {entry.row_id} ({label!r}) and {pk} {clash.row_id} "
         f"({clash_label!r}) recompute to the same dedup_key ({kind}), but a "
         f"{scope}-scoped '{verdict['status']}' verdict already settles the pair - "
-        f"{pk} {entry.row_id} was filed as occurrence {occurrence} of "
+        f"{pk} {entry.row_id} takes occurrence {occurrence} of "
         f"{entry.base[:12]}..., the surviving family"
     )
     report.changes.append(RekeyChange(
@@ -1742,6 +1792,7 @@ def _resolve_clash(
         status=verdict["status"], scope=scope, record_id=verdict["record_id"],
         verdict_base=verdict["dedup_base"], new_base=entry.base,
         new_occurrence=occurrence, message=message,
+        covered_row_ids=sorted(covered_row_ids),
     )
     report.resolved.append(resolution)
     return resolution

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -165,7 +165,10 @@ def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
     (#116) announces itself: a family verdict that settles a `rekey` collision is pinned
     to exactly the rows it already covered - so the merged-in row it never judged keeps
     rendering in its own clinical section - and this is where the human is told to
-    re-affirm or re-rule. Re-annotating collapses the breadcrumb and the notice with it.
+    re-affirm or re-rule. Re-annotating collapses the breadcrumb and the notice with it -
+    including for `merged-into`, whose re-affirm names the row's own (post-rekey) family,
+    which :func:`curation.annotate_record` accepts at row scope precisely so this notice
+    can be answered without downgrading or lifting the ruling.
     """
     if not curation.has_table(conn):
         return

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -160,6 +160,11 @@ def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
     resolves by row id, so a rekey no longer orphans it - only the row's removal does.
     Its stored `dedup_base` is a breadcrumb that may legitimately be stale, so the family
     check is deliberately skipped for it.
+
+    One family-scoped verdict is likewise never orphaned by a rekey: the one that
+    *resolved* a rekey collision (#116) follows its family onto the surviving base in the
+    same transaction as the keys it authorized, so this check has nothing to say about
+    it. The general story above is unchanged for every other family verdict.
     """
     if not curation.has_table(conn):
         return

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -159,12 +159,13 @@ def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
     A **row-scoped** verdict (#114) is checked against its row, not its family: it
     resolves by row id, so a rekey no longer orphans it - only the row's removal does.
     Its stored `dedup_base` is a breadcrumb that may legitimately be stale, so the family
-    check is deliberately skipped for it.
-
-    One family-scoped verdict is likewise never orphaned by a rekey: the one that
-    *resolved* a rekey collision (#116) follows its family onto the surviving base in the
-    same transaction as the keys it authorized, so this check has nothing to say about
-    it. The general story above is unchanged for every other family verdict.
+    check is deliberately skipped for it - but a stale breadcrumb is *reported*, because
+    it means a rekey moved the row out of the family the human ruled in and the ruling
+    may want re-affirming. That notice is also how a collision-resolving **narrowing**
+    (#116) announces itself: a family verdict that settles a `rekey` collision is pinned
+    to exactly the rows it already covered - so the merged-in row it never judged keeps
+    rendering in its own clinical section - and this is where the human is told to
+    re-affirm or re-rule. Re-annotating collapses the breadcrumb and the notice with it.
     """
     if not curation.has_table(conn):
         return
@@ -183,12 +184,24 @@ def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
         if record_id:
             pk = f"{record_type}_id"
             live = conn.execute(
-                f"SELECT 1 FROM {record_type} WHERE {pk} = ?", (record_id,)
+                f"SELECT dedup_base FROM {record_type} WHERE {pk} = ?", (record_id,)
             ).fetchone()
             if live is None:
                 report.warnings.append(
                     f"curation verdict {record_type} row #{record_id} names no live "
                     "row (removed?) - lift it with `pemr record annotate --clear --row`"
+                )
+            elif live["dedup_base"] != base:
+                # The verdict still resolves (by row id), so this is a notice, not an
+                # orphan: a rekey moved the row into a different family than the one it
+                # was ruled in - including the narrowing that resolves a collision
+                # (#116), where the row joined a family it was never judged against.
+                report.warnings.append(
+                    f"curation verdict {record_type} row #{record_id} was recorded in "
+                    f"family {short}... but the row now sits in "
+                    f"{str(live['dedup_base'])[:12]}... - a rekey moved it; re-affirm "
+                    f"with `pemr record annotate --row {record_type} {record_id}` or "
+                    "lift it with `--clear --row`"
                 )
         elif not dedup.load_family(conn, record_type, base):
             report.warnings.append(

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -5,7 +5,7 @@ import zipfile
 
 import pytest
 
-from pemr import cli, db
+from pemr import cli, db, verify
 
 
 def _run(tmp_path, *argv):
@@ -480,6 +480,67 @@ def test_rekey_json_reports_collisions_and_skipped_tables(ready, capsys, tmp_pat
     assert [c["record_type"] for c in payload["changed"]] == ["lab_result", "condition"]
 
 
+# --- collisions a recorded verdict settles (issue #116) -----------------------
+
+def _row_ids(tmp_path, record_type):
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        return [int(r[0]) for r in conn.execute(
+            f"SELECT {record_type}_id FROM {record_type} ORDER BY {record_type}_id")]
+    finally:
+        conn.close()
+
+
+def test_rekey_reports_a_verdict_resolved_collision_in_text_and_json(
+    ready, capsys, tmp_path
+):
+    """AC6. A collision the operator already ruled on is a `note`, not an `error`: the
+    table writes, both output modes say which pair was settled and by what, and the exit
+    code is 0 because nothing is left for the operator to fix."""
+    old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
+    new = _dict_file(tmp_path, "fuse.toml",
+                     '"alb" = "albumin"\n"t2dm" = "type 2 diabetes"\n')
+    _seed_fusing_lab_and_movable_condition(ready, capsys, tmp_path, old)
+    alb_id, albumin_id = _row_ids(tmp_path, "lab_result")
+    assert _run(tmp_path, "record", "annotate", "lab_result", str(alb_id),
+                "--status", "superseded", "--note", "one assay, two labels",
+                "--apply") == 0
+    capsys.readouterr()
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["collisions"] == [] and payload["skipped"] == []
+    assert [(r["row_id"], r["clash_row_id"], r["kind"], r["status"], r["scope"],
+             r["new_occurrence"]) for r in payload["resolved"]] == [
+        (albumin_id, alb_id, "fused", "superseded", "family", 1)]
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "lab_result: 2/2 key(s) change" in captured.out
+    assert "(skipped: collision)" not in captured.out
+    assert "note: lab_result: lab_result_id" in captured.out
+    assert "family-scoped 'superseded' verdict already settles the pair" in captured.out
+    assert "1 collision(s) resolved by verdict" in captured.out
+    assert "rekeyed 3 row(s)" in captured.out
+    assert captured.out.isascii()               # issue #23
+
+
+def test_rekey_json_still_reports_a_blocking_collision(ready, capsys, tmp_path):
+    """The same seed with no verdict recorded: `resolved` is empty, the table is still
+    skipped by name and the exit code is still 1 (the #92 contract, unwidened)."""
+    old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
+    new = _dict_file(tmp_path, "fuse.toml",
+                     '"alb" = "albumin"\n"t2dm" = "type 2 diabetes"\n')
+    _seed_fusing_lab_and_movable_condition(ready, capsys, tmp_path, old)
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--json") == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["resolved"] == []
+    assert payload["skipped"] == ["lab_result"]
+    assert [c["kind"] for c in payload["collisions"]] == ["fused"]
+
+
 # --- intake formats at the CLI (issue #66) ------------------------------------
 
 def test_ingest_refuses_a_google_drive_pointer_stub(ready, capsys):
@@ -682,6 +743,82 @@ def test_migrated_006_rows_rekey_per_table_when_one_table_collides(tmp_path, cap
                     if r["dedup_key"] in ("c1", "c2")]
     finally:
         conn.close()
+
+
+def _stage_006_allergy_collision(tmp_path, capsys):
+    """The real-world #116 trigger: a pre-006 database whose carried-forward
+    per-document allergy keys collide onto one dictionary-derived key after 006, with
+    conditions alongside that merely move. Returns the two allergy row ids."""
+    staged = _stage_pre_006(tmp_path)
+    assert _run(tmp_path, "migrate", "--create", "--migrations-dir", str(staged)) == 0
+    conn = db.connect(tmp_path / "cli.db")
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane-doe', 'Jane')")
+    for i, (sub, reaction) in enumerate((("PCN", "rash"),
+                                         ("Penicillin", "anaphylaxis")), start=1):
+        conn.execute(
+            "INSERT INTO observation (person_id, obs_type, key, value_text, dedup_key,"
+            " dedup_base) VALUES (1, 'allergy', ?, ?, ?, ?)",
+            (sub, reaction, f"a{i}", f"a{i}"))
+    for i, name in enumerate(("T2DM", "HTN"), start=1):
+        conn.execute(
+            "INSERT INTO observation (person_id, obs_type, key, dedup_key, dedup_base)"
+            " VALUES (1, 'condition', ?, ?, ?)", (name, f"c{i}", f"c{i}"))
+    conn.commit()
+    conn.close()
+    assert _run(tmp_path, "migrate") == 0
+    capsys.readouterr()
+    return _row_ids(tmp_path, "allergy")
+
+
+def test_migration_006_allergy_collision_clears_when_a_verdict_covers_it(
+    tmp_path, capsys
+):
+    """AC7, the case the issue was filed from: the 006 backfill parks the allergy table
+    on its old keys, and the operator has already ruled the colliding pair one allergy.
+    That verdict answers the collision, so the table finally rekeys and rc drops to 0."""
+    pcn_id, penicillin_id = _stage_006_allergy_collision(tmp_path, capsys)
+    assert _run(tmp_path, "record", "annotate", "allergy", str(pcn_id),
+                "--status", "merged-into", "--merged-into", str(penicillin_id),
+                "--note", "one allergy, two spellings", "--apply") == 0
+    capsys.readouterr()
+
+    new = _dict_file(tmp_path, "fuse006.toml",
+                     '"pcn" = "penicillin"\n"t2dm" = "type 2 diabetes"\n')
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "allergy: 2/2 key(s) change" in captured.out
+    assert "(skipped: collision)" not in captured.out
+    assert "1 collision(s) resolved by verdict" in captured.out
+    assert "rekeyed 4 row(s)" in captured.out
+
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        rows = {int(r["allergy_id"]): r
+                for r in conn.execute("SELECT * FROM allergy")}
+        # The carried-forward keys are gone from both rows, and the pair is one family.
+        assert not {r["dedup_key"] for r in rows.values()} & {"a1", "a2"}
+        assert rows[pcn_id]["dedup_base"] == rows[penicillin_id]["dedup_base"]
+        assert (rows[pcn_id]["dedup_occurrence"],
+                rows[penicillin_id]["dedup_occurrence"]) == (0, 1)
+        assert verify.verify_report(conn).warnings == []
+    finally:
+        conn.close()
+    # Idempotent: the follow-up run has nothing left to do.
+    assert _run(tmp_path, "rekey", "--dictionary", str(new)) == 0
+    assert "all dedup keys already match" in capsys.readouterr().out
+
+
+def test_migrated_006_collision_still_blocks_without_a_verdict(tmp_path, capsys):
+    """The same staging with no verdict recorded is the unchanged #92 behaviour — the
+    regression guard for the AC7 case above."""
+    _stage_006_allergy_collision(tmp_path, capsys)
+    new = _dict_file(tmp_path, "fuse006.toml",
+                     '"pcn" = "penicillin"\n"t2dm" = "type 2 diabetes"\n')
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 1
+    captured = capsys.readouterr()
+    assert "allergy: 1/2 key(s) change (skipped: collision)" in captured.out
+    assert "left 1 table(s) on their stored keys: allergy" in captured.err
 
 
 def test_post_006_stale_key_blocks_the_recommit_instead_of_forking_it(tmp_path, capsys):

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -5,7 +5,7 @@ import zipfile
 
 import pytest
 
-from pemr import cli, db, verify
+from pemr import cli, db, render, verify
 
 
 def _run(tmp_path, *argv):
@@ -775,12 +775,24 @@ def test_migration_006_allergy_collision_clears_when_a_verdict_covers_it(
 ):
     """AC7, the case the issue was filed from: the 006 backfill parks the allergy table
     on its old keys, and the operator has already ruled the colliding pair one allergy.
-    That verdict answers the collision, so the table finally rekeys and rc drops to 0."""
+    That verdict answers the collision, so the table finally rekeys and rc drops to 0.
+
+    And the ruling keeps exactly the extension it had: `Penicillin` was never judged, so
+    running a maintenance command must not take a live, high-criticality allergy out of
+    the Allergies section (the regression this issue was re-decided over)."""
     pcn_id, penicillin_id = _stage_006_allergy_collision(tmp_path, capsys)
     assert _run(tmp_path, "record", "annotate", "allergy", str(pcn_id),
                 "--status", "merged-into", "--merged-into", str(penicillin_id),
                 "--note", "one allergy, two spellings", "--apply") == 0
     capsys.readouterr()
+
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        before = render.render_summary(conn, "jane-doe")
+    finally:
+        conn.close()
+    assert "- Penicillin - anaphylaxis" in before
+    assert "allergy: PCN" in before.split("## Superseded / corrected")[1]
 
     new = _dict_file(tmp_path, "fuse006.toml",
                      '"pcn" = "penicillin"\n"t2dm" = "type 2 diabetes"\n')
@@ -790,6 +802,7 @@ def test_migration_006_allergy_collision_clears_when_a_verdict_covers_it(
     assert "allergy: 2/2 key(s) change" in captured.out
     assert "(skipped: collision)" not in captured.out
     assert "1 collision(s) resolved by verdict" in captured.out
+    assert "was narrowed to row scope on allergy row 1" in captured.out
     assert "rekeyed 4 row(s)" in captured.out
 
     conn = db.connect(tmp_path / "cli.db")
@@ -801,7 +814,14 @@ def test_migration_006_allergy_collision_clears_when_a_verdict_covers_it(
         assert rows[pcn_id]["dedup_base"] == rows[penicillin_id]["dedup_base"]
         assert (rows[pcn_id]["dedup_occurrence"],
                 rows[penicillin_id]["dedup_occurrence"]) == (0, 1)
-        assert verify.verify_report(conn).warnings == []
+        # The verdict still covers PCN and only PCN: Penicillin stays where it was.
+        after = render.render_summary(conn, "jane-doe")
+        assert "- Penicillin - anaphylaxis" in after
+        assert "allergy: PCN" in after.split("## Superseded / corrected")[1]
+        # Nothing orphaned; the narrowing surfaces as a re-affirm notice instead.
+        warnings = verify.verify_report(conn).warnings
+        assert not any("no live family" in w for w in warnings)
+        assert [w for w in warnings if "a rekey moved it" in w]
     finally:
         conn.close()
     # Idempotent: the follow-up run has nothing left to do.

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -5,7 +5,7 @@ import zipfile
 
 import pytest
 
-from pemr import cli, db, render, verify
+from pemr import cli, curation, db, render, verify
 
 
 def _run(tmp_path, *argv):
@@ -827,6 +827,52 @@ def test_migration_006_allergy_collision_clears_when_a_verdict_covers_it(
     # Idempotent: the follow-up run has nothing left to do.
     assert _run(tmp_path, "rekey", "--dictionary", str(new)) == 0
     assert "all dedup keys already match" in capsys.readouterr().out
+
+
+def test_the_re_affirm_notice_from_a_narrowing_is_runnable(tmp_path, capsys):
+    """The narrowing is announced so the human can re-affirm or re-rule (#116's ruling) —
+    which is only true if the command the notice names actually runs. For `merged-into`,
+    the dominant real-world shape, the same rekey has already moved the ruled row into
+    its merge target, so the re-affirm names the row's own family by necessity.
+
+    Continues the AC7 scenario above through that follow-up: rc 0, the notice clears, and
+    the ruling keeps its status, its merge pointer and its extension."""
+    pcn_id, penicillin_id = _stage_006_allergy_collision(tmp_path, capsys)
+    assert _run(tmp_path, "record", "annotate", "allergy", str(pcn_id),
+                "--status", "merged-into", "--merged-into", str(penicillin_id),
+                "--note", "one allergy, two spellings", "--apply") == 0
+    new = _dict_file(tmp_path, "fuse006.toml",
+                     '"pcn" = "penicillin"\n"t2dm" = "type 2 diabetes"\n')
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 0
+    capsys.readouterr()
+
+    # The notice's own instruction, run as the operator would: same row, same ruling.
+    assert _run(tmp_path, "record", "annotate", "allergy", str(pcn_id), "--row",
+                "--status", "merged-into", "--merged-into", str(penicillin_id),
+                "--note", "re-affirmed after the rekey", "--apply") == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert f"annotated allergy row #{pcn_id}" in captured.out
+
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        verdict = curation.get_verdict(conn, "allergy", "", record_id=pcn_id)
+        assert verdict["status"] == "merged-into"
+        assert verdict["note"] == "re-affirmed after the rekey"
+        live = conn.execute(
+            "SELECT dedup_base FROM allergy WHERE allergy_id = ?", (pcn_id,)
+        ).fetchone()["dedup_base"]
+        assert verdict["merged_into_base"] == live
+        assert verdict["dedup_base"] == live          # breadcrumb collapsed
+        warnings = verify.verify_report(conn).warnings
+        assert not any("a rekey moved it" in w or "no live family" in w
+                       for w in warnings)
+        # Extension unchanged: PCN in the appendix, Penicillin still live.
+        after = render.render_summary(conn, "jane-doe")
+        assert "- Penicillin - anaphylaxis" in after
+        assert "allergy: PCN" in after.split("## Superseded / corrected")[1]
+    finally:
+        conn.close()
 
 
 def test_migrated_006_collision_still_blocks_without_a_verdict(tmp_path, capsys):

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -650,12 +650,13 @@ def test_resolving_statuses_are_only_merged_into_and_superseded():
     assert set(curation.RESOLVING_STATUSES) <= set(curation.STATUSES)
 
 
-def test_a_resolving_verdict_follows_its_family_onto_the_surviving_base(seeded):
-    """AC5. The verdict that authorized the rekey is re-pointed at the family that
-    survived it — by UPDATE, so the human's words and timestamp survive verbatim — and
-    `pemr verify` has nothing new to warn about."""
+def test_a_resolving_family_verdict_is_narrowed_to_the_rows_it_covered(seeded):
+    """AC5, as re-decided: the verdict that authorized the rekey is pinned to exactly the
+    rows it already covered — by UPDATE, so the human's words and timestamp survive
+    verbatim — instead of following its family onto the (larger) surviving base. Nothing
+    is orphaned, and the row it never judged is left unruled."""
     conn = seeded["conn"]
-    _fusing_ids(conn)
+    hba1c_id, glucose_id = _fusing_ids(conn)
     glucose_base = _base(conn, "lab_result", "test_name", "Glucose")
     hba1c_base = _base(conn, "lab_result", "test_name", "HbA1c")
     curation.annotate_record(conn, "lab_result", glucose_base, status="superseded",
@@ -665,22 +666,33 @@ def test_a_resolving_verdict_follows_its_family_onto_the_surviving_base(seeded):
     report = dedup.rekey(conn, {"glucose": "hba1c"}, apply=True,
                          resolver=curation.collision_resolver(conn))
 
-    assert [r.verdict_action for r in report.resolved] == ["rebased"]
-    assert _curation_count(conn) == 1               # moved, not copied
-    moved = curation.get_verdict(conn, "lab_result", hba1c_base)
-    assert (moved["status"], moved["note"], moved["attributed_to"],
-            moved["created_at"]) == ("superseded", "restated as the A1c", "Dr Who",
-                                     "2026-01-01T00:00:00+00:00")
+    assert [r.verdict_action for r in report.resolved] == ["narrowed"]
+    assert [r.narrowed_row_ids for r in report.resolved] == [[glucose_id]]
+    assert [r.covered_row_ids for r in report.resolved] == [[glucose_id]]
+    assert _curation_count(conn) == 1               # narrowed, not copied
+    pinned = curation.get_verdict(conn, "lab_result", "", record_id=glucose_id)
+    assert (pinned["status"], pinned["note"], pinned["attributed_to"],
+            pinned["created_at"]) == ("superseded", "restated as the A1c", "Dr Who",
+                                      "2026-01-01T00:00:00+00:00")
+    assert pinned["scope"] == "row"
+    # No family verdict anywhere: not on the dead base, not on the surviving one.
     assert curation.get_verdict(conn, "lab_result", glucose_base) is None
-    assert verify.verify_report(conn).warnings == []
+    assert curation.get_verdict(conn, "lab_result", hba1c_base) is None
+    # ... so the row that was never judged carries no verdict at all.
+    assert curation.load_verdicts(conn).for_row(
+        "lab_result", hba1c_base, hba1c_id) is None
+    # Nothing orphaned; the narrowing announces itself as a re-affirm notice instead.
+    warnings = verify.verify_report(conn).warnings
+    assert not any("has no live family" in w for w in warnings)
+    assert [w for w in warnings if "a rekey moved it" in w]
 
 
-def test_an_existing_verdict_on_the_surviving_family_is_not_overwritten(seeded):
-    """Never destroy a human ruling: if the surviving base already carries one, the
-    incumbent wins and the moved-off verdict is left exactly where it is — reported, not
-    touched, and never auto-cleared."""
+def test_a_verdict_on_the_surviving_family_is_untouched_by_the_narrowing(seeded):
+    """Never destroy a human ruling: the incumbent on the surviving base is not
+    rewritten or cleared — narrowing writes only the resolver, row-scoped, and row scope
+    is what keeps the incumbent off those rows."""
     conn = seeded["conn"]
-    _fusing_ids(conn)
+    _hba1c_id, glucose_id = _fusing_ids(conn)
     glucose_base = _base(conn, "lab_result", "test_name", "Glucose")
     hba1c_base = _base(conn, "lab_result", "test_name", "HbA1c")
     curation.annotate_record(conn, "lab_result", hba1c_base, status="confirmed",
@@ -693,22 +705,25 @@ def test_an_existing_verdict_on_the_surviving_family_is_not_overwritten(seeded):
     report = dedup.rekey(conn, {"glucose": "hba1c"}, apply=True,
                          resolver=curation.collision_resolver(conn))
 
-    assert [r.verdict_action for r in report.resolved] == ["kept"]
-    assert _curation_count(conn) == 2               # nothing deleted, nothing rewritten
+    assert [r.verdict_action for r in report.resolved] == ["narrowed"]
+    assert _curation_count(conn) == 2               # nothing deleted, nothing added
     incumbent = curation.get_verdict(conn, "lab_result", hba1c_base)
     assert (incumbent["status"], incumbent["note"], incumbent["created_at"]) == \
         ("confirmed", "incumbent", "2026-01-01T00:00:00+00:00")
-    assert curation.get_verdict(
-        conn, "lab_result", glucose_base)["note"] == "the resolver"
-    # Left behind on a dead base, it is the ordinary orphan `verify` already warns about.
-    assert any("has no live family" in w for w in verify.verify_report(conn).warnings)
+    resolver_verdict = curation.get_verdict(
+        conn, "lab_result", "", record_id=glucose_id)
+    assert resolver_verdict["note"] == "the resolver"
+    # Precedence, not deletion, keeps the incumbent off the row the resolver ruled on.
+    assert curation.load_verdicts(conn).for_row(
+        "lab_result", hba1c_base, glucose_id)["note"] == "the resolver"
 
 
 def test_a_resolved_merge_verdict_follows_a_target_family_that_also_moved(seeded):
-    """A merge pointer is re-pointed too, through the same run's base map: the target
-    family moved under this very dictionary edit, and leaving the pointer behind would
-    trade one `verify` warning for another."""
+    """A merge pointer is re-pointed onto the narrowed verdict, through the same run's
+    base map: the target family moved under this very dictionary edit, and carrying the
+    dead pointer over would trade one `verify` warning for another."""
     conn = seeded["conn"]
+    _hba1c_id, glucose_id = _fusing_ids(conn)
     doc2 = _insert_document(conn, seeded["jane"].person_id, "cc33dd44ee55ff66")
     dedup.commit_extraction(conn, doc2, {"lab_result": [
         {"test_name": "ZZT", "collected_at": "2026-01-02", "value_num": 108}]})
@@ -721,28 +736,27 @@ def test_a_resolved_merge_verdict_follows_a_target_family_that_also_moved(seeded
     report = dedup.rekey(conn, {"glucose": "hba1c", "zzt": "zonulin"}, apply=True,
                          resolver=curation.collision_resolver(conn))
 
-    assert [r.verdict_action for r in report.resolved] == ["rebased"]
+    assert [r.verdict_action for r in report.resolved] == ["narrowed"]
     new_zzt = _base(conn, "lab_result", "test_name", "ZZT")
     assert new_zzt != zzt_base                       # the target moved in this same run
-    moved = curation.get_verdict(
-        conn, "lab_result", _base(conn, "lab_result", "test_name", "HbA1c"))
-    assert moved["merged_into_base"] == new_zzt
-    assert verify.verify_report(conn).warnings == []
+    pinned = curation.get_verdict(conn, "lab_result", "", record_id=glucose_id)
+    assert pinned["merged_into_base"] == new_zzt
+    assert not any("no live family" in w
+                   for w in verify.verify_report(conn).warnings)
 
 
 def test_a_merge_verdict_whose_target_is_the_surviving_family_completes_the_merge(
     seeded
 ):
     """The common shape of the real trigger: the pair is merged into *each other*, so
-    after the rekey the verdict's base and its merge target are the same family.
+    after the rekey the narrowed verdict's row sits in the very family it merges into.
 
-    `annotate_record` refuses a self-merge typed by a human (the family would render
-    nowhere), but reaching it this way is the merge having actually completed — both
-    rows are one family now. Nothing consumes `merged_into_base` for placement
-    (`APPENDIX_STATUSES` does that), `verify` sees a live target, and the alternative —
-    leaving the pointer on the dead base — is the orphan warning AC5 forbids."""
+    That is the merge having actually completed. Nothing consumes `merged_into_base` for
+    placement (`APPENDIX_STATUSES` does that), `verify` sees a live target, and the
+    alternative — leaving the pointer on the dead base — is the orphan warning AC5
+    forbids."""
     conn = seeded["conn"]
-    _fusing_ids(conn)
+    _hba1c_id, glucose_id = _fusing_ids(conn)
     glucose_base = _base(conn, "lab_result", "test_name", "Glucose")
     hba1c_base = _base(conn, "lab_result", "test_name", "HbA1c")
     curation.annotate_record(conn, "lab_result", glucose_base, status="merged-into",
@@ -752,15 +766,18 @@ def test_a_merge_verdict_whose_target_is_the_surviving_family_completes_the_merg
     report = dedup.rekey(conn, {"glucose": "hba1c"}, apply=True,
                          resolver=curation.collision_resolver(conn))
 
-    assert [r.verdict_action for r in report.resolved] == ["rebased"]
-    moved = curation.get_verdict(conn, "lab_result", hba1c_base)
-    assert moved["dedup_base"] == moved["merged_into_base"] == hba1c_base
-    assert verify.verify_report(conn).warnings == []
+    assert [r.verdict_action for r in report.resolved] == ["narrowed"]
+    pinned = curation.get_verdict(conn, "lab_result", "", record_id=glucose_id)
+    assert pinned["merged_into_base"] == hba1c_base
+    assert _base(conn, "lab_result", "test_name", "Glucose") == hba1c_base
+    assert not any("no live family" in w
+                   for w in verify.verify_report(conn).warnings)
 
 
-def test_a_row_scoped_verdict_needs_no_rebase(seeded):
-    """Row scope resolves by row id, which `rekey` never renumbers, so there is nothing
-    to move — and its stored base stays the deliberately stale breadcrumb 010 describes."""
+def test_a_row_scoped_verdict_needs_no_narrowing(seeded):
+    """Row scope resolves by row id, which `rekey` never renumbers, and it already names
+    exactly one row — so there is nothing to narrow, and its stored base stays the
+    deliberately stale breadcrumb 010 describes."""
     conn = seeded["conn"]
     _hba1c_id, glucose_id = _fusing_ids(conn)
     glucose_base = _base(conn, "lab_result", "test_name", "Glucose")
@@ -771,13 +788,15 @@ def test_a_row_scoped_verdict_needs_no_rebase(seeded):
                          resolver=curation.collision_resolver(conn))
 
     assert [r.verdict_action for r in report.resolved] == ["unchanged"]
+    assert [r.narrowed_row_ids for r in report.resolved] == [[]]
     live = curation.get_verdict(conn, "lab_result", "", record_id=glucose_id)
     assert live["dedup_base"] == glucose_base
     new_base = _base(conn, "lab_result", "test_name", "Glucose")
     assert new_base != glucose_base
     assert curation.load_verdicts(conn).for_row(
         "lab_result", new_base, glucose_id)["status"] == "superseded"
-    assert verify.verify_report(conn).warnings == []
+    assert not any("no live family" in w
+                   for w in verify.verify_report(conn).warnings)
 
 
 def test_a_row_verdict_shadows_its_familys_resolving_verdict(seeded):

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -632,6 +632,173 @@ def test_re_annotating_a_row_after_a_rekey_collapses_the_stale_breadcrumb(seeded
     assert live["dedup_base"] == new_base and live["note"] == "after"
 
 
+# --- the rekey collision seam (issue #116) -----------------------------------
+
+def _fusing_ids(conn):
+    """``(HbA1c id, Glucose id)`` — the pair `{"glucose": "hba1c"}` fuses.
+
+    `rekey` scans by primary key, so HbA1c is the incumbent that keeps occurrence 0 and
+    Glucose is the clash a verdict has to settle."""
+    return (_row_id(conn, "lab_result", "test_name", "HbA1c"),
+            _row_id(conn, "lab_result", "test_name", "Glucose"))
+
+
+def test_resolving_statuses_are_only_merged_into_and_superseded():
+    """The constant guard. `confirmed`/`disputed`/`erroneous-in-source` rule on a row's
+    content; only these two say two rows are one fact, which is what a collision asks."""
+    assert curation.RESOLVING_STATUSES == ("merged-into", "superseded")
+    assert set(curation.RESOLVING_STATUSES) <= set(curation.STATUSES)
+
+
+def test_a_resolving_verdict_follows_its_family_onto_the_surviving_base(seeded):
+    """AC5. The verdict that authorized the rekey is re-pointed at the family that
+    survived it — by UPDATE, so the human's words and timestamp survive verbatim — and
+    `pemr verify` has nothing new to warn about."""
+    conn = seeded["conn"]
+    _fusing_ids(conn)
+    glucose_base = _base(conn, "lab_result", "test_name", "Glucose")
+    hba1c_base = _base(conn, "lab_result", "test_name", "HbA1c")
+    curation.annotate_record(conn, "lab_result", glucose_base, status="superseded",
+                            note="restated as the A1c", attributed_to="Dr Who",
+                            now="2026-01-01T00:00:00+00:00", apply=True)
+
+    report = dedup.rekey(conn, {"glucose": "hba1c"}, apply=True,
+                         resolver=curation.collision_resolver(conn))
+
+    assert [r.verdict_action for r in report.resolved] == ["rebased"]
+    assert _curation_count(conn) == 1               # moved, not copied
+    moved = curation.get_verdict(conn, "lab_result", hba1c_base)
+    assert (moved["status"], moved["note"], moved["attributed_to"],
+            moved["created_at"]) == ("superseded", "restated as the A1c", "Dr Who",
+                                     "2026-01-01T00:00:00+00:00")
+    assert curation.get_verdict(conn, "lab_result", glucose_base) is None
+    assert verify.verify_report(conn).warnings == []
+
+
+def test_an_existing_verdict_on_the_surviving_family_is_not_overwritten(seeded):
+    """Never destroy a human ruling: if the surviving base already carries one, the
+    incumbent wins and the moved-off verdict is left exactly where it is — reported, not
+    touched, and never auto-cleared."""
+    conn = seeded["conn"]
+    _fusing_ids(conn)
+    glucose_base = _base(conn, "lab_result", "test_name", "Glucose")
+    hba1c_base = _base(conn, "lab_result", "test_name", "HbA1c")
+    curation.annotate_record(conn, "lab_result", hba1c_base, status="confirmed",
+                            note="incumbent", now="2026-01-01T00:00:00+00:00",
+                            apply=True)
+    curation.annotate_record(conn, "lab_result", glucose_base, status="superseded",
+                            note="the resolver", now="2026-02-01T00:00:00+00:00",
+                            apply=True)
+
+    report = dedup.rekey(conn, {"glucose": "hba1c"}, apply=True,
+                         resolver=curation.collision_resolver(conn))
+
+    assert [r.verdict_action for r in report.resolved] == ["kept"]
+    assert _curation_count(conn) == 2               # nothing deleted, nothing rewritten
+    incumbent = curation.get_verdict(conn, "lab_result", hba1c_base)
+    assert (incumbent["status"], incumbent["note"], incumbent["created_at"]) == \
+        ("confirmed", "incumbent", "2026-01-01T00:00:00+00:00")
+    assert curation.get_verdict(
+        conn, "lab_result", glucose_base)["note"] == "the resolver"
+    # Left behind on a dead base, it is the ordinary orphan `verify` already warns about.
+    assert any("has no live family" in w for w in verify.verify_report(conn).warnings)
+
+
+def test_a_resolved_merge_verdict_follows_a_target_family_that_also_moved(seeded):
+    """A merge pointer is re-pointed too, through the same run's base map: the target
+    family moved under this very dictionary edit, and leaving the pointer behind would
+    trade one `verify` warning for another."""
+    conn = seeded["conn"]
+    doc2 = _insert_document(conn, seeded["jane"].person_id, "cc33dd44ee55ff66")
+    dedup.commit_extraction(conn, doc2, {"lab_result": [
+        {"test_name": "ZZT", "collected_at": "2026-01-02", "value_num": 108}]})
+    glucose_base = _base(conn, "lab_result", "test_name", "Glucose")
+    zzt_base = _base(conn, "lab_result", "test_name", "ZZT")
+    curation.annotate_record(conn, "lab_result", glucose_base, status="merged-into",
+                            note="filed under the zonulin panel",
+                            merged_into_base=zzt_base, apply=True)
+
+    report = dedup.rekey(conn, {"glucose": "hba1c", "zzt": "zonulin"}, apply=True,
+                         resolver=curation.collision_resolver(conn))
+
+    assert [r.verdict_action for r in report.resolved] == ["rebased"]
+    new_zzt = _base(conn, "lab_result", "test_name", "ZZT")
+    assert new_zzt != zzt_base                       # the target moved in this same run
+    moved = curation.get_verdict(
+        conn, "lab_result", _base(conn, "lab_result", "test_name", "HbA1c"))
+    assert moved["merged_into_base"] == new_zzt
+    assert verify.verify_report(conn).warnings == []
+
+
+def test_a_merge_verdict_whose_target_is_the_surviving_family_completes_the_merge(
+    seeded
+):
+    """The common shape of the real trigger: the pair is merged into *each other*, so
+    after the rekey the verdict's base and its merge target are the same family.
+
+    `annotate_record` refuses a self-merge typed by a human (the family would render
+    nowhere), but reaching it this way is the merge having actually completed — both
+    rows are one family now. Nothing consumes `merged_into_base` for placement
+    (`APPENDIX_STATUSES` does that), `verify` sees a live target, and the alternative —
+    leaving the pointer on the dead base — is the orphan warning AC5 forbids."""
+    conn = seeded["conn"]
+    _fusing_ids(conn)
+    glucose_base = _base(conn, "lab_result", "test_name", "Glucose")
+    hba1c_base = _base(conn, "lab_result", "test_name", "HbA1c")
+    curation.annotate_record(conn, "lab_result", glucose_base, status="merged-into",
+                            note="the same draw, restated", merged_into_base=hba1c_base,
+                            apply=True)
+
+    report = dedup.rekey(conn, {"glucose": "hba1c"}, apply=True,
+                         resolver=curation.collision_resolver(conn))
+
+    assert [r.verdict_action for r in report.resolved] == ["rebased"]
+    moved = curation.get_verdict(conn, "lab_result", hba1c_base)
+    assert moved["dedup_base"] == moved["merged_into_base"] == hba1c_base
+    assert verify.verify_report(conn).warnings == []
+
+
+def test_a_row_scoped_verdict_needs_no_rebase(seeded):
+    """Row scope resolves by row id, which `rekey` never renumbers, so there is nothing
+    to move — and its stored base stays the deliberately stale breadcrumb 010 describes."""
+    conn = seeded["conn"]
+    _hba1c_id, glucose_id = _fusing_ids(conn)
+    glucose_base = _base(conn, "lab_result", "test_name", "Glucose")
+    curation.annotate_record(conn, "lab_result", str(glucose_id), status="superseded",
+                            note="this occurrence only", row=True, apply=True)
+
+    report = dedup.rekey(conn, {"glucose": "hba1c"}, apply=True,
+                         resolver=curation.collision_resolver(conn))
+
+    assert [r.verdict_action for r in report.resolved] == ["unchanged"]
+    live = curation.get_verdict(conn, "lab_result", "", record_id=glucose_id)
+    assert live["dedup_base"] == glucose_base
+    new_base = _base(conn, "lab_result", "test_name", "Glucose")
+    assert new_base != glucose_base
+    assert curation.load_verdicts(conn).for_row(
+        "lab_result", new_base, glucose_id)["status"] == "superseded"
+    assert verify.verify_report(conn).warnings == []
+
+
+def test_a_row_verdict_shadows_its_familys_resolving_verdict(seeded):
+    """`covering` resolves through :meth:`VerdictMap.for_row` rather than adding a second
+    precedence site: a row-scoped non-resolving verdict shadows the resolving family
+    verdict on the same row, so the collision still blocks."""
+    conn = seeded["conn"]
+    _hba1c_id, glucose_id = _fusing_ids(conn)
+    glucose_base = _base(conn, "lab_result", "test_name", "Glucose")
+    curation.annotate_record(conn, "lab_result", glucose_base, status="superseded",
+                            note="the family is settled", apply=True)
+    curation.annotate_record(conn, "lab_result", str(glucose_id), status="disputed",
+                            note="but not this row", row=True, apply=True)
+
+    report = dedup.rekey(conn, {"glucose": "hba1c"}, apply=True,
+                         resolver=curation.collision_resolver(conn))
+
+    assert report.resolved == []
+    assert [c.kind for c in report.collisions] == ["fused"]
+
+
 # --- verify integration ------------------------------------------------------
 
 

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -774,6 +774,84 @@ def test_a_merge_verdict_whose_target_is_the_surviving_family_completes_the_merg
                    for w in verify.verify_report(conn).warnings)
 
 
+def test_the_re_affirm_notice_can_be_followed_for_a_narrowed_merge_verdict(seeded):
+    """The narrowing is only "loud" if the human can act on what it says. `verify` tells
+    them to re-affirm the moved row verdict; for `merged-into` the same rekey has already
+    put that row *into* its merge target, so the re-affirm has no third family to name.
+    Row scope must therefore accept the row's own live family as the target — otherwise
+    the notice is permanent and the only exits are downgrading or lifting a human
+    ruling, which the #116 ruling forbids."""
+    conn = seeded["conn"]
+    hba1c_id, glucose_id = _fusing_ids(conn)
+    glucose_base = _base(conn, "lab_result", "test_name", "Glucose")
+    hba1c_base = _base(conn, "lab_result", "test_name", "HbA1c")
+    curation.annotate_record(conn, "lab_result", glucose_base, status="merged-into",
+                             note="the same draw, restated", merged_into_base=hba1c_base,
+                             apply=True)
+    dedup.rekey(conn, {"glucose": "hba1c"}, apply=True,
+                resolver=curation.collision_resolver(conn))
+    surviving = _base(conn, "lab_result", "test_name", "Glucose")
+    assert [w for w in verify.verify_report(conn).warnings if "a rekey moved it" in w]
+
+    # The literal follow-up the notice asks for: re-affirm this row, same ruling.
+    report = curation.annotate_record(
+        conn, "lab_result", str(glucose_id), status="merged-into",
+        note="re-affirmed after the rekey", merged_into_base=surviving,
+        row=True, apply=True,
+    )
+
+    assert (report.scope, report.record_id) == ("row", glucose_id)
+    assert report.merged_into_base == surviving
+    live = curation.get_verdict(conn, "lab_result", "", record_id=glucose_id)
+    assert live["dedup_base"] == surviving          # breadcrumb collapsed
+    assert live["note"] == "re-affirmed after the rekey"
+    assert _curation_count(conn) == 1               # re-affirmed, not duplicated
+    # ... and the notice it was meant to clear is gone, with no orphan taking its place.
+    warnings = verify.verify_report(conn).warnings
+    assert not any("a rekey moved it" in w or "no live family" in w for w in warnings)
+    # The row never judged is still unruled and still live in its own section.
+    assert curation.load_verdicts(conn).for_row(
+        "lab_result", surviving, hba1c_id) is None
+
+
+def test_a_family_verdict_still_cannot_merge_into_its_own_family(seeded):
+    """The relaxation above is row-scoped only. At family scope a self-merge still hides
+    the fact entirely — there is no sibling left to render it — so it stays refused."""
+    conn = seeded["conn"]
+    glucose_base = _base(conn, "lab_result", "test_name", "Glucose")
+    with pytest.raises(ValueError, match="into itself"):
+        curation.annotate_record(
+            conn, "lab_result", glucose_base, status="merged-into",
+            note="x", merged_into_base=glucose_base, apply=True,
+        )
+    assert _curation_count(conn) == 0
+
+
+def test_a_row_verdict_may_be_merged_into_a_sibling_row_id(seeded):
+    """`--merged-into` takes BASE-OR-ID, and after a narrowing the only sibling an
+    operator can see is a row id of the same surviving family. That resolves to the row's
+    own base, i.e. the case above, and must be accepted by the same rule."""
+    conn = seeded["conn"]
+    hba1c_id, glucose_id = _fusing_ids(conn)
+    glucose_base = _base(conn, "lab_result", "test_name", "Glucose")
+    hba1c_base = _base(conn, "lab_result", "test_name", "HbA1c")
+    curation.annotate_record(conn, "lab_result", glucose_base, status="merged-into",
+                             note="the same draw, restated", merged_into_base=hba1c_base,
+                             apply=True)
+    dedup.rekey(conn, {"glucose": "hba1c"}, apply=True,
+                resolver=curation.collision_resolver(conn))
+
+    report = curation.annotate_record(
+        conn, "lab_result", str(glucose_id), status="merged-into",
+        note="absorbed by the sibling", merged_into_base=str(hba1c_id),
+        row=True, apply=True,
+    )
+
+    assert report.merged_into_base == _base(conn, "lab_result", "test_name", "HbA1c")
+    assert not any("no live family" in w
+                   for w in verify.verify_report(conn).warnings)
+
+
 def test_a_row_scoped_verdict_needs_no_narrowing(seeded):
     """Row scope resolves by row id, which `rekey` never renumbers, and it already names
     exactly one row — so there is nothing to narrow, and its stored base stays the

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -3,7 +3,7 @@ new/duplicate/conflict split via commit_extraction."""
 
 import pytest
 
-from pemr import db, dedup, persons
+from pemr import curation, db, dedup, persons
 
 DICT_PATH = __import__("pathlib").Path(__file__).resolve().parent.parent \
     / "data" / "dictionary.example.toml"
@@ -1104,6 +1104,201 @@ def test_rekey_moves_dedup_base_with_the_key(conn):
     dedup.rekey(conn, _rekey_dict(zzt="zonulin_test"), apply=True)
     row = conn.execute("SELECT * FROM lab_result").fetchone()
     assert row["dedup_base"] == row["dedup_key"]   # occurrence 0: base IS the key
+
+
+# --- rekey collisions a recorded verdict settles (issue #116) -----------------
+
+def _fusing_pair(conn):
+    """The fusing albumin pair, committed. Returns ``(incumbent id, clash id)``.
+
+    Row ids are the scan order (`rekey` sorts by primary key), so the first-committed
+    row is the incumbent that keeps occurrence 0 and the second is the clash."""
+    dedup.commit_extraction(conn, _make_document(conn), _FUSING_ALBUMIN_PAIR,
+                            dedup.load_dictionary(DICT_PATH))
+    return tuple(int(r["lab_result_id"]) for r in conn.execute(
+        "SELECT lab_result_id FROM lab_result ORDER BY lab_result_id"))
+
+
+def _lab_rows(conn):
+    return {int(r["lab_result_id"]): r
+            for r in conn.execute("SELECT * FROM lab_result")}
+
+
+def _rule(conn, target, status, **kwargs):
+    """Record one verdict and hand back the resolver `rekey` adjudicates through."""
+    curation.annotate_record(conn, "lab_result", str(target), status=status,
+                             note="a clinician ruled on this pair", apply=True,
+                             **kwargs)
+    return curation.collision_resolver(conn)
+
+
+def test_a_merged_into_verdict_resolves_a_fused_collision(conn):
+    """AC1. The pair the dictionary fuses is exactly the pair a human already merged,
+    so the collision is answered rather than blocking: both rows land in the surviving
+    family, the later one as its next occurrence, and the table writes."""
+    peaf_id, albumin_id = _fusing_pair(conn)
+    resolver = _rule(conn, peaf_id, "merged-into",
+                     merged_into_base=_lab_rows(conn)[albumin_id]["dedup_base"])
+
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM), apply=True,
+                         resolver=resolver)
+
+    assert report.collisions == [] and report.blocked == []
+    assert [(r.row_id, r.clash_row_id, r.kind, r.status, r.scope, r.new_occurrence)
+            for r in report.resolved] == [
+        (albumin_id, peaf_id, "fused", "merged-into", "family", 1)]
+    rows = _lab_rows(conn)
+    survivor = rows[peaf_id]["dedup_base"]
+    assert rows[albumin_id]["dedup_base"] == survivor        # one family now
+    assert (rows[peaf_id]["dedup_occurrence"],
+            rows[albumin_id]["dedup_occurrence"]) == (0, 1)
+    assert rows[peaf_id]["dedup_key"] == survivor            # occurrence 0 IS the base
+    assert rows[albumin_id]["dedup_key"] == dedup.occurrence_key(survivor, 1)
+
+
+def test_a_superseded_row_verdict_resolves_a_collision(conn):
+    """AC2. Either row, either scope: the verdict here is row-scoped and recorded on the
+    *clash* row, not the incumbent, and still answers the pair."""
+    peaf_id, albumin_id = _fusing_pair(conn)
+    resolver = _rule(conn, albumin_id, "superseded", row=True)
+
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM), apply=True,
+                         resolver=resolver)
+
+    assert report.collisions == []
+    assert [(r.scope, r.record_id, r.status, r.verdict_action)
+            for r in report.resolved] == [
+        ("row", albumin_id, "superseded", "unchanged")]
+    rows = _lab_rows(conn)
+    assert rows[albumin_id]["dedup_base"] == rows[peaf_id]["dedup_base"]
+
+
+def test_an_unverdicted_collision_still_blocks_its_table(conn):
+    """AC3 — the #92 regression. A resolver that finds nothing changes nothing: the
+    table stays on its stored keys and the collision is reported as before."""
+    _fusing_pair(conn)
+    before = _keys(conn, "lab_result", "test_name")
+
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM), apply=True,
+                         resolver=curation.collision_resolver(conn))
+
+    assert report.resolved == []
+    assert [c.kind for c in report.collisions] == ["fused"]
+    assert report.blocked == ["lab_result"] and report.writable() == []
+    assert _keys(conn, "lab_result", "test_name") == before
+
+
+@pytest.mark.parametrize("status", ["confirmed", "disputed", "erroneous-in-source"])
+def test_a_non_resolving_verdict_does_not_resolve_a_collision(conn, status):
+    """AC4. Only `merged-into`/`superseded` say "these two are one fact"; the other
+    three rule on a row's content, not on its identity against another row."""
+    peaf_id, _albumin_id = _fusing_pair(conn)
+    resolver = _rule(conn, peaf_id, status)
+
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM), apply=True,
+                         resolver=resolver)
+
+    assert report.resolved == []
+    assert [c.kind for c in report.collisions] == ["fused"]
+    assert report.blocked == ["lab_result"]
+
+
+def _doubled_pair(conn):
+    """One fact filed twice, the second copy under a pre-drift key — the `doubled`
+    shape, which no dictionary edit is needed to reach."""
+    payload = {"test_name": "ZZT", "collected_at": "2026-01-02", "value_num": 108}
+    dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [payload]},
+                            dedup.load_dictionary(DICT_PATH))
+    pid = conn.execute("SELECT person_id FROM person").fetchone()["person_id"]
+    conn.execute(
+        "INSERT INTO lab_result (person_id, document_id, test_name, collected_at, "
+        "value_num, dedup_key, dedup_base, dedup_occurrence) "
+        "VALUES (?, ?, 'ZZT', '2026-01-02', 108, 'stale-key', 'stale-key', 0)",
+        (pid, _make_document(conn)),
+    )
+    conn.commit()
+    return tuple(int(r["lab_result_id"]) for r in conn.execute(
+        "SELECT lab_result_id FROM lab_result ORDER BY lab_result_id"))
+
+
+def test_a_doubled_collision_is_resolved_too(conn):
+    """`kind` is diagnostic, never eligibility: a covering verdict answers a doubled
+    pair (same fact, two keys) exactly as it answers a fused one."""
+    first_id, second_id = _doubled_pair(conn)
+    resolver = _rule(conn, first_id, "superseded")
+
+    report = dedup.rekey(conn, dedup.load_dictionary(DICT_PATH), apply=True,
+                         resolver=resolver)
+
+    assert report.collisions == []
+    assert [(r.row_id, r.kind) for r in report.resolved] == [(second_id, "doubled")]
+    rows = _lab_rows(conn)
+    assert rows[second_id]["dedup_base"] == rows[first_id]["dedup_base"]
+    assert rows[second_id]["dedup_occurrence"] == 1
+
+
+def test_rekey_without_a_resolver_blocks_every_collision(conn):
+    """`resolver=None` is the default and is today's behaviour byte-for-byte — the
+    verdict is in the database and is simply never consulted."""
+    peaf_id, _albumin_id = _fusing_pair(conn)
+    _rule(conn, peaf_id, "superseded")
+
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM), apply=True)
+
+    assert report.resolved == []
+    assert [c.kind for c in report.collisions] == ["fused"]
+
+
+def test_a_resolved_collision_leaves_no_key_drift(conn):
+    """The reason a resolved clash is rekeyed rather than left on its stored key: a row
+    left behind would be permanently drifted, and `_assert_no_key_drift` would refuse
+    every later ingest of that identity while `rekey` itself reported clean."""
+    peaf_id, _albumin_id = _fusing_pair(conn)
+    resolver = _rule(conn, peaf_id, "superseded")
+    d_new = _rekey_dict(**_FUSING_ALBUMIN_SYNONYM)
+    dedup.rekey(conn, d_new, apply=True, resolver=resolver)
+
+    pid = conn.execute("SELECT person_id FROM person").fetchone()["person_id"]
+    payloads = [{name: row[name] for name in dedup.FIELD_SPECS["lab_result"]}
+                for row in _lab_rows(conn).values()]
+    dedup._assert_no_key_drift(conn, "lab_result", payloads, pid, d_new)  # no raise
+
+
+def test_rekey_is_idempotent_after_a_resolved_collision(conn):
+    peaf_id, _albumin_id = _fusing_pair(conn)
+    resolver = _rule(conn, peaf_id, "superseded")
+    d_new = _rekey_dict(**_FUSING_ALBUMIN_SYNONYM)
+    assert len(dedup.rekey(conn, d_new, apply=True, resolver=resolver).resolved) == 1
+
+    again = dedup.rekey(conn, d_new, apply=True,
+                        resolver=curation.collision_resolver(conn))
+    assert (again.changes, again.collisions, again.resolved) == ([], [], [])
+
+
+def test_a_third_row_on_a_resolved_key_still_blocks_when_unverdicted(conn):
+    """Quarantine granularity is untouched (#92): one settled pair does not license the
+    unsettled third row that lands on the same key, and the table withholds everything —
+    the resolved change included."""
+    dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
+        {"test_name": "Protein Electrophoresis Albumin Fraction",
+         "collected_at": "2026-01-02", "value_num": 4.2},
+        {"test_name": "Albumin", "collected_at": "2026-01-02", "value_num": 3.6},
+        {"test_name": "ALBX", "collected_at": "2026-01-02", "value_num": 3.9},
+    ]}, dedup.load_dictionary(DICT_PATH))
+    peaf_id, albumin_id, albx_id = (int(r["lab_result_id"]) for r in conn.execute(
+        "SELECT lab_result_id FROM lab_result ORDER BY lab_result_id"))
+    # Row-scoped on the clash row, so it rules on that row and no other.
+    resolver = _rule(conn, albumin_id, "superseded", row=True)
+    before = _keys(conn, "lab_result", "test_name")
+
+    report = dedup.rekey(conn, _rekey_dict(albx="albumin", **_FUSING_ALBUMIN_SYNONYM),
+                         apply=True, resolver=resolver)
+
+    assert [r.row_id for r in report.resolved] == [albumin_id]
+    assert [(c.row_id, c.clash_row_id) for c in report.collisions] \
+        == [(albx_id, peaf_id)]
+    assert report.blocked == ["lab_result"] and report.writable() == []
+    assert _keys(conn, "lab_result", "test_name") == before
 
 
 # --- ingest-before-rekey drift guard ------------------------------------------

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1275,6 +1275,107 @@ def test_rekey_is_idempotent_after_a_resolved_collision(conn):
     assert (again.changes, again.collisions, again.resolved) == ([], [], [])
 
 
+def _extra_occurrence(conn, row_id, value_num):
+    """A second live row in ``row_id``'s family — the state `--keep both` leaves behind.
+
+    Same identity fields (so it recomputes onto the same base), same ``dedup_base``, next
+    occurrence. Returns its row id."""
+    row = _lab_rows(conn)[row_id]
+    occurrence = int(row["dedup_occurrence"]) + 1
+    cur = conn.execute(
+        "INSERT INTO lab_result (person_id, document_id, test_name, collected_at, "
+        "value_num, dedup_key, dedup_base, dedup_occurrence) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (row["person_id"], row["document_id"], row["test_name"], row["collected_at"],
+         value_num, dedup.occurrence_key(row["dedup_base"], occurrence),
+         row["dedup_base"], occurrence),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+def _curation_rows(conn):
+    return conn.execute("SELECT COUNT(*) AS n FROM curation").fetchone()["n"]
+
+
+def test_a_family_verdict_narrows_onto_every_row_it_covered(conn):
+    """The re-decided rule: a resolving family verdict is pinned to *exactly* the rows it
+    covered when it was made — all of them when the family holds two live occurrences —
+    and never reaches the row that only joined the family through this merge."""
+    peaf_id, albumin_id = _fusing_pair(conn)
+    peaf_occ1_id = _extra_occurrence(conn, peaf_id, 4.4)
+    resolver = _rule(conn, peaf_id, "superseded")           # family scope
+
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM), apply=True,
+                         resolver=resolver)
+
+    assert report.collisions == []
+    assert [(r.verdict_action, r.covered_row_ids, r.narrowed_row_ids)
+            for r in report.resolved] == [
+        ("narrowed", [peaf_id, peaf_occ1_id], [peaf_id, peaf_occ1_id])]
+    verdicts = curation.load_verdicts(conn)
+    assert verdicts.family == {}                            # nothing family-scoped left
+    survivor = _lab_rows(conn)[peaf_id]["dedup_base"]
+    for row_id in (peaf_id, peaf_occ1_id):
+        assert verdicts.for_row("lab_result", survivor, row_id)["scope"] == "row"
+    # The row the merge brought in was never judged and still is not.
+    assert verdicts.for_row("lab_result", survivor, albumin_id) is None
+
+
+def test_one_verdict_settling_two_clashes_is_narrowed_once(conn):
+    """Two occurrences of a judged family landing on two occurrences of the surviving
+    one: the verdict authorizes both resolutions, so it is narrowed once and every
+    resolution reports the same pinned rows — narrowing twice would find its own first
+    pass and silently no-op."""
+    peaf_id, albumin_id = _fusing_pair(conn)
+    peaf_occ1_id = _extra_occurrence(conn, peaf_id, 4.4)
+    albumin_occ1_id = _extra_occurrence(conn, albumin_id, 3.9)
+    resolver = _rule(conn, peaf_id, "superseded")           # family scope
+
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM), apply=True,
+                         resolver=resolver)
+
+    assert report.collisions == []
+    assert [r.row_id for r in report.resolved] == [albumin_id, albumin_occ1_id]
+    assert [(r.verdict_action, r.narrowed_row_ids) for r in report.resolved] == [
+        ("narrowed", [peaf_id, peaf_occ1_id])] * 2
+    assert _curation_rows(conn) == 2                        # one per pinned row
+    rows = _lab_rows(conn)
+    survivor = rows[peaf_id]["dedup_base"]
+    assert {r["dedup_base"] for r in rows.values()} == {survivor}
+    assert sorted(int(r["dedup_occurrence"]) for r in rows.values()) == [0, 1, 2, 3]
+
+
+def test_a_resolution_in_a_quarantined_table_is_reported_as_withheld(conn):
+    """Audit's advisory: a resolved pair in a table that also holds an *unresolved*
+    collision is withheld with the rest of the table, so its account must not describe a
+    write that never happened — and the verdict is not narrowed either."""
+    dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
+        {"test_name": "Protein Electrophoresis Albumin Fraction",
+         "collected_at": "2026-01-02", "value_num": 4.2},
+        {"test_name": "Albumin", "collected_at": "2026-01-02", "value_num": 3.6},
+        {"test_name": "ALBX", "collected_at": "2026-01-02", "value_num": 3.9},
+    ]}, dedup.load_dictionary(DICT_PATH))
+    peaf_id, albumin_id, albx_id = (int(r["lab_result_id"]) for r in conn.execute(
+        "SELECT lab_result_id FROM lab_result ORDER BY lab_result_id"))
+    # Family scope on the *clash* row's own family, so it settles that pair only.
+    resolver = _rule(conn, albumin_id, "superseded")
+    before = _keys(conn, "lab_result", "test_name")
+
+    report = dedup.rekey(conn, _rekey_dict(albx="albumin", **_FUSING_ALBUMIN_SYNONYM),
+                         apply=True, resolver=resolver)
+
+    assert [(c.row_id, c.clash_row_id) for c in report.collisions] \
+        == [(albx_id, peaf_id)]
+    assert [(r.row_id, r.verdict_action, r.narrowed_row_ids)
+            for r in report.resolved] == [(albumin_id, "withheld", [])]
+    assert "withheld: lab_result still holds an unresolved collision" \
+        in report.resolved[0].message
+    assert _keys(conn, "lab_result", "test_name") == before
+    # The ruling is exactly as the human left it: still family-scoped, untouched.
+    assert curation.load_verdicts(conn).rows == {}
+
+
 def test_a_third_row_on_a_resolved_key_still_blocks_when_unverdicted(conn):
     """Quarantine granularity is untouched (#92): one settled pair does not license the
     unsettled third row that lands on the same key, and the table withholds everything —


### PR DESCRIPTION
## Summary

`pemr rekey` refuses to write a table when two rows recompute onto the same dedup key, even
when a human `merged-into`/`superseded` verdict already resolves exactly that ambiguity
(currently 12 such collisions parking the allergy + condition tables on stored keys in the
family DB). This teaches `rekey` to consult the curation overlay:

- A collision covered by a `merged-into` or `superseded` verdict — on either row, at either
  scope — no longer blocks its table. The clash row is filed as the next free occurrence of
  the surviving family.
- The authorizing family verdict is **narrowed to row scope**, pinned to exactly the rows it
  covered when the ruling was made, rather than silently widening to cover the previously
  unjudged row it now shares a family with. No live row ever leaves its rendered clinical
  section as a side effect of a maintenance command (criticality-blind, by construction —
  confirmed structurally, not just by example).
- `pemr verify` gains a notice when a rekey moves a row out from under its own row-scoped
  verdict, pointing at `pemr record annotate --row` to re-affirm or re-rule; the notice is
  now runnable for `merged-into` too (a row-scoped self-merge onto the row's own live family
  is no longer refused — only family-scope self-merges still are).
- `pemr rekey` text and `--json` output distinguish "resolved by verdict" from "blocked",
  including a `withheld:` clause when a resolution sits in a table still quarantined by an
  unrelated unverdicted collision.
- Collisions with no covering verdict, or covered only by a non-resolving status
  (`confirmed`/`disputed`/`erroneous-in-source`), still block exactly as before (#92
  unaffected). Exit code changes in exactly one way: `rc 1` iff a *blocking* collision
  remains, so a run where every collision was verdict-resolved now exits 0.

`docs/Architecture.md` documents the resolver, the narrowing rule, the exit-code change, and
(this PR's own addition) a correction to the narrowing paragraph's scope: "nothing is
orphaned" holds only for the verdict that resolved the collision — when both colliding
families independently carry a verdict, the non-covering one is orphaned by the rekey the
same way an unrelated dictionary-driven rekey has always been able to orphan a family verdict
(documented since migration 008), and `pemr verify` is the only signal (not `rekey`'s own
output). That gap is real but is over-reporting, not data loss, and is tracked as a follow-up
rather than fixed here (see Notes).

Closes #116

## Pipeline history

Went through two build/verify round-trips: audit's first pass PARKed a design defect (a
family verdict could silently pull a *live* row out of its clinical section on resolution);
the human re-decided at `stage:audit` → `stage:build` that verdict scope must never widen
across a rekey merge, only narrow within its original extension. A follow-up verify BOUNCE
caught that the resulting re-affirm notice was unfollowable for `merged-into` verdicts; fixed
by relaxing the self-merge guard at row scope only. Full reports:

- Verify (final, `f9e5940`): https://github.com/meridun/pemr/issues/116#issuecomment-5246560269
- Audit (final, `f9e5940`): https://github.com/meridun/pemr/issues/116#issuecomment-5246635692

## Notes

- Audit flagged one advisory (not blocking, not fixed here): when *both* colliding families
  carry a resolving verdict, only the covering one is narrowed — the other is orphaned by the
  rekey and `rekey`'s own output doesn't say so (only `pemr verify` does). Worth a follow-up
  issue to extend the "resolved" loudness to verdict *loss*, not just verdict *scope change*.
- No migration, no schema change, additive-only `--json`/dataclass changes, ASCII-only
  console output.

## Test plan

- [x] Full suite green at ship time (`pytest`, 939 passed at verify's final pass; re-ran the
      dedup/curation/CLI subset after the docs-only commit here — 185 passed)
- [x] `npm run check:meta-drift` passed (docs touched)
- [x] Real-run smoke: out-of-process `python -m pemr` CLI walk of every acceptance criterion,
      including the migration-006 allergy/condition trigger this issue was filed from
      (verify's reports above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
