### PR TITLE
docs(cli): say "never an MCP tool" in record assert help

### DIFF
--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -2902,7 +2902,7 @@ def build_parser() -> argparse.ArgumentParser:
     r_assert = record_sub.add_parser(
         "assert",
         help="record a fact attested by a person, with no source document yet "
-             "(dry run by default); CLI-only, never an agent write",
+             "(dry run by default); CLI-only, never an MCP tool",
     )
     # Optional so `--list` can take an optional table and no payload; the handler
     # enforces "table and --field unless --list" with the usage line.

--- a/tests/test_cli_ascii.py
+++ b/tests/test_cli_ascii.py
@@ -258,6 +258,19 @@ def test_record_assert_output_is_console_safe(ready, capsys):
         _run(ready, "record", "assert", "--help")
     _assert_console_safe(capsys.readouterr().out)
 
+    # Issue #127: the subcommand's one-line help states a tool-surface exclusion,
+    # not a ban on an agent invoking the verb at the CLI -- the wording
+    # docs/Architecture.md and pemr/attestations.py already use. argparse renders
+    # that string in the *parent* listing (`pemr record --help`), wrapped to the
+    # terminal width, so collapse whitespace before matching.
+    with pytest.raises(SystemExit):
+        _run(ready, "record", "--help")
+    out = capsys.readouterr().out
+    _assert_console_safe(out)
+    listing = " ".join(out.split())
+    assert "never an agent write" not in listing
+    assert "CLI-only, never an MCP tool" in listing
+
     argv = ("record", "assert", "medication", "--person", "jane-doe",
             "--attributed-to", "Mom", "--date", "2026-08-09",
             "--field", "name=Metformin", "--field", "dose=500 mg")


### PR DESCRIPTION
## Summary
- `record assert`'s argparse help text said "CLI-only, never an agent write", which overstated the actual constraint and caused an observed false-negative (an agent session declined to run the command on the strength of this string).
- Reworded to "CLI-only, never an MCP tool", matching the phrasing already used in `docs/Architecture.md:258`, `pemr/attestations.py:36`, and `pemr/curation.py:86` — the constraint is a tool-surface exclusion (`record_assert` is absent from `mcp_server.WRITE_TOOLS`), not a ban on agent invocation via the CLI.
- `AGENTS.md` was swept per the AC; no change was needed — it's already tool-surface-scoped.
- No behavioral change: pure help-string wording, ASCII-safe (issue #23's console-safety invariant), `record annotate` untouched, MCP tool surface unchanged.

Closes #127

## Verify + audit reports
- Verify: https://github.com/meridun/pemr/issues/127#issuecomment (see issue #127 comment thread, 2026-08-15T00:40:00Z) — full suite 1005 passed, `node --test` 141 passed, exhaustive help-tree diff proved a single-line change, regression pin mutation-tested.
- Audit: see issue #127 comment thread, 2026-08-15T00:43:19Z — no blocking findings; confirmed `record_assert` absent from both `mcp_server.READ_ONLY_TOOLS` and `WRITE_TOOLS`.

## Advisories carried forward (non-blocking, flagged by verify/audit — not addressed in this PR)
1. **Trust-boundary wording ambiguity** (deferred, human call): `AGENTS.md:74-75` ("only a human at the CLI may vouch for one") and `pemr/attestations.py:38-39` ("keep an agent out of") read literally as human-at-the-keyboard rules, while this PR's wording is tool-surface-scoped. Both readings are compatible with the new string, so this PR doesn't need to resolve it, but the underlying policy question ("may an agent run `pemr record assert` from a shell?") is still open. Suggest a follow-up issue if a human wants it settled.
2. **AC #4 names a help surface argparse never renders**: the corrected wording shows up in `pemr record --help` (the parent listing), not `pemr record assert --help` (the subcommand's own help) — true before and after this change, since argparse renders a subparser's `help=` string only in its parent's listing. AC #4's substance (scripted `--help` check) is met via the parent-listing surface; the AC's literal wording names the wrong surface. No code implication.

## Test plan
- [x] `pytest tests/test_cli_ascii.py tests/test_mcp_server.py` (targeted, build)
- [x] `pytest` full suite — 1005 passed (verify)
- [x] `node --test` — 141 passed, 29 suites (verify)
- [x] `npm run sync:claude-config:check` / `npm run check:meta-drift` — pass
- [x] Manual: `pemr record --help` shows the corrected wording; `pemr record assert --help` still plain ASCII

🤖 Generated with the pemr SDLC pipeline (ship worker)