### PR TITLE
feat(sdlc): 3-tier priority ordering for the dispatcher

### DIFF
--- a/prompts/sdlc/README.md
+++ b/prompts/sdlc/README.md
@@ -54,7 +54,8 @@ comfortably.
    run), self-query as above. The snapshot only seeds candidate selection, never ownership — the
    claim race always runs against live GitHub data, so a stale entry (closed, relabeled, or claimed
    since the snapshot) just loses the claim; move to the next candidate. Pick the next: higher
-   priority first (`priority:critical` › `priority:medium` › `priority:future`), then oldest by
+   priority first (`priority:critical` › *unlabeled* › `priority:future` — untagged is the normal
+   default, only the two exceptional tiers carry a label), then oldest by
    creation date (FIFO). If none (or the snapshot is exhausted) → reply `<LANE>: idle` and stop.
 
    **CLI-first** (the primary path when the reference CLI is present — `scripts/sdlc.mjs`, see

--- a/scripts/sdlc.mjs
+++ b/scripts/sdlc.mjs
@@ -172,13 +172,16 @@ export const PARK_LABELS = ['sdlc:needs-human', 'sdlc:hold'];
 /** The wip-lock reap threshold: two full hourly cycles. */
 export const WIP_STALE_MS = 2 * 60 * 60 * 1000;
 
-/** Priority ordering for CLAIM: lower rank sorts first. Unlabeled sorts last. */
+/**
+ * Priority ordering for CLAIM: lower rank sorts first. Unlabeled is the normal
+ * default and sorts between critical and future — only the two exceptional
+ * tiers carry a label.
+ */
 export const PRIORITY_RANK = {
   'priority:critical': 0,
-  'priority:medium': 1,
   'priority:future': 2,
 };
-const NO_PRIORITY_RANK = 3;
+const NO_PRIORITY_RANK = 1;
 
 /** Every `stage:*` suffix on a label set (defensive: may be 0 or >1). */
 export function stagesOf(labelNames) {
@@ -347,7 +350,7 @@ export function lastUnlabeledAt(timelineEvents, label) {
  * `[{ number, labels:[{name}]|[name], createdAt }]`. Pure.
  *
  * Eligible = has that stage, not wip and not parked/hold; ordered exactly as a
- * worker's CLAIM would pick — priority (critical › medium › future › none),
+ * worker's CLAIM would pick — priority (critical › unlabeled › future),
  * then FIFO by createdAt. `integrity` lists every issue whose stage-label
  * state is corrupt (see the zero-vs-flagged rule below). Each lane also
  * carries an `ineligible` breakdown ({hold, needs-human, wip} counts) so the

--- a/test/sdlc.test.mjs
+++ b/test/sdlc.test.mjs
@@ -460,9 +460,20 @@ describe('computeLanes', () => {
 
   it('excludes wip/hold/needs-human from eligible and orders by priority then FIFO', () => {
     const { lanes } = computeLanes(issues);
-    // 11 (critical) before 10 (future); 12 (wip) and 13 (hold) excluded;
-    // 14 is dual-stage but still eligible for build.
-    assert.deepEqual(lanes.build.eligible, [11, 10, 14]);
+    // 11 (critical) › 14 (unlabeled) › 10 (future); 12 (wip) and 13 (hold)
+    // excluded; 14 is dual-stage but still eligible for build.
+    assert.deepEqual(lanes.build.eligible, [11, 14, 10]);
+  });
+
+  it('sorts unlabeled between critical and future, FIFO within a tier', () => {
+    const { lanes } = computeLanes([
+      { number: 20, createdAt: '2026-07-01T00:00:00Z', labels: ['stage:build', 'priority:future'] },
+      { number: 21, createdAt: '2026-07-02T00:00:00Z', labels: ['stage:build'] },
+      { number: 22, createdAt: '2026-07-03T00:00:00Z', labels: ['stage:build', 'priority:critical'] },
+      { number: 23, createdAt: '2026-07-04T00:00:00Z', labels: ['stage:build', 'priority:critical'] },
+      { number: 24, createdAt: '2026-07-05T00:00:00Z', labels: ['stage:build'] },
+    ]);
+    assert.deepEqual(lanes.build.eligible, [22, 23, 21, 24, 20]);
   });
 
   it('flags multi-stage issues and stage-less issues carrying machine flags', () => {


### PR DESCRIPTION
Rescopes the dispatcher's claim priority from four tiers to three.

**Ordering:** `priority:critical` › *untagged* › `priority:future`, then FIFO by creation date (unchanged).

Untagged is the normal default, so only the two exceptional tiers carry a label. `priority:medium` is dropped — it forced every ordinary issue to sort behind any labeled one.

- `scripts/sdlc.mjs` — `PRIORITY_RANK` is now `{critical: 0, future: 2}` with `NO_PRIORITY_RANK = 1`; doc comment on `computeLanes` updated.
- `prompts/sdlc/README.md` — CLAIM rule text updated.
- `test/sdlc.test.mjs` — fixed the existing ordering assertion, added a tier-boundary test (critical/untagged/future with FIFO within a tier). 124/124 pass.

The two GitHub labels were created out-of-band (neither existed before). No `priority:medium` label was created, and no open issue carried a priority label, so there is nothing to backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
