### PR TITLE
rekey: bulk re-affirm helper + apply-time orphan reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,12 +63,14 @@ Read/write separation is also declared to the client via MCP `readOnlyHint` anno
 
 **Deletion — and clinical verdicts, and unsourced writes — are never an MCP tool.** `document rm`,
 `record rm` (the CLI's destructive verbs — the latter added by issue #107), `record annotate`
-(issue #109), and `record assert` (issue #110) are deliberately excluded from the tool surface
+(issue #109), `record reaffirm` (issue #126), and `record assert` (issue #110) are deliberately
+excluded from the tool surface
 above. This is what keeps "an agent cannot delete PHI" true: removing a document or a single
 record row is a human-at-a-terminal action only, never something an agent can reach through this
 server. `record annotate` joins them for the adjacent reason — a `curation` verdict is a human's
 clinical judgment, and writing one can drop a record out of every generated document without
-deleting a row. `record assert` is the sharpest case of all — it is a *write*, not a deletion, and
+deleting a row; `record reaffirm` writes those same verdicts in bulk, so it is excluded for the
+same reason (an agent may still *read* the orphan list from `--json` and summarize it). `record assert` is the sharpest case of all — it is a *write*, not a deletion, and
 the only path in the system that can put a fact into the record with no external source; only a
 human at the CLI may vouch for one.
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -121,8 +121,8 @@ CREATE TABLE document_tombstone (
 -- live rows, where a family verdict would hide the occurrence it says should win. Row
 -- wins over family for its own row. Like 007 the table carries no FK to what it
 -- annotates, and `pemr verify` warns (never fails) on a verdict whose family - or row -
--- is gone. Written only by `record annotate`; read at render time by every generated
--- document.
+-- is gone. Written only by `record annotate` and `record reaffirm` (the bulk remedy for
+-- that orphaning, issue #126); read at render time by every generated document.
 CREATE TABLE curation (
   record_type      TEXT NOT NULL,   -- one of dedup.KNOWN_TYPES; validated in Python
   dedup_base       TEXT NOT NULL,   -- family identity; a breadcrumb when record_id <> 0
@@ -471,8 +471,8 @@ exactly one of them (`covering_verdicts()` reports both — row scope over famil
 row — and resolution takes the first), and the
 *other* family's verdict is not carried anywhere. Its rows move out from under it the same
 way an unrelated dictionary-driven rekey has always been able to orphan a family verdict
-(documented since migration 008) — `rekey`'s own output says nothing about it, and `pemr
-verify` is the only signal (`curation verdict ... has no live family (removed?)`). The
+(documented since migration 008). Since issue #126 `rekey --apply` **reports that fallout
+itself** (below) rather than leaving `pemr verify` as the only signal. The
 direction is over-reporting, not data loss: no fact disappears, but a row a human had ruled
 out of its clinical section can be promoted back into it until the operator re-rules or
 clears the stale verdict. Criticality-blind by construction — no live row silently leaves
@@ -491,6 +491,48 @@ the pointer still means something (this occurrence is absorbed into the family i
 it moves to the appendix while its siblings keep rendering live), so it is accepted. At
 **family** scope a self-merge would leave the fact rendering nowhere at all, and stays
 refused.
+
+**The orphans a rekey does cause are reported where they happen, and fixable in bulk**
+(issue #126). Two additions, both leaving the warn-and-reannotate design above exactly as
+it is — `rekey` still never re-points a verdict by itself:
+
+- `rekey --apply` computes, after its write, the verdicts *this run* orphaned — scoped to
+  the families it actually moved, so a pre-existing orphan is not blamed on it — and prints
+  them plus the follow-up command (`orphans` in `--json`, always present and `[]` on a dry
+  run, which wrote nothing to have fallout from). It is a `warning:`, not an `error:`: the
+  exit code stays `1 if collisions else 0`.
+- `pemr record reaffirm` is the batch remedy beside the per-row `record annotate --clear`.
+  The 57-row orphan batch one dictionary edit produced is what forced it. Dry run by
+  default, `--json` for an agent, one explicit `--apply`, no prompting.
+
+Both read **one** orphan detector, `curation.orphan_kinds` — which `pemr verify`'s two
+orphan warnings now read too. That sharing is the point: a bulk remedy that disagreed with
+the warning it answers would re-annotate the wrong rows. It owns exactly two classes:
+`no-live-family` (a family-scoped verdict whose `dedup_base` names no live family) and
+`dangling-merge-target` (either scope, `merged_into_base` names no live family). The
+row-scoped **stale breadcrumb** is deliberately not one of them — that verdict still
+resolves by row id, so nothing may re-point it — nor is the removed-row case, whose remedy
+is `--clear --row` and which the removal write paths already retire.
+
+The two halves compose **by file**, and have to: a `dedup_base` is a content hash
+overwritten in place, so once the run is over nothing in the database records that `F_old`
+became `F_new`. Only `rekey` knows, and the mapping is not persisted (no new table, no
+migration) — it travels on `RekeyReport.base_maps` and out through the report:
+
+```
+pemr rekey --apply --json > rekey.json      # applies, and reports its own orphans
+pemr record reaffirm --map-file rekey.json  # dry run: what would be re-pointed, where
+pemr record reaffirm --map-file rekey.json --apply
+```
+
+Every re-point is an explicit map entry plus `--apply`; the dry run shows the successor
+family's **label and size**, so a ruling about to widen over rows nobody judged is visible
+before approval; a successor that already carries its own verdict is **skipped**, never
+overwritten; and an entry matching no live orphan is reported `already handled` rather than
+failing, so re-running the same file is a clean no-op. Writes reuse `annotate_record` /
+`clear_curation` per row — annotate **before** clear, so a failure between the two leaves
+the ruling duplicated (recoverable) rather than destroyed. `record reaffirm` is CLI-only,
+absent from `WRITE_TOOLS` for the same reason `record annotate` is.
 
 **Ingesting against drifted keys is refused, not silently forked.** Until the rekey is
 applied, a stored row's frozen key is invisible to layer-2 dedup, so re-filing that same
@@ -813,6 +855,14 @@ pemr record annotate <table> <base-or-id> --status <s> --note <text> [--attribut
                                                          # pure overlay - no record row is mutated; dry run by default
 pemr record annotate --list [<table>] [--json]           # current verdicts, newest first (scope + orphans flagged)
 pemr record annotate <table> <base-or-id> [--row] --clear [--apply]   # lift one verdict, in the named scope
+pemr record reaffirm [<table>] [--json]                  # the verdicts a rekey ORPHANED: no live family, or a
+                                                         # dangling merged_into target (NOT the row-scope stale
+                                                         # breadcrumb - that one still resolves)
+pemr record reaffirm [<table>] (--map-file <file> | --clear) [--apply] [--json]
+                                                         # bulk remedy (§3): --map-file takes `rekey --apply --json`'s
+                                                         # payload and re-points each verdict onto its successor
+                                                         # family; --clear lifts them instead. Dry run by default;
+                                                         # a successor already carrying its own verdict is skipped
 pemr record assert <table> --person <slug> --attributed-to <who> --date <iso>
                    --field NAME=VALUE [--field ...] [--apply]
                                                          # commit a fact attested by a PERSON, with no
@@ -838,6 +888,9 @@ pemr restore latest [--force]                            # install a snapshot ba
 pemr verify                                              # integrity + row counts + source-blob resolution
 pemr migrate [--create]                                  # apply pending migrations (--create bootstraps a new DB)
 pemr rekey [--apply]                                     # re-derive dedup keys after a dictionary edit
+                                                         # --apply also reports the curation verdicts THIS run
+                                                         # orphaned; `--json` carries them as `orphans`, which is
+                                                         # the map file `record reaffirm` reads (§3)
 ```
 
 Every line above is implemented and parses today **except** the one flagged `NOT IMPLEMENTED`.
@@ -866,13 +919,15 @@ annotations expose the read/write split to the client.
 `commit_extraction`/`person_add`/`person_edit`/`ingest`/`document_set_text`; always `ingest` (with `ocr_text` populated) before
 extracting; dictionary additions go through human review, never agent-direct edits.
 
-`document rm`, `record rm` (issue #107), `record annotate` (issue #109) and `record assert`
+`document rm`, `record rm` (issue #107), `record annotate` (issue #109), `record reaffirm`
+(issue #126) and `record assert`
 (issue #110) are deliberately **absent** from `WRITE_TOOLS` — this is a rule, not an
 oversight. Deletion of PHI stays a human-at-a-terminal action; no MCP tool, and therefore no
 agent, can remove a record or a document. `record annotate` joins them for the adjacent
 reason: a `curation` verdict is a *human's clinical judgment*, recorded with attribution, and
 an agent that could write one could make a record disappear from every generated document
-without deleting a row. `record assert` is the sharpest case of all — it is a *write*, not a
+without deleting a row — and `record reaffirm` writes those same verdicts *in bulk*, which
+only sharpens the argument. `record assert` is the sharpest case of all — it is a *write*, not a
 deletion, and the only path in the system that can put a fact into the record with no
 external source. Any future destructive — or render-altering, or unsourced — verb should
 default to the same exclusion unless a human explicitly decides otherwise.

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -14,7 +14,7 @@ import shlex
 import sqlite3
 import sys
 import tomllib
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from . import (
@@ -1069,6 +1069,428 @@ def _cmd_record_annotate(args: argparse.Namespace) -> int:
 
 
 # --------------------------------------------------------------------------- #
+# bulk re-affirm of orphaned verdicts (`record reaffirm`) - issue #126
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class _ReaffirmAction:
+    """What `record reaffirm` plans to do about one orphaned verdict.
+
+    Also the ``--json`` payload shape (``as_dict`` widens
+    :meth:`curation.OrphanVerdict.as_dict`), so these key names are a contract.
+
+    ``action`` is one of:
+
+    * ``"list"`` — no disposition was supplied; this is the pure listing mode.
+    * ``"reaffirm"`` — re-record the same ruling against ``to_base`` (a family
+      ``dedup_base``, or the row id at row scope).
+    * ``"clear"`` — lift the verdict (``--clear``).
+    * ``"skip"`` — refused, with ``reason``: nothing in the map names it, no successor
+      family for a kind that needs one, or the successor already carries its own ruling.
+    * ``"already-handled"`` — a map entry that matches no live orphan, so an earlier run
+      already dealt with it. Not an error; re-running the same file is a clean no-op.
+    """
+
+    orphan: "curation.OrphanVerdict"
+    action: str
+    to_base: str | None = None
+    to_merge_base: str | None = None
+    target_label: str = ""
+    target_family_size: int = 0
+    reason: str = ""
+    applied: bool = False
+
+    def as_dict(self) -> dict:
+        return {
+            **self.orphan.as_dict(),
+            "action": self.action,
+            "to_base": self.to_base,
+            "to_merge_base": self.to_merge_base,
+            "target_label": self.target_label,
+            "target_family_size": self.target_family_size,
+            "reason": self.reason,
+            "applied": self.applied,
+        }
+
+
+#: The `record reaffirm` actions that refuse an orphan, and therefore set rc=1: the
+#: operator asked for a batch and did not get all of it. ``already-handled`` is
+#: deliberately absent - re-running the same map file is idempotent, not a failure.
+_REAFFIRM_REFUSALS = ("skip",)
+
+
+def _load_reaffirm_map(path: str) -> list[dict]:
+    """Read a ``--map-file`` into the list of orphan entries it carries.
+
+    Accepts either the object `pemr rekey --apply --json` emits (its ``orphans`` array is
+    taken) or a bare array of the same entries, so the composed pipeline is one
+    redirection: ``pemr rekey --apply --json > f`` then
+    ``pemr record reaffirm --map-file f``. Unknown keys are ignored — the rekey payload
+    carries much more than this command needs, and a consumer must not have to trim it.
+    """
+    with open(path, "rb") as fh:
+        payload = json.load(fh)
+    if isinstance(payload, dict):
+        payload = payload.get("orphans", [])
+    if not isinstance(payload, list):
+        raise ValueError(
+            f"{path} is not a rekey report: expected an object with an 'orphans' array, "
+            "or a bare array of orphan entries"
+        )
+    return [entry for entry in payload if isinstance(entry, dict)]
+
+
+def _reaffirm_map_key(record_type: object, record_id: object, base: object) -> tuple:
+    """The identity a map entry and a live orphan are matched on.
+
+    Row id when there is one, ``dedup_base`` otherwise — the same split every other
+    curation path uses, because a row-scoped verdict resolves by id alone and its stored
+    base may be a stale breadcrumb.
+    """
+    rid = int(record_id or 0)
+    return (str(record_type), rid) if rid else (str(record_type), str(base))
+
+
+def _orphan_from_entry(entry: dict) -> "curation.OrphanVerdict":
+    """A map-file entry read back as an :class:`curation.OrphanVerdict`.
+
+    Only for reporting an ``already-handled`` entry: the live table is always the authority
+    on what is orphaned, so a stored entry is never trusted as one.
+    """
+    return curation.OrphanVerdict(
+        record_type=str(entry.get("record_type") or ""),
+        dedup_base=str(entry.get("dedup_base") or ""),
+        record_id=int(entry.get("record_id") or 0),
+        scope=str(entry.get("scope") or ""),
+        status=str(entry.get("status") or ""),
+        note=str(entry.get("note") or ""),
+        attributed_to=entry.get("attributed_to"),
+        merged_into_base=entry.get("merged_into_base"),
+        created_at=str(entry.get("created_at") or ""),
+        kinds=[str(k) for k in (entry.get("kinds") or [])],
+    )
+
+
+def _reaffirm_target(
+    conn, orphan: "curation.OrphanVerdict", to_base: str
+) -> tuple[str, int]:
+    """``(label, family_size)`` for where a re-affirm would land — what a reviewer reads.
+
+    Load-bearing, not decoration (issue #126): the successor family is often *larger* than
+    the one the human ruled on, and seeing its size is how a reviewer catches a ruling that
+    would widen over rows nobody judged before approving the batch.
+    """
+    if orphan.record_id:
+        label, _live_base, size = curation.row_label(
+            conn, orphan.record_type, orphan.record_id
+        )
+        return label, size
+    return curation.family_label(conn, orphan.record_type, to_base)
+
+
+def _plan_reaffirm(
+    conn,
+    orphans: list["curation.OrphanVerdict"],
+    mapping: list[dict] | None,
+    clear: bool,
+) -> list[_ReaffirmAction]:
+    """Decide what to do about every live orphan — the whole batch, before any write.
+
+    ``mapping=None`` and ``clear=False`` is the pure listing mode: no disposition was
+    supplied, so nothing is planned and nothing is refused.
+
+    Nothing is ever *silently* re-pointed here (the #109/#114/#116 design this issue
+    preserves): a re-point needs an explicit map entry naming the successor family, the
+    successor's label and size are reported for review, and a successor that already
+    carries its own family-scoped verdict is **skipped** — a second human's ruling is never
+    overwritten.
+    """
+    listing = mapping is None and not clear
+    by_key: dict[tuple, dict] = {}
+    for entry in mapping or []:
+        by_key[_reaffirm_map_key(
+            entry.get("record_type"), entry.get("record_id"), entry.get("dedup_base")
+        )] = entry
+
+    plan: list[_ReaffirmAction] = []
+    matched: set[tuple] = set()
+    claimed: set[tuple[str, str]] = set()
+    for orphan in orphans:
+        key = _reaffirm_map_key(orphan.record_type, orphan.record_id, orphan.dedup_base)
+        if listing:
+            plan.append(_ReaffirmAction(orphan=orphan, action="list"))
+            continue
+        if clear:
+            plan.append(_ReaffirmAction(orphan=orphan, action="clear"))
+            continue
+        entry = by_key.get(key)
+        if entry is None:
+            plan.append(_ReaffirmAction(
+                orphan=orphan, action="skip",
+                reason="not named by the map file - re-run `pemr rekey --apply --json` "
+                       "for the run that orphaned it, or lift it with --clear",
+            ))
+            continue
+        matched.add(key)
+        action = _plan_one_reaffirm(conn, orphan, entry)
+        if action.action == "reaffirm" and not orphan.record_id:
+            # One family verdict per family, and `annotate_record` is an upsert: two
+            # orphans re-pointed onto the same successor would leave the second silently
+            # overwriting the first. The whole batch is planned before any write, so the
+            # per-row `get_verdict` check above cannot see an earlier row's claim - this
+            # does.
+            claim = (orphan.record_type, str(action.to_base))
+            if claim in claimed:
+                action = _ReaffirmAction(
+                    orphan=orphan, action="skip",
+                    reason="another verdict in this batch is already being re-pointed "
+                           "onto that family - reconcile the two by hand",
+                )
+            else:
+                claimed.add(claim)
+        plan.append(action)
+
+    # A map entry with no live orphan behind it: an earlier run already handled it (or a
+    # human did, by hand). Reported, never an error - re-running the same file must be a
+    # clean no-op, which is what makes the composed pipeline safe to retry.
+    for key, entry in by_key.items():
+        if key in matched:
+            continue
+        plan.append(_ReaffirmAction(
+            orphan=_orphan_from_entry(entry), action="already-handled",
+            reason="no longer orphaned",
+        ))
+    return plan
+
+
+def _plan_one_reaffirm(
+    conn, orphan: "curation.OrphanVerdict", entry: dict
+) -> _ReaffirmAction:
+    """Plan the re-affirm of one mapped orphan, or refuse it with a reason."""
+    successor = entry.get("successor_base") or None
+    successor_merge = entry.get("successor_merge_base") or None
+
+    def skip(reason: str) -> _ReaffirmAction:
+        return _ReaffirmAction(orphan=orphan, action="skip", reason=reason)
+
+    # Where the ruling itself goes. Only the family-scoped `no-live-family` class moves;
+    # a row-scoped verdict is re-affirmed against its own row (rekey never renumbers ids),
+    # and a family whose only fault is a dangling merge target is still live.
+    if curation.ORPHAN_NO_FAMILY in orphan.kinds:
+        if not successor:
+            return skip(
+                "the map names no successor family for this base - it was removed rather "
+                "than moved; lift the verdict with --clear"
+            )
+        to_base = str(successor)
+        if not dedup.load_family(conn, orphan.record_type, to_base):
+            return skip(
+                f"successor family {to_base[:12]}... is not live either - the map is "
+                "stale; re-run `pemr rekey --apply --json`"
+            )
+        if curation.get_verdict(conn, orphan.record_type, to_base) is not None:
+            return skip(
+                f"successor family {to_base[:12]}... already carries its own verdict - "
+                "refusing to overwrite a second ruling; reconcile the two by hand"
+            )
+    elif orphan.record_id:
+        # A row-scoped verdict is re-affirmed against its own row - `rekey` never renumbers
+        # a row id. Only reachable here for the dangling-merge class, and only while the row
+        # is still live: a removed row's remedy is `--clear --row`, and re-pointing it would
+        # just fail inside `resolve_row`.
+        to_base = str(orphan.record_id)
+        if not curation.row_label(conn, orphan.record_type, orphan.record_id)[2]:
+            return skip(
+                "the annotated row is gone - lift the verdict with --clear instead"
+            )
+    else:
+        to_base = orphan.dedup_base
+
+    # And where its merge pointer goes. `merged_into_base` is only legal on a
+    # `merged-into` verdict (:func:`curation.annotate_record` enforces that on the way in),
+    # so a dangling target on any other status can only be a hand-edited row - refused
+    # rather than reshaped.
+    to_merge_base: str | None = None
+    if orphan.merged_into_base:
+        if orphan.status != "merged-into":
+            return skip(
+                f"status '{orphan.status}' carries a merge target (hand-edited?) - "
+                "`--merged-into` is only meaningful with 'merged-into'; lift it with "
+                "--clear"
+            )
+        if curation.ORPHAN_DANGLING_MERGE in orphan.kinds:
+            if not successor_merge:
+                return skip(
+                    "the map names no successor for the merge target - it was removed "
+                    "rather than moved; re-rule the verdict with `pemr record annotate`"
+                )
+            to_merge_base = str(successor_merge)
+        else:
+            to_merge_base = orphan.merged_into_base
+        if not dedup.load_family(conn, orphan.record_type, to_merge_base):
+            return skip(
+                f"merge target {str(to_merge_base)[:12]}... is not live - the map is "
+                "stale; re-run `pemr rekey --apply --json`"
+            )
+        if to_merge_base == to_base and not orphan.record_id:
+            # This rekey fused the ruled family into its own merge target. A family merged
+            # into itself renders nowhere at all (`annotate_record` refuses it at family
+            # scope), so this needs a human, not a re-point.
+            return skip(
+                "this rekey merged the family into its own merge target - a family "
+                "merged into itself would render nowhere; re-rule it with "
+                "`pemr record annotate`"
+            )
+
+    label, size = _reaffirm_target(conn, orphan, to_base)
+    return _ReaffirmAction(
+        orphan=orphan, action="reaffirm", to_base=to_base,
+        to_merge_base=to_merge_base, target_label=label, target_family_size=size,
+    )
+
+
+def _apply_reaffirm(conn, plan: list[_ReaffirmAction]) -> str:
+    """Write the planned batch, per row, through the existing curation write paths.
+
+    Returns ``""`` on a clean batch, or the failure that stopped it. The plan is fully
+    validated before this is called, so a failure here is unexpected — and the batch stops
+    at it rather than pressing on, with :attr:`_ReaffirmAction.applied` naming exactly what
+    landed.
+
+    **Annotate before clear, never the reverse.** :func:`curation.annotate_record` and
+    :func:`curation.clear_curation` each own their own transaction (the requirements ask
+    for per-row reuse of those paths, not a new batch state machine), so a failure between
+    the two is possible: this order leaves the ruling *duplicated* on the old and new base,
+    which the next run reconciles, instead of destroying a human's verdict.
+    """
+    for action in plan:
+        orphan = action.orphan
+        row = orphan.scope == curation.SCOPE_ROW
+        token = str(orphan.record_id) if row else orphan.dedup_base
+        try:
+            if action.action == "clear":
+                curation.clear_curation(
+                    conn, orphan.record_type, token, row=row, apply=True
+                )
+            elif action.action == "reaffirm":
+                curation.annotate_record(
+                    conn, orphan.record_type, str(action.to_base),
+                    status=orphan.status, note=orphan.note,
+                    attributed_to=orphan.attributed_to,
+                    merged_into_base=action.to_merge_base,
+                    row=row, apply=True,
+                )
+                if not row and action.to_base != orphan.dedup_base:
+                    curation.clear_curation(
+                        conn, orphan.record_type, orphan.dedup_base, apply=True
+                    )
+            else:
+                continue
+        except (ValueError, curation.CurationNotFoundError) as exc:
+            action.reason = f"write failed: {exc}"
+            return str(exc)
+        action.applied = True
+    return ""
+
+
+def _reaffirm_line(action: _ReaffirmAction) -> str:
+    """One listing line: which verdict, why it is orphaned, and what happens to it."""
+    orphan = action.orphan
+    ident = (
+        f"row #{orphan.record_id}" if orphan.record_id
+        else str(orphan.dedup_base)[:12]
+    )
+    if action.action == "reaffirm":
+        target = f" -> {str(action.to_base)[:12]}"
+        if action.target_label:
+            target += f" ({action.target_label}, {action.target_family_size} row(s))"
+    elif action.reason:
+        target = f" ({action.reason})"
+    else:
+        target = ""
+    return (
+        f"{orphan.record_type:12}  {ident:12}  {orphan.scope:6}  "
+        f"{action.action:15}  {','.join(orphan.kinds):22}  "
+        f"[{curation.describe(orphan.as_dict())}]{target}"
+    )
+
+
+def _cmd_record_reaffirm(args: argparse.Namespace) -> int:
+    """`record reaffirm` — list the orphaned verdicts, then re-point or lift them in bulk.
+
+    The bulk remedy for the state `pemr rekey` deliberately leaves behind (issue #126):
+    `rekey` never re-points a verdict by itself, and the per-row `record annotate` remedy
+    does not scale to the 57-row orphan batch one dictionary edit produced. This is a
+    deterministic control, not an interactive tool: dry run by default (the
+    `annotate`/`clear` convention), `--json` so an agent can read and summarize it, and
+    exactly one explicit `--apply` as the human-approval gate. Nothing prompts.
+
+    A separate subcommand rather than a fourth `record annotate` mode: that handler already
+    hand-rolls cross-flag validation for three modes on one subparser, and a bulk verb with
+    its own disposition flags belongs on its own usage line.
+    """
+    mapping: list[dict] | None = None
+    if args.map_file:
+        try:
+            mapping = _load_reaffirm_map(args.map_file)
+        except OSError as exc:
+            print(f"error: cannot read {args.map_file}: {exc}", file=sys.stderr)
+            return 1
+        except ValueError as exc:      # includes json.JSONDecodeError
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+
+    def work(conn):
+        plan = _plan_reaffirm(
+            conn, curation.list_orphans(conn, args.table), mapping, args.clear
+        )
+        failure = ""
+        if args.apply and any(a.action in ("reaffirm", "clear") for a in plan):
+            failure = _apply_reaffirm(conn, plan)
+        refused = [a for a in plan if a.action in _REAFFIRM_REFUSALS]
+        rc = 1 if (refused or failure) else 0
+
+        if args.json:
+            _print_json([a.as_dict() for a in plan])
+            return rc
+
+        if not plan:
+            print("no orphaned curation verdicts")
+            return rc
+        print(
+            f"{'type':12}  {'target':12}  {'scope':6}  {'action':15}  "
+            f"{'orphaned by':22}  [verdict]"
+        )
+        for action in plan:
+            print(_reaffirm_line(action))
+
+        written = sum(1 for a in plan if a.applied)
+        if failure:
+            print(
+                f"error: the batch stopped after {written} write(s): {failure}",
+                file=sys.stderr,
+            )
+        elif args.apply:
+            print(f"re-annotated {written} verdict(s)")
+        elif mapping is None and not args.clear:
+            print(
+                "listing only: pass --map-file <file> (from `pemr rekey --apply --json`) "
+                "to re-point these,\n  or --clear to lift them - then --apply"
+            )
+        else:
+            print("dry run: nothing was written - re-run with --apply")
+        if refused:
+            print(
+                f"warning: {len(refused)} verdict(s) were not handled - see the reasons "
+                "above",
+                file=sys.stderr,
+            )
+        return rc
+
+    return _with_document_conn(args, work)
+
+
+# --------------------------------------------------------------------------- #
 # human-attested records (`record assert`) - issue #110
 # --------------------------------------------------------------------------- #
 
@@ -1393,6 +1815,92 @@ def _cmd_commit_extraction(args: argparse.Namespace) -> int:
     return 0
 
 
+def _rekey_orphans(
+    conn, report: "dedup.RekeyReport"
+) -> list[tuple["curation.OrphanVerdict", str | None, str | None]]:
+    """The curation verdicts *this* rekey run orphaned, each with its successor family.
+
+    Issue #126. `rekey` deliberately never re-points a verdict by itself (the #109/#114/#116
+    design), so a run that moves a family's `dedup_base` leaves that family's verdict inert.
+    Until now the operator only learned which ones on the *next* `pemr verify`; this is the
+    same detection (:func:`curation.list_orphans`) read at apply time and **scoped to what
+    this run moved**, so the report is this run's fallout rather than every orphan in the
+    database.
+
+    Assembled here rather than in `dedup` on purpose: `dedup` must never import `curation`
+    (the :class:`dedup.CollisionResolver` injected-seam rule), and this module imports both.
+
+    Returns ``(orphan, successor_base, successor_merge_base)`` per entry — the successors
+    being where the moved family and the moved merge target went, or ``None`` when this run
+    did not move that one. A table in :attr:`dedup.RekeyReport.blocked` is excluded by
+    construction: its changes were withheld, so it orphaned nothing.
+    """
+    blocked = set(report.blocked)
+    moved: dict[tuple[str, str], str] = {
+        (record_type, old): new
+        for record_type, base_map in report.base_maps.items()
+        if record_type not in blocked
+        for old, new in base_map.items()
+        if old != new
+    }
+    if not moved:
+        return []
+    out: list[tuple["curation.OrphanVerdict", str | None, str | None]] = []
+    for orphan in curation.list_orphans(conn):
+        successor = moved.get((orphan.record_type, orphan.dedup_base))
+        successor_merge = (
+            moved.get((orphan.record_type, orphan.merged_into_base))
+            if orphan.merged_into_base else None
+        )
+        if successor is None and successor_merge is None:
+            # A pre-existing orphan from an earlier run or an unrelated `record rm`:
+            # real, but not this run's doing, and `pemr verify` already names it.
+            continue
+        out.append((orphan, successor, successor_merge))
+    return out
+
+
+def _print_rekey_orphans(
+    orphans: list[tuple["curation.OrphanVerdict", str | None, str | None]]
+) -> None:
+    """The apply-time orphan block: what this rekey knocked loose, and how to fix it.
+
+    A `warning:`, not an `error:` — orphaning a verdict is the documented consequence of
+    the warn-and-reannotate design, not a failure, so `rekey`'s exit code is unchanged
+    (issue #126).
+    """
+    if not orphans:
+        return
+    print(
+        f"warning: {len(orphans)} curation verdict(s) were orphaned by this rekey",
+        file=sys.stderr,
+    )
+    for orphan, successor, successor_merge in orphans:
+        ident = (
+            f"row #{orphan.record_id}" if orphan.record_id
+            else f"{str(orphan.dedup_base)[:12]}..."
+        )
+        # The two successors are reported apart: one is where the family the verdict rules
+        # on went, the other where its merge target went, and a verdict can be flagged for
+        # either or both.
+        arrow = f" -> {str(successor)[:12]}..." if successor else ""
+        if successor_merge:
+            arrow += f" (merges into {str(successor_merge)[:12]}...)"
+        print(
+            f"  {orphan.record_type} {ident}  {','.join(orphan.kinds)}{arrow}  "
+            f"[{curation.describe(orphan.as_dict())}]",
+            file=sys.stderr,
+        )
+    print(
+        "  re-point them in one reviewed batch with\n"
+        "  `pemr record reaffirm --map-file <file>` (dry run), then --apply - where <file>\n"
+        "  is this run's own report: `pemr rekey --apply --json > <file>`. A dedup_base is\n"
+        "  overwritten in place, so the old->new mapping exists nowhere else.\n"
+        "  `pemr record reaffirm` alone lists them; `--clear` lifts them instead.",
+        file=sys.stderr,
+    )
+
+
 def _cmd_rekey(args: argparse.Namespace) -> int:
     conn = _connect_db(args)
     try:
@@ -1408,6 +1916,11 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
         except db.NotMigratedError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 1
+        # Read *after* the write, from live state: the orphan set is what the next `pemr
+        # verify` would say about this run, and a dry run wrote nothing to have fallout
+        # from (predicting it would mean simulating the post-write database - out of
+        # scope, issue #126).
+        orphans = _rekey_orphans(conn, report) if args.apply else []
     finally:
         conn.close()
 
@@ -1490,6 +2003,19 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
                 }
                 for r in report.resolved
             ],
+            # Appended (issue #126): the curation verdicts *this* run orphaned, so an
+            # agent sees the fallout here instead of on the next `pemr verify` - and can
+            # feed this very payload straight back as
+            # `pemr record reaffirm --map-file <file>`. Always present, `[]` on a dry run
+            # (which writes nothing, so it orphans nothing).
+            "orphans": [
+                {
+                    **orphan.as_dict(),
+                    "successor_base": successor,
+                    "successor_merge_base": successor_merge,
+                }
+                for orphan, successor, successor_merge in orphans
+            ],
         })
         return rc
 
@@ -1526,6 +2052,8 @@ def _cmd_rekey(args: argparse.Namespace) -> int:
             f"{len(report.resolved)} collision(s) resolved by verdict "
             f"({merged} as one fact, {distinct} as distinct facts)"
         )
+
+    _print_rekey_orphans(orphans)
 
     for collision in report.collisions:
         print(f"error: {collision.message}", file=sys.stderr)
@@ -2338,6 +2866,37 @@ def build_parser() -> argparse.ArgumentParser:
     )
     r_annotate.add_argument("--json", action="store_true", help="machine-readable output")
     r_annotate.set_defaults(func=_cmd_record_annotate, annotate_parser=r_annotate)
+
+    # --- bulk remedy for orphaned verdicts (issue #126) ---
+    r_reaffirm = record_sub.add_parser(
+        "reaffirm",
+        help="re-point or lift the curation verdicts a rekey orphaned, in one reviewed "
+             "batch (dry run by default)",
+    )
+    r_reaffirm.add_argument(
+        "table", nargs="?", choices=list(dedup.KNOWN_TYPES),
+        help="limit to one record type (default: every type)",
+    )
+    # A verdict is either re-pointed or lifted, never both: `--clear` ignores the map
+    # entirely, so accepting the pair would silently discard one of them. With neither,
+    # the command is a pure listing.
+    r_reaffirm_how = r_reaffirm.add_mutually_exclusive_group()
+    r_reaffirm_how.add_argument(
+        "--map-file", dest="map_file", metavar="FILE",
+        help="old->new base mapping from `pemr rekey --apply --json` (that payload, or a "
+             "bare array of its 'orphans' entries); required to re-point anything, since "
+             "the mapping cannot be re-derived once the rekey is over",
+    )
+    r_reaffirm_how.add_argument(
+        "--clear", action="store_true",
+        help="lift the listed verdicts instead of re-pointing them",
+    )
+    r_reaffirm.add_argument(
+        "--apply", action="store_true",
+        help="write the batch (default: report only)",
+    )
+    r_reaffirm.add_argument("--json", action="store_true", help="machine-readable output")
+    r_reaffirm.set_defaults(func=_cmd_record_reaffirm, reaffirm_parser=r_reaffirm)
 
     # --- human-attested records (issue #110) ---
     r_assert = record_sub.add_parser(

--- a/pemr/curation.py
+++ b/pemr/curation.py
@@ -16,6 +16,8 @@ write it.
     load_verdicts        -- the whole table as a lookup, for the render/verify hot path
     row_verdicts_for     -- the row-scoped verdicts naming a set of rows
     retire_row_verdicts  -- ... and drop them, for the row-removal write paths
+    orphan_kinds         -- why (if at all) one verdict points at nothing live
+    list_orphans         -- ... over the whole table, for `verify` and `record reaffirm`
 
 **Pure overlay.** No record row is ever written. `render` stays a pure function of DB
 state: it just reads two tables per section instead of one, and re-rendering after a
@@ -167,6 +169,29 @@ FAMILY_SCOPE = 0
 #: :data:`STATUSES` it has exactly one source of truth.
 SCOPE_FAMILY = "family"
 SCOPE_ROW = "row"
+
+#: The orphan vocabulary (issue #126) — the *one* source of truth for "this verdict
+#: points at nothing live", spoken by :func:`orphan_kinds`, :func:`list_orphans`,
+#: `pemr verify`'s warnings, `pemr rekey --apply`'s orphan block and
+#: `pemr record reaffirm`'s ``--json``.
+#:
+#: ``ORPHAN_NO_FAMILY`` — a **family-scoped** verdict whose ``dedup_base`` names no live
+#: family. Its ruling is inert: nothing renders the fact it judged.
+#:
+#: ``ORPHAN_DANGLING_MERGE`` — a verdict in **either** scope whose ``merged_into_base``
+#: names no live family. The merge target is always a family (``--merged-into`` takes a
+#: ``dedup_base``), so this one is scope-independent.
+#:
+#: Deliberately **not** an orphan kind, and this exclusion is load-bearing: the
+#: *row-scoped stale breadcrumb* — a row verdict whose stored ``dedup_base`` a rekey left
+#: behind. That verdict still resolves, by ``record_id``; the stale base is never consulted
+#: (see the module docstring). `verify` keeps reporting it as its own notice, and nothing
+#: here may re-annotate it.
+ORPHAN_NO_FAMILY = "no-live-family"
+ORPHAN_DANGLING_MERGE = "dangling-merge-target"
+
+#: Every orphan kind, in the order :func:`orphan_kinds` reports them.
+ORPHAN_KINDS: tuple[str, ...] = (ORPHAN_NO_FAMILY, ORPHAN_DANGLING_MERGE)
 
 
 class CurationNotFoundError(ValueError):
@@ -713,6 +738,125 @@ def list_curation(
         view["label"] = label
         view["family_size"] = size
         out.append(view)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# orphaned verdicts — one detector, three readers (issue #126)
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class OrphanVerdict:
+    """One stored verdict that points at nothing live, plus why.
+
+    Also the ``--json`` payload shape for `pemr record reaffirm` and the per-entry shape of
+    `pemr rekey --apply`'s ``orphans`` key, so — like :class:`CurationReport` — these key
+    names are a contract that may only widen.
+
+    ``label``/``family_size`` describe *what is left*, which for an orphan is usually
+    nothing: a ``no-live-family`` entry reports ``("", 0)``, while a
+    ``dangling-merge-target`` one still names the live family the verdict itself rules on.
+    """
+
+    record_type: str
+    dedup_base: str
+    record_id: int
+    scope: str
+    status: str
+    note: str
+    attributed_to: str | None
+    merged_into_base: str | None
+    created_at: str
+    kinds: list[str] = field(default_factory=list)
+    label: str = ""
+    family_size: int = 0
+
+    def as_dict(self) -> dict:
+        return {
+            "record_type": self.record_type,
+            "dedup_base": self.dedup_base,
+            "record_id": self.record_id,
+            "scope": self.scope,
+            "status": self.status,
+            "note": self.note,
+            "attributed_to": self.attributed_to,
+            "merged_into_base": self.merged_into_base,
+            "created_at": self.created_at,
+            "kinds": list(self.kinds),
+            "label": self.label,
+            "family_size": self.family_size,
+        }
+
+
+def orphan_kinds(conn: sqlite3.Connection, verdict: dict) -> list[str]:
+    """Why ``verdict`` points at nothing live — ``[]`` when it is healthy.
+
+    The single detector behind `pemr verify`'s two orphan warnings, `pemr record
+    reaffirm`'s listing and `pemr rekey --apply`'s orphan block (issue #126): all three
+    used to derive this state their own way, and a bulk remedy that disagreed with the
+    warning it answers would re-annotate the wrong rows.
+
+    ``verdict`` is a ``_row_view``-shaped dict, so both :meth:`VerdictMap.all` entries and
+    :func:`list_curation` entries are valid input. A verdict whose ``record_type`` is not
+    a known table reports ``[]``: the value can come off a hand-edited row and
+    :func:`dedup.load_family` interpolates it into a table name, so it must never reach
+    SQL — `verify` keeps its own separate warning for that case.
+
+    Kinds are returned in :data:`ORPHAN_KINDS` order, and a verdict can carry both.
+    """
+    record_type = verdict["record_type"]
+    if record_type not in dedup.FIELD_SPECS:
+        return []
+    kinds: list[str] = []
+    # Family scope only: a row-scoped verdict resolves by `record_id`, and its stored base
+    # is a breadcrumb a rekey may have left stale (the module docstring's scope rule).
+    if not verdict["record_id"] and not dedup.load_family(
+        conn, record_type, verdict["dedup_base"]
+    ):
+        kinds.append(ORPHAN_NO_FAMILY)
+    target = verdict.get("merged_into_base")
+    if target and not dedup.load_family(conn, record_type, target):
+        kinds.append(ORPHAN_DANGLING_MERGE)
+    return kinds
+
+
+def list_orphans(
+    conn: sqlite3.Connection, record_type: str | None = None
+) -> list[OrphanVerdict]:
+    """Every orphaned verdict (optionally one record type), newest first.
+
+    **One entry per verdict**, carrying every kind that flagged it: a verdict in both
+    classes must be re-annotated once, not twice.
+
+    Returns ``[]`` when `curation` is absent (pre-008 snapshot) — the
+    :func:`list_curation` guard, so callers need no second check. Deliberately narrower
+    than :func:`list_curation`'s ``family_size == 0`` signal, which also flags the
+    row-scoped orphan whose remedy is ``--clear --row``, not a re-point.
+    """
+    db.require_migrated(conn)
+    if record_type is not None:
+        _require_type(record_type)
+    if not has_table(conn):
+        return []
+    out: list[OrphanVerdict] = []
+    for verdict in list_curation(conn, record_type):
+        kinds = orphan_kinds(conn, verdict)
+        if not kinds:
+            continue
+        out.append(OrphanVerdict(
+            record_type=verdict["record_type"],
+            dedup_base=verdict["dedup_base"],
+            record_id=verdict["record_id"],
+            scope=verdict["scope"],
+            status=verdict["status"],
+            note=verdict["note"],
+            attributed_to=verdict["attributed_to"],
+            merged_into_base=verdict["merged_into_base"],
+            created_at=verdict["created_at"],
+            kinds=kinds,
+            label=verdict["label"],
+            family_size=verdict["family_size"],
+        ))
     return out
 
 

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -1530,6 +1530,18 @@ class RekeyReport:
     # `blocked`/`writable()`: a resolved pair does not quarantine its table.
     resolved: list[RekeyResolution] = field(default_factory=list)
     applied: bool = False
+    # Stored ``dedup_base`` -> recomputed base, per record type (issue #126). Appended,
+    # never inserted: the construction sites are keyword-only but `RekeyReport` is part of
+    # the `--json` contract's provenance and that contract may only widen.
+    #
+    # A ``dedup_base`` is a content hash overwritten in place by `apply=True`, so once the
+    # run is over *nothing in the database records that F_old became F_new*. Only this run
+    # knows, which is why the mapping has to leave on the report: it is what lets the CLI
+    # scope "which curation verdicts did this rekey orphan" and what `pemr record reaffirm
+    # --map-file` follows to the successor family. Deliberately a plain dict of strings -
+    # `dedup` must never import `curation`, so the orphan report itself is assembled in
+    # `cli.py`, which imports both.
+    base_maps: dict[str, dict[str, str]] = field(default_factory=dict)
 
     @property
     def blocked(self) -> list[str]:
@@ -1629,8 +1641,10 @@ def rekey(
     db.require_migrated(conn)
     report = RekeyReport(applied=False)
     # Stored dedup_base -> recomputed base, per table: how a family verdict's merge
-    # target is followed when the target family moved in this same run.
-    base_maps: dict[str, dict[str, str]] = {}
+    # target is followed when the target family moved in this same run - and, since #126,
+    # how the CLI scopes the orphan report to the families *this* run moved. The report's
+    # own dict, not a copy: one map, two readers, no chance of them drifting.
+    base_maps: dict[str, dict[str, str]] = report.base_maps
     # (record_type, verdict, resolution) — the narrowings the write block owes. Kept
     # beside the report rather than inside it so RekeyResolution stays a plain,
     # serializable account of what happened (the raw verdict dict is not part of it).

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -169,6 +169,14 @@ def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
     including for `merged-into`, whose re-affirm names the row's own (post-rekey) family,
     which :func:`curation.annotate_record` accepts at row scope precisely so this notice
     can be answered without downgrading or lifting the ruling.
+
+    The two *orphan* classes - a family verdict with no live family, and either scope's
+    dangling `merged_into_base` - are detected by :func:`curation.orphan_kinds`, the one
+    detector `pemr record reaffirm` reads too (issue #126): a bulk remedy that disagreed
+    with the warning it answers would re-annotate the wrong rows. `record reaffirm` is that
+    remedy at batch scale, beside the per-row `record annotate --clear`. The row-scoped
+    stale-breadcrumb notice below is deliberately *not* one of those classes: that verdict
+    still resolves by row id, so nothing re-points it.
     """
     if not curation.has_table(conn):
         return
@@ -184,6 +192,10 @@ def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
                 f"type (known: {', '.join(dedup.KNOWN_TYPES)})"
             )
             continue
+        # The shared detector (issue #126): the two *orphan* classes below are derived
+        # once, here, so this warning and `pemr record reaffirm`'s bulk remedy can never
+        # disagree about which verdicts are inert.
+        kinds = curation.orphan_kinds(conn, verdict)
         if record_id:
             pk = f"{record_type}_id"
             live = conn.execute(
@@ -206,13 +218,13 @@ def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
                     f"with `pemr record annotate --row {record_type} {record_id}` or "
                     "lift it with `--clear --row`"
                 )
-        elif not dedup.load_family(conn, record_type, base):
+        elif curation.ORPHAN_NO_FAMILY in kinds:
             report.warnings.append(
                 f"curation verdict {record_type}/{short}... has no live family "
                 "(removed?) - lift it with `pemr record annotate --clear`"
             )
         target = verdict.get("merged_into_base")
-        if target and not dedup.load_family(conn, record_type, target):
+        if curation.ORPHAN_DANGLING_MERGE in kinds:
             # The merge target is always a family, in either scope (`--merged-into`
             # names a `dedup_base`), so this check is scope-independent.
             ident = (

--- a/tests/test_cli_ascii.py
+++ b/tests/test_cli_ascii.py
@@ -213,6 +213,44 @@ def test_record_annotate_output_is_console_safe(ready, capsys):
     _assert_console_safe(captured.err)
 
 
+def test_record_reaffirm_output_is_console_safe(ready, capsys):
+    """Issue #126's new surfaces: `record reaffirm`'s listing (with its `->` successor
+    column) and the `rekey --apply` orphan block, both on a cp437 console."""
+    with pytest.raises(SystemExit):
+        _run(ready, "record", "reaffirm", "--help")
+    _assert_console_safe(capsys.readouterr().out)
+
+    scan = ready / "scan.txt"
+    scan.write_bytes(b"visit note: glucose 95")
+    assert _run(ready, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(ready / "sources"), "--ocr-text-file", str(scan)) == 0
+    payload = ready / "extract.json"
+    payload.write_text(json.dumps({"lab_result": [
+        {"test_name": "Glucose", "collected_at": "2026-01-02", "value_num": 95,
+         "unit": "mg/dL"},
+    ]}), encoding="utf-8")
+    assert _run(ready, "commit-extraction", "--document", "1", "--json",
+                str(payload)) == 0
+    assert _run(ready, "record", "annotate", "lab_result", "1", "--status",
+                "superseded", "--note", "old label", "--apply") == 0
+
+    dictionary = ready / "new.toml"
+    dictionary.write_text('[synonyms]\n"glucose" = "blood-sugar"\n', encoding="utf-8")
+    capsys.readouterr()
+    assert _run(ready, "rekey", "--dictionary", str(dictionary), "--apply") == 0
+    captured = capsys.readouterr()
+    assert "orphaned by this rekey" in captured.err
+    _assert_console_safe(captured.out)
+    _assert_console_safe(captured.err)
+
+    # And again through the map-file path, whose listing carries the `->` column.
+    assert _run(ready, "rekey", "--dictionary", str(dictionary), "--apply",
+                "--json") == 0
+    capsys.readouterr()
+    assert _run(ready, "record", "reaffirm") == 0
+    _assert_console_safe(capsys.readouterr().out)
+
+
 def test_record_assert_output_is_console_safe(ready, capsys):
     """Issue #110's new CLI + render surface: the report block, the `--list` table, the
     collision refusal, and the `(attested by ...)` marker in every render."""

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -698,6 +698,122 @@ def test_rekey_json_still_reports_a_blocking_collision(ready, capsys, tmp_path):
     assert [c["kind"] for c in payload["collisions"]] == ["fused"]
 
 
+# --- apply-time orphan reporting (issue #126) ---------------------------------
+#
+# `rekey` still never re-points a verdict by itself (the #109/#114/#116 design). What
+# changes here is *when the operator hears about it*: at the apply that caused it, rather
+# than on the next `pemr verify`.
+
+def _first_base(tmp_path, record_type):
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        return conn.execute(
+            f"SELECT dedup_base FROM {record_type} ORDER BY {record_type}_id"
+        ).fetchone()["dedup_base"]
+    finally:
+        conn.close()
+
+
+def _seed_ruled_lab(ready, capsys, tmp_path):
+    """One ZZT lab row under a verdict, plus the dictionary that will move its family."""
+    old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
+    new = _dict_file(tmp_path, "new.toml", '"zzt" = "zonulin_test"\n')
+    _seed_lab(ready, tmp_path, old)
+    base = _first_base(tmp_path, "lab_result")
+    assert _run(tmp_path, "record", "annotate", "lab_result", base, "--status",
+                "superseded", "--note", "old label", "--apply") == 0
+    capsys.readouterr()
+    return base, new
+
+
+def test_rekey_apply_names_the_orphans_it_produced(ready, capsys, tmp_path):
+    """AC 7: the fallout is on the apply's own output, with the follow-up command."""
+    base, new = _seed_ruled_lab(ready, capsys, tmp_path)
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply") == 0
+    captured = capsys.readouterr()
+    assert "1 curation verdict(s) were orphaned by this rekey" in captured.err
+    assert base[:12] in captured.err and "no-live-family" in captured.err
+    assert "pemr record reaffirm --map-file" in captured.err
+    # Orphaning a verdict is the documented consequence, not a failure: rc is unchanged
+    # and the run still reports itself as applied.
+    assert "rekeyed 1 row(s)" in captured.out
+    assert captured.err.isascii()               # issue #23
+
+
+def test_rekey_apply_json_carries_the_orphan_list(ready, capsys, tmp_path):
+    base, new = _seed_ruled_lab(ready, capsys, tmp_path)
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply", "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [o["dedup_base"] for o in payload["orphans"]] == [base]
+    orphan = payload["orphans"][0]
+    assert orphan["kinds"] == ["no-live-family"]
+    assert orphan["successor_base"] == _first_base(tmp_path, "lab_result")
+    assert orphan["successor_base"] != base
+    assert orphan["successor_merge_base"] is None
+    # Exit-code parity with the text mode, and the rest of the payload is untouched.
+    assert payload["applied"] is True and payload["collisions"] == []
+
+
+def test_rekey_dry_run_reports_no_orphans(ready, capsys, tmp_path):
+    """AC 8: dry-run behaviour is unchanged — it wrote nothing, so it orphaned nothing.
+    `orphans` is still present (always, so a consumer need not branch), just empty."""
+    _base, new = _seed_ruled_lab(ready, capsys, tmp_path)
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--json") == 0
+    assert json.loads(capsys.readouterr().out)["orphans"] == []
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new)) == 0
+    captured = capsys.readouterr()
+    assert "orphaned by this rekey" not in captured.err
+    assert "dry run: 1 row(s) would change" in captured.out
+
+
+def test_rekey_does_not_report_an_orphan_it_did_not_cause(ready, capsys, tmp_path):
+    """The report is *this run's* fallout, scoped to the families it moved. A verdict
+    orphaned earlier by `record rm` is still an orphan — `pemr verify` still says so — but
+    listing it here would blame this rekey for someone else's."""
+    old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
+    moves_condition = _dict_file(tmp_path, "cond.toml", '"t2dm" = "type 2 diabetes"\n')
+    _seed_fusing_lab_and_movable_condition(ready, capsys, tmp_path, old)
+    alb_id, _albumin_id = _row_ids(tmp_path, "lab_result")
+    assert _run(tmp_path, "record", "annotate", "lab_result", str(alb_id), "--status",
+                "superseded", "--note", "gone soon", "--apply") == 0
+    assert _run(tmp_path, "record", "rm", "lab_result", str(alb_id), "--apply") == 0
+    capsys.readouterr()
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(moves_condition), "--apply",
+                "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [c["record_type"] for c in payload["changed"]] == ["condition"]
+    assert payload["orphans"] == []
+
+    assert _run(tmp_path, "verify") == 0
+    assert "has no live family" in capsys.readouterr().out
+
+
+def test_rekey_reports_no_orphans_for_a_verdict_resolved_collision(
+    ready, capsys, tmp_path
+):
+    """The repro's 11/11 collision-fused rows, guarded (AC 8). That path *narrows* its
+    authorizing verdict to row scope in the same transaction as the keys, so the ruling is
+    never orphaned and the orphan report must stay empty."""
+    old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
+    new = _dict_file(tmp_path, "fuse.toml",
+                     '"alb" = "albumin"\n"t2dm" = "type 2 diabetes"\n')
+    _seed_fusing_lab_and_movable_condition(ready, capsys, tmp_path, old)
+    alb_id, _albumin_id = _row_ids(tmp_path, "lab_result")
+    assert _run(tmp_path, "record", "annotate", "lab_result", str(alb_id), "--status",
+                "superseded", "--note", "one assay, two labels", "--apply") == 0
+    capsys.readouterr()
+
+    assert _run(tmp_path, "rekey", "--dictionary", str(new), "--apply", "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [r["verdict_action"] for r in payload["resolved"]] == ["narrowed"]
+    assert payload["orphans"] == []
+
+
 # --- intake formats at the CLI (issue #66) ------------------------------------
 
 def test_ingest_refuses_a_google_drive_pointer_stub(ready, capsys):

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -1203,6 +1203,157 @@ def test_verify_warns_about_a_hand_edited_unknown_record_type(seeded):
     assert any("unknown record type" in w for w in report.warnings)
 
 
+# --- orphaned verdicts: one detector, three readers (issue #126) --------------
+#
+# `verify`'s two orphan warnings, `record reaffirm`'s listing and `rekey --apply`'s orphan
+# block all read `curation.orphan_kinds`. The tests that matter most here are the two
+# *exclusions*: a bulk remedy that re-annotated a verdict which still resolves would
+# silently re-point a live ruling, which is the failure the #109/#114 design forbids.
+
+
+def test_list_orphans_reports_a_family_a_rekey_moved(seeded):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    curation.annotate_record(conn, "lab_result", base, status="superseded",
+                            note="old label", attributed_to="Dr Who", apply=True)
+    assert curation.list_orphans(conn) == []
+
+    dedup.rekey(conn, {"glucose": "blood-sugar"}, apply=True)
+
+    orphans = curation.list_orphans(conn)
+    assert [(o.record_type, o.dedup_base, o.kinds) for o in orphans] == [
+        ("lab_result", base, [curation.ORPHAN_NO_FAMILY])]
+    # The ruling is carried verbatim: a bulk re-affirm re-annotates from exactly this.
+    assert (orphans[0].status, orphans[0].note, orphans[0].attributed_to) == (
+        "superseded", "old label", "Dr Who")
+    assert (orphans[0].label, orphans[0].family_size) == ("", 0)
+
+
+def test_list_orphans_reports_a_dangling_merge_target(seeded):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    target = _base(conn, "lab_result", "test_name", "HbA1c")
+    curation.annotate_record(conn, "lab_result", base, status="merged-into",
+                            note="same draw", merged_into_base=target, apply=True)
+    records.remove_record(
+        conn, "lab_result", _row_id(conn, "lab_result", "test_name", "HbA1c"),
+        apply=True,
+    )
+
+    orphans = curation.list_orphans(conn)
+    assert [o.kinds for o in orphans] == [[curation.ORPHAN_DANGLING_MERGE]]
+    # The verdict's own family is still live, so what remains is still described.
+    assert (orphans[0].label, orphans[0].family_size) == ("Glucose", 1)
+
+
+def test_list_orphans_reports_one_entry_carrying_both_kinds(seeded):
+    """A verdict in both classes must be re-annotated **once**, not twice — which is why
+    the detector returns a list of kinds per verdict rather than one entry per warning."""
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    target = _base(conn, "lab_result", "test_name", "HbA1c")
+    curation.annotate_record(conn, "lab_result", base, status="merged-into",
+                            note="same draw", merged_into_base=target, apply=True)
+    for name in ("Glucose", "HbA1c"):
+        records.remove_record(
+            conn, "lab_result", _row_id(conn, "lab_result", "test_name", name),
+            apply=True,
+        )
+
+    orphans = curation.list_orphans(conn)
+    assert len(orphans) == 1
+    assert orphans[0].kinds == [
+        curation.ORPHAN_NO_FAMILY, curation.ORPHAN_DANGLING_MERGE]
+    # `verify` still says both things about it; the orphan list names it once.
+    warnings = verify.verify_report(conn).warnings
+    assert any("has no live family" in w for w in warnings)
+    assert any("merges into" in w for w in warnings)
+
+
+def test_list_orphans_excludes_the_row_scoped_stale_breadcrumb(seeded):
+    """The scope boundary. A rekey moved the row out of the family it was ruled in, but
+    the verdict still resolves *by row id* — so it is a notice for the human, never an
+    orphan for a bulk re-point to touch."""
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    _occ0, occ1 = _occurrence_ids(conn, base)
+    curation.annotate_record(conn, "lab_result", str(occ1), status="superseded",
+                            note="this occurrence only", row=True, apply=True)
+
+    dedup.rekey(conn, {"glucose": "blood-sugar"}, apply=True)
+
+    assert curation.list_orphans(conn) == []
+    assert [w for w in verify.verify_report(conn).warnings if "a rekey moved it" in w]
+
+
+def test_list_orphans_excludes_a_removed_row(seeded):
+    """The other exclusion: a row-scoped verdict whose row is gone *is* inert, but its
+    remedy is `--clear --row` (and the removal write paths already retire it), not a
+    re-point — so it stays out of the set the bulk verb acts on."""
+    conn = seeded["conn"]
+    base = _second_occurrence(seeded)
+    _occ0, occ1 = _occurrence_ids(conn, base)
+    curation.annotate_record(conn, "lab_result", str(occ1), status="superseded",
+                            note="loser", row=True, apply=True)
+    # Straight to the table, behind the write paths' backs - the only way to this state.
+    conn.execute("DELETE FROM lab_result WHERE lab_result_id = ?", (occ1,))
+    conn.commit()
+
+    assert curation.list_orphans(conn) == []
+    assert any("names no live row" in w for w in verify.verify_report(conn).warnings)
+    # `list_curation`'s broader `family_size == 0` signal *does* flag it: the two are
+    # deliberately different sets, and this is the row they disagree about.
+    entry = next(r for r in curation.list_curation(conn) if r["record_id"] == occ1)
+    assert entry["family_size"] == 0
+
+
+def test_orphan_kinds_never_queries_a_hand_edited_record_type(seeded):
+    """The read-path re-validation: a stored `record_type` reaches `load_family`, which
+    interpolates it into a table name, so an unknown one must report nothing at all."""
+    conn = seeded["conn"]
+    assert curation.orphan_kinds(conn, {
+        "record_type": "family_history", "dedup_base": "b", "record_id": 0,
+        "merged_into_base": None,
+    }) == []
+    conn.execute(
+        "INSERT INTO curation (record_type, dedup_base, status, note, created_at) "
+        "VALUES ('family_history', 'b', 'disputed', 'hand-edited', "
+        "'2026-01-01T00:00:00')"
+    )
+    conn.commit()
+    assert curation.list_orphans(conn) == []
+    # `verify` keeps its own, separate warning for this case.
+    assert any("unknown record type" in w for w in verify.verify_report(conn).warnings)
+
+
+def test_list_orphans_filters_by_record_type(seeded):
+    conn = seeded["conn"]
+    lab = _base(conn, "lab_result", "test_name", "Glucose")
+    cond = _base(conn, "condition", "name", "Prediabetes")
+    for record_type, base in (("lab_result", lab), ("condition", cond)):
+        curation.annotate_record(conn, record_type, base, status="superseded",
+                                note="gone", apply=True)
+        records.remove_record(
+            conn, record_type,
+            _row_id(conn, record_type,
+                    "test_name" if record_type == "lab_result" else "name",
+                    "Glucose" if record_type == "lab_result" else "Prediabetes"),
+            apply=True,
+        )
+
+    assert len(curation.list_orphans(conn)) == 2
+    assert [o.record_type for o in curation.list_orphans(conn, "condition")] == [
+        "condition"]
+
+
+def test_list_orphans_is_empty_without_the_curation_table(seeded):
+    """The pre-008 snapshot guard, so no caller needs a second `has_table` check."""
+    conn = seeded["conn"]
+    conn.execute("DROP TABLE curation")
+    conn.commit()
+    assert curation.list_orphans(conn) == []
+
+
 # --- CLI surface -------------------------------------------------------------
 
 
@@ -1243,6 +1394,25 @@ def _cli_curation_count(tmp_path):
     conn = _cli_conn(tmp_path)
     try:
         return _curation_count(conn)
+    finally:
+        conn.close()
+
+
+def _cli_base(tmp_path, record_type, column, value):
+    conn = _cli_conn(tmp_path)
+    try:
+        return _base(conn, record_type, column, value)
+    finally:
+        conn.close()
+
+
+def _cli_curation_rows(tmp_path):
+    """Every stored verdict, in a stable order — the "nothing was written" assertion."""
+    conn = _cli_conn(tmp_path)
+    try:
+        return [dict(r) for r in conn.execute(
+            "SELECT * FROM curation ORDER BY record_type, dedup_base, record_id"
+        )]
     finally:
         conn.close()
 
@@ -1569,3 +1739,285 @@ def test_cli_annotate_render_remove_verify_drill(cli_ready, capsys):
     out = capsys.readouterr().out
     assert "warnings       1" in out
     assert "has no live family" in out
+
+
+# --- `record reaffirm`: the bulk remedy (issue #126) --------------------------
+
+
+def _cli_dict(tmp_path, name, body):
+    p = tmp_path / name
+    p.write_text("[synonyms]\n" + body, encoding="utf-8")
+    return str(p)
+
+
+def _orphaning_rekey(tmp_path, capsys):
+    """Rule on the Glucose family, then move it with a dictionary edit — the repro shape.
+
+    Returns ``(old base, new base, path of this run's `rekey --apply --json` report)``.
+    The report is the map file: a ``dedup_base`` is overwritten in place, so the old->new
+    mapping exists nowhere but the payload of the run that made it.
+    """
+    base = _cli_base(tmp_path, "lab_result", "test_name", "Glucose")
+    assert _run(tmp_path, "record", "annotate", "lab_result", base, "--status",
+                "superseded", "--note", "one assay, two labels",
+                "--attributed-to", "Dr Who", "--apply") == 0
+    dictionary = _cli_dict(tmp_path, "new.toml", '"glucose" = "blood-sugar"\n')
+    capsys.readouterr()
+    assert _run(tmp_path, "rekey", "--dictionary", dictionary, "--apply", "--json") == 0
+    report = tmp_path / "rekey.json"
+    report.write_text(capsys.readouterr().out, encoding="utf-8")
+    return base, _cli_base(tmp_path, "lab_result", "test_name", "Glucose"), str(report)
+
+
+def test_cli_reaffirm_is_friendly_when_nothing_is_orphaned(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "reaffirm") == 0
+    assert "no orphaned curation verdicts" in capsys.readouterr().out
+
+
+def test_cli_reaffirm_bare_listing_writes_nothing(cli_ready, capsys):
+    """No disposition supplied = a pure listing, rc 0: the default invocation reports the
+    orphan set and nothing else (AC 2)."""
+    base, _new, _report = _orphaning_rekey(cli_ready, capsys)
+    before = _cli_curation_rows(cli_ready)
+    capsys.readouterr()
+
+    assert _run(cli_ready, "record", "reaffirm") == 0
+    out = capsys.readouterr().out
+    assert base[:12] in out and "no-live-family" in out
+    assert "one assay, two labels" in out
+    assert "listing only" in out and "--map-file" in out
+    assert _cli_curation_rows(cli_ready) == before
+
+
+def test_cli_reaffirm_dry_run_with_a_map_file_writes_nothing(cli_ready, capsys):
+    base, new_base, report = _orphaning_rekey(cli_ready, capsys)
+    before = _cli_curation_rows(cli_ready)
+    capsys.readouterr()
+
+    assert _run(cli_ready, "record", "reaffirm", "--map-file", report) == 0
+    out = capsys.readouterr().out
+    # The successor's label *and size* are shown: that is how a reviewer catches a ruling
+    # about to widen over rows nobody judged.
+    assert f"-> {new_base[:12]} (Glucose, 1 row(s))" in out
+    assert "dry run: nothing was written - re-run with --apply" in out
+    assert _cli_curation_rows(cli_ready) == before
+
+
+def test_cli_reaffirm_json_shape_is_stable(cli_ready, capsys):
+    base, _new, _report = _orphaning_rekey(cli_ready, capsys)
+    capsys.readouterr()
+
+    assert _run(cli_ready, "record", "reaffirm", "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [e["dedup_base"] for e in payload] == [base]
+    entry = payload[0]
+    assert entry["kinds"] == [curation.ORPHAN_NO_FAMILY]
+    assert entry["scope"] == "family" and entry["record_id"] == 0
+    assert entry["status"] == "superseded" and entry["attributed_to"] == "Dr Who"
+    # No map file: nothing to point at yet, and nothing written.
+    assert entry["action"] == "list"
+    assert entry["to_base"] is None and entry["to_merge_base"] is None
+    assert entry["applied"] is False
+    assert set(entry) == {
+        "record_type", "dedup_base", "record_id", "scope", "status", "note",
+        "attributed_to", "merged_into_base", "created_at", "kinds", "label",
+        "family_size", "action", "to_base", "to_merge_base", "target_label",
+        "target_family_size", "reason", "applied",
+    }
+
+
+def test_cli_reaffirm_drill_moves_the_verdict_and_quiets_verify(cli_ready, capsys):
+    """The whole point (AC 4, 6, 7): rekey --apply --json -> reaffirm --map-file --apply,
+    and the verdict is live again on the successor family with the human's own words."""
+    base, new_base, report = _orphaning_rekey(cli_ready, capsys)
+    assert new_base != base
+    capsys.readouterr()
+
+    assert _run(cli_ready, "record", "reaffirm", "--map-file", report, "--apply") == 0
+    assert "re-annotated 1 verdict(s)" in capsys.readouterr().out
+
+    assert [(r["dedup_base"], r["record_id"], r["status"], r["note"],
+             r["attributed_to"]) for r in _cli_curation_rows(cli_ready)] == [
+        (new_base, 0, "superseded", "one assay, two labels", "Dr Who")]
+
+    capsys.readouterr()
+    assert _run(cli_ready, "verify") == 0
+    out = capsys.readouterr().out
+    assert "has no live family" not in out
+    assert not any(line.startswith("warnings") for line in out.splitlines())
+
+    # And the ruling is doing its job again on the new identity.
+    capsys.readouterr()
+    assert _run(cli_ready, "render", "summary", "--person", "jane-doe") == 0
+    summary = capsys.readouterr().out
+    assert "## Superseded / corrected" in summary
+    assert "one assay, two labels" in summary
+
+
+def test_cli_reaffirm_rerunning_the_same_map_file_is_a_clean_no_op(cli_ready, capsys):
+    """Idempotence: a map entry with no live orphan behind it is `already-handled`, not an
+    error — so the composed pipeline is safe to retry."""
+    _base_, _new, report = _orphaning_rekey(cli_ready, capsys)
+    assert _run(cli_ready, "record", "reaffirm", "--map-file", report, "--apply") == 0
+    after_first = _cli_curation_rows(cli_ready)
+    capsys.readouterr()
+
+    assert _run(cli_ready, "record", "reaffirm", "--map-file", report, "--apply") == 0
+    out = capsys.readouterr().out
+    assert "already-handled" in out and "no longer orphaned" in out
+    assert _cli_curation_rows(cli_ready) == after_first
+
+
+def test_cli_reaffirm_accepts_a_bare_orphans_array(cli_ready, capsys):
+    """The map file is `rekey --json`'s payload *or* a bare array of its `orphans`
+    entries, so a caller that already split the report needs no reassembly."""
+    _base_, new_base, report = _orphaning_rekey(cli_ready, capsys)
+    bare = cli_ready / "bare.json"
+    with open(report, encoding="utf-8") as fh:
+        bare.write_text(json.dumps(json.load(fh)["orphans"]), encoding="utf-8")
+    capsys.readouterr()
+
+    assert _run(cli_ready, "record", "reaffirm", "--map-file", str(bare),
+                "--apply") == 0
+    assert [r["dedup_base"] for r in _cli_curation_rows(cli_ready)] == [new_base]
+
+
+def test_cli_reaffirm_clear_lifts_exactly_the_orphan_set(cli_ready, capsys):
+    """AC 5: no blanket re-affirm — a healthy verdict elsewhere is not touched."""
+    _base_, _new, _report = _orphaning_rekey(cli_ready, capsys)
+    healthy = _cli_row_id(cli_ready, "condition", "name", "Prediabetes")
+    assert _run(cli_ready, "record", "annotate", "condition", str(healthy),
+                "--status", "confirmed", "--note", "checked", "--apply") == 0
+    capsys.readouterr()
+
+    assert _run(cli_ready, "record", "reaffirm", "--clear", "--apply") == 0
+    assert [(r["record_type"], r["status"]) for r in _cli_curation_rows(cli_ready)] == [
+        ("condition", "confirmed")]
+
+
+def test_cli_reaffirm_refuses_to_overwrite_a_verdict_on_the_successor(cli_ready, capsys):
+    """A second human already ruled on the family this one would land in. Refuse the row,
+    exit 1, and leave both verdicts exactly as they were."""
+    _base_, new_base, report = _orphaning_rekey(cli_ready, capsys)
+    assert _run(cli_ready, "record", "annotate", "lab_result", new_base,
+                "--status", "confirmed", "--note", "a second ruling", "--apply") == 0
+    before = _cli_curation_rows(cli_ready)
+    capsys.readouterr()
+
+    assert _run(cli_ready, "record", "reaffirm", "--map-file", report, "--apply") == 1
+    captured = capsys.readouterr()
+    assert "already carries its own verdict" in captured.out
+    assert "were not handled" in captured.err
+    assert _cli_curation_rows(cli_ready) == before
+
+
+def test_cli_reaffirm_skips_an_orphan_the_map_does_not_name(cli_ready, capsys):
+    """An orphan from some other run is reported and refused, never guessed at — rc 1 says
+    the operator asked for a batch and did not get all of it."""
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "Glucose")
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
+                "--status", "superseded", "--note", "gone soon", "--apply") == 0
+    assert _run(cli_ready, "record", "rm", "lab_result", str(target), "--apply") == 0
+    empty = cli_ready / "empty.json"
+    empty.write_text(json.dumps({"orphans": []}), encoding="utf-8")
+    before = _cli_curation_rows(cli_ready)
+    capsys.readouterr()
+
+    assert _run(cli_ready, "record", "reaffirm", "--map-file", str(empty),
+                "--apply") == 1
+    assert "not named by the map file" in capsys.readouterr().out
+    assert _cli_curation_rows(cli_ready) == before
+
+
+def test_cli_reaffirm_skips_a_merge_target_with_no_successor(cli_ready, capsys):
+    """`annotate_record` rejects a dangling `--merged-into`, so this row has to be refused
+    in the *plan* rather than blowing up mid-batch."""
+    glucose = _cli_base(cli_ready, "lab_result", "test_name", "Glucose")
+    hba1c = _cli_base(cli_ready, "lab_result", "test_name", "HbA1c")
+    assert _run(cli_ready, "record", "annotate", "lab_result", glucose,
+                "--status", "merged-into", "--merged-into", hba1c,
+                "--note", "same draw", "--apply") == 0
+    assert _run(cli_ready, "record", "rm", "lab_result",
+                str(_cli_row_id(cli_ready, "lab_result", "test_name", "HbA1c")),
+                "--apply") == 0
+    dictionary = _cli_dict(cli_ready, "new.toml", '"glucose" = "blood-sugar"\n')
+    capsys.readouterr()
+    assert _run(cli_ready, "rekey", "--dictionary", dictionary, "--apply",
+                "--json") == 0
+    report = cli_ready / "rekey.json"
+    report.write_text(capsys.readouterr().out, encoding="utf-8")
+    before = _cli_curation_rows(cli_ready)
+
+    assert _run(cli_ready, "record", "reaffirm", "--map-file", str(report),
+                "--apply") == 1
+    assert "no successor for the merge target" in capsys.readouterr().out
+    assert _cli_curation_rows(cli_ready) == before
+
+
+def test_cli_reaffirm_skips_a_row_verdict_whose_row_is_gone(cli_ready, capsys):
+    """A restored or hand-edited database can hold a row verdict whose merge target moved
+    *and* whose own row is gone. Refused in the plan, with the `--clear` pointer, rather
+    than raising out of `resolve_row` halfway through the batch."""
+    glucose_id = _cli_row_id(cli_ready, "lab_result", "test_name", "Glucose")
+    hba1c = _cli_base(cli_ready, "lab_result", "test_name", "HbA1c")
+    assert _run(cli_ready, "record", "annotate", "lab_result", str(glucose_id), "--row",
+                "--status", "merged-into", "--merged-into", hba1c,
+                "--note", "same draw", "--apply") == 0
+    # Straight to the table: the write paths would retire the verdict with the rows.
+    conn = _cli_conn(cli_ready)
+    try:
+        conn.execute("DELETE FROM lab_result")
+        conn.commit()
+    finally:
+        conn.close()
+
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "reaffirm", "--json") == 0
+    listed = json.loads(capsys.readouterr().out)
+    assert [e["kinds"] for e in listed] == [[curation.ORPHAN_DANGLING_MERGE]]
+    # The listing doubles as the map file - a bare array of the same entries.
+    bare = cli_ready / "bare.json"
+    bare.write_text(json.dumps(listed), encoding="utf-8")
+    before = _cli_curation_rows(cli_ready)
+
+    assert _run(cli_ready, "record", "reaffirm", "--map-file", str(bare),
+                "--apply") == 1
+    assert "the annotated row is gone" in capsys.readouterr().out
+    assert _cli_curation_rows(cli_ready) == before
+    # ... and --clear is the remedy it names, which does work.
+    assert _run(cli_ready, "record", "reaffirm", "--clear", "--apply") == 0
+    assert _cli_curation_rows(cli_ready) == []
+
+
+def test_cli_reaffirm_filters_by_table(cli_ready, capsys):
+    _base_, _new, _report = _orphaning_rekey(cli_ready, capsys)
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "reaffirm", "condition") == 0
+    assert "no orphaned curation verdicts" in capsys.readouterr().out
+    assert _run(cli_ready, "record", "reaffirm", "lab_result") == 0
+    assert "no-live-family" in capsys.readouterr().out
+
+
+def test_cli_reaffirm_map_file_misuse_is_friendly(cli_ready, capsys):
+    assert _run(cli_ready, "record", "reaffirm", "--map-file",
+                str(cli_ready / "nope.json")) == 1
+    assert "cannot read" in capsys.readouterr().err
+
+    bad = cli_ready / "bad.json"
+    bad.write_text("[1, 2", encoding="utf-8")
+    assert _run(cli_ready, "record", "reaffirm", "--map-file", str(bad)) == 1
+    assert "error:" in capsys.readouterr().err
+
+    wrong = cli_ready / "wrong.json"
+    wrong.write_text('"not a report"', encoding="utf-8")
+    assert _run(cli_ready, "record", "reaffirm", "--map-file", str(wrong)) == 1
+    assert "not a rekey report" in capsys.readouterr().err
+
+
+def test_cli_reaffirm_refuses_map_file_together_with_clear(cli_ready):
+    """A verdict is re-pointed or lifted, never both: `--clear` ignores the map entirely,
+    so accepting the pair would silently discard one of them."""
+    with pytest.raises(SystemExit) as exc:
+        _run(cli_ready, "record", "reaffirm", "--clear", "--map-file", "x.json")
+    assert exc.value.code == 2

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -2021,3 +2021,200 @@ def test_cli_reaffirm_refuses_map_file_together_with_clear(cli_ready):
     with pytest.raises(SystemExit) as exc:
         _run(cli_ready, "record", "reaffirm", "--clear", "--map-file", "x.json")
     assert exc.value.code == 2
+
+
+# --- the batch drill: the repro's 57 orphans in miniature (issue #126) --------
+#
+# Every test above rules on *one* family. The repro was a 57-verdict batch, and the write
+# loop is deliberately non-transactional and per-row, so a multi-row run is not the
+# single-verdict run repeated - it is the case this issue exists for. These two walk it
+# end to end through the CLI: four families moved by one dictionary edit, across two record
+# types, two of them merging into a sibling that moves in the same run (both orphan kinds
+# on one verdict), a row-scoped verdict alongside that must stay out of the batch, and a
+# healthy verdict that must not be touched.
+
+
+def _orphaning_rekey_batch(tmp_path, capsys):
+    """Rule on all four seeded families, then move all four with one dictionary edit.
+
+    Returns ``({name: (old base, new base)}, map file path)``. Also leaves a row-scoped
+    verdict on the Glucose row (a stale breadcrumb after the rekey, never an orphan) and a
+    ``confirmed`` family verdict on HbA1c that the batch must carry across verbatim.
+    """
+    bases = {n: _cli_base(tmp_path, rt, col, n) for rt, col, n in (
+        ("lab_result", "test_name", "HbA1c"),
+        ("lab_result", "test_name", "Glucose"),
+        ("condition", "name", "Type 2 Diabetes"),
+        ("condition", "name", "Prediabetes"),
+    )}
+    for table, name, args in (
+        ("lab_result", "HbA1c",
+         ("--status", "confirmed", "--note", "assay validated")),
+        ("lab_result", "Glucose",
+         ("--status", "merged-into", "--merged-into", bases["HbA1c"],
+          "--note", "same draw as the a1c")),
+        ("condition", "Type 2 Diabetes",
+         ("--status", "disputed", "--note", "onset year contested")),
+        ("condition", "Prediabetes",
+         ("--status", "merged-into", "--merged-into", bases["Type 2 Diabetes"],
+          "--note", "progressed, one condition")),
+    ):
+        assert _run(tmp_path, "record", "annotate", table, bases[name], *args,
+                    "--attributed-to", "Dr Who", "--apply") == 0
+    # A row verdict in the same database: the rekey leaves it a stale breadcrumb, which
+    # resolves by row id and so must never appear in the orphan batch. It sits on the HbA1c
+    # row, whose family verdict is `confirmed` — so shadowing it changes no rendering, and
+    # the appendix assertions below stay about the batch rather than about row precedence.
+    assert _run(tmp_path, "record", "annotate", "lab_result",
+                str(_cli_row_id(tmp_path, "lab_result", "test_name", "HbA1c")),
+                "--row", "--status", "disputed", "--note", "this draw only",
+                "--apply") == 0
+    dictionary = _cli_dict(tmp_path, "batch.toml",
+                           '"hba1c" = "hemoglobin a1c"\n'
+                           '"glucose" = "blood-sugar"\n'
+                           '"type 2 diabetes" = "diabetes mellitus type 2"\n'
+                           '"prediabetes" = "impaired glucose tolerance"\n')
+    capsys.readouterr()
+    assert _run(tmp_path, "rekey", "--dictionary", dictionary, "--apply", "--json") == 0
+    report = tmp_path / "batch-rekey.json"
+    report.write_text(capsys.readouterr().out, encoding="utf-8")
+    moved = {}
+    for rt, col, name in (("lab_result", "test_name", "HbA1c"),
+                          ("lab_result", "test_name", "Glucose"),
+                          ("condition", "name", "Type 2 Diabetes"),
+                          ("condition", "name", "Prediabetes")):
+        new = _cli_base(tmp_path, rt, col, name)
+        assert new != bases[name]
+        moved[name] = (bases[name], new)
+    return moved, str(report)
+
+
+def test_cli_reaffirm_carries_a_whole_batch_onto_the_new_identities(
+    cli_ready, capsys
+):
+    """The drill at batch scale: `rekey --apply --json` names all four orphans at apply
+    time, one `reaffirm --apply` re-points all four with the human's own words, `verify`
+    stops reporting them, and the appendix follows the rulings onto the new identities."""
+    moved, report = _orphaning_rekey_batch(cli_ready, capsys)
+    payload = json.loads(open(report, encoding="utf-8").read())
+
+    # Apply time, not the next `verify`: this run's own fallout, and only the four family
+    # verdicts - the row-scoped breadcrumb is not orphaned (AC 5, 7).
+    assert {(e["dedup_base"], tuple(e["kinds"])) for e in payload["orphans"]} == {
+        (moved["HbA1c"][0], (curation.ORPHAN_NO_FAMILY,)),
+        (moved["Type 2 Diabetes"][0], (curation.ORPHAN_NO_FAMILY,)),
+        (moved["Glucose"][0],
+         (curation.ORPHAN_NO_FAMILY, curation.ORPHAN_DANGLING_MERGE)),
+        (moved["Prediabetes"][0],
+         (curation.ORPHAN_NO_FAMILY, curation.ORPHAN_DANGLING_MERGE)),
+    }
+    assert all(e["scope"] == "family" for e in payload["orphans"])
+
+    # The dry run is a dry run at batch scale too, in both dispositions.
+    before = _cli_curation_rows(cli_ready)
+    for extra in (("--map-file", report), ("--clear",)):
+        capsys.readouterr()
+        assert _run(cli_ready, "record", "reaffirm", *extra) == 0
+        assert "dry run: nothing was written" in capsys.readouterr().out
+        assert _cli_curation_rows(cli_ready) == before
+
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "reaffirm", "--map-file", report, "--apply") == 0
+    assert "re-annotated 4 verdict(s)" in capsys.readouterr().out
+
+    # Every ruling landed on its successor, verbatim - and each merge verdict now points at
+    # its target's *new* base, which is the half a per-verdict remedy gets wrong.
+    stored = {(r["record_type"], r["dedup_base"], r["record_id"]): r
+              for r in _cli_curation_rows(cli_ready)}
+    assert len(stored) == 5   # four re-pointed families + the untouched row verdict
+    assert [(r["status"], r["note"], r["attributed_to"], r["merged_into_base"]) for r in (
+        stored[("lab_result", moved["HbA1c"][1], 0)],
+        stored[("lab_result", moved["Glucose"][1], 0)],
+        stored[("condition", moved["Type 2 Diabetes"][1], 0)],
+        stored[("condition", moved["Prediabetes"][1], 0)],
+    )] == [
+        ("confirmed", "assay validated", "Dr Who", None),
+        ("merged-into", "same draw as the a1c", "Dr Who", moved["HbA1c"][1]),
+        ("disputed", "onset year contested", "Dr Who", None),
+        ("merged-into", "progressed, one condition", "Dr Who",
+         moved["Type 2 Diabetes"][1]),
+    ]
+    # The row verdict was left exactly where it was: not this batch's business.
+    assert ("lab_result", moved["HbA1c"][0],
+            _cli_row_id(cli_ready, "lab_result", "test_name", "HbA1c")) in stored
+
+    capsys.readouterr()
+    assert _run(cli_ready, "verify") == 0
+    out = capsys.readouterr().out
+    assert "has no live family" not in out and "merges into" not in out
+    assert "warnings       1" in out            # only the row-scope breadcrumb, by design
+    assert "but the row now sits in" in out
+
+    capsys.readouterr()
+    assert _run(cli_ready, "render", "summary", "--person", "jane-doe") == 0
+    summary = capsys.readouterr().out
+    assert "## Superseded / corrected" in summary
+    for note in ("same draw as the a1c", "progressed, one condition"):
+        assert note in summary
+
+
+def test_cli_reaffirm_mixed_batch_lands_what_it_can_and_names_the_rest(
+    cli_ready, capsys
+):
+    """The loop is per-row and non-transactional on purpose, so a batch that cannot fully
+    succeed must still land every row that can and account for the rest: rc 1, each refusal
+    with its reason, the untouched rows still orphaned, and a second pass that finishes the
+    job without re-writing what already landed."""
+    moved, report = _orphaning_rekey_batch(cli_ready, capsys)
+    # (a) a second reviewer already ruled on the family HbA1c's verdict would land in.
+    assert _run(cli_ready, "record", "annotate", "lab_result", moved["HbA1c"][1],
+                "--status", "confirmed", "--note", "a second ruling",
+                "--attributed-to", "Dr Other", "--apply") == 0
+    # (b) one orphan the map does not name, and (c) an entry with no live orphan behind it.
+    full = json.loads(open(report, encoding="utf-8").read())
+    partial = cli_ready / "partial.json"
+    stale = dict(full["orphans"][0], dedup_base="0" * 64, record_id=0,
+                 successor_base="1" * 64)
+    partial.write_text(json.dumps({"orphans": [
+        *[e for e in full["orphans"]
+          if e["dedup_base"] != moved["Type 2 Diabetes"][0]],
+        stale,
+    ]}), encoding="utf-8")
+    before = _cli_curation_rows(cli_ready)
+    capsys.readouterr()
+
+    assert _run(cli_ready, "record", "reaffirm", "--map-file", str(partial),
+                "--apply") == 1
+    captured = capsys.readouterr()
+    assert "already carries its own verdict" in captured.out
+    assert "not named by the map file" in captured.out
+    assert "already-handled" in captured.out and "no longer orphaned" in captured.out
+    assert "re-annotated 2 verdict(s)" in captured.out
+    assert "were not handled" in captured.err
+
+    # The two clean rows landed; the refused ones sit exactly as they were.
+    stored = {(r["record_type"], r["dedup_base"], r["record_id"]): r
+              for r in _cli_curation_rows(cli_ready)}
+    assert ("lab_result", moved["Glucose"][1], 0) in stored
+    assert ("condition", moved["Prediabetes"][1], 0) in stored
+    assert ("lab_result", moved["HbA1c"][0], 0) in stored          # refused: conflict
+    assert ("condition", moved["Type 2 Diabetes"][0], 0) in stored  # refused: unmapped
+    assert stored[("lab_result", moved["HbA1c"][1], 0)]["note"] == "a second ruling"
+    assert len(stored) == len(before)   # two re-pointed in place, nothing lost or doubled
+
+    # Second pass with the full map finishes the unmapped one and re-refuses the conflict,
+    # without touching what already landed.
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "reaffirm", "--map-file", report, "--apply") == 1
+    out = capsys.readouterr().out
+    assert "re-annotated 1 verdict(s)" in out
+    assert "already carries its own verdict" in out
+    after = {(r["record_type"], r["dedup_base"], r["record_id"]) for r in
+             _cli_curation_rows(cli_ready)}
+    assert ("condition", moved["Type 2 Diabetes"][1], 0) in after
+    assert ("lab_result", moved["HbA1c"][0], 0) in after   # still the operator's call
+
+    # Only the deliberately-refused verdict and the row breadcrumb are still reported.
+    capsys.readouterr()
+    assert _run(cli_ready, "verify") == 0
+    assert "warnings       2" in capsys.readouterr().out

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1075,6 +1075,38 @@ def test_rekey_covers_every_record_type(conn):
     assert report.changes == []  # same dictionary (none) -> keys already current
 
 
+def test_rekey_report_carries_the_stored_to_recomputed_base_map(conn):
+    """Issue #126. A ``dedup_base`` is a content hash overwritten in place, so once the run
+    is over nothing in the database records that ``F_old`` became ``F_new``. Only `rekey`
+    knows, which is why the mapping leaves on the report: it is what scopes the CLI's
+    apply-time orphan report and what `record reaffirm --map-file` follows.
+
+    Stays a plain dict of strings on purpose — `dedup` must never import `curation`."""
+    doc = _make_document(conn)
+    dedup.commit_extraction(conn, doc, {
+        "lab_result": [{"test_name": "ZZT", "collected_at": "2026-01-02",
+                        "value_num": 108}],
+        "condition": [{"name": "Type 2 Diabetes", "status": "active"}],
+    }, dedup.load_dictionary(DICT_PATH))
+    stored = {
+        table: conn.execute(f"SELECT dedup_base FROM {table}").fetchone()["dedup_base"]
+        for table in ("lab_result", "condition")
+    }
+
+    report = dedup.rekey(conn, _rekey_dict(zzt="zonulin_test"))
+
+    # Every scanned type gets a map, and a table with no rows gets an empty one.
+    assert set(report.base_maps) == set(dedup.KNOWN_TYPES)
+    assert report.base_maps["medication"] == {}
+    # The moved family maps old -> new; the untouched one maps to itself.
+    moved = report.base_maps["lab_result"][stored["lab_result"]]
+    assert moved != stored["lab_result"]
+    assert report.base_maps["condition"] == {
+        stored["condition"]: stored["condition"]}
+    # A dry run still reports the mapping: it is what the run *would* do.
+    assert report.applied is False
+
+
 def test_rekey_is_a_no_op_over_a_keep_both_family(conn):
     """The whole reason occurrence lives in a column: `rekey` re-derives keys from
     payload, so siblings must recompute to their own keys rather than collide."""


### PR DESCRIPTION
## Summary

Closes #126.

`pemr rekey --apply` never auto-migrates a verdict's `curation.dedup_base` onto a re-derived
identity (deliberate, per #109/#114/#116 — silently re-pointing a human ruling risks widening it
over rows nobody judged). That leaves the operator's only remedy, `record annotate` one row at a
time, unable to scale to a real-world orphan batch (the reporting repro: 57 orphans in one rekey).

This PR keeps the warn + manual-reannotate design exactly as-is and scales the remedy:

1. **`pemr record reaffirm`** — a new subcommand beside `annotate`/`assert`/`rm`. Dry run by
   default (lists every currently orphaned verdict, writes nothing), `--json` for machine-readable
   output, `--map-file` to re-point orphans onto their successor family or `--clear` to lift them,
   and one explicit `--apply` step — no interactive prompting.
2. **`pemr rekey --apply` reports its own orphans at apply time** (text and `--json`), scoped to
   the families/rows *that run* actually moved, so the operator sees the fallout immediately
   instead of discovering it on the next `pemr verify`.
3. One shared orphan detector (`curation.orphan_kinds` / `curation.list_orphans`), consumed by both
   the new command and `verify._check_curation` (warning strings kept byte-identical) — replacing
   the two independent free-text derivations.

The existing collision-resolution/narrowing path (#116/#122/#124) is untouched beyond one additive
`RekeyReport.base_maps` field; `record reaffirm` stays CLI-only and is deliberately excluded from
`mcp_server.py`'s `WRITE_TOOLS` (a bulk writer of human clinical verdicts is a human-at-a-terminal
action, not an agent-write surface) — `AGENTS.md` and `docs/Architecture.md` both say so explicitly.

## Pipeline history

- Design: implementation plan in the issue body.
- Build: [ADVANCE report](https://github.com/meridun/pemr/issues/126#issuecomment-5284899382) — all
  three pieces implemented per plan; 22 new tests.
- Verify: [ADVANCE report](https://github.com/meridun/pemr/issues/126#issuecomment-5285189285) — full
  suite green (1005 pytest + 141 node), byte-for-byte parity checks against an `origin/dev`
  interpreter for dry-run/collision-narrowing behavior, and a real-run drill reproducing the
  reporting issue's orphan-batch shape.
- Audit: [ADVANCE report](https://github.com/meridun/pemr/issues/126#issuecomment-5285344337) — **no
  blocking findings**; 8 advisory notes (operator-guidance wording, a couple of untested defensive
  branches, one wrong CLI message after `--clear --apply`). None hold up the PR; worth a follow-up
  issue if not picked up separately — see below.

## Advisories carried forward (non-blocking)

Audit flagged these as real but non-blocking; noting here rather than fixing silently, since two of
them are behavior/wording changes that belong in build/design's hands, not ship's:

1. The remediation pointer printed after a plain `rekey --apply` (no `--json`) tells the operator to
   re-run `rekey --apply --json` to recover the old->new mapping — but that mapping only ever
   existed in *that* run's own JSON output and is gone by the time the pointer is read. Direction:
   print the mapping inline, or say plainly that re-pointing is no longer possible without that
   run's captured JSON.
2. The `record reaffirm` text dry run doesn't show the new `merged_into_base` target for the
   `dangling-merge-target` class (only `--json` does), so a human approving the batch can't see
   where the merge pointer lands from the text view alone.
3. `cli.py` prints `re-annotated N verdict(s)` after a `--clear --apply` run, which lifted verdicts
   rather than re-annotating them.

## Test plan

- [x] `pytest` full suite green (1005 passed) at the shipped HEAD.
- [x] `node --test` green (141 passed).
- [x] `node scripts/check-meta-drift.mjs` and `node scripts/sync-claude-config.mjs --check` clean.
- [x] Real-run drill: `rekey --apply --json` -> `record reaffirm --map-file --apply` -> `verify`
      quiet; mixed-batch (conflict/unmapped) partial-apply with correct rc; collision/narrowing path
      regression-free.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>