### PR TITLE
feat(records): pemr record edit — correct non-key display fields in place

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,8 @@ Read/write separation is also declared to the client via MCP `readOnlyHint` anno
 
 **Deletion — and clinical verdicts, and unsourced writes — are never an MCP tool.** `document rm`,
 `record rm` (the CLI's destructive verbs — the latter added by issue #107), `record annotate`
-(issue #109), `record reaffirm` (issue #126), and `record assert` (issue #110) are deliberately
+(issue #109), `record reaffirm` (issue #126), `record assert` (issue #110), and `record edit`
+(issue #129) are deliberately
 excluded from the tool surface
 above. This is what keeps "an agent cannot delete PHI" true: removing a document or a single
 record row is a human-at-a-terminal action only, never something an agent can reach through this
@@ -72,7 +73,10 @@ clinical judgment, and writing one can drop a record out of every generated docu
 deleting a row; `record reaffirm` writes those same verdicts in bulk, so it is excluded for the
 same reason (an agent may still *read* the orphan list from `--json` and summarize it). `record assert` is the sharpest case of all — it is a *write*, not a deletion, and
 the only path in the system that can put a fact into the record with no external source; only a
-human at the CLI may vouch for one.
+human at the CLI may vouch for one. `record edit` sits on the same trust boundary from the other
+side: it mutates a *stored clinical value* with no new source backing the change, so the row stops
+matching what its document says on one person's say-so — which is exactly the kind of write that
+must carry a named human, not an agent.
 
 ## MUST rules
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -139,7 +139,46 @@ CREATE TABLE curation (
 -- SQLite treats NULLs as distinct in a unique index.
 CREATE UNIQUE INDEX idx_curation_row ON curation(record_type, record_id)
   WHERE record_id <> 0;
+
+-- Append-only ledger of in-place field corrections (issue #129). Written only by
+-- `record edit`, which corrects a row's NON-KEY fields - a mislabelled unit, say - and
+-- leaves document_id, person_id, dedup_key and the source blob untouched. The editable
+-- set is DERIVED (dedup.FIELD_SPECS minus dedup.KEY_FIELDS, §3), so identity and
+-- provenance are unreachable from an edit by construction rather than by a denylist.
+-- One row per changed field, all sharing one edited_at, so a single command's correction
+-- reads as one act while each field stays individually legible.
+--
+-- Nothing RESOLVES THROUGH this table - render, verify, rekey and rekey's collision
+-- resolver never read it - which is what makes append-only affordable. Entries therefore
+-- outlive their row, the opposite of 010's answer to the same row-id-reuse hazard:
+-- retiring one would destroy the audit trail the table exists to create, while a stale
+-- entry mis-renders nothing. `record rm` discloses (never deletes) the entries naming the
+-- row it removes, and the dedup_base breadcrumb tells a reader whether a later occupant
+-- of that id is even the same family.
+CREATE TABLE record_edit (
+  record_edit_id INTEGER PRIMARY KEY,
+  record_type    TEXT NOT NULL,    -- one of dedup.KNOWN_TYPES; validated in Python
+  record_id      INTEGER NOT NULL, -- <record_type>_id at edit time; no FK (the 007/010 precedent)
+  dedup_base     TEXT NOT NULL,    -- breadcrumb, never a lookup key
+  field          TEXT NOT NULL,    -- a non-key FIELD_SPECS column
+  old_value      TEXT,             -- rendered TEXT; NULL = the column was NULL
+  new_value      TEXT,
+  note           TEXT NOT NULL,    -- required: why the correction was made
+  attributed_to  TEXT,
+  edited_at      TEXT NOT NULL     -- ISO8601 UTC; shared across one command
+);
+CREATE INDEX record_edit_row ON record_edit (record_type, record_id);
 ```
+
+A correction is **not** a re-attribution. Before `record edit`, a wrong display field
+could only be repaired by re-submitting the row through `commit-extraction` (or deleting
+and re-committing it), both of which re-file the fact under whichever document is passed
+at correction time — so a 2022 measurement would end up sourced to a 2026 chart export.
+An edit keeps the row's provenance exactly as it was; what changes is that the row now
+*differs* from what that source literally said, and the ledger is the record of that
+divergence. The visible consequence: since `unit` is one of the compared payload fields
+(§4), re-ingesting the original document after a unit correction stages a **conflict**
+rather than deduping. That is the honest outcome, not a bug.
 
 High-value typed tables (each carries `document_id` provenance + a `dedup_key`; migration
 005 added `dedup_base`/`dedup_occurrence` to every one of them — see the occurrence model
@@ -844,6 +883,12 @@ pemr document rm <id> [--apply] [--purge-blob] [--tombstone [--reason ...] [--no
                                                          # --tombstone: also refuse to re-ingest this content (§3)
 pemr record rm <table> <id> [--apply]                    # delete ONE record row; its document and every
                                                          # other record it produced survive; dry run by default
+pemr record edit <table> <id> --set NAME=VALUE [--set ...] --note <text>
+                 [--attributed-to ...] [--apply]         # correct a row's NON-KEY fields in place (§2 record_edit);
+                                                         # document_id/dedup_key/source blob untouched; NAME= clears;
+                                                         # identity fields refused (that is a dictionary edit + rekey);
+                                                         # every change ledgered; dry run by default
+pemr record edit --list [<table>] [--json]               # recorded corrections, newest first (field: old -> new)
 pemr record annotate <table> <base-or-id> --status <s> --note <text> [--attributed-to ...]
                      [--merged-into <base-or-id>] [--row] [--apply]
                                                          # record a human verdict over a record FAMILY (§2 curation):
@@ -920,8 +965,8 @@ annotations expose the read/write split to the client.
 extracting; dictionary additions go through human review, never agent-direct edits.
 
 `document rm`, `record rm` (issue #107), `record annotate` (issue #109), `record reaffirm`
-(issue #126) and `record assert`
-(issue #110) are deliberately **absent** from `WRITE_TOOLS` — this is a rule, not an
+(issue #126), `record assert`
+(issue #110) and `record edit` (issue #129) are deliberately **absent** from `WRITE_TOOLS` — this is a rule, not an
 oversight. Deletion of PHI stays a human-at-a-terminal action; no MCP tool, and therefore no
 agent, can remove a record or a document. `record annotate` joins them for the adjacent
 reason: a `curation` verdict is a *human's clinical judgment*, recorded with attribution, and
@@ -929,7 +974,8 @@ an agent that could write one could make a record disappear from every generated
 without deleting a row — and `record reaffirm` writes those same verdicts *in bulk*, which
 only sharpens the argument. `record assert` is the sharpest case of all — it is a *write*, not a
 deletion, and the only path in the system that can put a fact into the record with no
-external source. Any future destructive — or render-altering, or unsourced — verb should
+external source. `record edit` is that same boundary from the other side: it changes a stored
+clinical value with no new source behind the change. Any future destructive — or render-altering, or unsourced — verb should
 default to the same exclusion unless a human explicitly decides otherwise.
 
 ---

--- a/migrations/012_record_edit.sql
+++ b/migrations/012_record_edit.sql
@@ -1,0 +1,60 @@
+-- 012_record_edit: an append-only ledger of in-place field corrections (issue #129).
+--
+-- Before this, a record row had three mutation paths and none of them could *correct* a
+-- field: `record rm` deletes, `record annotate` rules over a row without touching it, and
+-- `record assert` writes a new unsourced fact. So a mislabelled display field - the
+-- reporting case was `lbs`/`F`/`breaths/min` beside `lb`/`degF`/`/min`, same scale, same
+-- stored value - could only be "fixed" by re-committing the row through
+-- `commit-extraction`, which re-attributes it to whichever document is passed. Correcting
+-- a unit is not a reason to rewrite provenance, and that re-attribution is precisely the
+-- invariant (Architecture §2: every row traces to a source document or a named human) a
+-- fix must not break.
+--
+-- `record edit` writes the row in place and records every change here. The ledger is the
+-- audit trail: what changed, from what to what, why, who said so, when. Nothing
+-- **resolves through** it - render, verify, rekey and rekey's collision resolver never
+-- read it - which is deliberate and is what makes append-only affordable (see below).
+--
+-- Which fields may be edited is not stated here. It is derived in Python as
+-- `dedup.FIELD_SPECS[type] - dedup.KEY_FIELDS[type]`, so `document_id`, `person_id`, the
+-- `dedup_*` columns and the `attested_*` columns - none of which are in FIELD_SPECS - are
+-- unreachable by construction rather than by a denylist that rots.
+--
+-- No FK to the edited row (the 007 document_tombstone / 010 curation precedent). A record
+-- id is a plain rowid alias (no AUTOINCREMENT, migrations 001/006), so a ledger entry can
+-- outlive its row and later name the id's next occupant. Curation resolves that hazard by
+-- retiring row-scoped verdicts with the row (010); the opposite answer is right here.
+-- Retiring an entry would destroy the audit trail this table exists to create, and the
+-- hazard is weaker: since nothing resolves through the ledger, a stale entry mis-renders
+-- nothing - it is a forensics ambiguity, not a live-row fault. So entries survive their
+-- row, `record rm` *discloses* the entries naming the row it is about to delete, and each
+-- entry keeps a `dedup_base` breadcrumb (never a lookup key - the 010 reading) so a reader
+-- can tell whether a later occupant is even the same family.
+--
+-- One row per changed field, all sharing one `edited_at`: that is what makes a single
+-- command's correction reconstructable as one act while each field stays individually
+-- readable. `old_value`/`new_value` are TEXT even for numeric columns - the ledger is a
+-- human-readable audit record, not a replayable patch. NULL means the column was (or
+-- became) NULL, which is distinct from the empty string.
+--
+-- Purely additive: CREATE TABLE + CREATE INDEX, no rebuild, safe under foreign_keys=ON.
+-- Readers guard with `records.has_edit_table` (the `curation.has_table` precedent) so a
+-- restored pre-012 snapshot reports no edits rather than raising `no such table`.
+
+CREATE TABLE record_edit (
+  record_edit_id INTEGER PRIMARY KEY,
+  record_type    TEXT NOT NULL,    -- one of dedup.KNOWN_TYPES; validated in Python
+  record_id      INTEGER NOT NULL, -- <record_type>_id at edit time
+  dedup_base     TEXT NOT NULL,    -- BREADCRUMB (the 010 reading), never a lookup key
+  field          TEXT NOT NULL,    -- a non-key FIELD_SPECS column
+  old_value      TEXT,             -- rendered TEXT; NULL = the column was NULL
+  new_value      TEXT,
+  note           TEXT NOT NULL,    -- required: why the correction was made
+  attributed_to  TEXT,
+  edited_at      TEXT NOT NULL,    -- ISO8601 UTC seconds; shared across one command
+  -- The 008/010 `curation` precedent for the identical rule: a correction with no stated
+  -- reason is not an audit trail. Python refuses it first; this is the backstop.
+  CHECK (trim(note) <> '')
+);
+
+CREATE INDEX record_edit_row ON record_edit (record_type, record_id);

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -411,6 +411,7 @@ def _with_document_conn(args: argparse.Namespace, work):
             documents.OcrTextPresentError,
             records.RecordNotFoundError,
             records.AnchoredConflictError,
+            records.FieldNotEditableError,
             curation.CurationNotFoundError,
             curation.FamilyNotFoundError,
             curation.RowNotFoundError,
@@ -870,6 +871,7 @@ def _cmd_record_rm(args: argparse.Namespace) -> int:
                 "conflicts_reanchored": report.conflicts_reanchored,
                 # Appended, never inserted: the --json key set is a contract.
                 "curation_retired": report.curation_retired,
+                "edits_recorded": report.edits_recorded,
                 "applied": report.applied,
             })
             return 0
@@ -904,11 +906,140 @@ def _cmd_record_rm(args: argparse.Namespace) -> int:
                 f"  curation verdict (row scope) {lifted}: "
                 f"{curation.describe(verdict)}"
             )
+        if report.edits_recorded:
+            # Kept, not lifted (issue #129) — the opposite of the verdict above, and the
+            # difference is worth stating out loud on the one screen that shows both.
+            print(
+                f"  {len(report.edits_recorded)} recorded correction(s) name this row; "
+                "the ledger is append-only, so they are kept as history"
+            )
+            for entry in report.edits_recorded:
+                print(f"    {_edit_change_line(entry)}  ({entry['edited_at'][:10]})")
         if report.applied:
             print(f"removed {report.record_type} #{report.row_id}")
         else:
             print(
                 "dry run: nothing was deleted - re-run with --apply "
+                "(back up first: `pemr backup`)"
+            )
+        return 0
+
+    return _with_document_conn(args, work)
+
+
+# --------------------------------------------------------------------------- #
+# in-place correction of non-key fields (`record edit`) - issue #129
+# --------------------------------------------------------------------------- #
+
+def _fmt_edit_value(value: object) -> str:
+    """A ledger value for display. ``None`` is the column being unset, and printing it
+    as an empty string would make "cleared" indistinguishable from "set to ''"."""
+    return "(none)" if value is None else str(value)
+
+
+def _edit_change_line(change: dict) -> str:
+    """``field: old -> new`` — shared by the report body and `record rm`'s disclosure."""
+    return (
+        f"{change['field']}: {_fmt_edit_value(change['old'])} -> "
+        f"{_fmt_edit_value(change['new'])}"
+    )
+
+
+def _edit_row_line(entry: dict) -> str:
+    """One `--list` line, in the `_curation_row_line` style: which row, what moved, when.
+
+    A ledger entry outlives the row it names (issue #129), so an entry with no live label
+    is annotated rather than hidden — it is history, not an error.
+    """
+    gone = "" if entry["label"] else "  (no live row)"
+    who = f"  [{entry['attributed_to']}]" if entry["attributed_to"] else ""
+    return (
+        f"{entry['record_type']:12}  #{entry['record_id']:<6}  "
+        f"{(entry['edited_at'] or '')[:10]:10}  {entry['label']}  "
+        f"{_edit_change_line(entry)}{who}{gone}"
+    )
+
+
+def _print_record_edit_report(report: "records.RecordEditReport") -> None:
+    """The human block, shaped like `_cmd_record_rm`'s: the fact, then what moves."""
+    print(
+        f"{report.record_type} #{report.row_id}  {_fmt(report.person_slug)}  "
+        f"{report.label}"
+    )
+    for change in report.changes:
+        print(f"  {_edit_change_line(change)}")
+    for name in report.unchanged:
+        print(f"  {name}: unchanged (already that value)")
+    owner = f"#{report.document_id}" if report.document_id is not None else "none"
+    print(f"  document: {owner} (unchanged - a correction is not a re-attribution)")
+    print(f"  identity: dedup_key {report.dedup_key[:12]}... (unchanged)")
+    print(f"  note: {report.note}")
+    if report.attributed_to:
+        print(f"  attributed to: {report.attributed_to}")
+
+
+def _cmd_record_edit(args: argparse.Namespace) -> int:
+    """`record edit` — list recorded corrections, or correct one row's non-key fields.
+
+    Two modes on one subparser, the `_cmd_record_assert` shape: `--list` takes an
+    optional table and no payload; otherwise the table, the row id and at least one
+    `--set` are required. The handler owns the rules argparse cannot express across
+    ``nargs='?'``.
+    """
+    parser = args.edit_parser
+    if args.list:
+        def work(conn):
+            entries = records.list_edits(conn, args.table)
+            if args.json:
+                _print_json(entries)
+                return 0
+            if not entries:
+                print("no record corrections recorded")
+                return 0
+            print(f"{'type':12}  {'row':7}  {'edited':10}  label  field: old -> new")
+            for entry in entries:
+                print(_edit_row_line(entry))
+            return 0
+
+        return _with_document_conn(args, work)
+
+    if args.table is None or args.row_id is None:
+        parser.error("table and row id are required unless --list is given")
+    if not args.set:
+        parser.error(
+            "at least one --set NAME=VALUE is required - the field being corrected"
+        )
+    if not args.note:
+        parser.error("--note is required: why the correction is being made")
+
+    updates = _parse_set_args(parser, args.table, args.set)
+    dictionary = dedup.load_dictionary(_resolve_dictionary_path(args))
+
+    def work(conn):
+        report = records.edit_record(
+            conn,
+            args.table,
+            args.row_id,
+            updates,
+            dictionary,
+            note=args.note,
+            attributed_to=args.attributed_to,
+            apply=args.apply,
+        )
+        if args.json:
+            _print_json(report.as_dict())
+            return 0
+        _print_record_edit_report(report)
+        if not report.changes:
+            print("nothing to do: every named field already holds that value")
+        elif report.applied:
+            print(
+                f"corrected {report.record_type} #{report.row_id} "
+                f"({len(report.changes)} field(s), recorded in the edit ledger)"
+            )
+        else:
+            print(
+                "dry run: nothing was written - re-run with --apply "
                 "(back up first: `pemr backup`)"
             )
         return 0
@@ -1533,6 +1664,53 @@ def _parse_field_args(
         else:
             payload[name] = value
     return payload
+
+
+def _parse_set_args(
+    parser: argparse.ArgumentParser, table: str, raw: list[str] | None
+) -> dict:
+    """``--set NAME=VALUE`` repeats -> an update dict for :func:`records.edit_record`.
+
+    :func:`_parse_field_args` with two differences, both of them the point of the verb:
+
+    * unknown names are checked against :func:`dedup.editable_fields`, so the usage
+      error names the **editable** set rather than every column — an operator who tried
+      to `--set collected_at=...` needs to be told it is an identity field, and the
+      engine's :class:`records.FieldNotEditableError` says exactly that, so a
+      key-participating name is passed through rather than caught here;
+    * a bare ``NAME=`` yields ``None`` — clear the column — matching `document edit`'s
+      documented "\"\" clears" convention.
+    """
+    editable = dedup.editable_fields(table)
+    spec = dedup.FIELD_SPECS[table]
+    updates: dict = {}
+    for item in raw or []:
+        name, sep, value = item.partition("=")
+        name = name.strip()
+        if not sep or not name:
+            parser.error(f"--set expects NAME=VALUE, got {item!r}")
+        if name not in spec:
+            parser.error(
+                f"unknown {table} field '{name}' - editable fields: "
+                f"{', '.join(editable)}"
+            )
+        if name in updates:
+            parser.error(f"--set {name} given twice")
+        if value == "":
+            updates[name] = None
+            continue
+        types = spec[name][0]
+        if isinstance(types, tuple) and int in types:
+            try:
+                updates[name] = int(value)
+            except ValueError:
+                try:
+                    updates[name] = float(value)
+                except ValueError:
+                    updates[name] = value
+        else:
+            updates[name] = value
+    return updates
 
 
 def _attested_row_line(row: dict) -> str:
@@ -2826,6 +3004,43 @@ def build_parser() -> argparse.ArgumentParser:
     )
     r_rm.add_argument("--json", action="store_true", help="machine-readable output")
     r_rm.set_defaults(func=_cmd_record_rm)
+
+    # --- in-place correction of non-key display fields (issue #129) ---
+    r_edit = record_sub.add_parser(
+        "edit",
+        help="correct one row's non-key fields in place, leaving document_id, "
+             "dedup_key and the source blob untouched (dry run by default); every "
+             "change is recorded in an append-only ledger. CLI-only, never an MCP tool",
+    )
+    # Both optional so `--list` can take an optional table and no row; the handler
+    # enforces "table and row id unless --list" with the usage line.
+    r_edit.add_argument("table", nargs="?", choices=list(dedup.KNOWN_TYPES))
+    r_edit.add_argument("row_id", type=int, nargs="?", metavar="ID")
+    r_edit.add_argument(
+        "--set", action="append", metavar="NAME=VALUE",
+        help="one field to correct; repeat for each (e.g. --set unit=lb). A bare "
+             "NAME= clears the column. Identity fields are refused - correcting one "
+             "is a dictionary edit + `pemr rekey`, not an edit. Note that correcting "
+             "a compared field (e.g. unit) makes a later re-ingest of the original "
+             "document stage a conflict rather than dedup, which is honest: the row "
+             "no longer says what its source says",
+    )
+    r_edit.add_argument(
+        "--note", help="required: why the correction is being made"
+    )
+    r_edit.add_argument("--attributed-to", help="who made the correction")
+    r_edit.add_argument(
+        "--list", action="store_true",
+        help="list recorded corrections and exit",
+    )
+    r_edit.add_argument(
+        "--apply", action="store_true", help="write the edit (default: report only)"
+    )
+    r_edit.add_argument(
+        "--dictionary", help="synonym dictionary TOML (overrides default)"
+    )
+    r_edit.add_argument("--json", action="store_true", help="machine-readable output")
+    r_edit.set_defaults(func=_cmd_record_edit, edit_parser=r_edit)
 
     # --- recorded human verdicts (curation overlay, issue #109) ---
     r_annotate = record_sub.add_parser(

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -449,6 +449,45 @@ def _condition_subject(row: dict, dictionary: dict[str, str] | None = None) -> s
     return "family:" + norm(row.get("relation"), dictionary)
 
 
+# Per record type: the :data:`FIELD_SPECS` names :func:`_key_parts` reads — the fields
+# whose value participates in the identity. Written down once, here, beside the function
+# it must stay true to, so `record edit` (issue #129) can derive its editable set as
+# "everything else" instead of carrying a denylist that rots the next time a key changes.
+#
+# `person_id` is deliberately absent: it is not in FIELD_SPECS at all (it is inherited
+# from the document), so nothing reading this table could offer it for editing anyway.
+# `condition` lists `status` **and** `relation` because :func:`_condition_subject` reads
+# them together — moving status to/from `family-history` moves the key, and `relation` is
+# what it moves it to.
+KEY_FIELDS: dict[str, frozenset[str]] = {
+    "lab_result": frozenset({"test_name", "collected_at"}),
+    "medication": frozenset({"name", "dose", "started_on"}),
+    "procedure": frozenset({"name", "performed_on"}),
+    "appointment": frozenset({"provider", "scheduled_for"}),
+    "observation": frozenset({"obs_type", "observed_at", "key"}),
+    "allergy": frozenset({"substance"}),
+    "condition": frozenset({"name", "status", "relation"}),
+}
+
+
+def editable_fields(record_type: str) -> tuple[str, ...]:
+    """The non-key payload columns of ``record_type``, in :data:`FIELD_SPECS` order.
+
+    The safety property `record edit` (issue #129) rests on: identity is excluded by
+    **derivation**, not by a hand-maintained denylist. Provenance is excluded for free —
+    ``document_id``, ``person_id``, the ``dedup_*`` columns and
+    :data:`ATTESTATION_COLUMNS` are not in :data:`FIELD_SPECS` at all, so no caller
+    reading this list can name one.
+    """
+    if record_type not in FIELD_SPECS:
+        raise ValueError(
+            f"unknown record type '{record_type}' - known types: "
+            f"{', '.join(KNOWN_TYPES)}"
+        )
+    key = KEY_FIELDS[record_type]
+    return tuple(name for name in FIELD_SPECS[record_type] if name not in key)
+
+
 def identity_label(
     record_type: str, row: dict, person_id: int, dictionary: dict[str, str] | None = None
 ) -> str:

--- a/pemr/records.py
+++ b/pemr/records.py
@@ -1,20 +1,46 @@
-"""Row-level record repair — `pemr record rm` (issue #107).
+"""Row-level record repair — `pemr record rm` (issue #107), `record edit` (issue #129).
 
 The scalpel next to `document rm`'s hammer. When `pemr rekey` reports a
 **doubled** collision — one clinical fact filed twice, once under a pre-drift key
 (:func:`dedup.rekey`) — the offending row often lives inside a visit note that
 also holds a dozen perfectly good records. `document rm` would take all of them,
 and the project's write-path rule (`AGENTS.md`) forbids the other option, a hand
-edit in SQLite. This module is the missing third door: delete **one** row, by
+edit in SQLite. This module is the missing third door: reach **one** row, by
 primary key, and nothing else.
 
-One operation, shaped like `documents.remove_document`:
+Two operations, both shaped like `documents.remove_document`:
 
     * ``remove_record`` — delete a single typed record row, dry-run by default
+    * ``edit_record`` — correct a single row's **non-key** fields in place,
+      dry-run by default, every change written to an append-only ledger
 
-``record_fts`` needs no explicit maintenance: migrations 003 and 006 put an
-AFTER DELETE trigger on every one of :data:`dedup.KNOWN_TYPES`, which is the same
-thing `documents.remove_document` relies on.
+``record_fts`` needs no explicit maintenance for either: migrations 003 and 006
+put AFTER DELETE **and** AFTER UPDATE triggers on every one of
+:data:`dedup.KNOWN_TYPES`, which is the same thing `documents.remove_document`
+relies on.
+
+**An edit corrects a field; it never rewrites provenance** (issue #129). The
+editable set is *derived* — :func:`dedup.editable_fields`, i.e. ``FIELD_SPECS``
+minus ``KEY_FIELDS`` — so ``document_id``, ``person_id``, the ``dedup_*`` columns
+and the ``attested_*`` columns are unreachable from an edit by construction, not
+by a denylist. That is the whole point: the two workarounds this replaces
+(re-committing the corrected row through `commit-extraction`, or
+delete-and-recommit) both re-attribute the row to whichever document is passed at
+correction time, which is a lie about where the fact came from. After an edit the
+row still traces to its original source; what changed is that it now *differs*
+from what that source literally said — and that is exactly what the ledger
+records.
+
+**Ledger entries outlive their row, deliberately.** A record id is a plain rowid
+alias, so an entry naming a deleted row could later look like it belongs to the
+id's next occupant — the #114 hazard, which row-scoped curation answers by
+retiring the verdict with the row. Here the answer is the opposite: nothing
+*resolves through* the ledger (render, verify, rekey and rekey's collision
+resolver never read it), so a stale entry mis-renders nothing, while retiring one
+would destroy the audit trail this feature exists to create. Handled by
+disclosure instead — :func:`remove_record` names the entries pointing at the row
+it is about to delete, and each entry keeps its ``dedup_base`` breadcrumb so a
+reader can tell whether a later occupant is even the same family.
 
 **Occurrence numbers are not renumbered.** Deleting occurrence 0 of a
 multi-occurrence family leaves the base occupied only at ``n >= 1``; that is a
@@ -42,7 +68,9 @@ dry run names the verdict; ``apply`` lifts it in the same transaction as the del
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Iterable
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 
 from . import curation, db, dedup
 
@@ -54,6 +82,26 @@ class RecordNotFoundError(ValueError):
 class AnchoredConflictError(ValueError):
     """Refused: removing the row would strand an open conflict with nothing to
     resolve against (its identity family would be empty)."""
+
+
+class FieldNotEditableError(ValueError):
+    """Refused: a named field is unknown, or participates in the row's identity.
+
+    Identity fields are not off-limits because editing them is unthinkable — it is
+    because an identity change is a *different operation*, with its own answers
+    (a dictionary edit + `pemr rekey`, or `record rm` + re-commit). The message
+    points there rather than leaving the operator guessing.
+    """
+
+
+def _require_type(record_type: str) -> None:
+    """Guard every f-string table interpolation below: a record type reaches SQL only
+    after matching a known key."""
+    if record_type not in dedup.FIELD_SPECS:
+        raise ValueError(
+            f"unknown record type '{record_type}' - known types: "
+            f"{', '.join(dedup.KNOWN_TYPES)}"
+        )
 
 
 @dataclass
@@ -77,7 +125,52 @@ class RecordRemoveReport:
     # Row-scoped curation verdicts naming this row - lifted with it (issue #114), and
     # named in the dry run because a recorded clinical judgment is going away.
     curation_retired: list[dict] = field(default_factory=list)
+    # Ledger entries (issue #129) naming this row — DISCLOSED, never retired, unlike the
+    # row-scoped verdicts above. See the module docstring for why the two hazards get
+    # opposite answers.
+    edits_recorded: list[dict] = field(default_factory=list)
     applied: bool = False
+
+
+@dataclass
+class RecordEditReport:
+    record_type: str
+    row_id: int
+    person_id: int | None
+    person_slug: str | None
+    document_id: int | None
+    label: str
+    # One entry per field this edit actually moves: {"field", "old", "new"}.
+    changes: list[dict] = field(default_factory=list)
+    # Named fields whose stored value already equalled the requested one. Reported, not
+    # silently dropped: a re-run of the same command has to be visibly a no-op.
+    unchanged: list[str] = field(default_factory=list)
+    dedup_key: str = ""
+    dedup_base: str = ""
+    dedup_occurrence: int = 0
+    note: str = ""
+    attributed_to: str | None = None
+    edited_at: str = ""
+    applied: bool = False
+
+    def as_dict(self) -> dict:
+        return {
+            "record_type": self.record_type,
+            "row_id": self.row_id,
+            "person": self.person_slug,
+            "person_id": self.person_id,
+            "document_id": self.document_id,
+            "label": self.label,
+            "changes": self.changes,
+            "unchanged": self.unchanged,
+            "dedup_key": self.dedup_key,
+            "dedup_base": self.dedup_base,
+            "dedup_occurrence": self.dedup_occurrence,
+            "note": self.note,
+            "attributed_to": self.attributed_to,
+            "edited_at": self.edited_at,
+            "applied": self.applied,
+        }
 
 
 def _slug_for(conn: sqlite3.Connection, person_id: int | None) -> str | None:
@@ -123,11 +216,7 @@ def remove_record(
     survives.
     """
     db.require_migrated(conn)
-    if record_type not in dedup.FIELD_SPECS:
-        raise ValueError(
-            f"unknown record type '{record_type}' - known types: "
-            f"{', '.join(dedup.KNOWN_TYPES)}"
-        )
+    _require_type(record_type)
     pk = f"{record_type}_id"
     row = conn.execute(
         f"SELECT * FROM {record_type} WHERE {pk} = ?", (row_id,)
@@ -173,6 +262,11 @@ def remove_record(
     # The row id is about to become reusable, so any row-scoped verdict naming it is
     # about to become a mis-render waiting for the next insert (issue #114).
     report.curation_retired = curation.row_verdicts_for(conn, record_type, [row_id])
+    # Corrections recorded against this row (issue #129). Disclosed and left in place:
+    # the ledger is append-only, and nothing resolves through it. The operator still has
+    # to be told, because a row someone deliberately corrected is more likely to be the
+    # wrong one to delete.
+    report.edits_recorded = edits_for_rows(conn, record_type, [row_id])
 
     if apply:
         # record_fts follows via the per-table AFTER DELETE triggers (migrations
@@ -187,5 +281,295 @@ def remove_record(
             # Same transaction as the delete: a commit that dropped the row but kept
             # its verdict is exactly the state that mis-renders once the id is reused.
             curation.retire_row_verdicts(conn, record_type, [row_id])
+    report.applied = apply
+    return report
+
+
+# --------------------------------------------------------------------------- #
+# in-place correction of non-key fields (`record edit`) - issue #129
+# --------------------------------------------------------------------------- #
+
+def has_edit_table(conn: sqlite3.Connection) -> bool:
+    """Whether `record_edit` exists — false for a database predating migration 012.
+
+    The :func:`curation.has_table` guard: a restored older snapshot must report "no
+    edits" rather than raise ``no such table``.
+    """
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='record_edit'"
+    ).fetchone()
+    return row is not None
+
+
+def _ledger_view(row: sqlite3.Row) -> dict:
+    return {
+        "record_edit_id": int(row["record_edit_id"]),
+        "record_type": row["record_type"],
+        "record_id": int(row["record_id"]),
+        "dedup_base": row["dedup_base"],
+        "field": row["field"],
+        "old": row["old_value"],
+        "new": row["new_value"],
+        "note": row["note"],
+        "attributed_to": row["attributed_to"],
+        "edited_at": row["edited_at"],
+    }
+
+
+def _ledger_text(value: object) -> str | None:
+    """How a field value is rendered into the ledger: ``None`` stays NULL (the column
+    *was* unset, which is not the same as an empty string), everything else becomes its
+    ``str``. The ledger is a human-readable audit record, not a replayable patch."""
+    return None if value is None else str(value)
+
+
+def edits_for_rows(
+    conn: sqlite3.Connection, record_type: str, record_ids: Iterable[int]
+) -> list[dict]:
+    """The ledger entries naming any of ``record_ids``, newest first.
+
+    The :func:`curation.row_verdicts_for` twin, for :func:`remove_record`'s disclosure —
+    but note the different ending: these entries are reported and then *left alone*.
+    """
+    _require_type(record_type)
+    wanted = {int(rid) for rid in record_ids}
+    if not wanted or not has_edit_table(conn):
+        return []
+    rows = conn.execute(
+        "SELECT * FROM record_edit WHERE record_type = ? "
+        "ORDER BY edited_at DESC, record_edit_id DESC",
+        (record_type,),
+    ).fetchall()
+    return [e for e in (_ledger_view(r) for r in rows) if e["record_id"] in wanted]
+
+
+def list_edits(
+    conn: sqlite3.Connection, record_type: str | None = None
+) -> list[dict]:
+    """Every recorded correction (optionally one record type), newest first.
+
+    Each entry carries the **live** ``label`` of the row it names, or ``""`` when that
+    row is gone — the ledger outlives its row on purpose (module docstring), and an
+    entry whose row has since been deleted is history, not an error.
+    """
+    db.require_migrated(conn)
+    if record_type is not None:
+        _require_type(record_type)
+    if not has_edit_table(conn):
+        return []
+    sql = "SELECT * FROM record_edit"
+    params: tuple = ()
+    if record_type is not None:
+        sql += " WHERE record_type = ?"
+        params = (record_type,)
+    sql += " ORDER BY edited_at DESC, record_edit_id DESC"
+    out: list[dict] = []
+    for row in conn.execute(sql, params).fetchall():
+        entry = _ledger_view(row)
+        entry["label"] = _live_label(conn, entry["record_type"], entry["record_id"])
+        out.append(entry)
+    return out
+
+
+def _live_label(conn: sqlite3.Connection, record_type: str, record_id: int) -> str:
+    """``dedup._rekey_label`` for a row that may no longer exist (``""`` when it does
+    not). A stored ledger row can name anything, so the type is re-validated here before
+    it is interpolated into a table name — the :func:`curation.list_curation` idiom."""
+    if record_type not in dedup.FIELD_SPECS:
+        return ""
+    pk = f"{record_type}_id"
+    row = conn.execute(
+        f"SELECT * FROM {record_type} WHERE {pk} = ?", (record_id,)
+    ).fetchone()
+    return "" if row is None else dedup._rekey_label(record_type, row)
+
+
+def _same_value(stored: object, incoming: object) -> bool:
+    """Whether an edit would actually move the column.
+
+    Numbers compare numerically (`dedup._rows_equal`'s rule): a numeric column
+    round-trips out of SQLite as ``float``, so ``--set value_num=45`` against a stored
+    ``45.0`` is a no-op, not a change to be ledgered.
+    """
+    if stored is None or incoming is None:
+        return stored is incoming
+    if isinstance(stored, (int, float)) and isinstance(incoming, (int, float)):
+        if not isinstance(stored, bool) and not isinstance(incoming, bool):
+            return float(stored) == float(incoming)
+    return stored == incoming
+
+
+def edit_record(
+    conn: sqlite3.Connection,
+    record_type: str,
+    row_id: int,
+    updates: dict,
+    dictionary: dict[str, str] | None = None,
+    *,
+    note: str,
+    attributed_to: str | None = None,
+    now: str | None = None,
+    apply: bool = False,
+) -> RecordEditReport:
+    """Correct one row's **non-key** fields in place, addressed by primary key.
+
+    Dry-run by default: pass ``apply=True`` to write. The third door beside
+    :func:`remove_record` — same single-row scalpel, same dry-run contract — except it
+    corrects rather than deletes. The case it exists for is a display field that is
+    simply *mislabelled*: a unit recorded as ``lbs`` beside forty-five ``lb``, same
+    scale, same value, differing only by which extraction submitted it.
+
+    ``updates`` maps field name -> new value; ``None`` clears the column. Which names
+    are accepted is **derived**, not listed: :func:`dedup.editable_fields`, i.e. every
+    ``FIELD_SPECS`` column that is not in ``KEY_FIELDS``. So the identity fields are
+    refused (:class:`FieldNotEditableError`), and ``document_id`` / ``person_id`` /
+    ``dedup_*`` / ``attested_*`` are not nameable at all — they are outside
+    ``FIELD_SPECS``. That is the provenance guarantee: after an edit the row still
+    traces to its original document (or attestation), which is exactly what the
+    workarounds this replaces could not promise.
+
+    ``note`` is required and must be non-empty after ``strip()`` (the
+    :func:`curation.annotate_record` rule): an unexplained mutation of a stored clinical
+    value is not an audit trail. Every changed field is written to the append-only
+    ``record_edit`` ledger in the **same transaction** as the UPDATE.
+
+    Validation is entirely front-loaded — nothing is written on any raise. In order:
+    schema present; known type; row exists; at least one update; every name editable;
+    a real note; the merged payload passes :func:`dedup.validate_row` (so type, ISO-date
+    and enum rules bind exactly as they did at commit); and finally the identity guard —
+    the ``dedup_key`` recomputed over the payload *before* and *after* must be equal.
+    That last check is belt-and-braces over :data:`dedup.KEY_FIELDS`, and is drift-immune
+    because it compares like with like: a row whose stored key predates a dictionary edit
+    is still editable, since both sides are recomputed under the same dictionary.
+
+    **Re-ingest divergence.** Once a unit is corrected, re-committing the *original*
+    document stages a CONFLICT rather than deduping, because ``unit`` is one of
+    ``dedup._COMPARE_FIELDS`` for ``lab_result`` and ``observation``. That is correct and
+    loud: the stored row genuinely no longer says what its source says.
+
+    Raises :class:`FieldNotEditableError`, :class:`RecordNotFoundError`,
+    ``dedup.ValidationError`` or plain ``ValueError`` — all friendly rc=1 at the CLI.
+    """
+    db.require_migrated(conn)
+    _require_type(record_type)
+    pk = f"{record_type}_id"
+    row = conn.execute(
+        f"SELECT * FROM {record_type} WHERE {pk} = ?", (row_id,)
+    ).fetchone()
+    if row is None:
+        raise RecordNotFoundError(
+            f"no {record_type} with id {row_id} - row ids come from `pemr rekey`'s "
+            "collision report, or `pemr query`"
+        )
+
+    if not updates:
+        raise ValueError(
+            f"no fields to edit - pass at least one --set NAME=VALUE; editable "
+            f"{record_type} fields: {', '.join(dedup.editable_fields(record_type))}; "
+            "nothing was written"
+        )
+    editable = dedup.editable_fields(record_type)
+    key_fields = dedup.KEY_FIELDS[record_type]
+    for name in updates:
+        if name in editable:
+            continue
+        if name in key_fields:
+            raise FieldNotEditableError(
+                f"{record_type}.{name} is part of the row's identity (it feeds the "
+                "dedup_key), so it cannot be corrected in place - that is a different "
+                "operation: edit `data/dictionary.toml` and run `pemr rekey`, or "
+                f"`pemr record rm {record_type} {row_id}` and re-commit. Editable "
+                f"{record_type} fields: {', '.join(editable)}; nothing was written"
+            )
+        raise FieldNotEditableError(
+            f"unknown {record_type} field '{name}' - editable fields: "
+            f"{', '.join(editable)}; nothing was written"
+        )
+
+    cleaned_note = (note or "").strip()
+    if not cleaned_note:
+        raise ValueError(
+            "an edit note is required - it records why the correction was made and who "
+            "made it; a stored clinical value changed for no stated reason is not an "
+            "audit trail; nothing was written"
+        )
+
+    before = {name: row[name] for name in dedup.FIELD_SPECS[record_type]}
+    after = {**before, **updates}
+    # Exactly the validation a commit would apply, so an edit can never leave a row in a
+    # state `commit-extraction` would have refused.
+    dedup.validate_row(record_type, {k: v for k, v in after.items() if v is not None})
+
+    person_id = row["person_id"]
+    before_key = dedup.dedup_key(record_type, before, person_id, dictionary)
+    after_key = dedup.dedup_key(record_type, after, person_id, dictionary)
+    if before_key != after_key:
+        # Unreachable while KEY_FIELDS agrees with dedup._key_parts. Kept as the
+        # structural backstop: if a future key derivation reads a field this table does
+        # not list, the edit refuses instead of silently forking the fact.
+        raise FieldNotEditableError(
+            f"refusing to edit {record_type} {row_id}: the requested change would move "
+            "its dedup_key, which is an identity change rather than a correction "
+            "(this means dedup.KEY_FIELDS has fallen out of step with the key "
+            "derivation - please report it); nothing was written"
+        )
+
+    changes = [
+        {"field": name, "old": _ledger_text(before[name]),
+         "new": _ledger_text(updates[name])}
+        for name in editable
+        if name in updates and not _same_value(before[name], updates[name])
+    ]
+    unchanged = [
+        name for name in editable
+        if name in updates and _same_value(before[name], updates[name])
+    ]
+
+    stamp = now or datetime.now(timezone.utc).isoformat(timespec="seconds")
+    report = RecordEditReport(
+        record_type=record_type,
+        row_id=row_id,
+        person_id=person_id,
+        person_slug=_slug_for(conn, person_id),
+        document_id=row["document_id"],
+        label=dedup._rekey_label(record_type, row),
+        changes=changes,
+        unchanged=unchanged,
+        dedup_key=row["dedup_key"],
+        dedup_base=row["dedup_base"],
+        dedup_occurrence=int(row["dedup_occurrence"] or 0),
+        note=cleaned_note,
+        attributed_to=(attributed_to or "").strip() or None,
+        edited_at=stamp,
+    )
+
+    if apply and changes:
+        # One transaction for the UPDATE and its ledger rows: a correction that commits
+        # without its audit trail is exactly the failure the trail exists to prevent
+        # (the `curation.retire_row_verdicts` precedent). record_fts follows via the
+        # per-table AFTER UPDATE triggers (migrations 003/006).
+        assignments = ", ".join(f"{c['field']} = ?" for c in changes)
+        values = [updates[c["field"]] for c in changes]
+        with conn:
+            cur = conn.execute(
+                f"UPDATE {record_type} SET {assignments} WHERE {pk} = ?",
+                [*values, row_id],
+            )
+            if cur.rowcount != 1:
+                raise RecordNotFoundError(
+                    f"no {record_type} with id {row_id} - nothing was edited"
+                )
+            for change in changes:
+                conn.execute(
+                    """
+                    INSERT INTO record_edit
+                      (record_type, record_id, dedup_base, field, old_value, new_value,
+                       note, attributed_to, edited_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (record_type, row_id, row["dedup_base"], change["field"],
+                     change["old"], change["new"], cleaned_note,
+                     report.attributed_to, stamp),
+                )
     report.applied = apply
     return report

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -30,6 +30,7 @@ COUNTED_TABLES = (
     "document",
     "document_tombstone",
     "curation",
+    "record_edit",
     "lab_result",
     "medication",
     "procedure",

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -47,6 +47,7 @@ ALL_MIGRATIONS = [
     "009_record_attestation.sql",
     "010_curation_row_scope.sql",
     "011_curation_distinct_status.sql",
+    "012_record_edit.sql",
 ]
 
 # Every record table carries the occurrence-family columns (migration 005; 006's two
@@ -137,6 +138,7 @@ def test_migration_006_moves_condition_and_allergy_observations(conn, tmp_path):
         "006_condition_allergy.sql", "007_document_tombstone.sql",
         "008_curation.sql", "009_record_attestation.sql",
         "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
+        "012_record_edit.sql",
     ]
 
     a = conn.execute("SELECT * FROM allergy").fetchone()
@@ -270,6 +272,7 @@ def test_migration_008_applies_on_a_007_era_database(conn, tmp_path):
     assert db.migrate(conn) == [
         "008_curation.sql", "009_record_attestation.sql",
         "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
+        "012_record_edit.sql",
     ]
 
     assert curation.has_table(conn) is True
@@ -321,7 +324,7 @@ def test_migration_009_applies_on_an_008_era_database(conn, tmp_path):
 
     assert db.migrate(conn) == [
         "009_record_attestation.sql", "010_curation_row_scope.sql",
-        "011_curation_distinct_status.sql",
+        "011_curation_distinct_status.sql", "012_record_edit.sql",
     ]
 
     assert attestations.has_columns(conn) is True
@@ -372,6 +375,7 @@ def test_migration_010_rebuilds_curation_and_preserves_every_verdict(conn, tmp_p
 
     assert db.migrate(conn) == [
         "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
+        "012_record_edit.sql",
     ]
 
     after = [dict(r) for r in conn.execute(
@@ -454,7 +458,9 @@ def test_migration_011_widens_the_status_check_and_preserves_every_verdict(
         "SELECT * FROM curation ORDER BY dedup_base"
     ).fetchall()]
 
-    assert db.migrate(conn) == ["011_curation_distinct_status.sql"]
+    assert db.migrate(conn) == [
+        "011_curation_distinct_status.sql", "012_record_edit.sql",
+    ]
 
     after = [dict(r) for r in conn.execute(
         "SELECT * FROM curation ORDER BY dedup_base"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -498,3 +498,15 @@ def test_record_assert_is_not_on_the_mcp_surface():
     for spelling in ("assert", "attest", "record_assert", "attestation"):
         assert spelling not in surface, spelling
     assert "record_assert" not in mcp_server.WRITE_TOOLS
+
+
+def test_record_edit_is_not_on_the_mcp_surface():
+    """Trust boundary (issue #129): `record edit` mutates a stored clinical value with no
+    new source behind the change, so the row stops matching what its document says on one
+    person's say-so. Same standing as `record assert` — CLI-only, and not in AGENTS.md's
+    blessed write set (commit_extraction/person_add/person_edit/ingest/
+    document_set_text)."""
+    surface = " ".join(mcp_server.TOOL_NAMES).lower()
+    for spelling in ("record_edit", "edit_record", "record_edits"):
+        assert spelling not in surface, spelling
+    assert "record_edit" not in mcp_server.WRITE_TOOLS

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,15 +1,16 @@
-"""Row-level record repair: `pemr record rm` (issue #107).
+"""Row-level record repair: `pemr record rm` (issue #107), `record edit` (issue #129).
 
 Covers the module surface (pemr/records.py) and the CLI wiring, in the shape
-test_documents.py uses for the `document` group. The scenario the verb exists for
-— a doubled fact quarantining a table from `rekey` — gets its own end-to-end test.
+test_documents.py uses for the `document` group. Each verb gets the end-to-end test of
+the scenario it exists for: a doubled fact quarantining a table from `rekey` for
+`record rm`, and the reporter's unit-label normalisation for `record edit`.
 """
 
 import json
 
 import pytest
 
-from pemr import cli, db, dedup, documents, persons, records
+from pemr import cli, curation, db, dedup, documents, persons, records
 
 RECORDS = {
     "lab_result": [
@@ -421,6 +422,9 @@ def test_cli_record_rm_json_shape_is_stable(cli_ready, capsys):
         # Appended by #114: the row-scoped curation verdicts retired with the row.
         # Appended, never inserted - the --json key set is a contract.
         "curation_retired",
+        # Appended by #129: the edit-ledger entries naming the row. Disclosed, not
+        # retired - the contrast with `curation_retired` is the point.
+        "edits_recorded",
     }
     capsys.readouterr()
     assert _run(cli_ready, "record", "rm", "lab_result", str(target), "--json") == 0
@@ -581,3 +585,676 @@ def test_cli_smoke_walks_the_whole_doubled_collision_loop(tmp_path, capsys):
 
     # 6. And the database is still internally consistent.
     assert _run(tmp_path, "verify", "--sources", str(tmp_path / "sources")) == 0
+
+
+# =============================================================================
+# in-place correction of non-key fields: `record edit` (issue #129)
+# =============================================================================
+#
+# The reporting case: stored values correct and on one scale, but the unit STRING
+# varies by whichever extraction submitted it (`lbs` beside `lb`, `F` beside `degF`).
+# Both pre-existing repairs — re-submitting through `commit-extraction`, or
+# delete-and-recommit — re-attribute the row to whichever document is passed, so a 2022
+# measurement ends up sourced to a 2026 chart export. `record edit` corrects the field
+# and leaves provenance alone.
+
+# One fully-populated payload per record type, plus a different-but-valid value for
+# every field. Used to prove the KEY_FIELDS/`_key_parts` agreement behaviourally, for
+# every type, rather than by eyeballing the two lists.
+FIELD_VALUES = {
+    "lab_result": {
+        "test_name": ("HbA1c", "Glucose"),
+        "loinc": ("4548-4", "2345-7"),
+        "value_num": (5.7, 6.1),
+        "value_text": ("normal", "high"),
+        "unit": ("%", "pct"),
+        "ref_low": (4.0, 3.5),
+        "ref_high": (6.0, 6.5),
+        "flag": ("H", "L"),
+        "collected_at": ("2026-01-02", "2026-02-03"),
+    },
+    "medication": {
+        "name": ("Metformin", "Insulin"),
+        "dose": ("500 mg", "1000 mg"),
+        "route": ("PO", "SC"),
+        "frequency": ("BID", "QD"),
+        "started_on": ("2025-06-01", "2025-07-01"),
+        "ended_on": ("2026-01-01", "2026-02-01"),
+        "prescriber": ("Dr Who", "Dr No"),
+        "status": ("active", "discontinued"),
+    },
+    "procedure": {
+        "name": ("Colonoscopy", "Endoscopy"),
+        "performed_on": ("2025-03-04", "2025-04-05"),
+        "provider": ("Dr Who", "Dr No"),
+        "outcome": ("normal", "abnormal"),
+    },
+    "appointment": {
+        "scheduled_for": ("2026-02-01", "2026-03-01"),
+        "provider": ("Dr Who", "Dr No"),
+        "specialty": ("cardiology", "neurology"),
+        "reason": ("follow-up", "consult"),
+        "summary": ("seen", "rescheduled"),
+    },
+    "observation": {
+        "obs_type": ("vital", "anthropometric"),
+        "observed_at": ("2026-01-02T09:00", "2026-01-03T09:00"),
+        "key": ("weight", "height"),
+        "value_num": (180.0, 175.0),
+        "value_text": ("one eighty", "one seventy five"),
+        "unit": ("lb", "lbs"),
+    },
+    "allergy": {
+        "substance": ("Penicillin", "Sulfa"),
+        "reaction": ("rash", "hives"),
+        "criticality": ("high", "low"),
+        "noted_on": ("2010-01-01", "2011-01-01"),
+    },
+    "condition": {
+        "name": ("Asthma", "Eczema"),
+        "status": ("active", "resolved"),
+        "onset_on": ("2024-01-01", "2025-01-01"),
+        "resolved_on": ("2026-01-01", "2026-02-01"),
+        "relation": ("mother", "father"),
+        "note": ("dx by PCP", "dx by specialist"),
+    },
+}
+
+# One key-participating change per type that really does move the dedup_key — the
+# positive direction, so the KEY_FIELDS test cannot pass by the key being inert.
+KEY_MOVES = {
+    "lab_result": {"test_name": "Glucose"},
+    "medication": {"dose": "1000 mg"},
+    "procedure": {"performed_on": "2025-04-05"},
+    "appointment": {"provider": "Dr No"},
+    "observation": {"key": "height"},
+    "allergy": {"substance": "Sulfa"},
+    # The one status change that moves the key: `_condition_subject` keys on the
+    # relative once the status is family-history, and on "self" for every other status.
+    "condition": {"status": "family-history"},
+}
+
+
+def _full_payload(record_type):
+    return {name: pair[0] for name, pair in FIELD_VALUES[record_type].items()}
+
+
+# --- KEY_FIELDS must stay true to dedup._key_parts ---------------------------
+
+
+@pytest.mark.parametrize("record_type", dedup.KNOWN_TYPES)
+def test_no_editable_field_can_move_the_dedup_key(record_type):
+    """The safety-critical direction, proved behaviourally for every type.
+
+    `record edit` derives its editable set as FIELD_SPECS - KEY_FIELDS, so if
+    KEY_FIELDS ever drifts from `dedup._key_parts` an "editable" field would silently
+    re-key a stored row. This is what stops that drift: mutate every non-key field, one
+    at a time, and require the key byte-identical each time.
+    """
+    base = _full_payload(record_type)
+    expected = dedup.dedup_key(record_type, base, 1)
+    editable = dedup.editable_fields(record_type)
+    assert editable, record_type
+    for name in editable:
+        other = FIELD_VALUES[record_type][name][1]
+        moved = {**base, name: other}
+        assert dedup.dedup_key(record_type, moved, 1) == expected, name
+        # And clearing it is equally key-neutral (`--set NAME=` writes None).
+        cleared = {**base, name: None}
+        assert dedup.dedup_key(record_type, cleared, 1) == expected, name
+
+
+@pytest.mark.parametrize("record_type", dedup.KNOWN_TYPES)
+def test_key_fields_really_do_move_the_key(record_type):
+    """The positive direction: a hand-listed key change per type moves the key, so the
+    test above is not passing because the key is inert."""
+    base = _full_payload(record_type)
+    moved = {**base, **KEY_MOVES[record_type]}
+    assert dedup.dedup_key(record_type, moved, 1) != dedup.dedup_key(
+        record_type, base, 1
+    )
+
+
+def test_editable_fields_excludes_identity_and_never_names_provenance():
+    for record_type in dedup.KNOWN_TYPES:
+        editable = set(dedup.editable_fields(record_type))
+        assert editable.isdisjoint(dedup.KEY_FIELDS[record_type])
+        assert editable == (
+            set(dedup.FIELD_SPECS[record_type]) - dedup.KEY_FIELDS[record_type]
+        )
+        # Provenance is out for free: it was never in FIELD_SPECS to begin with.
+        for column in ("document_id", "person_id", *dedup.INTERNAL_COLUMNS,
+                       *dedup.ATTESTATION_COLUMNS):
+            assert column not in editable
+
+
+def test_editable_fields_rejects_an_unknown_type():
+    with pytest.raises(ValueError, match="lab_result"):
+        dedup.editable_fields("family_history")
+
+
+# --- the module surface ------------------------------------------------------
+
+
+def _ledger(conn, record_type=None):
+    sql = "SELECT * FROM record_edit"
+    params = ()
+    if record_type is not None:
+        sql += " WHERE record_type = ?"
+        params = (record_type,)
+    return [dict(r) for r in conn.execute(sql + " ORDER BY record_edit_id", params)]
+
+
+def _row(conn, record_type, row_id):
+    return dict(conn.execute(
+        f"SELECT * FROM {record_type} WHERE {record_type}_id = ?", (row_id,)
+    ).fetchone())
+
+
+def test_dry_run_reports_the_change_and_writes_nothing(seeded):
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    before = _row(conn, "lab_result", target)
+    before_fts = _fts_ids(conn, "lab_result")
+
+    report = records.edit_record(
+        conn, "lab_result", target, {"unit": "percent"}, note="normalise the unit"
+    )
+
+    assert report.applied is False
+    assert report.changes == [{"field": "unit", "old": "%", "new": "percent"}]
+    assert report.unchanged == []
+    assert report.label == "HbA1c"
+    assert report.person_slug == "jane-doe"
+    assert report.document_id == seeded["doc"]
+    assert _row(conn, "lab_result", target) == before
+    assert _ledger(conn) == []
+    assert _fts_ids(conn, "lab_result") == before_fts
+
+
+def test_apply_moves_the_field_and_leaves_identity_and_provenance_alone(seeded):
+    """AC 1 and AC 4 together: the display field changes, and every column that says
+    where the fact came from or which fact it is stays bit-identical."""
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    before = _row(conn, "lab_result", target)
+
+    report = records.edit_record(
+        conn, "lab_result", target, {"unit": "percent", "flag": "H"},
+        note="normalise the unit", attributed_to="Jane", apply=True,
+    )
+
+    after = _row(conn, "lab_result", target)
+    assert after["unit"] == "percent" and after["flag"] == "H"
+    for column in ("document_id", "person_id", "test_name", "collected_at",
+                   "dedup_key", "dedup_base", "dedup_occurrence",
+                   *dedup.ATTESTATION_COLUMNS):
+        assert after[column] == before[column], column
+    assert report.applied is True
+
+    entries = _ledger(conn)
+    assert len(entries) == 2                       # one row per changed field
+    assert {e["field"] for e in entries} == {"unit", "flag"}
+    assert {e["edited_at"] for e in entries} == {report.edited_at}   # one act
+    unit_entry = next(e for e in entries if e["field"] == "unit")
+    assert (unit_entry["old_value"], unit_entry["new_value"]) == ("%", "percent")
+    assert unit_entry["record_type"] == "lab_result"
+    assert unit_entry["record_id"] == target
+    assert unit_entry["dedup_base"] == before["dedup_base"]
+    assert unit_entry["note"] == "normalise the unit"
+    assert unit_entry["attributed_to"] == "Jane"
+
+
+def test_editing_to_the_stored_value_is_a_no_op(seeded):
+    """A re-run must not accrete history: the ledger is append-only, so a second
+    identical `--apply` has to write nothing at all."""
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    records.edit_record(conn, "lab_result", target, {"unit": "percent"},
+                        note="normalise", apply=True)
+    assert len(_ledger(conn)) == 1
+
+    report = records.edit_record(conn, "lab_result", target, {"unit": "percent"},
+                                 note="normalise", apply=True)
+
+    assert report.changes == []
+    assert report.unchanged == ["unit"]
+    assert len(_ledger(conn)) == 1
+
+
+def test_a_numeric_no_op_compares_numerically(seeded):
+    """A numeric column round-trips out of SQLite as float, so `--set value_num=95`
+    against a stored 95.0 is a no-op, not a ledgered change."""
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "Glucose")
+    report = records.edit_record(conn, "lab_result", target, {"value_num": 95},
+                                 note="restate", apply=True)
+    assert report.changes == [] and report.unchanged == ["value_num"]
+    assert _ledger(conn) == []
+
+
+def test_clearing_a_field_nulls_it_and_ledgers_the_old_value(seeded):
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+
+    report = records.edit_record(conn, "lab_result", target, {"unit": None},
+                                 note="the source states no unit", apply=True)
+
+    assert report.changes == [{"field": "unit", "old": "%", "new": None}]
+    assert _row(conn, "lab_result", target)["unit"] is None
+    entry = _ledger(conn)[0]
+    assert (entry["old_value"], entry["new_value"]) == ("%", None)
+
+
+def test_every_known_type_can_be_edited(conn):
+    """The verb covers the whole typed record surface, not just lab_result."""
+    jane = persons.add_person(conn, "jane-doe", "Jane Doe")
+    doc_id = _insert_document(conn, jane.person_id, "cc33")
+    dedup.commit_extraction(
+        conn, doc_id,
+        {record_type: [_full_payload(record_type)]
+         for record_type in dedup.KNOWN_TYPES},
+    )
+    for record_type in dedup.KNOWN_TYPES:
+        row_id = int(conn.execute(
+            f"SELECT {record_type}_id FROM {record_type}"
+        ).fetchone()[f"{record_type}_id"])
+        name = dedup.editable_fields(record_type)[0]
+        before = _row(conn, record_type, row_id)
+        report = records.edit_record(
+            conn, record_type, row_id,
+            {name: FIELD_VALUES[record_type][name][1]},
+            note="correction", apply=True,
+        )
+        assert report.changes, record_type
+        after = _row(conn, record_type, row_id)
+        assert after["dedup_key"] == before["dedup_key"], record_type
+        assert after["document_id"] == before["document_id"], record_type
+
+
+# --- refusals: nothing is written on any raise -------------------------------
+
+
+def _assert_untouched(conn, record_type, row_id, before):
+    assert _row(conn, record_type, row_id) == before
+    assert _ledger(conn) == []
+
+
+def test_a_key_field_is_refused_and_points_at_the_right_operation(seeded):
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    before = _row(conn, "lab_result", target)
+    with pytest.raises(records.FieldNotEditableError) as exc:
+        records.edit_record(conn, "lab_result", target, {"test_name": "A1c"},
+                            note="rename", apply=True)
+    message = str(exc.value)
+    assert "identity" in message and "rekey" in message
+    assert "unit" in message                       # names the editable set
+    _assert_untouched(conn, "lab_result", target, before)
+
+
+def test_an_unknown_field_is_refused(seeded):
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    with pytest.raises(records.FieldNotEditableError, match="editable fields"):
+        records.edit_record(conn, "lab_result", target, {"colour": "blue"},
+                            note="n", apply=True)
+    assert _ledger(conn) == []
+
+
+def test_an_unknown_row_id_is_refused(seeded):
+    with pytest.raises(records.RecordNotFoundError):
+        records.edit_record(seeded["conn"], "lab_result", 9999, {"unit": "lb"},
+                            note="n", apply=True)
+
+
+def test_an_unknown_type_is_refused_by_edit(seeded):
+    with pytest.raises(ValueError, match="lab_result"):
+        records.edit_record(seeded["conn"], "family_history", 1, {"unit": "lb"},
+                            note="n")
+
+
+def test_no_updates_is_refused(seeded):
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    with pytest.raises(ValueError, match="at least one"):
+        records.edit_record(conn, "lab_result", target, {}, note="n", apply=True)
+
+
+def test_a_blank_note_is_refused(seeded):
+    """The `curation.annotate_record` rule: an unexplained mutation of a stored clinical
+    value is not an audit trail."""
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    before = _row(conn, "lab_result", target)
+    with pytest.raises(ValueError, match="note is required"):
+        records.edit_record(conn, "lab_result", target, {"unit": "percent"},
+                            note="   ", apply=True)
+    _assert_untouched(conn, "lab_result", target, before)
+
+
+@pytest.mark.parametrize("record_type,updates", [
+    ("lab_result", {"value_num": "abc"}),          # wrong type
+    ("medication", {"ended_on": "06/15/2026"}),    # non-ISO date
+    ("condition", {"note": 5}),                    # wrong type
+])
+def test_a_value_that_fails_validation_is_refused(conn, record_type, updates):
+    jane = persons.add_person(conn, "jane-doe", "Jane Doe")
+    doc_id = _insert_document(conn, jane.person_id, "dd44")
+    dedup.commit_extraction(conn, doc_id, {record_type: [_full_payload(record_type)]})
+    row_id = int(conn.execute(
+        f"SELECT {record_type}_id FROM {record_type}"
+    ).fetchone()[f"{record_type}_id"])
+    before = _row(conn, record_type, row_id)
+
+    with pytest.raises(dedup.ValidationError):
+        records.edit_record(conn, record_type, row_id, updates, note="n", apply=True)
+
+    _assert_untouched(conn, record_type, row_id, before)
+
+
+def test_an_enum_value_that_fails_validation_is_refused(conn):
+    """`allergy.criticality` is an ENUM_FIELDS column and editable — the enum rule has
+    to bind at edit time exactly as it does at commit."""
+    jane = persons.add_person(conn, "jane-doe", "Jane Doe")
+    doc_id = _insert_document(conn, jane.person_id, "ee55")
+    dedup.commit_extraction(conn, doc_id, {"allergy": [_full_payload("allergy")]})
+    row_id = int(conn.execute("SELECT allergy_id FROM allergy").fetchone()[0])
+    before = _row(conn, "allergy", row_id)
+
+    with pytest.raises(dedup.ValidationError, match="criticality"):
+        records.edit_record(conn, "allergy", row_id, {"criticality": "extreme"},
+                            note="n", apply=True)
+
+    _assert_untouched(conn, "allergy", row_id, before)
+
+
+# --- the seams the plan calls risky ------------------------------------------
+
+
+def test_the_fts_row_follows_an_edit(conn):
+    """Migration 003's AFTER UPDATE trigger does this. `observation.value_text` is the
+    field that proves it: it is editable AND indexed (the trigger indexes `key` +
+    `value_text`; `unit` is deliberately not in the FTS text at all)."""
+    jane = persons.add_person(conn, "jane-doe", "Jane Doe")
+    doc_id = _insert_document(conn, jane.person_id, "ff66")
+    dedup.commit_extraction(conn, doc_id, {"observation": [
+        {"obs_type": "vital", "observed_at": "2026-01-02T09:00", "key": "weight",
+         "value_text": "onehundredeighty"},
+    ]})
+    row_id = int(conn.execute("SELECT observation_id FROM observation").fetchone()[0])
+
+    def _matches(token):
+        return [int(r["source_id"]) for r in conn.execute(
+            "SELECT source_id FROM record_fts WHERE source_table = 'observation' "
+            "AND record_fts MATCH ?", (token,)
+        ).fetchall()]
+
+    assert _matches("onehundredeighty") == [row_id]
+
+    records.edit_record(conn, "observation", row_id,
+                        {"value_text": "onehundredseventyfive"},
+                        note="transcription error", apply=True)
+
+    assert _matches("onehundredseventyfive") == [row_id]
+    assert _matches("onehundredeighty") == []
+
+
+def test_curation_verdicts_in_both_scopes_survive_an_edit(seeded):
+    """No editable field feeds the key, so `dedup_base` never moves — which means an
+    edit orphans nothing, in either scope (contrast `rekey`, issue #126)."""
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    base = _row(conn, "lab_result", target)["dedup_base"]
+    curation.annotate_record(conn, "lab_result", base, status="confirmed",
+                             note="family verdict", apply=True)
+    curation.annotate_record(conn, "lab_result", str(target), status="disputed",
+                             note="row verdict", row=True, apply=True)
+
+    records.edit_record(conn, "lab_result", target, {"unit": "percent"},
+                        note="normalise", apply=True)
+
+    verdicts = curation.load_verdicts(conn)
+    assert verdicts.family[("lab_result", base)]["status"] == "confirmed"
+    assert verdicts.rows[("lab_result", target)]["status"] == "disputed"
+    # Neither is orphaned: both still resolve to a live target.
+    assert all(entry["family_size"] for entry in curation.list_curation(conn))
+
+
+def test_record_rm_discloses_the_ledger_and_keeps_it(seeded):
+    """The opposite ending to a row-scoped verdict (issue #114): the verdict is retired
+    with the row, the ledger entry is disclosed and kept — nothing resolves through it,
+    and retiring it would destroy the audit trail."""
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    base = _row(conn, "lab_result", target)["dedup_base"]
+    records.edit_record(conn, "lab_result", target, {"unit": "percent"},
+                        note="normalise", apply=True)
+    curation.annotate_record(conn, "lab_result", str(target), status="disputed",
+                             note="row verdict", row=True, apply=True)
+
+    dry = records.remove_record(conn, "lab_result", target)
+    assert [e["field"] for e in dry.edits_recorded] == ["unit"]
+    assert dry.edits_recorded[0]["dedup_base"] == base
+    assert len(dry.curation_retired) == 1
+
+    records.remove_record(conn, "lab_result", target, apply=True)
+
+    assert len(_ledger(conn)) == 1                      # kept
+    assert curation.row_verdicts_for(conn, "lab_result", [target]) == []   # retired
+    # And the entry is still listable, annotated as naming no live row.
+    listed = records.list_edits(conn)
+    assert len(listed) == 1 and listed[0]["label"] == ""
+
+
+def test_re_ingesting_the_original_document_stages_a_conflict_after_a_correction(
+    seeded,
+):
+    """Pinned deliberately: `unit` is one of `dedup._COMPARE_FIELDS`, so once a unit is
+    corrected the original document no longer matches the stored row and re-committing
+    it stages a CONFLICT rather than deduping. Loud and correct — the divergence is
+    real — and the sharpest argument for #136."""
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    original = RECORDS["lab_result"][0]
+
+    # Before the edit, re-committing the same payload is a plain duplicate.
+    doc2 = _insert_document(conn, seeded["jane"].person_id, "9999aaaa")
+    assert dedup.commit_extraction(
+        conn, doc2, {"lab_result": [original]}
+    ).counts["duplicate"] == 1
+
+    records.edit_record(conn, "lab_result", target, {"unit": "percent"},
+                        note="normalise", apply=True)
+
+    doc3 = _insert_document(conn, seeded["jane"].person_id, "9999bbbb")
+    summary = dedup.commit_extraction(conn, doc3, {"lab_result": [original]})
+    assert summary.counts["conflict"] == 1
+    assert summary.counts["duplicate"] == 0
+
+
+def test_list_edits_is_empty_on_a_database_predating_the_migration(seeded):
+    """The `curation.has_table` guard: a restored older snapshot reports no edits rather
+    than raising `no such table`."""
+    conn = seeded["conn"]
+    conn.execute("DROP TABLE record_edit")
+    conn.commit()
+    assert records.has_edit_table(conn) is False
+    assert records.list_edits(conn) == []
+    assert records.edits_for_rows(conn, "lab_result", [1]) == []
+    # And `record rm` still works against it.
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    assert records.remove_record(conn, "lab_result", target).edits_recorded == []
+
+
+# --- the reporter's scenario, end to end -------------------------------------
+
+
+def test_the_reporters_unit_normalisation_scenario(conn):
+    """Issue #129's own case: a majority unit beside a minority spelling of it. Correct
+    the minority rows, and `rekey` stays clean while every corrected row still points at
+    the document it came from (AC 4)."""
+    jane = persons.add_person(conn, "jane-doe", "Jane Doe")
+    majority_doc = _insert_document(conn, jane.person_id, "a" * 16)
+    minority_doc = _insert_document(conn, jane.person_id, "b" * 16)
+
+    def _weights(count, unit, start_day):
+        return [
+            {"obs_type": "vital", "observed_at": f"2026-01-{start_day + i:02d}T09:00",
+             "key": "weight", "value_num": 180.0 + i, "unit": unit}
+            for i in range(count)
+        ]
+
+    dedup.commit_extraction(conn, majority_doc, {"observation": _weights(5, "lb", 1)})
+    dedup.commit_extraction(conn, minority_doc, {"observation": _weights(3, "lbs", 10)})
+
+    doomed = [
+        (int(r["observation_id"]), r["document_id"], r["dedup_key"])
+        for r in conn.execute(
+            "SELECT * FROM observation WHERE unit = 'lbs' ORDER BY observation_id"
+        ).fetchall()
+    ]
+    assert len(doomed) == 3
+
+    for row_id, _doc, _key in doomed:
+        records.edit_record(conn, "observation", row_id, {"unit": "lb"},
+                            note="normalise unit label to the majority spelling",
+                            attributed_to="Jane", apply=True)
+
+    assert conn.execute(
+        "SELECT COUNT(*) AS n FROM observation WHERE unit = 'lb'"
+    ).fetchone()["n"] == 8
+    # AC 4: provenance and identity untouched on every corrected row.
+    for row_id, document_id, key in doomed:
+        after = _row(conn, "observation", row_id)
+        assert after["document_id"] == document_id
+        assert after["dedup_key"] == key
+    # AC 2: a discoverable audit trail, one entry per corrected row.
+    assert len(records.list_edits(conn, "observation")) == 3
+    # And the identity layer is untouched by the whole batch.
+    assert dedup.rekey(conn).collisions == []
+    assert dedup.rekey(conn).changes == []
+
+
+# --- CLI surface -------------------------------------------------------------
+
+
+def _cli_field(tmp_path, record_type, row_id, column):
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        return _row(conn, record_type, row_id)[column]
+    finally:
+        conn.close()
+
+
+def test_cli_record_edit_dry_run(cli_ready, capsys):
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "HbA1c")
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "edit", "lab_result", str(target),
+                "--set", "unit=percent", "--note", "normalise") == 0
+    out = capsys.readouterr().out
+    assert f"lab_result #{target}" in out
+    assert "unit: % -> percent" in out
+    assert "document: #1 (unchanged - a correction is not a re-attribution)" in out
+    assert "dry run: nothing was written - re-run with --apply" in out
+    assert _cli_field(cli_ready, "lab_result", target, "unit") == "%"
+
+
+def test_cli_record_edit_apply(cli_ready, capsys):
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "HbA1c")
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "edit", "lab_result", str(target),
+                "--set", "unit=percent", "--note", "normalise",
+                "--attributed-to", "Jane", "--apply") == 0
+    out = capsys.readouterr().out
+    assert f"corrected lab_result #{target}" in out
+    assert _cli_field(cli_ready, "lab_result", target, "unit") == "percent"
+
+
+def test_cli_record_edit_clears_with_a_bare_name(cli_ready, capsys):
+    """`document edit`'s documented `"" clears` convention, carried over."""
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "HbA1c")
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "edit", "lab_result", str(target),
+                "--set", "unit=", "--note", "the source states no unit",
+                "--apply") == 0
+    assert "unit: % -> (none)" in capsys.readouterr().out
+    assert _cli_field(cli_ready, "lab_result", target, "unit") is None
+
+
+def test_cli_record_edit_json_shape_is_stable(cli_ready, capsys):
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "HbA1c")
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "edit", "lab_result", str(target),
+                "--set", "unit=percent", "--note", "normalise", "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == {
+        "record_type", "row_id", "person", "person_id", "document_id", "label",
+        "changes", "unchanged", "dedup_key", "dedup_base", "dedup_occurrence",
+        "note", "attributed_to", "edited_at", "applied",
+    }
+    assert payload["changes"] == [{"field": "unit", "old": "%", "new": "percent"}]
+    assert payload["applied"] is False
+
+
+def test_cli_record_rm_json_gained_the_edit_disclosure(cli_ready, capsys):
+    """Appended, never inserted: the `record rm` --json key set is a contract."""
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "HbA1c")
+    assert _run(cli_ready, "record", "edit", "lab_result", str(target),
+                "--set", "unit=percent", "--note", "normalise", "--apply") == 0
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "rm", "lab_result", str(target), "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [e["field"] for e in payload["edits_recorded"]] == ["unit"]
+
+
+def test_cli_record_edit_list(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "edit", "--list") == 0
+    assert "no record corrections recorded" in capsys.readouterr().out
+
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "HbA1c")
+    assert _run(cli_ready, "record", "edit", "lab_result", str(target),
+                "--set", "unit=percent", "--note", "normalise", "--apply") == 0
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "edit", "--list", "lab_result") == 0
+    out = capsys.readouterr().out
+    assert "unit: % -> percent" in out and "HbA1c" in out
+
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "edit", "--list", "--json") == 0
+    entries = json.loads(capsys.readouterr().out)
+    assert len(entries) == 1 and entries[0]["field"] == "unit"
+
+
+def test_cli_record_edit_refusals_are_friendly_rc1(cli_ready, capsys):
+    target = _cli_row_id(cli_ready, "lab_result", "test_name", "HbA1c")
+    capsys.readouterr()
+    assert _run(cli_ready, "record", "edit", "lab_result", str(target),
+                "--set", "test_name=A1c", "--note", "rename", "--apply") == 1
+    assert "part of the row's identity" in capsys.readouterr().err
+
+    assert _run(cli_ready, "record", "edit", "lab_result", "9999",
+                "--set", "unit=lb", "--note", "n", "--apply") == 1
+    assert "no lab_result with id 9999" in capsys.readouterr().err
+
+    assert _run(cli_ready, "record", "edit", "lab_result", str(target),
+                "--set", "value_num=abc", "--note", "n", "--apply") == 1
+    assert "value_num" in capsys.readouterr().err
+    assert _cli_field(cli_ready, "lab_result", target, "unit") == "%"
+
+
+@pytest.mark.parametrize("argv", [
+    ("record", "edit", "lab_result", "1", "--set", "unit", "--note", "n"),
+    ("record", "edit", "lab_result", "1", "--set", "unit=a", "--set", "unit=b",
+     "--note", "n"),
+    ("record", "edit", "lab_result", "1", "--set", "colour=blue", "--note", "n"),
+    ("record", "edit", "lab_result", "1", "--note", "n"),          # no --set
+    ("record", "edit", "lab_result", "1", "--set", "unit=lb"),     # no --note
+    ("record", "edit", "lab_result", "--set", "unit=lb", "--note", "n"),  # no row id
+    ("record", "edit", "family_history", "1", "--set", "unit=lb", "--note", "n"),
+])
+def test_cli_record_edit_misuse_is_argparse_rc2(cli_ready, argv):
+    with pytest.raises(SystemExit) as exc:
+        _run(cli_ready, *argv)
+    assert exc.value.code == 2

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1258,3 +1258,128 @@ def test_cli_record_edit_misuse_is_argparse_rc2(cli_ready, argv):
     with pytest.raises(SystemExit) as exc:
         _run(cli_ready, *argv)
     assert exc.value.code == 2
+
+
+# --- smoke: the correction loop, end to end through the CLI ------------------
+
+
+def _commit_plain(tmp_path, name, document, payload):
+    """`_commit` without a dictionary override - this story needs no synonym edit."""
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    assert _run(tmp_path, "commit-extraction", "--document", str(document),
+                "--json", str(path)) == 0
+
+
+def _weights(unit, month, first_value):
+    return [
+        {"obs_type": "vital", "observed_at": f"{month}-0{i}T09:00", "key": "weight",
+         "value_num": first_value + i, "unit": unit}
+        for i in (1, 2, 3)
+    ]
+
+
+def _observation_identity(tmp_path, where):
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        return {
+            int(r["observation_id"]): (r["document_id"], r["dedup_key"])
+            for r in conn.execute(
+                f"SELECT * FROM observation WHERE {where} ORDER BY observation_id"
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+
+
+def test_cli_smoke_walks_the_reporters_correction_loop(tmp_path, capsys):
+    """The issue's operator story, driven entirely through the CLI (issue #129).
+
+    The engine-level test builds the corpus with `dedup.commit_extraction`; this one earns
+    it the way an operator does - a 2026 chart export spelling the unit `lb` beside a 2022
+    outside note spelling it `lbs`, the exact provenance trap the issue reports - and then
+    walks the whole loop: dry run (AC 3) -> `--apply` per row (AC 1) -> `record edit
+    --list` (AC 2) -> `rekey`/`verify` still clean with every corrected row still on its
+    own document (AC 4) -> `record rm` disclosing the append-only ledger -> re-committing
+    the original extraction staging a conflict rather than silently deduping.
+    """
+    assert _run(tmp_path, "migrate", "--create") == 0
+    assert _run(tmp_path, "person", "add", "--slug", "jane-doe", "--name", "Jane") == 0
+    _ingest(tmp_path, "chart.txt", b"2026 chart export: weights recorded in lb")
+    _ingest(tmp_path, "outside.txt", b"2022 outside clinic note: weights in lbs")
+    _commit_plain(tmp_path, "chart.json", 1,
+                  {"observation": _weights("lb", "2026-01", 180.0)})
+    _commit_plain(tmp_path, "outside.json", 2,
+                  {"observation": _weights("lbs", "2022-06", 175.0)})
+
+    # The minority spelling: three rows, sourced to the 2022 note. Re-submitting them
+    # through `commit-extraction` is what would re-attribute them to the 2026 export.
+    before = _observation_identity(tmp_path, "unit = 'lbs'")
+    assert len(before) == 3
+    assert {doc for doc, _key in before.values()} == {2}
+    targets = sorted(before)
+
+    # 1. AC 3: dry run is the default, and it writes nothing.
+    capsys.readouterr()
+    assert _run(tmp_path, "record", "edit", "observation", str(targets[0]),
+                "--set", "unit=lb", "--note", "normalise unit label") == 0
+    dry = capsys.readouterr().out
+    assert "unit: lbs -> lb" in dry
+    assert "document: #2 (unchanged - a correction is not a re-attribution)" in dry
+    assert "dry run: nothing was written - re-run with --apply" in dry
+    assert _cli_field(tmp_path, "observation", targets[0], "unit") == "lbs"
+    assert _run(tmp_path, "record", "edit", "--list") == 0
+    assert "no record corrections recorded" in capsys.readouterr().out
+
+    # 2. AC 1: --apply corrects each minority row in place.
+    for row_id in targets:
+        assert _run(tmp_path, "record", "edit", "observation", str(row_id),
+                    "--set", "unit=lb", "--note", "normalise unit label to `lb`",
+                    "--attributed-to", "Jane", "--apply") == 0
+        assert f"corrected observation #{row_id}" in capsys.readouterr().out
+    assert _cli_count(tmp_path, "observation") == 6
+    assert _observation_identity(tmp_path, "unit = 'lb'").keys() == set(range(1, 7))
+
+    # 3. AC 4: provenance and identity are bit-identical on every corrected row - the
+    #    failure both pre-existing workarounds have.
+    after = _observation_identity(tmp_path, "unit = 'lb'")
+    assert {row_id: after[row_id] for row_id in targets} == before
+
+    # 4. AC 2: a discoverable audit trail, one entry per corrected row.
+    capsys.readouterr()
+    assert _run(tmp_path, "record", "edit", "--list", "observation", "--json") == 0
+    entries = json.loads(capsys.readouterr().out)
+    assert [e["record_id"] for e in entries] == sorted(targets, reverse=True)
+    assert {(e["field"], e["old"], e["new"], e["attributed_to"]) for e in entries} == {
+        ("unit", "lbs", "lb", "Jane")
+    }
+
+    # 5. The identity layer never noticed: no rekey work, and the database still verifies
+    #    (with the new ledger counted).
+    capsys.readouterr()
+    assert _run(tmp_path, "rekey") == 0
+    assert "all dedup keys already match" in capsys.readouterr().out
+    assert _run(tmp_path, "verify", "--sources", str(tmp_path / "sources")) == 0
+    verified = capsys.readouterr().out
+    assert "integrity      ok" in verified
+    assert "record_edit    3" in verified
+
+    # 6. `record rm` discloses the ledger entries naming a doomed row - and the ledger is
+    #    append-only, so they are disclosed as kept history, never retired.
+    capsys.readouterr()
+    assert _run(tmp_path, "record", "rm", "observation", str(targets[0])) == 0
+    disclosure = capsys.readouterr().out
+    assert "1 recorded correction(s) name this row" in disclosure
+    assert "append-only" in disclosure and "unit: lbs -> lb" in disclosure
+
+    # 7. The deliberate behaviour change: re-committing the *original* extraction now
+    #    stages a conflict where it previously deduped. The divergence is real - the
+    #    stored row no longer says what its document says - so it is loud, not silent.
+    capsys.readouterr()
+    payload = tmp_path / "outside.json"
+    assert _run(tmp_path, "commit-extraction", "--document", "2",
+                "--json", str(payload)) == 0
+    recommit = capsys.readouterr().out
+    assert "0 new, 0 duplicate, 0 enriched, 3 conflict" in recommit
+    assert "review-conflicts" in recommit
+    assert _cli_count(tmp_path, "observation") == 6


### PR DESCRIPTION
## Summary

Adds `pemr record edit`, a CLI verb to correct a non-key display field (e.g. a
mislabelled unit) on an existing record row in place, leaving `document_id`,
`dedup_key` and the source blob untouched, with an append-only audit ledger of
every correction.

- `dedup.KEY_FIELDS` / `dedup.editable_fields()` name the identity fields once;
  the editable set for `--set` is derived as `FIELD_SPECS - KEY_FIELDS`, so
  provenance and identity columns are unreachable by construction, not by a
  denylist.
- Migration `012_record_edit.sql` — additive append-only ledger table
  (`record_edit`), one row per changed field, sharing one `edited_at` per
  command.
- `records.edit_record` / `list_edits` / `edits_for_rows` / `has_edit_table`;
  `record rm` now discloses (never retires) ledger entries naming the row it
  removes.
- CLI: `record edit <table> <id> --set NAME=VALUE [--set ...] --note <text>
  [--attributed-to ...] [--apply]` and `record edit --list [<table>] [--json]`,
  dry-run by default.
- `record edit` is CLI-only — excluded from `mcp_server.WRITE_TOOLS` and
  `TOOL_NAMES`, same trust boundary as `record rm`/`record annotate`/`record
  assert`.
- Docs: `docs/Architecture.md` (§2 schema + rationale, §5 CLI listing, §6 MCP
  exclusion list) and `AGENTS.md` (CLI-only / never-an-MCP-tool paragraph)
  updated in the same commit as the implementation.
- Deliberate, documented behavior: since `unit` is a compared payload field,
  re-ingesting the original document after a unit correction now stages a
  conflict rather than silently deduping — this is correct, not a bug (see
  Architecture.md §2).
- Dictionary-driven unit normalisation (the issue's option 2) is explicitly
  deferred to #136, not silently dropped.

Closes #129

**Reports:** [design plan](https://github.com/meridun/pemr/issues/129#issuecomment-5299575369) · [build](https://github.com/meridun/pemr/issues/129#issuecomment-5299998287) · [verify](https://github.com/meridun/pemr/issues/129#issuecomment-5300045498) · [audit](https://github.com/meridun/pemr/issues/129#issuecomment-5300081115)

## Test plan
- [x] Full suite green at verify (1070 passed)
- [x] Targeted re-run after merging `origin/dev` (`tests/test_records.py`,
      `tests/test_mcp_server.py`, `tests/test_db.py`) — all green, no
      conflicts from the merge (only unrelated `prompts/sdlc/`,
      `scripts/sdlc.mjs`, `test/sdlc.test.mjs` overlap)
- [x] Audit pass: no blocking findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)