### PR TITLE
feat(curation): add a distinct verdict that settles a rekey collision as two facts

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -127,7 +127,7 @@ CREATE TABLE curation (
   record_type      TEXT NOT NULL,   -- one of dedup.KNOWN_TYPES; validated in Python
   dedup_base       TEXT NOT NULL,   -- family identity; a breadcrumb when record_id <> 0
   record_id        INTEGER NOT NULL DEFAULT 0,  -- 0 = family scope; else <record_type>_id
-  status           TEXT NOT NULL,   -- confirmed|superseded|erroneous-in-source|disputed|merged-into
+  status           TEXT NOT NULL,   -- confirmed|superseded|erroneous-in-source|disputed|merged-into|distinct
   note             TEXT NOT NULL,   -- required: the why, and who said so
   merged_into_base TEXT,            -- set iff status = 'merged-into'; always a FAMILY
   attributed_to    TEXT,
@@ -390,6 +390,12 @@ Electrophoresis Albumin Fraction` off one draw) and the fix belongs in the dicti
 *identical* payloads mean one fact was filed twice, once
 under a pre-drift key, and the fix belongs in the data.
 
+There is a third case the dictionary cannot fix (issue #122). When the colliding labels
+are generic *extraction placeholders* — `diagnosis`, `diagnosis 2`,
+`past_medical_history 3` — they are synonyms of nothing, so there is no dictionary entry
+to narrow, and nothing in the data to drop either: both rows are real and different. That
+one is settled by a `distinct` verdict (below), not by an edit anywhere.
+
 **A collision quarantines its own table, not the run** (issue #92). The record tables are
 scanned independently, so a fused pair in `allergy` says nothing about `condition`. The
 scan therefore never stops at the first collision: it reports every collision in every
@@ -402,21 +408,40 @@ cross-reference `skipped` to tell written from withheld. Exit code is 1 whenever
 **blocking** collision was found, in both output modes: partial progress is fine, silent
 partial progress is not.
 
-**A collision a human already ruled on is settled, not blocking** (issue #116). Many
-collisions are exactly the pair the curation overlay exists to answer: a `merged-into` or
-`superseded` verdict says "these two are one fact", which is the question the guard is
-stuck on. So `rekey` consults the overlay — through an injected resolver, because
-`curation` imports `dedup` and not the reverse — and a clash covered by such a verdict on
-**either** row at **either** scope stops being blocking. The clash row is filed as the
-next free *occurrence* of the surviving family (the `--keep both` shape; leaving it on its
-stored key would strand it permanently drifted while `rekey` itself reported clean). Only
-`merged-into`/`superseded` resolve — `confirmed`, `disputed` and `erroneous-in-source`
-rule on a row's content, not on its identity against another row — and a table holding any
-*unresolved* collision still withholds every change in it, resolved pairs included (its
-resolutions say exactly that, rather than describing a write that did not happen). Both
-output modes distinguish the two: a resolved pair is a `note:` line and an entry in
-`--json`'s `resolved` list, a blocked one stays `error:` plus `skipped`. A run whose every
-collision was verdict-resolved therefore exits **0**.
+**A collision a human already ruled on is settled, not blocking** (issues #116, #122).
+Many collisions are exactly the pair the curation overlay exists to answer. So `rekey`
+consults the overlay — through an injected resolver, because `curation` imports `dedup`
+and not the reverse — and a clash covered by a **resolving** verdict on **either** row at
+**either** scope stops being blocking. The clash row is filed as the next free
+*occurrence* of the shared family (the `--keep both` shape; leaving it on its stored key
+would strand it permanently drifted while `rekey` itself reported clean).
+
+Resolving verdicts come in two kinds, and they answer the identity question opposite ways:
+
+- **one fact** — `merged-into` / `superseded`: the pair is a single fact filed twice;
+- **two facts** — `distinct` (issue #122): the rows are genuinely different, and only
+  their generic extracted labels recompute onto one key.
+
+Both take the *same* write, because occurrence numbering is already the representation of
+"two live rows on one identity". What differs is rendering, and it differs by omission:
+`distinct` is deliberately **not** one of the appendix statuses, so neither row leaves its
+clinical section — they render as two live siblings, exactly like a `--keep both` pair.
+That absence is the whole guarantee, and `tests/test_curation.py` asserts the two tuples
+stay disjoint.
+
+`confirmed`, `disputed` and `erroneous-in-source` resolve nothing — they rule on a row's
+content, not on its identity against another row — and a table holding any *unresolved*
+collision still withholds every change in it, resolved pairs included (its resolutions say
+exactly that, rather than describing a write that did not happen). All three cases are
+distinguishable in output: a resolved pair is a `note:` line naming which way it was
+settled plus an entry in `--json`'s `resolved` list carrying `settlement`
+(`"merged"` | `"distinct"`), a blocked one stays `error:` plus `skipped`. A run whose
+every collision was verdict-resolved therefore exits **0**.
+
+A resolving verdict is **unary** — it names one row or one family, never a counterpart —
+so like `superseded` since #116 it settles any collision its target takes part in,
+including one that would otherwise have blocked. Every resolution is reported with both
+row ids, the status and the scope, so the reach of a ruling is stated rather than assumed.
 
 **A verdict's scope never widens across that merge.** Resolution joins a judged family to
 an unjudged one, so the surviving family is *larger* than the one the human ruled on.
@@ -766,7 +791,9 @@ pemr record rm <table> <id> [--apply]                    # delete ONE record row
 pemr record annotate <table> <base-or-id> --status <s> --note <text> [--attributed-to ...]
                      [--merged-into <base-or-id>] [--row] [--apply]
                                                          # record a human verdict over a record FAMILY (§2 curation):
-                                                         # confirmed|superseded|erroneous-in-source|disputed|merged-into
+                                                         # confirmed|superseded|erroneous-in-source|disputed|merged-into|distinct
+                                                         # distinct: two rows that recompute to one dedup_key are TWO facts
+                                                         #        (generic extracted labels); unblocks `rekey`, both stay live
                                                          # --row: scope it to that ROW only (a keep-both family holds
                                                          #        two live rows; row scope beats family scope there)
                                                          # pure overlay - no record row is mutated; dry run by default
@@ -857,7 +884,8 @@ Every section is filtered at read time against the `curation` overlay (§2, issu
 #114): `superseded` / `erroneous-in-source` / `merged-into` leave their section for a
 `## Superseded / corrected` appendix, `disputed` renders in place with a
 `[DISPUTED: <note>]` marker and reaches the brief's `## Questions for the Clinician`, and
-`confirmed` renders unchanged. Both new sections are omitted entirely when empty, so a record
+`confirmed` — and `distinct` (§3, issue #122), whose whole point is that both rows stay
+live — render unchanged. Both new sections are omitted entirely when empty, so a record
 with no verdicts renders byte-identically to before the overlay existed. This does not weaken
 the purity rule: the filter is a read, and output changes after a verdict because the
 *database* changed. Resolution is **per row**: a row-scoped verdict affects only its own

--- a/migrations/011_curation_distinct_status.sql
+++ b/migrations/011_curation_distinct_status.sql
@@ -1,0 +1,66 @@
+-- 011_curation_distinct_status: a verdict may rule two colliding rows DISTINCT (issue #122).
+--
+-- Since #116 a `pemr rekey` collision is settled by a `merged-into` or `superseded`
+-- verdict - both of which say "these two rows are one fact". There was no way to record
+-- the opposite ruling: "these are two different facts that happen to recompute to one
+-- dedup_key because their extracted labels are generic placeholders (`diagnosis 2`,
+-- `past_medical_history 3`)". Those labels are synonyms of nothing, so the standing
+-- advice for a fused collision - fix the dictionary - has nothing to narrow, and the
+-- table stayed quarantined (#92) indefinitely.
+--
+-- `distinct` is that missing ruling. It is a *resolving* status (it settles the identity
+-- question a collision asks, so `rekey` may act on it) but deliberately NOT an appendix
+-- status: neither row is superseded or merged, both stay live, and after the rekey they
+-- sit in one family at two occurrences - the `--keep both` shape that already renders as
+-- two independent siblings. Absence from `curation.APPENDIX_STATUSES` is what guarantees
+-- that; see the disjointness assertion in tests/test_curation.py.
+--
+-- The verdict is **unary**: it names the row (or family) it rules on and no counterpart,
+-- exactly as `superseded` has since #116. A pair-shaped column was rejected because the
+-- counterpart is as often a row as a family, and every resolution is reported with both
+-- row ids, the status and the scope, so the ruling's reach is never silent.
+--
+-- This is a table REBUILD rather than an ALTER: SQLite cannot alter a CHECK constraint,
+-- and the widened status vocabulary lives in one. It follows 010's rebuild verbatim -
+-- same columns, same PK, 010's four CHECKs with only the status list widened - and, as
+-- there, `curation` has no FK in or out and no dependent view or trigger, so the rebuild
+-- is safe under foreign_keys=ON and db.migrate wraps the whole script in one
+-- BEGIN/COMMIT. The partial unique index is dropped with the old table and must be
+-- re-created below; losing it would let a rekey leave two copies of one row's verdict.
+--
+-- Still no FK to the row (the 007/010 precedent): `pemr verify` warns on an orphaned
+-- verdict rather than the schema erasing one.
+
+CREATE TABLE curation_new (
+  record_type      TEXT NOT NULL,   -- one of dedup.KNOWN_TYPES; validated in Python
+  dedup_base       TEXT NOT NULL,   -- family identity; a BREADCRUMB when record_id <> 0
+  record_id        INTEGER NOT NULL DEFAULT 0,  -- 0 = family scope; else <record_type>_id
+  status           TEXT NOT NULL,
+  note             TEXT NOT NULL,   -- required: the why, and who said so
+  merged_into_base TEXT,            -- set iff status = 'merged-into'; always a FAMILY
+  attributed_to    TEXT,
+  created_at       TEXT NOT NULL,   -- ISO8601 UTC, timespec=seconds (as document.ingested_at)
+  PRIMARY KEY (record_type, dedup_base, record_id),
+  CHECK (record_id >= 0),
+  CHECK (status IN ('confirmed', 'superseded', 'erroneous-in-source', 'disputed',
+                    'merged-into', 'distinct')),
+  CHECK (trim(note) <> ''),
+  CHECK ((merged_into_base IS NOT NULL) = (status = 'merged-into'))
+);
+
+INSERT INTO curation_new
+  (record_type, dedup_base, record_id, status, note, merged_into_base, attributed_to,
+   created_at)
+SELECT record_type, dedup_base, record_id, status, note, merged_into_base, attributed_to,
+       created_at
+FROM curation;
+
+DROP TABLE curation;
+
+ALTER TABLE curation_new RENAME TO curation;
+
+-- Re-created because the DROP took it with the old table (010's own reasoning): one live
+-- verdict per row, whatever base it was recorded under, which the PK cannot state since
+-- its dedup_base member is a breadcrumb.
+CREATE UNIQUE INDEX idx_curation_row ON curation(record_type, record_id)
+  WHERE record_id <> 0;

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -1468,6 +1468,11 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
                     "verdict_action": r.verdict_action,
                     "narrowed_row_ids": r.narrowed_row_ids,
                     "message": r.message,
+                    # Appended (issue #122): which question the verdict answered -
+                    # "merged" (the pair is one fact) or "distinct" (two facts that share
+                    # a recomputed key). `status` carries the raw vocabulary; this is the
+                    # two-valued contract a consumer can branch on.
+                    "settlement": r.settlement,
                 }
                 for r in report.resolved
             ],
@@ -1498,7 +1503,15 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
                 f"`pemr record annotate --row {resolution.record_type} <id>`"
             )
     if report.resolved:
-        print(f"{len(report.resolved)} collision(s) resolved by verdict")
+        # Both counts, always: "resolved by verdict" alone hides the difference between
+        # "a human folded these into one fact" and "a human ruled them two facts that
+        # both keep rendering" (issue #122).
+        merged = sum(1 for r in report.resolved if r.settlement != "distinct")
+        distinct = len(report.resolved) - merged
+        print(
+            f"{len(report.resolved)} collision(s) resolved by verdict "
+            f"({merged} as one fact, {distinct} as distinct facts)"
+        )
 
     for collision in report.collisions:
         print(f"error: {collision.message}", file=sys.stderr)

--- a/pemr/curation.py
+++ b/pemr/curation.py
@@ -105,6 +105,7 @@ STATUSES: tuple[str, ...] = (
     "erroneous-in-source",
     "disputed",
     "merged-into",
+    "distinct",
 )
 
 #: The statuses that move a family **out** of its normal rendered section and into the
@@ -118,14 +119,40 @@ APPENDIX_STATUSES: tuple[str, ...] = (
 )
 
 #: The statuses that say "a human settled *which fact this is*" — and therefore the only
-#: ones that may resolve a `pemr rekey` collision (issue #116). ``confirmed`` records
-#: agreement with the row as filed, ``disputed`` records that the question is still open,
-#: and ``erroneous-in-source`` rules on the *content* of one row without saying anything
-#: about its identity relative to another — none of the three settles "these two rows are
-#: one fact", which is the question a collision asks.
+#: ones that may resolve a `pemr rekey` collision (issues #116, #122). They answer that
+#: question two opposite ways: ``merged-into``/``superseded`` say **one fact** (the pair
+#: is a single fact filed twice), ``distinct`` says **two facts** (issue #122 — the labels
+#: are generic extraction placeholders that recompute onto one key, and there is no
+#: dictionary entry to narrow because they are synonyms of nothing). Both settle the
+#: identity question, so both let `rekey` proceed; which of the two was recorded is
+#: reported as the resolution's ``settlement`` (:meth:`CollisionResolver.settlement`).
+#:
+#: ``confirmed`` records agreement with the row as filed, ``disputed`` records that the
+#: question is still open, and ``erroneous-in-source`` rules on the *content* of one row
+#: without saying anything about its identity relative to another — none of the three
+#: settles the pair either way, so none of them resolves a collision.
+#:
+#: Every resolving verdict is **unary**: it names one row or one family and no
+#: counterpart, so it settles *any* collision that target takes part in, including a
+#: future one that would otherwise have blocked. That generality is deliberate and
+#: unchanged since #116 — every resolution is reported with both row ids, the status and
+#: the scope, so the reach of a ruling is never silent.
 RESOLVING_STATUSES: tuple[str, ...] = (
     "merged-into",
     "superseded",
+    "distinct",
+)
+
+#: The resolving statuses that say **two facts**, not one (issue #122) — the sub-vocabulary
+#: :meth:`CollisionResolver.settlement` reports as ``"distinct"``.
+#:
+#: Deliberately **disjoint from** :data:`APPENDIX_STATUSES`, and that disjointness *is* the
+#: guarantee both rows keep rendering as live, independent facts: a distinct-resolved pair
+#: lands in one family at two occurrences — the ``--keep both`` shape — and nothing about
+#: rendering changes. If a status ever appeared in both tuples, a live row would silently
+#: leave its clinical section, the failure issue #114 was raised for.
+DISTINCT_STATUSES: tuple[str, ...] = (
+    "distinct",
 )
 
 #: The key a rendered row carries its verdict under, when it has one.
@@ -811,6 +838,20 @@ class CollisionResolver:
             if verdict is not None and verdict["status"] in RESOLVING_STATUSES:
                 return verdict
         return None
+
+    def settlement(self, verdict: dict) -> str:
+        """Which question the resolving ``verdict`` answered: ``"merged"`` | ``"distinct"``.
+
+        ``"merged"`` — the pair is **one fact** (``merged-into``/``superseded``).
+        ``"distinct"`` — it is **two facts** that share a recomputed key
+        (:data:`DISTINCT_STATUSES`, issue #122).
+
+        A method rather than a constant `dedup` could read: the status vocabulary lives
+        here and must not leak across the seam, since ``dedup`` cannot import ``curation``.
+        The two return values are the stable contract `rekey` and the CLI report on, while
+        the vocabulary behind them stays free to grow.
+        """
+        return "distinct" if verdict["status"] in DISTINCT_STATUSES else "merged"
 
     def narrow(
         self,

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -1397,6 +1397,13 @@ class CollisionResolver(Protocol):
     ) -> dict | None:
         """The verdict settling this pair's identity, or None if none does."""
 
+    def settlement(self, verdict: dict) -> str:
+        """Which way ``verdict`` settled the pair (issue #122): ``"merged"`` — the two
+        rows are one fact — or ``"distinct"`` — they are two different facts that
+        recompute onto one key. Both let the rekey proceed and both file the clash row as
+        a new occurrence; the difference is what the operator is told, and (outside this
+        module) that a distinct-resolved pair keeps rendering as two live siblings."""
+
     def narrow(
         self,
         conn: sqlite3.Connection,
@@ -1429,12 +1436,16 @@ class RekeyResolution:
     """A collision a recorded human verdict settled, instead of blocking on (issue #116).
 
     The pair still recomputes onto one identity; what the verdict supplies is the answer
-    `rekey` cannot derive — that a human already ruled these two rows are one fact. The
-    clash row is then filed as the next free **occurrence** of the surviving family, the
-    shape a ``--keep both`` conflict resolution produces, rather than left on its stored
-    key: a row left behind would stay permanently drifted, and
+    `rekey` cannot derive — that a human already ruled on these two rows. The ruling comes
+    in two kinds, reported as :attr:`settlement` (issue #122): ``"merged"`` says the pair
+    is **one fact**, ``"distinct"`` says it is **two facts** whose extracted labels are
+    generic enough to recompute onto one key. Both are settled rather than blocking, and
+    both take the same write: the clash row is filed as the next free **occurrence** of
+    the shared family, the shape a ``--keep both`` conflict resolution produces, rather
+    than left on its stored key — a row left behind would stay permanently drifted, and
     :func:`_assert_no_key_drift` would refuse the next ingest deriving that identity
-    while this very command reported clean.
+    while this very command reported clean. A distinct-resolved pair therefore renders as
+    two live siblings, which is exactly what "two facts" has to mean.
 
     Resolution merges a judged family into a larger one, so the authorizing verdict is
     **narrowed** to the rows it already covered rather than moved onto the surviving
@@ -1455,6 +1466,12 @@ class RekeyResolution:
     new_base: str           # the surviving family both rows land in
     new_occurrence: int     # occurrence the clash row takes under new_base
     message: str            # full account, ready to print
+    # Which question the verdict answered (issue #122): "merged" — the pair is one fact —
+    # or "distinct" — two facts sharing a recomputed key. Kept apart from `status` on
+    # purpose: `status` is the raw curation vocabulary and may grow, `settlement` is the
+    # stable two-valued contract the CLI reports. Defaults to the #116 answer, so a
+    # resolution built without one reads as it always did.
+    settlement: str = "merged"
     # Rows the verdict covered before this rekey — its extension at ruling time. For a
     # row-scoped verdict, the one row it names.
     covered_row_ids: list[int] = field(default_factory=list)
@@ -1558,11 +1575,17 @@ def rekey(
     :attr:`RekeyReport.blocked`. Callers surface a non-empty ``collisions`` as a failure;
     partial progress with an explicit account of what was skipped beats all-or-nothing.
 
-    ``resolver`` is the optional curation-overlay seam (issue #116). Many collisions are
-    exactly the pair a human already ruled on — since migrations 008/010 a
-    ``merged-into`` or ``superseded`` verdict says "these are one fact", which is the
-    very question the guard is stuck on. With a resolver injected, a clash whose pair
-    carries such a verdict (either row, either scope) is **not** blocking: the clash row
+    ``resolver`` is the optional curation-overlay seam (issues #116, #122). Many
+    collisions are exactly the pair a human already ruled on — since migrations 008/010 a
+    ``merged-into`` or ``superseded`` verdict says "these are one fact", and since
+    migration 011 a ``distinct`` verdict says "these are two different facts whose
+    extracted labels merely recompute onto one key" — either way the very question the
+    guard is stuck on. Both are reported as :attr:`RekeyResolution.settlement`
+    (``"merged"`` / ``"distinct"``) and both take the same write, because "two live rows
+    on one identity" already has exactly one representation: occurrence numbering, the
+    ``--keep both`` shape that renders as two independent siblings. With a resolver
+    injected, a clash whose pair carries such a verdict (either row, either scope) is
+    **not** blocking: the clash row
     is filed as the next free occurrence of the surviving family — the shape a
     ``--keep both`` conflict resolution produces — and reported in
     :attr:`RekeyReport.resolved` instead of :attr:`RekeyReport.collisions`, so the table
@@ -1644,6 +1667,7 @@ def rekey(
                 resolution = _resolve_clash(
                     report, record_type, pk, entry, clash, kind, verdict,
                     by_base[entry.base], seen, label, clash_label, covered,
+                    resolver.settlement(verdict),
                 )
                 pending_narrowings.append((record_type, verdict, resolution))
                 continue
@@ -1766,6 +1790,7 @@ def _resolve_clash(
     label: str,
     clash_label: str,
     covered_row_ids: list[int],
+    settlement: str,
 ) -> RekeyResolution:
     """File a verdict-settled clash as the next free occurrence of its family.
 
@@ -1774,6 +1799,11 @@ def _resolve_clash(
     keeps its occurrence and the later row takes the next free one, which is the state a
     ``--keep both`` conflict resolution leaves behind and exactly what row-scoped
     curation (issue #114) exists to annotate.
+
+    ``settlement`` is which way the verdict settled the pair (issue #122) — ``"merged"``
+    or ``"distinct"``. It selects the wording only: the write is identical either way,
+    because the ``--keep both`` shape is *already* "two live siblings on one identity",
+    which is what a distinct ruling asks for.
 
     Mutates ``entry`` and ``seen`` so a *third* row landing on this family sees the
     occupancy this one just created, and appends to ``report``.
@@ -1790,13 +1820,22 @@ def _resolve_clash(
     scope = "row" if verdict["record_id"] else "family"
     # Present tense, not past: whether this actually lands depends on `apply` and on the
     # rest of the table coming out clean, and the caller appends that verdict.
-    message = (
+    preamble = (
         f"{record_type}: {pk} {entry.row_id} ({label!r}) and {pk} {clash.row_id} "
         f"({clash_label!r}) recompute to the same dedup_key ({kind}), but a "
-        f"{scope}-scoped '{verdict['status']}' verdict already settles the pair - "
-        f"{pk} {entry.row_id} takes occurrence {occurrence} of "
-        f"{entry.base[:12]}..., the surviving family"
+        f"{scope}-scoped '{verdict['status']}' verdict already "
     )
+    if settlement == "distinct":
+        message = (
+            f"{preamble}rules them two distinct facts - {pk} {entry.row_id} takes "
+            f"occurrence {occurrence} of {entry.base[:12]}..., the shared family, and "
+            "both rows keep rendering as live, independent facts"
+        )
+    else:
+        message = (
+            f"{preamble}settles the pair - {pk} {entry.row_id} takes occurrence "
+            f"{occurrence} of {entry.base[:12]}..., the surviving family"
+        )
     report.changes.append(RekeyChange(
         record_type, entry.row_id, label, entry.row["dedup_key"], entry.key,
         entry.base, new_occurrence=occurrence,
@@ -1806,7 +1845,7 @@ def _resolve_clash(
         clash_row_id=clash.row_id, clash_label=clash_label, kind=kind,
         status=verdict["status"], scope=scope, record_id=verdict["record_id"],
         verdict_base=verdict["dedup_base"], new_base=entry.base,
-        new_occurrence=occurrence, message=message,
+        new_occurrence=occurrence, message=message, settlement=settlement,
         covered_row_ids=sorted(covered_row_ids),
     )
     report.resolved.append(resolution)

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -34,7 +34,9 @@ family or to a **single row** (:meth:`curation.VerdictMap.for_row` resolves per 
 scope winning over family scope): ``superseded`` / ``erroneous-in-source`` /
 ``merged-into`` leave their section for a ``## Superseded / corrected``
 appendix, ``disputed`` renders in place with a ``[DISPUTED: ...]`` marker (and
-reach the brief's ``## Questions for the Clinician``), and ``confirmed`` renders exactly
+reach the brief's ``## Questions for the Clinician``), and ``confirmed`` — like
+``distinct``, the collision ruling that says both rows are real facts (issue #122) —
+renders exactly
 as before. Both new sections are **omitted entirely** when empty, so a record with no
 verdicts renders byte-identically to what it did before the overlay existed. This is
 still a pure function of DB state -- the filter is a read, and output changes after a

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -527,6 +527,42 @@ def test_rekey_reports_a_verdict_resolved_collision_in_text_and_json(
     assert captured.out.isascii()               # issue #23
 
 
+def test_rekey_reports_a_distinct_resolved_collision_in_text_and_json(
+    ready, capsys, tmp_path
+):
+    """Issue #122 at the CLI: a pair the operator ruled *two distinct facts* unblocks its
+    table exactly as a merge-shaped ruling does, and both output modes say which of the
+    two happened - `settlement` in `--json`, the wording plus the summary counts in
+    text."""
+    old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
+    new = _dict_file(tmp_path, "fuse.toml",
+                     '"alb" = "albumin"\n"t2dm" = "type 2 diabetes"\n')
+    _seed_fusing_lab_and_movable_condition(ready, capsys, tmp_path, old)
+    alb_id, albumin_id = _row_ids(tmp_path, "lab_result")
+    assert _run(tmp_path, "record", "annotate", "lab_result", str(alb_id),
+                "--status", "distinct", "--note", "two assays, one generic label",
+                "--apply") == 0
+    capsys.readouterr()
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["collisions"] == [] and payload["skipped"] == []
+    assert [(r["row_id"], r["clash_row_id"], r["status"], r["settlement"])
+            for r in payload["resolved"]] == [
+        (albumin_id, alb_id, "distinct", "distinct")]
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "lab_result: 2/2 key(s) change" in captured.out
+    assert "(skipped: collision)" not in captured.out
+    assert "rules them two distinct facts" in captured.out
+    assert "both rows keep rendering as live, independent facts" in captured.out
+    assert "1 collision(s) resolved by verdict (0 as one fact, 1 as distinct facts)" \
+        in captured.out
+    assert captured.out.isascii()               # issue #23
+
+
 def test_rekey_json_still_reports_a_blocking_collision(ready, capsys, tmp_path):
     """The same seed with no verdict recorded: `resolved` is empty, the table is still
     skipped by name and the exit code is still 1 (the #92 contract, unwidened)."""

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -563,6 +563,82 @@ def test_rekey_reports_a_distinct_resolved_collision_in_text_and_json(
     assert captured.out.isascii()               # issue #23
 
 
+def _seed_generic_condition_pair(ready, capsys, tmp_path, old):
+    """The `meridun/pemr-data#12` item 6 shape at the CLI: two real, different conditions
+    that the extractor labelled with numbered placeholders, one document each. A
+    `"diagnosis 2" = "diagnosis"` dictionary entry folds them onto one key - the fuse a
+    dictionary edit cannot undo, because the labels are synonyms of nothing."""
+    for i, (name, note) in enumerate(
+        (("diagnosis", "hypertension, per cardiology"),
+         ("diagnosis 2", "asthma, per pulmonology")), start=1
+    ):
+        scan = tmp_path / f"generic{i}.txt"
+        scan.write_bytes(f"scan {i}".encode())
+        assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                    "--sources", str(tmp_path / "sources")) == 0
+        doc = _document_id(tmp_path)[-1]["document_id"]
+        payload = _write_json(tmp_path, f"generic{i}.json", {"condition": [
+            {"name": name, "status": "active", "onset_on": f"2024-0{i}-05", "note": note},
+        ]})
+        assert _run(tmp_path, "commit-extraction", "--document", str(doc),
+                    "--json", str(payload), "--dictionary", str(old)) == 0
+    capsys.readouterr()
+
+
+@pytest.mark.parametrize("status, both_live", [("distinct", True),
+                                               ("superseded", False)])
+def test_a_distinct_resolved_pair_still_renders_as_two_live_problems(
+    ready, capsys, tmp_path, status, both_live
+):
+    """AC2 + AC3 as one chain at the CLI, on the real-world trigger (AC6): declare the
+    pair distinct, `rekey --apply` writes the table, and the rendered summary still shows
+    *both* conditions with no `## Superseded / corrected` appendix at all.
+
+    The `superseded` leg is the control that keeps the assertion honest. Both statuses
+    resolve the collision and both produce the identical two-occurrence family, so the
+    only thing separating them is `distinct`'s absence from
+    `curation.APPENDIX_STATUSES` - and on that leg the ruled row *does* leave Active
+    Problems for the appendix. Without the contrast, "no appendix" could equally mean the
+    appendix never fires for conditions."""
+    old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
+    new = _dict_file(tmp_path, "fuse.toml", '"diagnosis 2" = "diagnosis"\n')
+    _seed_generic_condition_pair(ready, capsys, tmp_path, old)
+    first_id, second_id = _row_ids(tmp_path, "condition")
+
+    # Unruled, the whole table is withheld (AC5 / the #92 quarantine).
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 1
+    assert "condition was not written" in capsys.readouterr().err
+
+    assert _run(tmp_path, "record", "annotate", "condition", str(first_id), "--row",
+                "--status", status, "--note", "two diagnoses, numbered labels",
+                "--apply") == 0
+    capsys.readouterr()
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "condition: 1/2 key(s) change" in captured.out
+    assert "(skipped: collision)" not in captured.out
+    assert captured.out.isascii()               # issue #23
+
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        rows = {int(r["condition_id"]): r
+                for r in conn.execute("SELECT * FROM condition")}
+        # Identical write either way: one family, occurrences 0 and 1.
+        assert rows[first_id]["dedup_base"] == rows[second_id]["dedup_base"]
+        assert (rows[first_id]["dedup_occurrence"],
+                rows[second_id]["dedup_occurrence"]) == (0, 1)
+        summary = render.render_summary(conn, "jane-doe")
+    finally:
+        conn.close()
+
+    problems = summary.split("## Active Problems")[1].split("##")[0]
+    assert "asthma, per pulmonology" in problems           # never the ruled row
+    assert ("hypertension, per cardiology" in problems) is both_live
+    assert ("## Superseded / corrected" not in summary) is both_live
+
+
 def test_rekey_json_still_reports_a_blocking_collision(ready, capsys, tmp_path):
     """The same seed with no verdict recorded: `resolved` is empty, the table is still
     skipped by name and the exit code is still 1 (the #92 contract, unwidened)."""

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -643,11 +643,70 @@ def _fusing_ids(conn):
             _row_id(conn, "lab_result", "test_name", "Glucose"))
 
 
-def test_resolving_statuses_are_only_merged_into_and_superseded():
+def test_resolving_statuses_settle_identity_either_way():
     """The constant guard. `confirmed`/`disputed`/`erroneous-in-source` rule on a row's
-    content; only these two say two rows are one fact, which is what a collision asks."""
-    assert curation.RESOLVING_STATUSES == ("merged-into", "superseded")
+    content; the three below settle *identity* - two of them saying "one fact", `distinct`
+    saying "two facts" (issue #122) - which is what a collision asks.
+
+    The disjointness assertion is load-bearing, not decoration: a `distinct` verdict that
+    leaked into `APPENDIX_STATUSES` would pull a live row out of its clinical section, the
+    failure #114 was raised for, and it is the *absence* from that tuple that makes both
+    rows of a distinct-resolved pair keep rendering."""
+    assert curation.RESOLVING_STATUSES == ("merged-into", "superseded", "distinct")
+    assert curation.DISTINCT_STATUSES == ("distinct",)
     assert set(curation.RESOLVING_STATUSES) <= set(curation.STATUSES)
+    assert set(curation.DISTINCT_STATUSES) <= set(curation.RESOLVING_STATUSES)
+    assert set(curation.DISTINCT_STATUSES) & set(curation.APPENDIX_STATUSES) == set()
+
+
+def test_settlement_reports_which_question_the_verdict_answered():
+    """The seam `dedup` reads instead of importing the status vocabulary: two values, and
+    every resolving status maps onto one of them."""
+    resolver = curation.CollisionResolver(curation.VerdictMap())
+    assert resolver.settlement({"status": "distinct"}) == "distinct"
+    assert resolver.settlement({"status": "merged-into"}) == "merged"
+    assert resolver.settlement({"status": "superseded"}) == "merged"
+
+
+def test_a_distinct_verdict_rejects_a_merge_target(seeded):
+    """`distinct` is unary: it names the row or family it rules on and no counterpart, so
+    `--merged-into` is meaningless with it and must fail before anything is written."""
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    target = _base(conn, "lab_result", "test_name", "HbA1c")
+
+    with pytest.raises(ValueError, match="only meaningful with status 'merged-into'"):
+        curation.annotate_record(conn, "lab_result", base, status="distinct",
+                                 note="two different assays", merged_into_base=target,
+                                 apply=True)
+
+    assert _curation_count(conn) == 0
+
+
+def test_a_distinct_family_verdict_is_narrowed_to_the_rows_it_covered(seeded):
+    """The #116 narrowing, unchanged for the new status: a resolving family verdict is
+    pinned to exactly the rows it covered, and a NULL `merged_into_base` survives the pin
+    (the coupling CHECK would reject anything else)."""
+    conn = seeded["conn"]
+    _hba1c_id, glucose_id = _fusing_ids(conn)
+    glucose_base = _base(conn, "lab_result", "test_name", "Glucose")
+    curation.annotate_record(conn, "lab_result", glucose_base, status="distinct",
+                             note="different analytes, generic labels",
+                             attributed_to="Dr Who",
+                             now="2026-01-01T00:00:00+00:00", apply=True)
+
+    report = dedup.rekey(conn, {"glucose": "hba1c"}, apply=True,
+                         resolver=curation.collision_resolver(conn))
+
+    assert [r.verdict_action for r in report.resolved] == ["narrowed"]
+    assert [r.narrowed_row_ids for r in report.resolved] == [[glucose_id]]
+    assert [r.settlement for r in report.resolved] == ["distinct"]
+    assert _curation_count(conn) == 1               # narrowed, not copied
+    pinned = curation.get_verdict(conn, "lab_result", "", record_id=glucose_id)
+    assert (pinned["status"], pinned["scope"], pinned["merged_into_base"],
+            pinned["created_at"]) == ("distinct", "row", None,
+                                      "2026-01-01T00:00:00+00:00")
+    assert curation.get_verdict(conn, "lab_result", glucose_base) is None
 
 
 def test_a_resolving_family_verdict_is_narrowed_to_the_rows_it_covered(seeded):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -46,6 +46,7 @@ ALL_MIGRATIONS = [
     "008_curation.sql",
     "009_record_attestation.sql",
     "010_curation_row_scope.sql",
+    "011_curation_distinct_status.sql",
 ]
 
 # Every record table carries the occurrence-family columns (migration 005; 006's two
@@ -135,7 +136,7 @@ def test_migration_006_moves_condition_and_allergy_observations(conn, tmp_path):
     assert db.migrate(conn) == [
         "006_condition_allergy.sql", "007_document_tombstone.sql",
         "008_curation.sql", "009_record_attestation.sql",
-        "010_curation_row_scope.sql",
+        "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
     ]
 
     a = conn.execute("SELECT * FROM allergy").fetchone()
@@ -268,7 +269,7 @@ def test_migration_008_applies_on_a_007_era_database(conn, tmp_path):
 
     assert db.migrate(conn) == [
         "008_curation.sql", "009_record_attestation.sql",
-        "010_curation_row_scope.sql",
+        "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
     ]
 
     assert curation.has_table(conn) is True
@@ -320,6 +321,7 @@ def test_migration_009_applies_on_an_008_era_database(conn, tmp_path):
 
     assert db.migrate(conn) == [
         "009_record_attestation.sql", "010_curation_row_scope.sql",
+        "011_curation_distinct_status.sql",
     ]
 
     assert attestations.has_columns(conn) is True
@@ -368,7 +370,9 @@ def test_migration_010_rebuilds_curation_and_preserves_every_verdict(conn, tmp_p
         "SELECT * FROM curation ORDER BY dedup_base"
     ).fetchall()]
 
-    assert db.migrate(conn) == ["010_curation_row_scope.sql"]
+    assert db.migrate(conn) == [
+        "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
+    ]
 
     after = [dict(r) for r in conn.execute(
         "SELECT * FROM curation ORDER BY dedup_base"
@@ -409,6 +413,79 @@ def test_migration_010_lets_scopes_coexist_but_pins_one_verdict_per_row(conn):
             "INSERT INTO curation (record_type, dedup_base, record_id, status, note, "
             "created_at) VALUES ('lab_result', 'base-a', -1, 'disputed', 'why', "
             "'2026-01-01T00:00:00')"
+        )
+
+
+def _migrate_through_010(conn, tmp_path):
+    """Apply every migration up to 010, leaving 011 pending (a 010-era database)."""
+    import shutil
+
+    staged = tmp_path / "pre011"
+    staged.mkdir()
+    for path in sorted(db.DEFAULT_MIGRATIONS_DIR.glob("*.sql")):
+        if path.name < "011":
+            shutil.copy(path, staged / path.name)
+    db.migrate(conn, staged)
+    return staged
+
+
+def test_migration_011_widens_the_status_check_and_preserves_every_verdict(
+    conn, tmp_path
+):
+    """Issue #122's rebuild, checked the way 010's is: a widened CHECK cannot be ALTERed
+    in, so the table is rebuilt, and the round trip must carry every 010-era verdict of
+    *both* scopes through byte-for-byte. The partial index is the failure mode of a
+    rebuild - it is dropped with the old table - so its survival is asserted explicitly."""
+    from pemr import curation
+
+    _migrate_through_010(conn, tmp_path)
+    conn.execute(
+        "INSERT INTO curation (record_type, dedup_base, record_id, status, note, "
+        "attributed_to, created_at) VALUES ('lab_result', 'base-a', 0, 'disputed', "
+        "'two sources', 'Dr Who', '2026-01-01T00:00:00+00:00')"
+    )
+    conn.execute(
+        "INSERT INTO curation (record_type, dedup_base, record_id, status, note, "
+        "merged_into_base, created_at) VALUES ('condition', 'base-b', 7, "
+        "'merged-into', 'same episode', 'base-c', '2026-02-02T00:00:00+00:00')"
+    )
+    conn.commit()
+    before = [dict(r) for r in conn.execute(
+        "SELECT * FROM curation ORDER BY dedup_base"
+    ).fetchall()]
+
+    assert db.migrate(conn) == ["011_curation_distinct_status.sql"]
+
+    after = [dict(r) for r in conn.execute(
+        "SELECT * FROM curation ORDER BY dedup_base"
+    ).fetchall()]
+    assert after == before
+    assert [r["record_id"] for r in after] == [0, 7]      # both scopes survived
+    verdicts = curation.load_verdicts(conn)
+    assert len(verdicts.family) == 1 and len(verdicts.rows) == 1
+
+    # The uniqueness rule the rebuild would silently lose.
+    assert conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_curation_row'"
+    ).fetchone() is not None
+    with pytest.raises(sqlite3.IntegrityError):          # same row, a different base
+        conn.execute(
+            "INSERT INTO curation (record_type, dedup_base, record_id, status, note, "
+            "created_at) VALUES ('condition', 'base-z', 7, 'disputed', 'why', "
+            "'2026-03-03T00:00:00+00:00')"
+        )
+
+    # The point of the migration: the new status is accepted, and only it widened.
+    conn.execute(
+        "INSERT INTO curation (record_type, dedup_base, record_id, status, note, "
+        "created_at) VALUES ('condition', 'base-d', 0, 'distinct', 'two diagnoses', "
+        "'2026-03-03T00:00:00+00:00')"
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO curation (record_type, dedup_base, record_id, status, note, "
+            "created_at) VALUES ('condition', 'base-e', 0, 'made-up', 'nope', "
+            "'2026-03-03T00:00:00+00:00')"
         )
 
 

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1469,6 +1469,134 @@ def test_a_third_row_on_a_resolved_key_still_blocks_when_unverdicted(conn):
     assert _keys(conn, "lab_result", "test_name") == before
 
 
+# --- collisions ruled TWO distinct facts (issue #122) -------------------------
+
+def test_a_distinct_verdict_resolves_a_collision_without_merging(conn):
+    """AC2. A `distinct` ruling settles the identity question the opposite way from
+    `merged-into`/`superseded` - two facts, not one - and that is enough to unblock the
+    table. The write is the same either way, because the `--keep both` occurrence shape
+    *is* "two live rows on one identity"."""
+    peaf_id, albumin_id = _fusing_pair(conn)
+    resolver = _rule(conn, peaf_id, "distinct")
+
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM), apply=True,
+                         resolver=resolver)
+
+    assert report.collisions == [] and report.blocked == []
+    assert [(r.row_id, r.clash_row_id, r.status, r.settlement, r.new_occurrence)
+            for r in report.resolved] == [
+        (albumin_id, peaf_id, "distinct", "distinct", 1)]
+    rows = _lab_rows(conn)
+    shared = rows[peaf_id]["dedup_base"]
+    assert rows[albumin_id]["dedup_base"] == shared              # one family, two rows
+    assert (rows[peaf_id]["dedup_occurrence"],
+            rows[albumin_id]["dedup_occurrence"]) == (0, 1)
+    assert rows[peaf_id]["dedup_key"] == shared
+    assert rows[albumin_id]["dedup_key"] == dedup.occurrence_key(shared, 1)
+
+
+@pytest.mark.parametrize("status,settlement", [
+    ("distinct", "distinct"),
+    ("merged-into", "merged"),
+    ("superseded", "merged"),
+])
+def test_a_resolution_reports_which_way_the_verdict_settled_it(conn, status,
+                                                               settlement):
+    """AC4 at the engine level. `status` is the raw vocabulary and may grow; `settlement`
+    is the two-valued contract the CLI and any consumer branch on."""
+    peaf_id, albumin_id = _fusing_pair(conn)
+    kwargs = ({"merged_into_base": _lab_rows(conn)[albumin_id]["dedup_base"]}
+              if status == "merged-into" else {})
+    resolver = _rule(conn, peaf_id, status, **kwargs)
+
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM), apply=True,
+                         resolver=resolver)
+
+    assert [(r.status, r.settlement) for r in report.resolved] == [(status, settlement)]
+    marker = ("rules them two distinct facts" if settlement == "distinct"
+              else "settles the pair")
+    assert marker in report.resolved[0].message
+
+
+def test_a_distinct_resolution_leaves_no_key_drift(conn):
+    """The #116 reason for rekeying a settled clash rather than leaving it behind, which
+    a `distinct` ruling inherits unchanged: a stranded row stays permanently drifted and
+    `_assert_no_key_drift` would refuse every later ingest of that identity."""
+    peaf_id, _albumin_id = _fusing_pair(conn)
+    resolver = _rule(conn, peaf_id, "distinct")
+    d_new = _rekey_dict(**_FUSING_ALBUMIN_SYNONYM)
+    dedup.rekey(conn, d_new, apply=True, resolver=resolver)
+
+    pid = conn.execute("SELECT person_id FROM person").fetchone()["person_id"]
+    payloads = [{name: row[name] for name in dedup.FIELD_SPECS["lab_result"]}
+                for row in _lab_rows(conn).values()]
+    dedup._assert_no_key_drift(conn, "lab_result", payloads, pid, d_new)  # no raise
+
+
+def test_rekey_is_idempotent_after_a_distinct_resolution(conn):
+    peaf_id, _albumin_id = _fusing_pair(conn)
+    resolver = _rule(conn, peaf_id, "distinct")
+    d_new = _rekey_dict(**_FUSING_ALBUMIN_SYNONYM)
+    assert len(dedup.rekey(conn, d_new, apply=True, resolver=resolver).resolved) == 1
+
+    again = dedup.rekey(conn, d_new, apply=True,
+                        resolver=curation.collision_resolver(conn))
+    assert (again.changes, again.collisions, again.resolved) == ([], [], [])
+
+
+def _generic_condition_pair(conn):
+    """Two real, different conditions extracted under generic placeholder labels.
+
+    The `meridun/pemr-data#12` item 6 shape: an extractor that numbers repeated fields
+    emits `diagnosis` / `diagnosis 2`, so the labels carry no clinical identity at all and
+    the payloads differ only in the note. Returns ``(first id, second id)``."""
+    dedup.commit_extraction(conn, _make_document(conn), {"condition": [
+        {"name": "diagnosis", "status": "active", "note": "hypertension, per cardiology"},
+        {"name": "diagnosis 2", "status": "active", "note": "asthma, per pulmonology"},
+    ]}, dedup.load_dictionary(DICT_PATH))
+    return tuple(int(r["condition_id"]) for r in conn.execute(
+        "SELECT condition_id FROM condition ORDER BY condition_id"))
+
+
+def test_generic_condition_labels_declared_distinct_are_rekeyed_apart(conn):
+    """AC6 - the real-world trigger, end to end at the engine.
+
+    A dictionary edit folds `diagnosis 2` onto `diagnosis`, and because the labels are
+    placeholders rather than synonyms of anything there is no dictionary fix available:
+    both rows are real and different. Without a verdict the whole `condition` table is
+    withheld; with a `distinct` verdict `--apply` writes it and both rows survive as
+    occurrences 0 and 1 of one family."""
+    first_id, second_id = _generic_condition_pair(conn)
+    d_new = _rekey_dict(**{"diagnosis 2": "diagnosis"})
+    before = _keys(conn, "condition", "name")
+
+    blocked = dedup.rekey(conn, d_new, apply=True,
+                          resolver=curation.collision_resolver(conn))
+    assert [c.kind for c in blocked.collisions] == ["fused"]
+    assert blocked.blocked == ["condition"]
+    assert _keys(conn, "condition", "name") == before        # #92 quarantine held
+
+    curation.annotate_record(conn, "condition", str(first_id), status="distinct",
+                             note="two different diagnoses under numbered labels",
+                             attributed_to="Dr Who", apply=True)
+
+    report = dedup.rekey(conn, d_new, apply=True,
+                         resolver=curation.collision_resolver(conn))
+
+    assert report.collisions == [] and report.blocked == []
+    assert [(r.record_type, r.row_id, r.clash_row_id, r.settlement)
+            for r in report.resolved] == [
+        ("condition", second_id, first_id, "distinct")]
+    rows = {int(r["condition_id"]): r
+            for r in conn.execute("SELECT * FROM condition")}
+    shared = rows[first_id]["dedup_base"]
+    assert rows[second_id]["dedup_base"] == shared
+    assert sorted(int(r["dedup_occurrence"]) for r in rows.values()) == [0, 1]
+    # Both facts are still there, unmutated: only the key machinery moved.
+    assert {r["note"] for r in rows.values()} == {
+        "hypertension, per cardiology", "asthma, per pulmonology"}
+
+
 # --- ingest-before-rekey drift guard ------------------------------------------
 
 def test_commit_refuses_an_ingest_against_a_drifted_key(conn):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -760,6 +760,30 @@ def test_a_row_verdict_overrides_its_family_verdict_at_render_time(seeded):
     assert appendix.count("lab_result: Glucose, fasting") == 1
 
 
+def test_a_distinct_verdict_keeps_both_siblings_live(seeded):
+    """AC3 (issue #122). `distinct` is a *resolving* status but deliberately not an
+    appendix one, so it changes rendering not at all: the two-live-row family a
+    distinct-resolved rekey leaves behind keeps both rows in their normal section, and no
+    `## Superseded / corrected` appendix appears at all.
+
+    The contrast with `superseded` on the same family is the point - that one takes both
+    rows out (see the keep-both test above); this one is the ruling that says both facts
+    are real."""
+    base, _occ0, _occ1 = _keep_both_sibling(seeded)
+    before = _renders(seeded)
+
+    curation.annotate_record(seeded, "lab_result", base, status="distinct",
+                             note="two different draws under one generic label",
+                             apply=True)
+
+    after = _renders(seeded)
+    assert after == before                  # like `confirmed`: recorded, not rendered
+    for name, md in after.items():
+        assert "Superseded / corrected" not in md, name
+    summary = after["summary"]
+    assert "200.0" in summary and "205.0" in summary
+
+
 def test_a_row_scoped_verdict_filters_only_its_own_journal_event(seeded):
     """The journal resolves per row too, via the `record_id` `with_identity` now
     stamps: without it a row verdict could only ever be applied family-wide."""


### PR DESCRIPTION
## What shipped

Adds a `distinct` curation verdict status so a human can declare two `rekey`-colliding rows
**genuinely different facts** (e.g. generic extraction placeholders like `diagnosis` /
`diagnosis 2`) instead of the only prior options — leave the whole table withheld (#92
quarantine) or misrepresent the pair as one fact via `merged-into`/`superseded` (#116).

- `migrations/011_curation_distinct_status.sql` — widens the `curation.status` CHECK to
  include `distinct` via a 010-style table rebuild (re-creates `idx_curation_row`).
- `pemr/curation.py` — `STATUSES` gains `distinct`; `RESOLVING_STATUSES` now covers both
  "one fact" (`merged-into`/`superseded`) and "two facts" (`distinct`) resolutions; new
  `DISTINCT_STATUSES` tuple, asserted disjoint from `APPENDIX_STATUSES` so a `distinct`
  verdict never pushes a row into the "Superseded / corrected" appendix — both rows keep
  rendering live. New `CollisionResolver.settlement()` classifies a verdict as
  `"merged"` or `"distinct"` without leaking the status vocabulary across the
  `dedup`/`curation` import seam.
- `pemr/dedup.py` — `rekey()` computes and reports `settlement` on each resolution;
  `RekeyResolution.settlement` (default `"merged"`, additive) surfaces it; message wording
  branches by settlement without changing eligibility, occurrence assignment, or the #92
  withheld-table behavior.
- `pemr/cli.py` — `--json` `resolved` entries gain `"settlement"` (additive-only); the text
  summary line distinguishes "as one fact" vs. "as distinct facts" counts.
- `docs/Architecture.md` — documents the third un-fixable-by-dictionary case (generic
  placeholder labels), the two kinds of resolving verdict, `distinct`'s deliberate absence
  from the appendix statuses, and `settlement` in both output modes.
- Test coverage across `tests/test_dedup.py`, `tests/test_curation.py`,
  `tests/test_render.py`, `tests/test_db.py`, `tests/test_cli_phase2.py`, including the
  real-world trigger reproduction (two `condition` rows on generic `diagnosis N` labels,
  declared distinct, `rekey --apply` writes the table and both rows survive as independent
  occurrences) — mirrors `meridun/pemr-data#12` item 6.

Closes #122

## Pipeline reports

- Verify: full suite green (963 passed), all 7 acceptance criteria walked through the real
  CLI. https://github.com/meridun/pemr/issues/122#issuecomment-5253990165
- Audit: read-only security/invariant review, no blocking findings; independent re-run of
  the touched test files (350 passed). https://github.com/meridun/pemr/issues/122#issuecomment-5254070284

### Advisories carried from audit (non-blocking)

1. `CollisionResolver.covering()` returns the first resolving verdict found by scan order.
   A pair carrying `distinct` on one row and `superseded` on the other would report an
   arbitrary settlement between two contradictory human rulings — confirmed
   reporting-only (no state divergence; rendering is driven per-row, not by
   `settlement`). Worth a follow-up issue: detect and report contradictory rulings on a
   pair instead of silently picking one.
2. A `distinct` verdict is invisible in rendered output by design (AC3 requires
   byte-identical rendering, consistent with `confirmed`) — it surfaces only in `rekey`
   output and `record annotate --list`. Already documented in `docs/Architecture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
