### PR TITLE
feat(dedup): detect contradictory verdicts on a rekey collision pair

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -429,14 +429,27 @@ clinical section — they render as two live siblings, exactly like a `--keep bo
 That absence is the whole guarantee, and `tests/test_curation.py` asserts the two tuples
 stay disjoint.
 
+Because the two kinds answer the *same* question opposite ways, a pair carrying a resolving
+verdict on **each** row can be **contradictory** — one row ruled `distinct`, the other
+`merged-into`/`superseded` (issue #124). Two opposite rulings settle nothing, so such a pair
+is **not** resolved: it stays a blocking collision, quarantines its own table like any other,
+and its `--json` entry carries a `contradiction` list naming both rulings (row id, status,
+scope, `verdict_base`, `settlement`); the text message says which row was ruled which way.
+No occurrence is assigned and **no narrowing is written** — pinning one arbitrarily chosen
+side would convert a family verdict to row scope to authorize a write that never happened.
+The fix is the operator's: re-rule or clear one of the two verdicts and re-run. Rulings that
+merely *agree* — or a pair carrying only one — resolve exactly as they always have.
+
 `confirmed`, `disputed` and `erroneous-in-source` resolve nothing — they rule on a row's
 content, not on its identity against another row — and a table holding any *unresolved*
 collision still withholds every change in it, resolved pairs included (its resolutions say
-exactly that, rather than describing a write that did not happen). All three cases are
+exactly that, rather than describing a write that did not happen). All four cases are
 distinguishable in output: a resolved pair is a `note:` line naming which way it was
 settled plus an entry in `--json`'s `resolved` list carrying `settlement`
-(`"merged"` | `"distinct"`), a blocked one stays `error:` plus `skipped`. A run whose
-every collision was verdict-resolved therefore exits **0**.
+(`"merged"` | `"distinct"`), a blocked one stays `error:` plus `skipped`, and a
+contradictory one is an `error:` naming both rulings plus a non-empty `contradiction` on
+its `collisions` entry. A run whose every collision was verdict-resolved therefore exits
+**0**.
 
 A resolving verdict is **unary** — it names one row or one family, never a counterpart —
 so like `superseded` since #116 it settles any collision its target takes part in,
@@ -453,8 +466,9 @@ to row scope** instead, pinned to exactly the rows whose stored `dedup_base` was
 in the same transaction as the keys: the ruling keeps precisely the extension it had when
 it was made, the merged-in row keeps rendering where it was, and the verdict that *resolved*
 the collision is never orphaned. That guarantee is scoped to the resolving verdict only: a
-clash covered by verdicts on **both** colliding families still resolves through exactly one
-of them (`covering()` returns a single verdict — row scope over family scope), and the
+clash covered by *agreeing* verdicts on **both** colliding families still resolves through
+exactly one of them (`covering_verdicts()` reports both — row scope over family scope per
+row — and resolution takes the first), and the
 *other* family's verdict is not carried anywhere. Its rows move out from under it the same
 way an unrelated dictionary-driven rekey has always been able to orphan a family verdict
 (documented since migration 008) — `rekey`'s own output says nothing about it, and `pemr

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -1445,6 +1445,20 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
                     "clash_label": c.clash_label,
                     "kind": c.kind,
                     "message": c.message,
+                    # Appended (issue #124): the two rulings that disagree, when *that*
+                    # is why the pair blocks. Empty on every ordinary collision, so a
+                    # consumer can branch on it without a second lookup - and a
+                    # contradiction is never reported as a clean one-sided resolution.
+                    "contradiction": [
+                        {
+                            "row_id": v.row_id,
+                            "status": v.status,
+                            "scope": v.scope,
+                            "verdict_base": v.verdict_base,
+                            "settlement": v.settlement,
+                        }
+                        for v in c.contradiction
+                    ],
                 }
                 for c in report.collisions
             ],

--- a/pemr/curation.py
+++ b/pemr/curation.py
@@ -817,27 +817,41 @@ class CollisionResolver:
     def __init__(self, verdicts: VerdictMap) -> None:
         self._verdicts = verdicts
 
-    def covering(
+    def covering_verdicts(
         self, record_type: str, row: sqlite3.Row, clash: sqlite3.Row
-    ) -> dict | None:
-        """The verdict that settles a collision between two rows, or None.
+    ) -> list[dict]:
+        """**Every** verdict that rules on a collision between two rows, in ``(row,
+        clash)`` order — 0, 1 or 2 of them.
 
         Either row, either scope: the operator annotated whichever of the pair they were
         looking at, and a family verdict on one is as much a ruling on the pair as a row
         verdict on the other. Resolution runs through :meth:`VerdictMap.for_row`, so the
         row-over-family precedence rule stays defined in exactly one place.
 
+        Reporting *both* rulings is the point (issue #124). Since #122 the resolving
+        vocabulary holds opposite answers — ``distinct`` says two facts, the others say
+        one — so a pair carrying a resolving verdict on each row can be contradictory,
+        and returning only the first would report one side's settlement as if it were
+        unanimous, decided by nothing but scan order. Choosing among the rulings, or
+        refusing to, is no longer this method's job: the caller decides on the set of
+        :meth:`settlement` values.
+
+        When a single family verdict covers both rows, ``for_row`` returns the same dict
+        twice and it is returned twice — deliberate, and harmless precisely because the
+        caller decides on settlements rather than on verdict identity.
+
         The **stored** ``dedup_base`` is the lookup key, not the recomputed one: the
         human ruled on the family as it exists today, before this rekey moves it.
         """
         pk = f"{record_type}_id"
+        verdicts: list[dict] = []
         for candidate in (row, clash):
             verdict = self._verdicts.for_row(
                 record_type, candidate["dedup_base"], candidate[pk]
             )
             if verdict is not None and verdict["status"] in RESOLVING_STATUSES:
-                return verdict
-        return None
+                verdicts.append(verdict)
+        return verdicts
 
     def settlement(self, verdict: dict) -> str:
         """Which question the resolving ``verdict`` answered: ``"merged"`` | ``"distinct"``.

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -1392,10 +1392,13 @@ class CollisionResolver(Protocol):
     silently reintroduce the cycle this seam exists to prevent.
     """
 
-    def covering(
+    def covering_verdicts(
         self, record_type: str, row: sqlite3.Row, clash: sqlite3.Row
-    ) -> dict | None:
-        """The verdict settling this pair's identity, or None if none does."""
+    ) -> list[dict]:
+        """Every verdict ruling on this pair's identity, in ``(row, clash)`` order —
+        empty when none does. A pair may carry **two** rulings, one per row, and since
+        #122 they can disagree: one saying "two facts", the other "one fact". Deciding
+        what that means is the caller's (issue #124)."""
 
     def settlement(self, verdict: dict) -> str:
         """Which way ``verdict`` settled the pair (issue #122): ``"merged"`` — the two
@@ -1483,6 +1486,21 @@ class RekeyResolution:
 
 
 @dataclass
+class RekeyVerdictClash:
+    """One row's ruling on a pair whose two rulings contradict each other (issue #124).
+
+    Flattened rather than the raw verdict dict, following :class:`RekeyResolution`'s rule
+    that a report is a plain, serializable account: the curation row itself never crosses
+    the seam.
+    """
+    row_id: int             # the colliding row this ruling applies to
+    status: str             # the verdict's status (one of curation.RESOLVING_STATUSES)
+    scope: str              # "family" | "row"
+    verdict_base: str       # dedup_base the verdict is stored under
+    settlement: str         # "merged" (one fact) | "distinct" (two facts)
+
+
+@dataclass
 class RekeyCollision:
     """Two rows in one table that recompute onto a single ``dedup_key``.
 
@@ -1497,6 +1515,10 @@ class RekeyCollision:
     clash_label: str
     kind: str               # "fused" (dictionary merges two facts) | "doubled" (data)
     message: str            # full diagnosis, ready to print
+    # The two rulings that contradict each other, when *that* is why this pair blocks
+    # (issue #124) — entry row first, then clash row. Empty on every ordinary collision.
+    # Appended, never inserted: the existing construction sites are positional.
+    contradiction: list[RekeyVerdictClash] = field(default_factory=list)
 
 
 @dataclass
@@ -1595,6 +1617,14 @@ def rekey(
     a verdict carried over wholesale would extend a ruling over a row nobody judged and
     (for the appendix statuses) pull that live row out of its rendered section. With
     ``resolver=None`` (the default) every collision blocks, exactly as before.
+
+    A pair may carry a resolving verdict on **each** row, and since the vocabulary holds
+    opposite answers those two rulings can **contradict** each other — one says two facts,
+    the other says one (issue #124). Two opposite rulings settle nothing, so the pair stays
+    a blocking collision (its table quarantined as usual) and the rulings are reported on
+    :attr:`RekeyCollision.contradiction`; no occurrence is assigned and no verdict is
+    narrowed. Rulings that merely *agree* (or a pair carrying only one) resolve exactly as
+    they always have.
     """
     db.require_migrated(conn)
     report = RekeyReport(applied=False)
@@ -1659,9 +1689,34 @@ def rekey(
                                   _rekey_label(record_type, clash.row))
             kind = ("doubled" if _rows_equal(record_type, clash.row, entry.payload)
                     else "fused")
-            verdict = (None if resolver is None
-                       else resolver.covering(record_type, entry.row, clash.row))
-            if verdict is not None:
+            verdicts = ([] if resolver is None
+                        else resolver.covering_verdicts(record_type, entry.row,
+                                                        clash.row))
+            # Empty without a resolver, so `resolver.settlement` is never reached there.
+            settlements = {resolver.settlement(v) for v in verdicts}
+            if len(settlements) > 1:
+                # Two rulings that answer the identity question opposite ways settle
+                # nothing (issue #124). Checked *before* `_resolve_clash`, which mutates
+                # `entry`/`seen` — a resolution can never be built and then rejected. No
+                # narrowing is queued either: pinning one arbitrarily chosen side would
+                # convert a family verdict to row scope to authorize a write that never
+                # happened.
+                rulings = [
+                    RekeyVerdictClash(
+                        row_id=row_id, status=verdict["status"],
+                        scope="row" if verdict["record_id"] else "family",
+                        verdict_base=verdict["dedup_base"],
+                        settlement=resolver.settlement(verdict),
+                    )
+                    for row_id, verdict in zip((entry.row_id, clash.row_id), verdicts)
+                ]
+                report.collisions.append(_contradictory_collision(
+                    record_type, pk, entry, clash, kind, label, clash_label, rulings,
+                ))
+                continue
+
+            if verdicts:
+                verdict = verdicts[0]
                 covered = ([int(verdict["record_id"])] if verdict["record_id"]
                            else stored_family.get(verdict["dedup_base"], []))
                 resolution = _resolve_clash(
@@ -1775,6 +1830,49 @@ def rekey(
                 resolution.verdict_action, resolution.narrowed_row_ids = done[ident]
     report.applied = apply
     return report
+
+
+def _contradictory_collision(
+    record_type: str,
+    pk: str,
+    entry: _RekeyEntry,
+    clash: _RekeyEntry,
+    kind: str,
+    label: str,
+    clash_label: str,
+    rulings: list[RekeyVerdictClash],
+) -> RekeyCollision:
+    """A collision whose two rows carry rulings that disagree on settlement (issue #124).
+
+    Blocking, not resolved: the premise of the resolution path is "a human already
+    answered the identity question", and a pair ruled *two facts* by one verdict and *one
+    fact* by the other has not been answered. Reporting either side's settlement as the
+    outcome would be scan order deciding what the operator is told a human decided.
+
+    Builds nothing but the account — no occurrence is taken and no narrowing is queued —
+    so the pair lands in :attr:`RekeyReport.collisions` and the existing per-table
+    quarantine (issue #92) and exit code follow with no new rule.
+    """
+    first, second = rulings
+
+    def _ruled(settlement: str) -> str:
+        return "two facts" if settlement == "distinct" else "one fact"
+
+    message = (
+        f"{record_type}: {pk} {entry.row_id} ({label!r}) and {pk} {clash.row_id} "
+        f"({clash_label!r}) recompute to the same dedup_key ({kind}), but the two rows "
+        f"carry contradictory verdicts - a {first.scope}-scoped '{first.status}' on {pk} "
+        f"{entry.row_id} rules them {_ruled(first.settlement)} while a "
+        f"{second.scope}-scoped '{second.status}' on {pk} {clash.row_id} rules them "
+        f"{_ruled(second.settlement)}. A pair ruled two opposite ways is not settled: "
+        f"re-rule or clear one of them (`pemr record annotate [--row] {record_type} "
+        "<id> --status ...` / `--clear`) and re-run; "
+        f"{record_type} was not written"
+    )
+    return RekeyCollision(
+        record_type, entry.row_id, label, clash.row_id, clash_label, kind, message,
+        contradiction=rulings,
+    )
 
 
 def _resolve_clash(

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -563,6 +563,50 @@ def test_rekey_reports_a_distinct_resolved_collision_in_text_and_json(
     assert captured.out.isascii()               # issue #23
 
 
+def test_rekey_reports_contradictory_verdicts_in_text_and_json(
+    ready, capsys, tmp_path
+):
+    """Issue #124 end to end. One row ruled *two facts* and the other ruled *one fact*
+    settles nothing, so the pair blocks like any unresolved collision: rc 1 in both modes,
+    the table withheld by name, the contradiction spelled out on stderr and carried on the
+    `--json` collision entry - never reported as a clean one-sided resolution."""
+    old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
+    new = _dict_file(tmp_path, "fuse.toml",
+                     '"alb" = "albumin"\n"t2dm" = "type 2 diabetes"\n')
+    _seed_fusing_lab_and_movable_condition(ready, capsys, tmp_path, old)
+    alb_id, albumin_id = _row_ids(tmp_path, "lab_result")
+    assert _run(tmp_path, "record", "annotate", "lab_result", str(alb_id),
+                "--status", "distinct", "--note", "two assays, one generic label",
+                "--apply") == 0
+    assert _run(tmp_path, "record", "annotate", "lab_result", str(albumin_id), "--row",
+                "--status", "superseded", "--note", "no, one assay filed twice",
+                "--apply") == 0
+    capsys.readouterr()
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--json") == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["resolved"] == [] and payload["skipped"] == ["lab_result"]
+    collision = payload["collisions"][0]
+    assert collision["kind"] == "fused"
+    assert [(c["row_id"], c["status"], c["scope"], c["settlement"])
+            for c in collision["contradiction"]] == [
+        (albumin_id, "superseded", "row", "merged"),
+        (alb_id, "distinct", "family", "distinct")]
+
+    # Same rc in text mode, and the unaffected table is still written (the #92 quarantine
+    # is per table, and a contradiction is an ordinary blocking collision).
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 1
+    captured = capsys.readouterr()
+    assert "contradictory verdicts" in captured.err
+    assert "A pair ruled two opposite ways is not settled" in captured.err
+    assert "lab_result was not written" in captured.err
+    assert "left 1 table(s) on their stored keys: lab_result" in captured.err
+    assert "lab_result: 1/2 key(s) change (skipped: collision)" in captured.out
+    assert "resolved by verdict" not in captured.out
+    assert "rekeyed 1 row(s)" in captured.out
+    assert captured.out.isascii() and captured.err.isascii()   # issue #23
+
+
 def _seed_generic_condition_pair(ready, capsys, tmp_path, old):
     """The `meridun/pemr-data#12` item 6 shape at the CLI: two real, different conditions
     that the extractor labelled with numbered placeholders, one document each. A

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -668,6 +668,44 @@ def test_settlement_reports_which_question_the_verdict_answered():
     assert resolver.settlement({"status": "superseded"}) == "merged"
 
 
+def _lab_row(conn, test_name):
+    return conn.execute("SELECT * FROM lab_result WHERE test_name = ?",
+                        (test_name,)).fetchone()
+
+
+def test_covering_verdicts_reports_both_rows_rulings(seeded):
+    """Issue #124. The seam hands back *every* ruling on the pair, in `(row, clash)`
+    order, instead of the first one it happens to find: which of two opposite rulings a
+    scan order lands on first is no basis for telling the operator what a human decided.
+    Non-resolving verdicts contribute nothing, exactly as before."""
+    conn = seeded["conn"]
+    resolver = curation.collision_resolver(conn)
+    glucose, hba1c = _lab_row(conn, "Glucose"), _lab_row(conn, "HbA1c")
+    assert resolver.covering_verdicts("lab_result", glucose, hba1c) == []
+
+    curation.annotate_record(conn, "lab_result", str(glucose["lab_result_id"]),
+                             status="distinct", note="two analytes", row=True,
+                             apply=True)
+    resolver = curation.collision_resolver(conn)
+    assert [v["status"] for v in
+            resolver.covering_verdicts("lab_result", glucose, hba1c)] == ["distinct"]
+
+    curation.annotate_record(conn, "lab_result", str(hba1c["lab_result_id"]),
+                             status="confirmed", note="rules on content, not identity",
+                             row=True, apply=True)
+    resolver = curation.collision_resolver(conn)
+    assert [v["status"] for v in
+            resolver.covering_verdicts("lab_result", glucose, hba1c)] == ["distinct"]
+
+    curation.annotate_record(conn, "lab_result", str(hba1c["lab_result_id"]),
+                             status="superseded", note="one fact after all", row=True,
+                             apply=True)
+    resolver = curation.collision_resolver(conn)
+    assert [v["status"] for v in
+            resolver.covering_verdicts("lab_result", glucose, hba1c)] \
+        == ["distinct", "superseded"]                  # (row, clash) order
+
+
 def test_a_distinct_verdict_rejects_a_merge_target(seeded):
     """`distinct` is unary: it names the row or family it rules on and no counterpart, so
     `--merged-into` is meaningless with it and must fail before anything is written."""

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1633,6 +1633,37 @@ def test_one_resolving_verdict_beside_an_unverdicted_row_still_resolves(conn):
         == [(albumin_id, "distinct")]
 
 
+def test_a_contradictory_pair_blocks_a_third_row_the_same_anchor_resolves(conn):
+    """Contradiction is judged per `(entry, clash)` pair against the first-seen anchor, so
+    a third row on the one key is adjudicated on its own: the contradictory pair blocks
+    while the third row's clash against that same anchor is settled by the family verdict.
+    The table is quarantined either way (issue #92), so the resolution says it was withheld
+    and not one row moves."""
+    peaf_id, albumin_id = _fusing_pair(conn)
+    dedup.commit_extraction(conn, _make_document(conn), {"lab_result": [
+        {"test_name": "SPEP Albumin", "collected_at": "2026-01-02", "value_num": 3.9},
+    ]}, dedup.load_dictionary(DICT_PATH))
+    third_id = max(_lab_rows(conn))
+    before = _keys(conn, "lab_result", "test_name")
+    _rule(conn, peaf_id, "distinct")                       # family, on the anchor
+    resolver = _rule(conn, albumin_id, "superseded", row=True)   # contradicts it
+
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM,
+                                           **{"spep albumin": "albumin"}),
+                         apply=True, resolver=resolver)
+
+    assert [(c.row_id, c.clash_row_id) for c in report.collisions] \
+        == [(albumin_id, peaf_id)]
+    assert [(v.row_id, v.settlement) for v in report.collisions[0].contradiction] \
+        == [(albumin_id, "merged"), (peaf_id, "distinct")]
+    # The third row carries no ruling of its own, so its pair holds exactly one verdict
+    # and resolves as it always did - the contradiction next door does not spread.
+    assert [(r.row_id, r.clash_row_id, r.settlement) for r in report.resolved] \
+        == [(third_id, peaf_id, "distinct")]
+    assert report.blocked == ["lab_result"] and report.writable() == []
+    assert _keys(conn, "lab_result", "test_name") == before
+
+
 def _generic_condition_pair(conn):
     """Two real, different conditions extracted under generic placeholder labels.
 

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1544,6 +1544,95 @@ def test_rekey_is_idempotent_after_a_distinct_resolution(conn):
     assert (again.changes, again.collisions, again.resolved) == ([], [], [])
 
 
+# --- pairs ruled two opposite ways (issue #124) -------------------------------
+
+@pytest.mark.parametrize("one_fact_status", ["merged-into", "superseded"])
+@pytest.mark.parametrize("distinct_on", ["incumbent", "clash"])
+def test_contradictory_verdicts_block_the_collision(conn, one_fact_status, distinct_on):
+    """AC1-AC3. One row ruled *two facts* and the other ruled *one fact* is not a settled
+    pair, whichever row carries which - and the parametrization over `distinct_on` *is*
+    the bug: first-wins made the reported settlement a function of scan order, so a run
+    would tell the operator the opposite of what a human decided depending on which row
+    happened to be scanned first. The pair blocks like any unresolved collision, and no
+    narrowing is written on the strength of an arbitrarily chosen side."""
+    peaf_id, albumin_id = _fusing_pair(conn)
+    distinct_id, other_id = ((peaf_id, albumin_id) if distinct_on == "incumbent"
+                             else (albumin_id, peaf_id))
+    before = _keys(conn, "lab_result", "test_name")
+    _rule(conn, distinct_id, "distinct")
+    kwargs = ({"merged_into_base": _lab_rows(conn)[distinct_id]["dedup_base"]}
+              if one_fact_status == "merged-into" else {})
+    resolver = _rule(conn, other_id, one_fact_status, **kwargs)
+
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM), apply=True,
+                         resolver=resolver)
+
+    assert report.resolved == []
+    assert [(c.row_id, c.clash_row_id, c.kind) for c in report.collisions] \
+        == [(albumin_id, peaf_id, "fused")]
+    assert report.blocked == ["lab_result"] and report.writable() == []
+    # Both rulings are reported, in (entry row, clash row) order, with the settlements
+    # that disagree - never one side presented as the answer.
+    expected = {distinct_id: ("distinct", "distinct"),
+                other_id: (one_fact_status, "merged")}
+    assert [(v.row_id, v.status, v.settlement, v.scope)
+            for v in report.collisions[0].contradiction] == [
+        (albumin_id, *expected[albumin_id], "family"),
+        (peaf_id, *expected[peaf_id], "family")]
+    assert "contradictory verdicts" in report.collisions[0].message
+    assert report.collisions[0].message.isascii()            # issue #23
+    # Nothing was written: not the keys (the #92 quarantine)...
+    assert _keys(conn, "lab_result", "test_name") == before
+    # ...and not the verdicts either - both are still the family-scoped rulings the
+    # operator recorded, so re-ruling one of them is all that is needed.
+    assert sorted(r["record_id"] for r in
+                  conn.execute("SELECT record_id FROM curation")) == [0, 0]
+
+
+@pytest.mark.parametrize("first_status,second_status,settlement", [
+    ("distinct", "distinct", "distinct"),
+    ("merged-into", "superseded", "merged"),
+])
+def test_agreeing_resolving_verdicts_on_both_rows_still_resolve(
+    conn, first_status, second_status, settlement
+):
+    """AC4 regression. Two rulings that answer the identity question the *same* way are
+    not a contradiction - they are the pre-#124 "one resolving verdict wins" case with a
+    redundant second ruling, and it must resolve exactly as it always did."""
+    peaf_id, albumin_id = _fusing_pair(conn)
+    kwargs = ({"merged_into_base": _lab_rows(conn)[albumin_id]["dedup_base"]}
+              if first_status == "merged-into" else {})
+    _rule(conn, peaf_id, first_status, **kwargs)
+    kwargs = ({"merged_into_base": _lab_rows(conn)[peaf_id]["dedup_base"]}
+              if second_status == "merged-into" else {})
+    resolver = _rule(conn, albumin_id, second_status, **kwargs)
+
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM), apply=True,
+                         resolver=resolver)
+
+    assert report.collisions == [] and report.blocked == []
+    assert [(r.row_id, r.clash_row_id, r.settlement, r.new_occurrence)
+            for r in report.resolved] == [(albumin_id, peaf_id, settlement, 1)]
+    rows = _lab_rows(conn)
+    assert rows[albumin_id]["dedup_base"] == rows[peaf_id]["dedup_base"]
+    assert (rows[peaf_id]["dedup_occurrence"],
+            rows[albumin_id]["dedup_occurrence"]) == (0, 1)
+
+
+def test_one_resolving_verdict_beside_an_unverdicted_row_still_resolves(conn):
+    """The other half of AC4: a pair carrying exactly one ruling has nothing to disagree
+    with, so the #124 check must not touch it."""
+    peaf_id, albumin_id = _fusing_pair(conn)
+    resolver = _rule(conn, albumin_id, "distinct")
+
+    report = dedup.rekey(conn, _rekey_dict(**_FUSING_ALBUMIN_SYNONYM), apply=True,
+                         resolver=resolver)
+
+    assert report.collisions == []
+    assert [(r.row_id, r.settlement) for r in report.resolved] \
+        == [(albumin_id, "distinct")]
+
+
 def _generic_condition_pair(conn):
     """Two real, different conditions extracted under generic placeholder labels.
 


### PR DESCRIPTION
## What shipped

Follow-up from the #122 audit (advisory 1, PR #123): `CollisionResolver.covering()`
(`pemr/curation.py`) iterated `(row, clash)` and returned the *first* resolving verdict, so a
collision pair where one row was ruled `distinct` ("two facts") and the other row was ruled
`merged-into`/`superseded` ("one fact") got reported as an arbitrary, unanimous settlement —
scan-order dependent and silently wrong about what the human actually decided. Confirmed
reporting-only by the #122 audit (no state divergence today), but user-facing.

- `pemr/curation.py` — `covering()` renamed to `covering_verdicts()`; returns **both** rows'
  resolving verdicts (0, 1, or 2 entries) instead of the first one found, so the caller can
  detect disagreement instead of an arbitrary pick.
- `pemr/dedup.py` — `rekey()` pass 2 branches on the settlement *set*: more than one distinct
  settlement is now **contradictory and stays blocking** (joins `report.collisions`, no
  `_resolve_clash` call, no narrowing written) — chosen over resolve-but-flag because the
  latter still narrows an arbitrarily chosen verdict to row scope. New `RekeyVerdictClash`
  dataclass and an appended `RekeyCollision.contradiction` field (empty list on every ordinary
  collision, two entries — entry row then clash row — on a contradictory pair). New
  `_contradictory_collision()` builds the collision message. Existing single-verdict and
  agreeing-verdicts paths are unchanged.
- `pemr/cli.py` — `_cmd_rekey` `--json` appends `"contradiction"` as the last key of each
  `collisions` entry (additive-only; `resolved`/`settlement` untouched). Text output needed no
  new branch — the contradiction message already prints via the existing collision path.
- `docs/Architecture.md` — documents the contradictory case in the "A collision a human already
  ruled on is settled, not blocking" section; "All three cases" corrected to "All four cases".
- Tests across `tests/test_dedup.py` (contradictory pair parametrized over which row carries
  which verdict, agreeing-verdicts regression, a third row on the same key beside a
  contradictory pair), `tests/test_curation.py` (`covering_verdicts()` unit coverage), and
  `tests/test_cli_phase2.py` (end-to-end text + `--json`).

Closes #124

## Pipeline reports

- Verify: full suite green (973 passed), all 7 acceptance criteria walked through the real CLI
  in both scan orders, plus a differential real run against pre-change `origin/dev` proving the
  non-contradictory paths are byte-identical except the additive `contradiction: []` key.
  https://github.com/meridun/pemr/issues/124#issuecomment-5258530246
- Audit: read-only security/invariant review, no blocking findings — the change tightens
  authorization (a contradictory pair now authorizes neither the rekey write nor the verdict
  narrowing), ordering (contradiction check runs before the `entry`/`seen`-mutating
  `_resolve_clash`) and additive-only JSON confirmed against the diff.
  https://github.com/meridun/pemr/issues/124#issuecomment-5258594193

### Advisories carried from audit (non-blocking)

1. `pemr/dedup.py:1711` — `zip((entry.row_id, clash.row_id), verdicts)` is positionally correct
   only because the enclosing `len(settlements) > 1` guard guarantees exactly two verdicts in
   `(entry, clash)` order; `zip(..., strict=True)` would make that assumption self-enforcing
   (Python >= 3.11 is already required).
2. `pemr/dedup.py:1707` — `scope="row" if verdict["record_id"] else "family"` re-derives
   curation's scope vocabulary on the `dedup` side of the seam rather than through a
   `resolver.scope()` companion method; correct today, worth tidying if a third scope is ever
   added.
3. `_contradictory_collision`'s "re-rule or clear one of them" advice doesn't distinguish a
   `doubled` pair, where `pemr record rm` is the likelier real fix. Help-text nicety only.
4. Pre-existing, not introduced here: every collision message interpolates extractor-derived
   labels via `{label!r}`, so a non-ASCII label would break the #23 ASCII assertion for
   ordinary collisions as much as for this one — worth its own issue if not already open.

docs/Architecture.md was already updated in-branch at build time; no further L3 edit was needed
at ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
