### PR TITLE
fix(dedup): key lab_result on the collection date, not the timestamp (#117)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,8 +270,11 @@ Agents never resolve staged conflicts silently.
   document simply didn't repeat. On the dated types an unstated field IS a clearing and is written
   as one.
 - `commit_extraction` **rejects** two rows of one submission that derive the same key and disagree;
-  that is an extraction error, not a conflict. Re-read the source for collection times; if there
-  genuinely are none, submit them separately and ask the human about `keep both`.
+  that is an extraction error, not a conflict. For `observation`, re-read the source for times; if
+  there genuinely are none, submit them separately and ask the human about `keep both`. For
+  `lab_result` the key holds only the collection **date** (issue #117), so a time cannot separate
+  two same-day draws — submit them separately and ask the human about `keep both`. The rejection
+  message names the applicable path.
 
 ### 6. Medication-interaction section
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -487,7 +487,11 @@ makes the rare case recoverable while the common case is now correct by construc
 `collected_at` is deliberately **not** in `_COMPARE_FIELDS["lab_result"]`: comparing it
 would turn every mixed-precision pair into a conflict, recreating the same bug as noise.
 The first document to state a draw therefore fixes its stored precision — a later
-restatement with a time reports `duplicate` and does not upgrade the column.
+restatement with a time reports `duplicate` and does not upgrade the column. The same
+exclusion means a same-day repeat draw with an *identical* value (e.g. a QC re-run
+confirming the prior result) compares equal on every `_COMPARE_FIELDS` entry and so
+collapses to one row reported as `duplicate` too — only a *differing* value on a same-day
+repeat takes the conflict path above.
 
 **Conflict handling.** On dedup-key collision with *differing* non-key fields (e.g. a
 corrected value), don't silently drop — write to a `conflict` staging table and surface

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -304,7 +304,7 @@ Each typed/observation row computes a deterministic `dedup_key` from normalized 
 so the *same clinical fact* extracted from two different documents collapses to one row.
 
 ```
-lab_result.dedup_key   = hash(person_id | key_token(test_name) | collected_at)
+lab_result.dedup_key   = hash(person_id | key_token(test_name) | date_only(collected_at))
 medication.dedup_key    = hash(person_id | norm(name) | dose | started_on)
 procedure.dedup_key     = hash(person_id | norm(name) | performed_on)
 appointment.dedup_key   = hash(person_id | provider | scheduled_for)
@@ -443,15 +443,51 @@ under the old identity and a three-way fusion under the new one. A collision qua
 table only (above), so the clean tables are still written and the fusion is settled in the
 dictionary or the data before a re-run.
 
+`rekey` is likewise a **required upgrade step for the `lab_result` date-only key** (issue
+#117). Every stored lab whose `collected_at` carries a time recomputes to a new key the
+moment that change lands, so run the `pemr rekey` dry-run and then `pemr rekey --apply`
+before the next `commit-extraction` that restates one of those draws. As with 006 nothing is
+silent — the drift guard raises `DictionaryDriftError` naming `pemr rekey --apply` and writes
+nothing — and this note is the signpost, not the enforcement. Read the dry-run's collisions
+with the key change in mind, because `rekey`'s vocabulary describes the shape, not the cause:
+
+- a `lab_result` **`"doubled"`** collision (same payload, two keys) is exactly the
+  mixed-precision duplicate pair this change fixes — one draw stored twice. Resolve it with
+  `pemr record rm` on the redundant row, per `rekey`'s own guidance.
+- a `lab_result` **`"fused"`** collision (different payloads onto one key) most likely means
+  two *genuine* same-day draws already stored as separate rows, **not** a dictionary fault —
+  the message's dictionary diagnosis is wrong here. Re-admit the second through
+  `review-conflicts --resolve --keep both` rather than editing the dictionary.
+
+Either way the collision quarantines only `lab_result`; the other tables are rekeyed.
+
 The **measured value is deliberately *not* in the key** — temporal identity carries the
-draw instead. `collected_at`/`observed_at` are used at full precision (timestamp when the
-document gives one, date when it only gives a date), not truncated to the date. Two draws
-of the same analyte on the same day at different times (serial glucose, peri-op, inpatient
-q6h) get distinct timestamps → distinct keys → two rows preserved; a correction or OCR
-re-read of the *same* draw carries the same timestamp → collides → surfaces as a conflict
-(below). When only a date is available, same-day differing values collide → conflict; that
-safety bias is intentional (a spurious conflict on a genuine repeat is human-recoverable, a
-silent duplicate of a correction poisons `trends`/brief/`query` irrecoverably).
+draw instead. The two temporal types differ in *how much* of that timestamp is identity.
+
+`observation.observed_at` is used at **full precision** (timestamp when the document gives
+one, date when it only gives a date), not truncated to the date. Two readings of the same
+measurement on the same day at different times get distinct timestamps → distinct keys →
+two rows preserved; a correction or OCR re-read of the *same* reading carries the same
+timestamp → collides → surfaces as a conflict (below). When only a date is available,
+same-day differing values collide → conflict; that safety bias is intentional (a spurious
+conflict on a genuine repeat is human-recoverable, a silent duplicate of a correction
+poisons `trends`/brief/`query` irrecoverably).
+
+`lab_result.collected_at` is **truncated to the date** for key purposes (issue #117); the
+column itself still stores the most precise prefix the source gave, and the read layer
+(`trends`, `query labs`, render) uses that full value. Full precision in the key forked one
+draw into two rows whenever two documents stated it at different precision — `2026-04-01`
+in a summary, `2026-04-01T09:15` in the lab report — which is the common real-world case
+and the one layer-2 dedup exists to collapse. The cost is that a genuine second draw on the
+same day (a GTT timepoint) now collides on the date-only key and **stages a conflict**
+rather than landing as a second clean row; it is re-admitted with `review-conflicts
+--resolve --keep both`. That trade is this issue's recorded `decision:` — same-day distinct
+draws are rare, mixed-precision restatements of one draw are not, and the conflict path
+makes the rare case recoverable while the common case is now correct by construction.
+`collected_at` is deliberately **not** in `_COMPARE_FIELDS["lab_result"]`: comparing it
+would turn every mixed-precision pair into a conflict, recreating the same bug as noise.
+The first document to state a draw therefore fixes its stored precision — a later
+restatement with a time reports `duplicate` and does not upgrade the column.
 
 **Conflict handling.** On dedup-key collision with *differing* non-key fields (e.g. a
 corrected value), don't silently drop — write to a `conflict` staging table and surface
@@ -525,9 +561,12 @@ that table until the collision is fixed.
 derive the same key and disagree fail validation (pass 1) and roll the batch back, naming
 the identity and the recovery path. A conflict whose "existing" side was inserted
 milliseconds earlier in the same batch has no independent provenance to adjudicate
-against; the overwhelmingly likely cause is a collection time the source did give and the
-extraction dropped. Two *identical* rows in one payload stay benign (first inserts, second
-reports `duplicate`) — that is an agent listing one fact twice. Genuine untimestampable
+against; for `observation` the overwhelmingly likely cause is a time the source did give and
+the extraction dropped, and the rejection message says so. For `lab_result` it is not —
+the key holds only the collection date (above), so adding times cannot separate the rows and
+the message omits that advice: two same-day draws go through two submissions plus
+`--keep both`. Two *identical* rows in one payload stay benign (first inserts, second
+reports `duplicate`) — that is an agent listing one fact twice. Genuine same-day
 repeats go through two submissions plus `--keep both`, which keeps the human sign-off in
 the loop rather than letting an agent self-admit near-duplicates.
 

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -357,7 +357,12 @@ def enum_token(value: object) -> str:
 
 
 def _date_only(value: object) -> str:
-    """Date portion of an ISO datetime/date string ('2026-01-02T09:00' -> '2026-01-02')."""
+    """Date portion of an ISO datetime/date string ('2026-01-02T09:00' -> '2026-01-02').
+
+    The identity granularity for every dated type except ``observation``: medication
+    start / procedure date / appointment date, and — since issue #117 —
+    ``lab_result.collected_at``, whose documents state the same draw at mixed precision.
+    """
     if value is None:
         return ""
     text = str(value).strip()
@@ -368,13 +373,14 @@ def _norm_ts(value: object) -> str:
     """Normalize an ISO date/datetime for use as a dedup-key identity part, keeping
     *full precision* (unlike :func:`_date_only`, which truncates to the date).
 
-    A timestamped draw (``2026-01-02T09:00``) and a bare-date draw (``2026-01-02``)
-    stay distinct, and two draws on the same day at different times keep distinct keys
-    — so serial same-day repeats (GTT, peri-op, inpatient q6h) survive as separate
-    rows. A re-read/correction of the *same* draw carries the same timestamp, collides,
-    and surfaces as a CONFLICT via :data:`_COMPARE_FIELDS`. Only the ``T``/space
-    separator and surrounding/collapsed whitespace are normalized, so trivial
-    formatting differences don't fork the key."""
+    Its one remaining consumer is ``observation.observed_at``: a timestamped
+    observation (``2026-01-02T09:00``) and a bare-date one (``2026-01-02``) stay
+    distinct, and two observations on the same day at different times keep distinct
+    keys, so serial same-day repeats survive as separate rows. A re-read/correction of
+    the *same* observation carries the same timestamp, collides, and surfaces as a
+    CONFLICT via :data:`_COMPARE_FIELDS`. Only the ``T``/space separator and
+    surrounding/collapsed whitespace are normalized, so trivial formatting differences
+    don't fork the key."""
     if value is None:
         return ""
     return _WS.sub(" ", str(value).strip().replace("T", " "))
@@ -407,7 +413,7 @@ def _key_parts(
         return key_token(row.get(field_name), dictionary)
 
     if record_type == "lab_result":
-        return [person_id, kt("test_name"), _norm_ts(row.get("collected_at"))]
+        return [person_id, kt("test_name"), _date_only(row.get("collected_at"))]
     if record_type == "medication":
         return [person_id, n("name"), _collapse(str(row.get("dose") or "")),
                 _date_only(row.get("started_on"))]
@@ -612,10 +618,11 @@ class CommitSummary:
 # Identity fields (those feeding the dedup_key) are equal by construction — a
 # difference there yields a *different* key and hence a new row, never a collision —
 # so they are deliberately excluded here. The measured value is deliberately NOT an
-# identity field: the lab/observation keys carry temporal identity (collected_at /
-# observed_at at full precision) but not the value, so a corrected or re-read value on
-# an otherwise-matching key collides and surfaces here as a CONFLICT instead of a
-# silent duplicate — hence value_num/value_text appear below.
+# identity field: the lab and observation keys carry temporal identity — the collection
+# *date* for lab_result (issue #117), the full observed_at timestamp for observation —
+# but not the value, so a corrected or re-read value on an otherwise-matching key
+# collides and surfaces here as a CONFLICT instead of a silent duplicate — hence
+# value_num/value_text appear below.
 _COMPARE_FIELDS: dict[str, list[str]] = {
     "lab_result": ["value_num", "value_text", "unit", "ref_low", "ref_high", "flag", "loinc"],
     "medication": ["route", "frequency", "ended_on", "prescriber", "status"],
@@ -833,15 +840,23 @@ def commit_extraction(
             if prior is None:
                 seen[base] = (index, row)
             elif not _rows_equal(record_type, prior[1], row):
+                # Adding times only helps where the key still keeps the time
+                # component, which after issue #117 is `observation` alone —
+                # lab_result keys on the collection *date*, so for it that advice
+                # cannot separate the rows.
+                time_hint = (
+                    "If the source gives distinct times, add them (AGENTS.md "
+                    "date-precision rule). "
+                    if record_type == "observation"
+                    else ""
+                )
                 raise ValidationError(
                     f"{record_type}: rows {prior[0]} and {index} of this submission "
                     f"derive the same dedup_key "
                     f"({identity_label(record_type, row, person_id, dictionary)}) "
-                    "but carry different values. If the source gives distinct "
-                    "collection times, add them (AGENTS.md date-precision rule). If "
-                    "these are two genuine same-day results the source cannot "
-                    "timestamp, commit them in separate submissions and resolve the "
-                    "conflict with `--keep both`"
+                    f"but carry different values. {time_hint}If these are two genuine "
+                    "same-day results, commit them in separate submissions and "
+                    "resolve the conflict with `--keep both`"
                 )
         # Still pass 1 (nothing written yet): a stored row whose frozen key no longer
         # matches its recompute would be missed by pass 2's dedup, forking the fact.

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -1,11 +1,12 @@
 """End-to-end CLI wiring for phase 2: ingest -> commit-extraction -> review-conflicts."""
 
+import hashlib
 import json
 import zipfile
 
 import pytest
 
-from pemr import cli, db
+from pemr import cli, db, dedup
 
 
 def _run(tmp_path, *argv):
@@ -904,3 +905,158 @@ def test_curated_synonyms_dedup_across_documents_through_the_cli(ready, capsys):
     # nothing to move and no collision to report.
     assert _run(tmp_path, "rekey") == 0
     assert "all dedup keys already match the current dictionary" in capsys.readouterr().out
+
+
+# --- issue #117: lab_result keys on the collection date, walked through the real CLI ---
+
+def _ingest_lab_document(tmp_path, name, text, payload):
+    """Ingest a scan and commit one `lab_result` payload against it, CLI-only."""
+    scan = tmp_path / name
+    scan.write_bytes(text)
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources")) == 0
+    doc = _document_id(tmp_path)[-1]["document_id"]
+    json_path = _write_json(tmp_path, f"{name}.json", {"lab_result": [payload]})
+    return _run(tmp_path, "commit-extraction", "--document", str(doc),
+                "--json", str(json_path))
+
+
+def test_mixed_precision_same_draw_dedups_at_the_cli(ready, capsys):
+    """The reported bug (pemr-data#9) end to end: a summary states the draw as a bare
+    date, the lab report timestamps it. One fact, so one row -- and the read layer still
+    sees the precision the first document gave."""
+    tmp_path = ready
+    payload = {"test_name": "HbA1c", "value_num": 5.7, "unit": "%",
+               "ref_low": 4.0, "ref_high": 5.6}
+    assert _ingest_lab_document(tmp_path, "summary.txt", b"hba1c 5.7 (no time given)",
+                                {**payload, "collected_at": "2026-04-01"}) == 0
+    assert "1 new, 0 duplicate" in capsys.readouterr().out
+    assert _ingest_lab_document(tmp_path, "labreport.txt", b"hba1c 5.7 collected 09:15",
+                                {**payload, "collected_at": "2026-04-01T09:15"}) == 0
+    assert "0 new, 1 duplicate" in capsys.readouterr().out
+
+    assert _run(tmp_path, "query", "labs", "--person", "jane-doe", "--json") == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert [(r["test_name"], r["collected_at"]) for r in rows] == [("HbA1c", "2026-04-01")]
+
+
+def test_same_day_distinct_draw_is_staged_and_keep_both_admits_it(ready, capsys):
+    """The accepted cost of the date-only key, walked through the operator's recovery:
+    a genuine second same-day draw (a GTT timepoint) collides and STAGES -- it is never
+    silently doubled and never silently dropped -- and `--keep both` admits it."""
+    tmp_path = ready
+    common = {"test_name": "glucose", "unit": "mg/dL"}
+    assert _ingest_lab_document(tmp_path, "gtt-0h.txt", b"glucose 92 fasting",
+                                {**common, "collected_at": "2026-04-01T08:00",
+                                 "value_num": 92}) == 0
+    assert _ingest_lab_document(tmp_path, "gtt-2h.txt", b"glucose 130 two hour",
+                                {**common, "collected_at": "2026-04-01T14:00",
+                                 "value_num": 130}) == 0
+    assert "0 new, 0 duplicate, 0 enriched, 1 conflict" in capsys.readouterr().out
+
+    assert _run(tmp_path, "review-conflicts", "--resolve", "1", "--keep", "both",
+                "--note", "GTT timepoints") == 0
+    out = capsys.readouterr().out
+    assert "occurrence 1" in out and out.isascii()
+
+    assert _run(tmp_path, "query", "labs", "--person", "jane-doe", "--json") == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert [(r["value_num"], r["collected_at"]) for r in rows] == [
+        (92.0, "2026-04-01T08:00"), (130.0, "2026-04-01T14:00")]
+
+
+def test_observation_keeps_its_full_precision_key_at_the_cli(ready, capsys):
+    """The scope boundary: `observation` was deliberately left on `_norm_ts`, so the
+    same mixed-precision pair still forks there -- two rows, no conflict."""
+    tmp_path = ready
+    for name, observed_at in (("obs1.txt", "2026-04-02"), ("obs2.txt", "2026-04-02T07:30")):
+        scan = tmp_path / name
+        scan.write_bytes(b"weight 180 lb")
+        assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                    "--sources", str(tmp_path / "sources")) == 0
+        doc = _document_id(tmp_path)[-1]["document_id"]
+        payload = _write_json(tmp_path, f"{name}.json", {"observation": [
+            {"obs_type": "vital", "key": "weight", "observed_at": observed_at,
+             "value_num": 180, "unit": "lb"}]})
+        assert _run(tmp_path, "commit-extraction", "--document", str(doc),
+                    "--json", str(payload)) == 0
+        assert "1 new" in capsys.readouterr().out
+
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        counts = conn.execute("SELECT COUNT(*), COUNT(DISTINCT dedup_key) "
+                              "FROM observation").fetchone()
+    finally:
+        conn.close()
+    assert tuple(counts) == (2, 2)
+
+
+def _seed_pre_117_mixed_precision_pair(tmp_path):
+    """The state an existing database is in when this change lands: one draw stored
+    twice because the two documents dated it differently, both rows on the *legacy*
+    full-precision keys. Inserted directly -- `commit-extraction` would now dedup them."""
+    scan = tmp_path / "legacy.txt"
+    scan.write_bytes(b"hba1c 5.7 stated twice")
+    assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources")) == 0
+    row = {"test_name": "HbA1c", "value_num": 5.7, "unit": "%"}
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        person_id = conn.execute("SELECT person_id FROM person").fetchone()["person_id"]
+        doc = conn.execute("SELECT document_id FROM document").fetchone()["document_id"]
+        for collected_at in ("2026-04-01", "2026-04-01T09:15"):
+            legacy = hashlib.sha256("|".join([          # pre-#117: _norm_ts(collected_at)
+                str(person_id), dedup.key_token(row["test_name"]),
+                collected_at.replace("T", " "),
+            ]).encode("utf-8")).hexdigest()
+            dedup._insert_record(conn, "lab_result",
+                                 {**row, "collected_at": collected_at},
+                                 person_id, doc, legacy)
+        conn.commit()
+    finally:
+        conn.close()
+    return _write_json(tmp_path, "legacy.json",
+                       {"lab_result": [{**row, "collected_at": "2026-04-01"}]})
+
+
+def test_rekey_is_the_migration_for_a_pre_change_database(ready, capsys):
+    """The upgrade path an existing database takes, at the CLI: the drift guard refuses
+    to file the fact a third time, `rekey` names the pair as `doubled` (data, not
+    dictionary) and writes nothing, `record rm` clears it, and the same document then
+    dedups cleanly."""
+    tmp_path = ready
+    payload = _seed_pre_117_mixed_precision_pair(tmp_path)
+    doc = _document_id(tmp_path)[-1]["document_id"]
+    capsys.readouterr()
+
+    # 1. Nothing silent: the next commit touching that identity is refused outright.
+    assert _run(tmp_path, "commit-extraction", "--document", str(doc),
+                "--json", str(payload)) == 1
+    err = capsys.readouterr().err
+    assert "pemr rekey --apply" in err and err.isascii()
+
+    # 2. The dry run diagnoses it as doubled DATA and quarantines only lab_result.
+    assert _run(tmp_path, "rekey", "--json") == 1
+    report = json.loads(capsys.readouterr().out)
+    assert [c["kind"] for c in report["collisions"]] == ["doubled"]
+    assert report["skipped"] == ["lab_result"]
+    assert "pemr record rm" in report["collisions"][0]["message"]
+
+    # 3. `--apply` still writes nothing for the blocked table.
+    assert _run(tmp_path, "rekey", "--apply") == 1
+    capsys.readouterr()
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        assert conn.execute("SELECT COUNT(DISTINCT dedup_key) AS n "
+                            "FROM lab_result").fetchone()["n"] == 2
+    finally:
+        conn.close()
+
+    # 4. The documented resolution, then a clean rekey and a clean re-commit.
+    assert _run(tmp_path, "record", "rm", "lab_result", "2", "--apply") == 0
+    assert "removed lab_result #2" in capsys.readouterr().out
+    assert _run(tmp_path, "rekey") == 0
+    assert "all dedup keys already match" in capsys.readouterr().out
+    assert _run(tmp_path, "commit-extraction", "--document", str(doc),
+                "--json", str(payload)) == 0
+    assert "0 new, 1 duplicate" in capsys.readouterr().out

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -604,9 +604,11 @@ def test_far_apart_correction_conflicts_not_duplicates(conn):
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
 
 
-def test_serial_same_day_draws_are_distinct_rows(conn):
-    # Two genuine draws on the same day at different times (GTT / peri-op / inpatient
-    # q6h) carry distinct timestamps -> distinct keys -> two rows, no data loss.
+def test_serial_same_day_draws_in_one_submission_are_rejected(conn):
+    # Issue #117 flipped the lab key to the collection DATE, so two same-day timepoints
+    # (GTT / peri-op / inpatient q6h) of ONE submission now derive one key with differing
+    # values -> pass-1 rejection, not two rows. The message must not send the agent back
+    # to the source for times that would be truncated away.
     d = dedup.load_dictionary(DICT_PATH)
     doc = _make_document(conn)
     rows = [
@@ -615,9 +617,71 @@ def test_serial_same_day_draws_are_distinct_rows(conn):
         {"test_name": "Glucose", "collected_at": "2026-04-01T14:00", "value_num": 130,
          "unit": "mg/dL"},
     ]
-    summary = dedup.commit_extraction(conn, doc, {"lab_result": rows}, d)
-    assert summary.counts == {"new": 2, "duplicate": 0, "enriched": 0, "conflict": 0, "promoted": 0}
-    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
+    with pytest.raises(dedup.ValidationError) as exc:
+        dedup.commit_extraction(conn, doc, {"lab_result": rows}, d)
+    message = str(exc.value)
+    assert "rows 0 and 1" in message
+    assert "person 1 | glucose | 2026-04-01" in message   # the identity, date-only
+    assert "--keep both" in message                       # the recovery that works
+    assert "date-precision rule" not in message           # the advice that no longer can
+    assert message.isascii()                              # cp1252 console (issue #23)
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 0
+
+
+def test_mixed_precision_same_draw_dedups_to_one_row(conn):
+    # Issue #117 headline (pemr-data#9): a summary states the draw as a bare date and the
+    # lab report timestamps it. Same person/analyte/value/unit/refs -> one clinical fact,
+    # which the full-precision key used to fork into two rows.
+    d = dedup.load_dictionary(DICT_PATH)
+    payload = {"value_num": 95, "unit": "mg/dL", "ref_low": 70, "ref_high": 99}
+    dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2026-04-01", **payload}]}, d)
+    summary = dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2026-04-01T09:15", **payload}]}, d)
+    assert summary.counts == {"new": 0, "duplicate": 1, "enriched": 0, "conflict": 0, "promoted": 0}
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
+    # First writer fixes the stored precision: collected_at is payload, not compared.
+    assert conn.execute(
+        "SELECT collected_at FROM lab_result").fetchone()["collected_at"] == "2026-04-01"
+
+
+def test_same_day_distinct_draw_stages_a_conflict(conn):
+    # The cost of the date-only key, and its recovery: a genuine second same-day draw
+    # (a GTT timepoint) collides instead of landing as a second clean row -- but it is
+    # STAGED, never dropped, and `--keep both` admits it as occurrence 1.
+    d = dedup.load_dictionary(DICT_PATH)
+    dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2026-04-01T08:00", "value_num": 92,
+         "unit": "mg/dL"}]}, d)
+    summary = dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2026-04-01T14:00", "value_num": 130,
+         "unit": "mg/dL"}]}, d)
+    assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1, "promoted": 0}
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
+
+    dedup.resolve_conflict(conn, dedup.list_conflicts(conn)[0]["conflict_id"], keep="both")
+    rows = conn.execute(
+        "SELECT * FROM lab_result ORDER BY dedup_occurrence").fetchall()
+    assert [r["dedup_occurrence"] for r in rows] == [0, 1]
+    assert [r["value_num"] for r in rows] == [92, 130]
+
+
+def test_lab_key_is_date_only_and_observation_is_not(conn):
+    """The scope boundary issue #117 draws: `lab_result` truncates `collected_at` to the
+    date, `observation` keeps `observed_at` at full precision."""
+    d = dedup.load_dictionary(DICT_PATH)
+    pid = conn.execute("SELECT person_id FROM person").fetchone()["person_id"]
+    bare = {"test_name": "Glucose", "collected_at": "2026-04-01", "value_num": 95}
+    timed = {"test_name": "Glucose", "collected_at": "2026-04-01T09:15", "value_num": 95}
+    assert dedup.dedup_key("lab_result", bare, pid, d) \
+        == dedup.dedup_key("lab_result", timed, pid, d)
+
+    o_bare = {"obs_type": "vital", "key": "systolic", "observed_at": "2026-04-01",
+              "value_num": 120}
+    o_timed = {"obs_type": "vital", "key": "systolic", "observed_at": "2026-04-01T09:15",
+               "value_num": 120}
+    assert dedup.dedup_key("observation", o_bare, pid, d) \
+        != dedup.dedup_key("observation", o_timed, pid, d)
 
 
 def test_observation_correction_conflicts_not_duplicates(conn):
@@ -686,13 +750,16 @@ def test_intra_payload_collision_checked_per_record_type(conn):
     """Distinct types never collide with each other, and a same-key observation pair is
     caught the same way a lab pair is."""
     doc = _make_document(conn)
-    with pytest.raises(dedup.ValidationError, match="observation: rows 0 and 1"):
+    with pytest.raises(dedup.ValidationError, match="observation: rows 0 and 1") as exc:
         dedup.commit_extraction(conn, doc, {"observation": [
             {"obs_type": "vital", "key": "systolic", "observed_at": "2024-04-01",
              "value_num": 120},
             {"obs_type": "vital", "key": "systolic", "observed_at": "2024-04-01",
              "value_num": 138},
         ]})
+    # `observation` keeps the time in its key, so "add the times" is still real advice
+    # here -- the clause issue #117 dropped for `lab_result`.
+    assert "date-precision rule" in str(exc.value)
 
 
 # --- occurrence numbering -----------------------------------------------------
@@ -1050,7 +1117,7 @@ def test_rekey_over_unqualified_names_reports_no_changes(conn):
         legacy = "|".join([
             str(pid),
             dedup.norm(row["test_name"], d),                    # pre-fix: norm(), not key_token()
-            row["collected_at"].replace("T", " "),
+            row["collected_at"].replace("T", " ").split(" ")[0],   # issue #117: date only
         ])
         assert dedup.dedup_key("lab_result", row, pid, d) \
             == hashlib.sha256(legacy.encode("utf-8")).hexdigest(), row["test_name"]
@@ -1181,6 +1248,43 @@ def test_rekey_names_a_doubled_fact_instead_of_blaming_the_dictionary(conn):
     assert conn.execute(
         "SELECT COUNT(*) AS n FROM lab_result WHERE dedup_key = 'stale-base-0000'"
     ).fetchone()["n"] == 1
+
+
+def test_rekey_reports_a_mixed_precision_pair_as_doubled(conn):
+    """The issue-#117 upgrade path: a database written *before* the date-only lab key
+    holds the reported bug's pair -- one draw under two keys because the documents stated
+    it at different precision. `rekey` is the migration, and it names the pair correctly:
+    the dictionary is fine, the data is doubled, so `pemr record rm` is the fix."""
+    import hashlib
+
+    d = dedup.load_dictionary(DICT_PATH)
+    pid = conn.execute("SELECT person_id FROM person").fetchone()["person_id"]
+    doc = _make_document(conn)
+    payload = {"test_name": "Glucose", "value_num": 95, "unit": "mg/dL"}
+    # Seed the pre-change state directly: commit_extraction would now dedup these.
+    for collected_at in ("2026-04-01", "2026-04-01T09:15"):
+        legacy = hashlib.sha256("|".join([                     # pre-#117: _norm_ts()
+            str(pid),
+            dedup.key_token(payload["test_name"], d),
+            collected_at.replace("T", " "),
+        ]).encode("utf-8")).hexdigest()
+        dedup._insert_record(conn, "lab_result",
+                             {**payload, "collected_at": collected_at}, pid, doc, legacy)
+    conn.commit()
+
+    report = dedup.rekey(conn, d)
+    assert [c.kind for c in report.collisions] == ["doubled"]
+    assert "pemr record rm" in report.collisions[0].message
+    assert report.blocked == ["lab_result"]
+    # Dry run wrote nothing: both rows still sit on their legacy keys.
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
+
+    report = dedup.rekey(conn, d, apply=True)
+    assert [c.kind for c in report.collisions] == ["doubled"]
+    assert report.blocked == ["lab_result"]
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 2
+    assert len({r["dedup_key"] for r in conn.execute(
+        "SELECT dedup_key FROM lab_result")}) == 2      # left on stored keys, unfused
 
 
 def test_rekey_still_blames_the_dictionary_when_it_fuses_distinct_facts(conn):


### PR DESCRIPTION
## Summary
- `lab_result`'s dedup key now truncates `collected_at` to the date part (`_date_only`), matching the pattern already used for `medication`/`procedure`/`appointment`. `observation` is unchanged and stays on full-precision `_norm_ts(observed_at)`.
- Fixes the reported bug: two documents describing the same draw at different `collected_at` precision (`YYYY-MM-DD` vs `YYYY-MM-DDTHH:MM`) now dedup to one row instead of two.
- A genuine same-day distinct draw (different value) now collides on the date-only key and stages a `conflict`, recoverable via the existing `review-conflicts --resolve --keep both` (#58) — no new recovery mechanism.
- `pemr rekey` (existing tooling, per #71/#94) is the migration path for existing databases: a pre-existing mixed-precision duplicate now surfaces as a `"doubled"` collision (resolve with `pemr record rm`); an operator holding two genuine same-day draws instead gets a `"fused"` collision, which is a dictionary-flavored misdiagnosis for this one upgrade case — documented explicitly in `docs/Architecture.md` rather than made type-aware in code.
- Docs fan-out (this PR): `docs/Architecture.md` updated for the date-only key, the split full-precision-vs-date-truncated rationale, the `rekey` upgrade note, and — per audit's advisory — one added sentence documenting that an *identical*-value same-day repeat (e.g. a QC re-run) also collapses to one row (`duplicate`), the same outcome as the mixed-precision fix, since `collected_at` stays out of `_COMPARE_FIELDS["lab_result"]`. `AGENTS.md` §5 gains the lab qualifier on its "add the collection times" advice, which no longer applies to `lab_result`.

Full pipeline history — intake's option framing and recorded `decision:`, design's implementation plan, build's implementation, verify's real-CLI e2e proof, and audit's security/invariant review — is in the issue thread:
- Build: https://github.com/meridun/pemr/issues/117#issuecomment-5247295892
- Verify: https://github.com/meridun/pemr/issues/117#issuecomment-5247421461
- Audit: https://github.com/meridun/pemr/issues/117#issuecomment-5247455679

## Test plan
- [x] `pytest tests/test_dedup.py tests/test_conflict.py` green (verify: 211 passed at `a7abbf9` including audit's re-run)
- [x] `pytest` full suite green (918 passed at verify; docs-only ship commit re-checked with `pytest tests/test_dedup.py -q`)
- [x] `node scripts/check-meta-drift.mjs` pass
- [x] Real-CLI e2e (verify, `tests/test_cli_phase2.py`): mixed-precision pair dedups to one row; same-day distinct draw stages a conflict and `--keep both` admits it; `pemr rekey` against a seeded legacy mixed-precision pair reports one `"doubled"` collision and blocks only `lab_result`
- [x] Audit: no blocking findings; security dimensions, invariants, and scope discipline all reviewed clean

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)