### PR TITLE
fix(tooling): make .claude mirror check line-ending agnostic (#118)

### DIFF
--- a/scripts/sync-claude-config.mjs
+++ b/scripts/sync-claude-config.mjs
@@ -57,6 +57,21 @@ async function listFilesRecursive(dir) {
   return files;
 }
 
+// CRLF -> LF only. A lone `\r` is deliberately left alone: nothing in the mirror
+// set uses classic-Mac endings, and a blanket `\r` strip would corrupt a literal
+// carriage return inside content.
+export function normalizeEol(text) {
+  return text.replace(/\r\n/g, '\n');
+}
+
+// Line-ending-agnostic comparison. Git may materialize the mirrors with CRLF in a
+// fresh worktree/clone (core.autocrlf=true, no .gitattributes) while the script
+// regenerates them with LF, so strict equality false-positives as "out of date".
+// A missing destination (existing === null) is deliberately NOT in sync.
+export function isInSync(existing, content) {
+  return typeof existing === 'string' && normalizeEol(existing) === normalizeEol(content);
+}
+
 async function writeIfChanged(destPath, content) {
   let existing = null;
   try {
@@ -65,7 +80,7 @@ async function writeIfChanged(destPath, content) {
     // destination doesn't exist yet
   }
 
-  if (existing === content) {
+  if (isInSync(existing, content)) {
     return;
   }
 
@@ -77,7 +92,8 @@ async function writeIfChanged(destPath, content) {
   }
 
   await fs.mkdir(path.dirname(destPath), { recursive: true });
-  await fs.writeFile(destPath, content, 'utf8');
+  // Write LF on disk so the next --check pass (in any checkout) stays stable.
+  await fs.writeFile(destPath, normalizeEol(content), 'utf8');
   console.log(`Wrote ${relPath}`);
 }
 
@@ -159,10 +175,17 @@ async function syncAgents() {
   }
 }
 
-await syncSkills();
-await syncAgents();
+async function main() {
+  await syncSkills();
+  await syncAgents();
 
-if (CHECK_MODE && outOfDate) {
-  console.error('\n.claude/ mirrors are out of date. Run `npm run sync:claude-config`.');
-  process.exit(1);
+  if (CHECK_MODE && outOfDate) {
+    console.error('\n.claude/ mirrors are out of date. Run `npm run sync:claude-config`.');
+    process.exit(1);
+  }
+}
+
+// Only run when invoked directly, so tests can import the pure helpers.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
 }

--- a/test/sync-claude-config.test.mjs
+++ b/test/sync-claude-config.test.mjs
@@ -1,0 +1,65 @@
+// Tests for scripts/sync-claude-config.mjs — zero-dependency, node's built-in runner:
+//   node --test              (default discovery finds test/*.test.mjs)
+//   node --test "test/*.test.mjs"
+// Regression coverage for #118: a fresh git worktree materializes the .claude/
+// mirrors with CRLF (core.autocrlf=true, no .gitattributes) while the script
+// regenerates them with LF, so strict string equality reported them "out of date".
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizeEol, isInSync } from '../scripts/sync-claude-config.mjs';
+
+describe('normalizeEol', () => {
+  it('converts CRLF to LF', () => {
+    assert.equal(normalizeEol('a\r\nb\r\n'), 'a\nb\n');
+  });
+
+  it('leaves LF-only text unchanged (idempotent)', () => {
+    const lf = 'a\nb\n';
+    assert.equal(normalizeEol(lf), lf);
+    assert.equal(normalizeEol(normalizeEol(lf)), lf);
+  });
+
+  it('normalizes mixed CRLF/LF to all LF', () => {
+    assert.equal(normalizeEol('---\nname: scout\n---\r\nbody\r\n'), '---\nname: scout\n---\nbody\n');
+  });
+
+  it('preserves a lone carriage return', () => {
+    assert.equal(normalizeEol('a\rb'), 'a\rb');
+  });
+});
+
+describe('isInSync', () => {
+  it('treats CRLF vs LF of the same text as in sync', () => {
+    assert.equal(isInSync('a\r\nb\r\n', 'a\nb\n'), true);
+  });
+
+  it('treats a mixed-ending mirror vs a pure-CRLF checkout as in sync (.claude/agents/*.md case)', () => {
+    // syncAgents() concatenates LF-joined frontmatter onto a CRLF body, so the
+    // main checkout holds mixed endings while a fresh worktree holds pure CRLF.
+    const mixed = '---\nname: scout\n---\r\nBody line.\r\n';
+    const crlf = '---\r\nname: scout\r\n---\r\nBody line.\r\n';
+    assert.equal(isInSync(crlf, mixed), true);
+  });
+
+  it('treats identical text as in sync', () => {
+    assert.equal(isInSync('same\n', 'same\n'), true);
+  });
+
+  it('still detects genuine drift with matching line endings', () => {
+    assert.equal(isInSync('old\n', 'new\n'), false);
+  });
+
+  it('still detects genuine drift when line endings also differ', () => {
+    assert.equal(isInSync('old\r\ntext\r\n', 'new\ntext\n'), false);
+  });
+
+  it('does not mask added or removed lines', () => {
+    assert.equal(isInSync('a\r\nb\r\n', 'a\nb\nc\n'), false);
+  });
+
+  it('treats a missing destination as not in sync', () => {
+    assert.equal(isInSync(null, 'anything\n'), false);
+  });
+});


### PR DESCRIPTION
## What shipped

`scripts/sync-claude-config.mjs`'s `.github/` → `.claude/` mirror comparison is now line-ending
agnostic, fixing a false-positive `npm run sync:claude-config:check` failure in fresh git
worktrees on Windows (`core.autocrlf=true`, no `.gitattributes`).

- New exports `normalizeEol(text)` (`\r\n` → `\n`, lone `\r` preserved) and
  `isInSync(existing, content)`.
- `writeIfChanged` now compares via `isInSync` and writes `normalizeEol(content)` (LF on disk for
  anything the script actually rewrites); already-in-sync mirrors are left untouched.
- Top-level `syncSkills()/syncAgents()` side effects moved into `main()` behind the same
  direct-invocation guard `scripts/check-meta-drift.mjs` already uses, so the new test can import
  the module without triggering a real sync.
- New `test/sync-claude-config.test.mjs` (11 tests): CRLF/LF/mixed normalization, in-sync vs.
  genuine-drift detection (same and different line endings), `null` destination.

Root cause was narrower than the original report: only the 7 `.claude/agents/*.md` mirrors are
mixed-ending (`syncAgents` concatenates an LF-joined frontmatter block onto a CRLF-materialized
body); skills mirrors were already CRLF-consistent on both sides.

No docs fan-out — audit flagged this as internal tooling behavior with no user-facing surface and
no L1/L2 documentation warranted.

Closes #118

## Verify + audit reports
- Verify: https://github.com/meridun/pemr/issues/118#issuecomment-5248009980
- Audit: https://github.com/meridun/pemr/issues/118#issuecomment-5248036086

---
🤖 Generated with a `pemr` SDLC pipeline ship worker (run `dispatch-20260811-0117-936e-ship`)
