### PR TITLE
render: suppress resulted orders in Orders & Referrals

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -942,7 +942,12 @@ default to the same exclusion unless a human explicitly decides otherwise.
   abnormal labs, open follow-ups, open conflicts. One query bundle → Markdown. The
   conflicts section is not decoration: an open conflict means a stored value is disputed
   and its correction is still staged, so the summary would otherwise print the stale
-  value silently (the brief carries the same section, but it is per-appointment).
+  value silently (the brief carries the same section, but it is per-appointment). An
+  order in `Orders & Referrals` leaves the section once a matching `lab_result` lands
+  (issue #128) — matching is deliberately narrow (exact `key_token` plus a tight,
+  edge-tested date window) and biased toward under-suppression, since age alone is never
+  a signal and a hidden-but-still-open order would be the worse failure; the window
+  constants are guarded by a pinned edge test so a casual widening doesn't slip through.
 - **appointment brief** — for a given upcoming appointment: relevant history for that
   specialty, recent labs/imaging, current meds, med-interaction flags, suggested
   questions. This is your "walk-in readiness" as a repeatable command.

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -61,7 +61,7 @@ prints it correctly instead of ``?`` (issue #46). Literal vs. data are orthogona
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime
+from datetime import date, datetime
 
 from . import curation, db, query
 from .dedup import enum_token, is_attested, key_token
@@ -69,6 +69,19 @@ from .dedup import enum_token, is_attested, key_token
 # Observation obs_type conventions this layer reads (see module docstring).
 OBS_VITAL = "vital"
 OBS_ORDER = "order"
+
+# How an order is matched to the `lab_result` that answered it (issue #128). No FK links
+# the two tables, so the linkage is *inferred* at render time from item-name and date
+# proximity -- and deliberately narrowly. Over-suppression hides a genuinely open order,
+# the exact miss this section exists to prevent; under-suppression merely leaves the
+# noise the section already had. Every ambiguity therefore resolves to "still open" (see
+# `_is_resulted`), and age is never a suppression signal on its own.
+#: How long after an order a result may land and still count as *that* order's result.
+ORDER_RESULT_WINDOW_DAYS = 30
+#: Slack on the early side, for a document dating the draw a day ahead of the order
+#: text. A result genuinely predating its order answers an *earlier* order, so this side
+#: stays tight.
+ORDER_RESULT_BACKDATE_DAYS = 1
 
 # `condition.status` buckets, one rendered section each (family history last: it is
 # context about relatives, not the patient's own record).
@@ -97,6 +110,22 @@ def _date_part(value: object) -> str:
     if value is None:
         return ""
     return str(value).strip().replace("T", " ").split(" ")[0]
+
+
+def _as_date(value: object) -> date | None:
+    """:func:`_date_part` parsed to a real date; ``None`` for empty or malformed input.
+
+    Never raises. ``observation.observed_at`` is nullable and free-form-ish and
+    ``lab_result.collected_at`` is only ``NOT NULL``, not validated to ISO -- a
+    malformed date must not crash a summary, it must merely fail to close an order.
+    """
+    text = _date_part(value)
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        return None
 
 
 def _generated_at(now: datetime | None) -> str:
@@ -432,13 +461,74 @@ def _order_display(row: dict) -> str:
     return row["key"] or row["value_text"] or "(unspecified)"
 
 
+def _result_index(
+    conn: sqlite3.Connection,
+    person_id: int,
+    dictionary: dict[str, str] | None,
+    cur: "_CurationPass | None" = None,
+) -> dict[str, list[date]]:
+    """``key_token`` -> collection dates of this person's live ``lab_result`` rows.
+
+    The lookup side of the order/result linkage (issue #128). Keyed by the *same*
+    :func:`key_token` -- and the same ``dictionary`` -- the order grouping folds on, so
+    matching can never disagree with #71/#93 about what counts as one item: a
+    qualifier-bearing order (``HbA1c (POC)``) is not closed by a plain-stem result.
+
+    Scoped to ``person_id``: one person's results can never close another's order.
+
+    Verdicts are read **directly** rather than through :func:`_apply_curation`, on
+    purpose. A result in :data:`curation.APPENDIX_STATUSES` must not close an order, but
+    this helper runs *before* ``_abnormal_labs``, and filing appendix entries from here
+    would re-order ``## Superseded / corrected`` for existing records. Reading without
+    recording keeps the overlay additive. ``disputed``/``confirmed``/``distinct``
+    results still count: they are live rows.
+    """
+    index: dict[str, list[date]] = {}
+    rows = conn.execute(
+        "SELECT * FROM lab_result WHERE person_id = ?", (person_id,)
+    ).fetchall()
+    annotated = cur is not None and bool(cur.verdicts)   # fast path: no verdicts at all
+    for raw in rows:
+        row = dict(raw)
+        if annotated:
+            verdict = cur.verdicts.for_row(
+                "lab_result", row["dedup_base"], row.get("lab_result_id")
+            )
+            if verdict is not None and verdict["status"] in curation.APPENDIX_STATUSES:
+                continue
+        token = key_token(row["test_name"], dictionary)
+        when = _as_date(row["collected_at"])
+        if token and when:
+            index.setdefault(token, []).append(when)
+    return index
+
+
+def _is_resulted(
+    token: str, observed_at: object, index: dict[str, list[date]]
+) -> bool:
+    """Has a ``lab_result`` landed that plausibly answers this order? (issue #128)
+
+    An unusable identity token and an unusable order date both answer *no*: the section
+    exists to surface still-open orders, so every ambiguity resolves to "render".
+    Matching is exact-token plus a bounded window around the order date -- never a
+    substring match, never an unbounded window, and never age alone.
+    """
+    ordered = _as_date(observed_at)
+    if not token or ordered is None:
+        return False
+    return any(
+        -ORDER_RESULT_BACKDATE_DAYS <= (d - ordered).days <= ORDER_RESULT_WINDOW_DAYS
+        for d in index.get(token, ())
+    )
+
+
 def _grouped_orders(
     conn: sqlite3.Connection,
     person_id: int,
     dictionary: dict[str, str] | None,
     cur: "_CurationPass | None" = None,
 ) -> list[dict]:
-    """``obs_type='order'`` rows folded to one entry per normalized item, newest first.
+    """Still-open ``obs_type='order'`` rows, folded per normalized item, oldest first.
 
     A repeated order/referral is restated by every document that mentions it, so a raw
     row dump renders one identical bullet per document (issue #93). Orders are *events*,
@@ -456,6 +546,15 @@ def _grouped_orders(
     Each returned dict is the group's **latest** row (most recent ``observed_at``, then
     highest ``observation_id``) plus ``group_count`` and ``group_first`` (earliest dated
     ``observed_at`` among the *earlier* rows, ``""`` when none of them is dated).
+
+    A group whose item already has a matching ``lab_result`` is then dropped entirely
+    (issue #128): the section is a list of things still outstanding, and before this it
+    listed every order ever placed -- inverting its meaning, since most were resulted on
+    the order date itself. The question is asked **after** the fold, of the group's
+    *latest* row -- the live restatement the bullet already speaks for -- so
+    ``group_count``/``+N earlier`` disclosure is unchanged for everything that still
+    renders. Referral-type orders have no ``lab_result`` by construction and so are
+    never suppressed by this; closing them needs a mechanism that does not exist yet.
     """
     rows = conn.execute(
         "SELECT * FROM observation WHERE person_id = ? AND obs_type = ? "
@@ -470,19 +569,34 @@ def _grouped_orders(
         token = key_token(r["key"], dictionary) or key_token(r["value_text"], dictionary)
         groups.setdefault(token or ("", r["observation_id"]), []).append(r)
 
-    out = []
-    for members in groups.values():
+    # Carry each group's identity token alongside it: the suppression lookup needs the
+    # very token the fold grouped on, and a keyless group (identity is the
+    # `("", observation_id)` fallback tuple) has none -- so it is never suppressed.
+    folded: list[tuple[str, dict]] = []
+    for identity, members in groups.items():
         latest = members[-1]                      # ascending -> last is the latest
         earlier = sorted(
             d for d in (_date_part(m["observed_at"]) for m in members[:-1]) if d
         )
-        out.append(dict(latest, group_count=len(members),
-                        group_first=earlier[0] if earlier else ""))
-    # Two stable passes: alphabetical, then latest-date descending (undated sorts last,
-    # keeping its alphabetical order). Orders are actionable events, so recency leads --
-    # matching the other event sections rather than the vitals panel's fixed A-Z.
+        folded.append((
+            identity if isinstance(identity, str) else "",
+            dict(latest, group_count=len(members),
+                 group_first=earlier[0] if earlier else ""),
+        ))
+
+    # Drop what a result already answered (issue #128), asking the group's latest row.
+    index = _result_index(conn, person_id, dictionary, cur) if folded else {}
+    out = [g for token, g in folded
+           if not _is_resulted(token, g["observed_at"], index)]
+
+    # Two stable passes: alphabetical, then order-date ascending (undated sorts last,
+    # keeping its alphabetical order). This section diverges from the other event
+    # sections' newest-first on purpose (issue #128): what is left after suppression is
+    # what is still outstanding, and an order still open after years is the *most*
+    # actionable row on the page, not the least.
     out.sort(key=lambda g: (_order_display(g).lower(), g["observation_id"]))
-    out.sort(key=lambda g: _date_part(g["observed_at"]), reverse=True)
+    out.sort(key=lambda g: (not _date_part(g["observed_at"]),
+                            _date_part(g["observed_at"])))
     return out
 
 

--- a/tests/test_cli_phase4.py
+++ b/tests/test_cli_phase4.py
@@ -115,7 +115,7 @@ def test_render_summary_groups_repeated_orders_end_to_end(ready, capsys):
     """Issue #93, walked through the real CLI: an order restated by three documents is
     one bullet carrying the latest detail plus the `+N earlier` disclosure; distinct and
     qualifier-bearing items stay their own bullets; a timestamped row shows a bare date;
-    an undated row shows none; newest first, undated last. (Keyless rows are covered in
+    an undated row shows none; oldest first, undated last. (Keyless rows are covered in
     `tests/test_render.py` -- two undated ones collide on the storage dedup key, so that
     case cannot be seeded through the commit path.)"""
     tmp_path, _ = ready
@@ -143,11 +143,11 @@ def test_render_summary_groups_repeated_orders_end_to_end(ready, capsys):
     section = out.split("## Orders & Referrals")[1].split("\n## ")[0]
     lines = [ln for ln in section.splitlines() if ln.startswith("- ")]
     assert lines == [
+        "- outpatient physical therapy  (ordered 2026-01-05)",
+        "- sleep study - home study  (ordered 2026-02-01)",
         "- cervical collar - Dr. Jones, ortho  (ordered 2026-06-14; +2 earlier, "
         "first 2026-01-05)",
         "- outpatient physical therapy (aquatic)  (ordered 2026-06-14)",
-        "- sleep study - home study  (ordered 2026-02-01)",
-        "- outpatient physical therapy  (ordered 2026-01-05)",
         "- wheelchair evaluation - seating clinic",
     ]
     # the collapse is render-only: every stored row survives, keys untouched
@@ -157,6 +157,31 @@ def test_render_summary_groups_repeated_orders_end_to_end(ready, capsys):
     ).fetchone()["n"] == 7
     conn.close()
     assert out.isascii()          # cp1252/cp437 console contract
+
+
+def test_render_summary_hides_resulted_order_end_to_end(ready, capsys):
+    """Issue #128 through the real CLI (the render helpers are private, so the seam only
+    stays honest if the behaviour is pinned at the command boundary): the `ready` fixture
+    already holds an LDL result collected 2026-01-01, so an LDL order placed that day is
+    gone from the section while the referral beside it stays."""
+    tmp_path, _ = ready
+    _commit_orders(tmp_path, "sha-r1", [
+        {"key": "LDL", "value_text": "fasting", "observed_at": "2026-01-01"},
+        {"key": "cervical collar", "observed_at": "2026-01-01"},   # no result: still open
+    ])
+    capsys.readouterr()
+
+    assert _run(tmp_path, "render", "summary", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    section = out.split("## Orders & Referrals")[1].split("\n## ")[0]
+    assert "LDL" not in section
+    assert "- cervical collar  (ordered 2026-01-01)" in section
+    # render-only: the suppressed order row is untouched in the DB
+    conn = db.connect(tmp_path / "cli.db")
+    assert conn.execute(
+        "SELECT COUNT(*) AS n FROM observation WHERE obs_type='order' AND key='LDL'"
+    ).fetchone()["n"] == 1
+    conn.close()
 
 
 def test_render_on_unmigrated_db_is_friendly(tmp_path, capsys, unmigrated_db):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -327,6 +327,25 @@ def test_summary_orders_result_within_window_suppresses(seeded):
     assert "LDL" not in _orders_section(seeded)
 
 
+def test_summary_orders_match_window_edges_are_exact(seeded):
+    """...and the window is a hard `[-1, +30]` days around the order date, pinned on
+    both edges so any later widening is a deliberate edit rather than a drift (widening
+    is the over-suppression risk this design is built against). A result on day +30
+    closes its order, day +31 does not; a draw dated one day *ahead* of the order text
+    still closes it, two days ahead does not -- that one answered an earlier order."""
+    _seed_orders(seeded, [
+        {"key": "TSH", "observed_at": "2022-12-02"},               # result +30d: closed
+        {"key": "HbA1c", "observed_at": "2023-12-01"},             # result +31d: open
+        {"key": "LDL", "observed_at": "2025-01-02"},               # result -1d: closed
+        {"key": "Glucose, fasting", "observed_at": "2026-01-03"},  # result -2d: open
+    ])
+    section = _orders_section(seeded)
+    assert "TSH" not in section
+    assert "LDL" not in section
+    assert "- HbA1c  (ordered 2023-12-01)" in section
+    assert "- Glucose, fasting  (ordered 2026-01-03)" in section
+
+
 def test_summary_orders_open_order_is_never_aged_out(seeded):
     """Age is never a suppression signal (the issue's whole point): a 2019 order no
     result answers keeps rendering, and a result four years adrift does not close it."""

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -291,14 +291,107 @@ def test_summary_orders_undated_earlier_row_keeps_the_count(seeded):
     assert "first" not in section
 
 
-def test_summary_orders_newest_first_undated_last(seeded):
-    """Orders are actionable events, so the section leads with the most recent (the other
-    event sections' ordering), undated last then alphabetical."""
+def test_summary_orders_oldest_first_undated_last(seeded):
+    """Issue #128: what survives suppression is what is still *outstanding*, and the
+    order open longest is the most actionable row -- so this section leads with the
+    oldest, diverging from the other event sections' newest-first. Undated last, then
+    alphabetical."""
     _seed_orders(seeded, [{"key": "sleep study", "observed_at": "2026-07-01"}])
     section = _orders_section(seeded)
-    assert (section.index("sleep study")
-            < section.index("cervical collar")
-            < section.index("outpatient physical therapy"))
+    assert (section.index("cervical collar")                  # 2026-02-01
+            < section.index("sleep study")                    # 2026-07-01
+            < section.index("outpatient physical therapy"))   # undated
+
+
+# --- issue #128: an order with a result is no longer outstanding ---------------
+#
+# `Orders & Referrals` listed every `obs_type='order'` row ever stored, so a section
+# meant to read as "still open" filled up with orders resulted years ago -- most of them
+# on the order date itself. Suppression is render-only inference (no FK exists) and is
+# biased hard toward *under*-suppressing: hiding a genuinely open order is the miss this
+# section exists to prevent. The `seeded` fixture already carries jane's four results --
+# HbA1c 2024-01-01, LDL 2025-01-01, Glucose fasting 2026-01-01, TSH 2023-01-01.
+
+def test_summary_orders_resulted_order_is_suppressed(seeded):
+    """The common case from the problem statement: ordered and resulted the same day."""
+    _seed_orders(seeded, [{"key": "HbA1c", "observed_at": "2024-01-01"}])
+    section = _orders_section(seeded)
+    assert "HbA1c" not in section
+    assert "cervical collar" in section          # control: unresulted rows untouched
+
+
+def test_summary_orders_result_within_window_suppresses(seeded):
+    """Matching is a bounded window around the order date, not exact-date equality: a
+    draw that lands a few days after the order still closes it."""
+    _seed_orders(seeded, [{"key": "LDL", "observed_at": "2024-12-20"}])  # result 2025-01-01
+    assert "LDL" not in _orders_section(seeded)
+
+
+def test_summary_orders_open_order_is_never_aged_out(seeded):
+    """Age is never a suppression signal (the issue's whole point): a 2019 order no
+    result answers keeps rendering, and a result four years adrift does not close it."""
+    _seed_orders(seeded, [{"key": "TSH", "observed_at": "2019-01-01"}])  # result 2023-01-01
+    assert "- TSH  (ordered 2019-01-01)" in _orders_section(seeded)
+
+
+def test_summary_orders_referral_without_result_still_renders(seeded):
+    """Referral/DME orders have no `lab_result` by construction, so they fall through the
+    matching untouched -- which is already the wanted "still open" behaviour."""
+    _seed_orders(seeded, [{"key": "HbA1c", "observed_at": "2024-01-01"}])
+    section = _orders_section(seeded)
+    assert "- cervical collar - Dr. Smith, ortho  (ordered 2026-02-01)" in section
+    assert "- outpatient physical therapy" in section
+    assert "HbA1c" not in section                # the lab order beside them is gone
+
+
+def test_summary_orders_qualifier_result_does_not_close_plain_order(seeded):
+    """Matching runs on the same `key_token` the grouping fold uses (issue #71), so the
+    two layers can never disagree about what one item is: a plain `HbA1c` result does not
+    close a point-of-care `HbA1c (POC)` order."""
+    _seed_orders(seeded, [{"key": "HbA1c (POC)", "observed_at": "2024-01-01"}])
+    assert "HbA1c (POC)" in _orders_section(seeded)
+
+
+def test_summary_orders_suppression_decides_on_the_latest_row(seeded):
+    """Suppression is asked of the group's *latest* row -- the live restatement the
+    bullet already speaks for -- and runs after the fold, so the `+N earlier` disclosure
+    is unchanged for what still renders (issue #93 preserved)."""
+    _seed_orders(seeded, [
+        {"key": "HbA1c", "observed_at": "2024-01-01"},   # resulted the same day
+        {"key": "HbA1c", "observed_at": "2026-06-01"},   # re-ordered, no result yet
+    ])
+    section = _orders_section(seeded)
+    assert section.count("HbA1c") == 1
+    assert "- HbA1c  (ordered 2026-06-01; +1 earlier, first 2024-01-01)" in section
+
+
+def test_summary_orders_superseded_result_does_not_suppress(seeded):
+    """A result a human ruled superseded sits in the appendix, not in the record -- so it
+    cannot be the thing that closed an order, and the order comes back."""
+    _seed_orders(seeded, [{"key": "HbA1c", "observed_at": "2024-01-01"}])
+    assert "HbA1c" not in _orders_section(seeded)
+    _annotate(seeded, "lab_result", "test_name", "HbA1c", status="superseded",
+              note="wrong patient")
+    assert "- HbA1c  (ordered 2024-01-01)" in _orders_section(seeded)
+
+
+def test_summary_orders_other_person_result_does_not_suppress(seeded):
+    """`person_id` scoping: john's identically-named result must not close jane's order
+    (his LDL is collected 2026-01-01, jane's own a year earlier and out of window)."""
+    _seed_orders(seeded, [{"key": "LDL", "observed_at": "2026-01-01"}])
+    assert "- LDL  (ordered 2026-01-01)" in _orders_section(seeded)
+
+
+def test_summary_orders_suppression_is_render_only(seeded):
+    """AC8: nothing is deleted or mutated -- the suppressed order is still in the DB,
+    exactly where `record show` would find it."""
+    _seed_orders(seeded, [{"key": "HbA1c", "observed_at": "2024-01-01"}])
+    before = _row_counts(seeded)
+    assert "HbA1c" not in _orders_section(seeded)
+    assert _row_counts(seeded) == before
+    assert seeded.execute(
+        "SELECT COUNT(*) AS n FROM observation WHERE obs_type='order' AND key='HbA1c'"
+    ).fetchone()["n"] == 1
 
 
 def test_summary_latest_vitals_pick(seeded):


### PR DESCRIPTION
## Summary
- `render.py`'s `Orders & Referrals` section now suppresses an order row once a matching `lab_result` row exists for it, instead of listing every `obs_type='order'` row unconditionally.
- Matching combines exact `key_token` overlap (the same normalization the order-grouping fold already uses, per #71/#93) with a tight, edge-tested date window (`ORDER_RESULT_WINDOW_DAYS = 30`, `ORDER_RESULT_BACKDATE_DAYS = 1`) — age alone is never a suppression signal, and every ambiguous case (missing token, unparseable date, appendix-status verdict) resolves to "render", biasing the whole design toward under- rather than over-suppression.
- Suppression happens after the existing grouping fold, on the group's latest row, so `+N earlier` disclosure is unchanged for rows that still render.
- Remaining rows now sort oldest-first (an old open order is the most actionable row in this section) instead of newest-first.
- Docs: amended `docs/Architecture.md` §6's master-summary bullet to describe the new linkage and note the match window is deliberately narrow and pinned by an edge test.

Closes #128

## Verify + audit reports
- Verify: https://github.com/meridun/pemr/issues/128#issuecomment-5299835718
- Audit: https://github.com/meridun/pemr/issues/128#issuecomment-5299862147

🤖 Generated with [Claude Code](https://claude.com/claude-code)