### PR TITLE
fix(query): consult the curation overlay in meds/labs/timeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,12 @@ side: it mutates a *stored clinical value* with no new source backing the change
 matching what its document says on one person's say-so — which is exactly the kind of write that
 must carry a named human, not an agent.
 
+The verbs above are CLI-only; verdict *content* is not. Since issue #131, `query`
+(`kind` = `labs`/`meds`/`timeline`) carries each row's `curation` verdict on the MCP read
+payload, same as `--json` — an agent reading `query` sees which rows a human has marked
+`superseded`, `erroneous-in-source`, `merged-into`, or `disputed`, and why. That is unchanged
+from the rule above: an agent may read a verdict, never write or clear one.
+
 ## MUST rules
 
 ### 1. Extraction naming

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -918,9 +918,15 @@ pemr document tombstone add (--file <path> | --sha256 <hex>) [--reason ...] [--n
                                                          # pre-emptive exclusion; ingests and copies nothing
 pemr document tombstone rm <sha256>                      # lift one (full hash only)
 pemr document set-text <id> --ocr-text-file <path> [--force]     # attach/replace ocr_text after ingest; FTS follows via trigger
-pemr query labs --person jane --test hba1c --since 2023-01-01
-pemr query meds --person jane --active
-pemr query timeline --person jane --since 2024-01-01     # merged event stream
+pemr query labs --person jane --test hba1c --since 2023-01-01 [--raw]
+pemr query meds --person jane --active [--raw]
+pemr query timeline --person jane --since 2024-01-01 [--raw] # merged event stream
+                                                         # all three (issue #131): filtered at read
+                                                         # time against the curation overlay, same
+                                                         # rule §6 describes for render - a suppressed
+                                                         # row prints a "N hidden; --raw to include"
+                                                         # note; --raw restores them, marked; --json
+                                                         # always carries the verdict regardless
 pemr find --person jane "cholesterol"                    # full-text over ocr_text + records
 pemr find "mmr booster"                                  # omit --person: whole-household, slug-prefixed hits
 pemr trends --person jane --test hba1c                   # min/max/latest/slope
@@ -958,6 +964,13 @@ replace is CLI-only), `review_conflicts` (resolution gated on human sign-off). E
 same `--json`-shaped payload as the CLI; the MCP server (`pemr/mcp_server.py`) parses args and
 calls the same Python functions the CLI calls — one implementation, two front doors. `readOnlyHint`
 annotations expose the read/write split to the client.
+
+Since issue #131, `query`'s MCP payload also carries the `curation` overlay — every row/event
+that resolved a verdict is annotated, unfiltered (the MCP surface mirrors `--json`, never the
+human view's suppression). The nested verdict's `dedup_base` is a **breadcrumb, never a lookup
+key** (§2/§3): it can go stale across a `rekey`, so a caller keys on `status`, not on it. This is
+the one place verdict *content* reaches an agent — the write verbs (`record annotate`,
+`record reaffirm`, below) stay CLI-only regardless.
 
 `AGENTS.md` documents this contract so any agent (Cowork, Claude Code, local) knows to
 **call tools, not reinvent** — and specifically: never write to the DB except through
@@ -1010,7 +1023,19 @@ with no verdicts renders byte-identically to before the overlay existed. This do
 the purity rule: the filter is a read, and output changes after a verdict because the
 *database* changed. Resolution is **per row**: a row-scoped verdict affects only its own
 occurrence — the sibling of a `--keep both` pair renders untouched — and beats the family
-verdict for that row. One consequence of the read-time join: if a dictionary-driven `rekey`
+verdict for that row.
+
+The read layer's three `query` verbs (`meds`/`labs`/`timeline`, §5) apply the same rule as of
+issue #131, via shared stampers in `pemr/curation.py` (`annotate_rows`/`annotate_events`) that
+`render` now delegates to rather than duplicates: their default human-readable output suppresses
+appendix-status rows the same way, `--raw` opts back into the unfiltered view (marked), and
+`--json` — like the MCP `query` tool, §5 — always carries the verdict under a `_curation` key
+regardless of suppression, so a programmatic caller can filter for itself. That verdict payload
+is now part of the `--json` **and MCP** read contract: its `dedup_base` is a breadcrumb (§2/§3),
+not a lookup key, since a dictionary `rekey` can move it out from under a stale reference — a
+consumer should key on `status`, not on it.
+
+One consequence of the read-time join: if a dictionary-driven `rekey`
 (§3) has renamed a family since its verdict was recorded, a *family*-scoped verdict's join
 misses and the family renders as if unannotated (`pemr verify` flags the orphan; nothing
 re-attaches it automatically). A *row*-scoped verdict is immune — it joins on the row id,

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -2343,6 +2343,19 @@ def _resolved_as(result: dedup.ResolveResult) -> str:
 # Internal columns never emitted in --json (unstable / not part of the contract).
 _HIDDEN_FIELDS = dedup.INTERNAL_COLUMNS
 
+# The keys `query.query_timeline(with_identity=True)` adds so the curation overlay can
+# resolve an event (issue #131). They are resolution scaffolding, not output: stripped
+# again before **both** the human and the --json path, because `dedup_base` is one of
+# :data:`dedup.INTERNAL_COLUMNS` and letting it reach --json would break the same read
+# contract :func:`_clean` enforces for rows.
+_QUERY_IDENTITY_KEYS = ("record_type", "dedup_base", "record_id")
+
+# One help string for the three `query` subcommands' --raw flag (issue #131).
+_RAW_HELP = (
+    "ignore the curation overlay: include superseded/corrected rows in the listing "
+    "(--json is unaffected; it always carries the verdict)"
+)
+
 
 def _clean(row: dict) -> dict:
     """Strip a record row down to its ``--json`` contract (:func:`dedup.public_row`).
@@ -2379,19 +2392,65 @@ def _with_conn_person(args: argparse.Namespace, work):
         conn.close()
 
 
+def _verdict_suffix(carrier: dict, *, raw: bool = False) -> str:
+    """The marker one listed row/event carries because of its curation verdict.
+
+    ``""`` for an unannotated carrier, and for ``confirmed``/``distinct`` — both record
+    that the row renders exactly as filed. ``disputed`` reuses
+    :func:`render._dispute_suffix` verbatim (the precedent `_cmd_query_labs` already sets
+    with :func:`render._ref_range`), so the one ``[DISPUTED: ...]`` format is written
+    once. An :data:`curation.APPENDIX_STATUSES` verdict is marked **only under
+    ``--raw``** — in the default view that row is not printed at all, and a raw listing
+    has to say which rows the overlay would have hidden.
+    """
+    verdict = curation.verdict_of(carrier)
+    if verdict is None:
+        return ""
+    if verdict["status"] == "disputed":
+        return render._dispute_suffix(carrier)
+    if raw and verdict["status"] in curation.APPENDIX_STATUSES:
+        return f"  [{curation.describe(verdict)}]"
+    return ""
+
+
+def _visible(carriers: list[dict], *, raw: bool) -> list[dict]:
+    """The carriers a human-readable listing prints: everything under ``--raw``, else
+    everything the curation overlay has not sent to the appendix."""
+    if raw:
+        return carriers
+    return [c for c in carriers if not curation.is_appendix(c)]
+
+
+def _hidden_note(hidden: int, noun: str) -> str:
+    """The trailing line disclosing what the overlay suppressed.
+
+    Printed whenever anything was hidden — **including** when everything was, alongside
+    the "no ..." line. Silently shortening a clinical list is the one failure this
+    feature must not introduce, so it follows the disclose-don't-drop rule
+    `trends.other_assays` and render's appendix section already do.
+    """
+    return f"({hidden} superseded/corrected {noun} hidden; --raw to include)"
+
+
 def _cmd_query_labs(args: argparse.Namespace) -> int:
     def work(conn):
         dictionary = dedup.load_dictionary(_resolve_dictionary_path(args))
         rows = query.query_labs(
             conn, args.person, test=args.test, since=args.since, dictionary=dictionary
         )
+        # The curation overlay (issue #131): `render summary` has consulted it since
+        # #109, and a `query` that did not made the two verbs disagree about what is
+        # live. Always stamped, never suppressed in --json — a programmatic caller
+        # filters for itself.
+        rows = curation.annotate_rows(rows, "lab_result", curation.load_verdicts(conn))
         if args.json:
             _print_json([_clean(r) for r in rows])
             return 0
-        if not rows:
+        shown = _visible(rows, raw=args.raw)
+        hidden = len(rows) - len(shown)
+        if not shown:
             print("no lab results")
-            return 0
-        for r in rows:
+        for r in shown:
             value = r["value_num"] if r["value_num"] is not None else r["value_text"]
             unit = f" {r['unit']}" if r["unit"] else ""
             flag = f"  [{r['flag']}]" if r["flag"] else ""
@@ -2399,7 +2458,9 @@ def _cmd_query_labs(args: argparse.Namespace) -> int:
             # as "(ref <= 20)" / "(ref >= 8)" instead of a bogus "(ref -20.0)".
             ref = render._ref_range(r)
             print(f"{_fmt(r['collected_at']):19}  {r['test_name']:20}  "
-                  f"{_fmt(value)}{unit}{flag}{ref}")
+                  f"{_fmt(value)}{unit}{flag}{ref}{_verdict_suffix(r, raw=args.raw)}")
+        if hidden:
+            print(_hidden_note(hidden, "lab results"))
         return 0
 
     return _with_conn_person(args, work)
@@ -2408,13 +2469,15 @@ def _cmd_query_labs(args: argparse.Namespace) -> int:
 def _cmd_query_meds(args: argparse.Namespace) -> int:
     def work(conn):
         rows = query.query_meds(conn, args.person, active=args.active)
+        rows = curation.annotate_rows(rows, "medication", curation.load_verdicts(conn))
         if args.json:
             _print_json([_clean(r) for r in rows])
             return 0
-        if not rows:
+        shown = _visible(rows, raw=args.raw)
+        hidden = len(rows) - len(shown)
+        if not shown:
             print("no active medications" if args.active else "no medications")
-            return 0
-        for r in rows:
+        for r in shown:
             dose = f"  {r['dose']}" if r["dose"] else ""
             freq = f"  {r['frequency']}" if r["frequency"] else ""
             if r["ended_on"]:
@@ -2425,7 +2488,10 @@ def _cmd_query_meds(args: argparse.Namespace) -> int:
                 end = " -> (ended)"
             span = _fmt(r["started_on"]) + end
             status = f"  [{r['status']}]" if r["status"] else ""
-            print(f"{r['name']:24}{dose}{freq}  {span}{status}")
+            print(f"{r['name']:24}{dose}{freq}  {span}{status}"
+                  f"{_verdict_suffix(r, raw=args.raw)}")
+        if hidden:
+            print(_hidden_note(hidden, "medications"))
         return 0
 
     return _with_conn_person(args, work)
@@ -2433,16 +2499,30 @@ def _cmd_query_meds(args: argparse.Namespace) -> int:
 
 def _cmd_query_timeline(args: argparse.Namespace) -> int:
     def work(conn):
-        events = query.query_timeline(conn, args.person, since=args.since)
+        # `render_journal`'s idiom: ask for row identity only when there is a verdict to
+        # resolve, so an unannotated database builds the exact event shape it always has.
+        verdicts = curation.load_verdicts(conn)
+        events = query.query_timeline(
+            conn, args.person, since=args.since, with_identity=bool(verdicts)
+        )
+        curation.annotate_events(events, verdicts)
+        events = [
+            {k: v for k, v in e.items() if k not in _QUERY_IDENTITY_KEYS}
+            for e in events
+        ]
         if args.json:
             _print_json(events)
             return 0
-        if not events:
+        shown = _visible(events, raw=args.raw)
+        hidden = len(events) - len(shown)
+        if not shown:
             print("no events")
-            return 0
-        for e in events:
+        for e in shown:
             prov = f"  (doc #{e['document_id']})" if e["document_id"] is not None else ""
-            print(f"{e['date']:10}  {e['type']:12}  {e['summary']}{prov}")
+            print(f"{e['date']:10}  {e['type']:12}  {e['summary']}{prov}"
+                  f"{_verdict_suffix(e, raw=args.raw)}")
+        if hidden:
+            print(_hidden_note(hidden, "events"))
         return 0
 
     return _with_conn_person(args, work)
@@ -3250,12 +3330,14 @@ def build_parser() -> argparse.ArgumentParser:
     q_labs.add_argument("--since", help="ISO date; keep rows on/after this date")
     q_labs.add_argument("--dictionary", help="synonym dictionary TOML (overrides default)")
     q_labs.add_argument("--json", action="store_true", help="machine-readable output")
+    q_labs.add_argument("--raw", action="store_true", help=_RAW_HELP)
     q_labs.set_defaults(func=_cmd_query_labs)
 
     q_meds = query_sub.add_parser("meds", help="medications for a person")
     q_meds.add_argument("--person", required=True, help="owner slug")
     q_meds.add_argument("--active", action="store_true", help="current meds only")
     q_meds.add_argument("--json", action="store_true", help="machine-readable output")
+    q_meds.add_argument("--raw", action="store_true", help=_RAW_HELP)
     q_meds.set_defaults(func=_cmd_query_meds)
 
     q_timeline = query_sub.add_parser(
@@ -3264,6 +3346,7 @@ def build_parser() -> argparse.ArgumentParser:
     q_timeline.add_argument("--person", required=True, help="owner slug")
     q_timeline.add_argument("--since", help="ISO date; keep events on/after this date")
     q_timeline.add_argument("--json", action="store_true", help="machine-readable output")
+    q_timeline.add_argument("--raw", action="store_true", help=_RAW_HELP)
     q_timeline.set_defaults(func=_cmd_query_timeline)
 
     p_find = sub.add_parser("find", help="full-text search over OCR text + record fields")

--- a/pemr/curation.py
+++ b/pemr/curation.py
@@ -14,6 +14,9 @@ write it.
     list_curation        -- every verdict, newest first
     clear_curation       -- lift one verdict, dry-run by default
     load_verdicts        -- the whole table as a lookup, for the render/verify hot path
+    annotate_rows        -- stamp a section's rows with their verdicts (read-time overlay)
+    annotate_events      -- ... the same for timeline events
+    is_appendix          -- does a stamped carrier leave the live view?
     row_verdicts_for     -- the row-scoped verdicts naming a set of rows
     retire_row_verdicts  -- ... and drop them, for the row-removal write paths
     orphan_kinds         -- why (if at all) one verdict points at nothing live
@@ -94,7 +97,7 @@ of.
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
@@ -388,6 +391,107 @@ def load_verdicts(conn: sqlite3.Connection) -> VerdictMap:
         else:
             out.family[(view["record_type"], view["dedup_base"])] = view
     return out
+
+
+# --------------------------------------------------------------------------- #
+# Read-time overlay — the stamping half, shared by every front door (issue #131)
+# --------------------------------------------------------------------------- #
+#
+# The *stamping* rule (which verdict applies to which carrier) lives here, beside
+# :meth:`VerdictMap.for_row` and :data:`APPENDIX_STATUSES`; the *policy* rule (what to do
+# with a carrier bound for the appendix) stays with each front door, because they
+# legitimately differ: `render` collects the carrier into its "Superseded / corrected"
+# section, `pemr query` hides it behind a count, and the MCP payload hides nothing at all.
+#
+# Before #131 the stamping half lived only inside `render`, and `pemr query` had no
+# overlay at all — the two verbs disagreed about which medications a person is on.
+
+
+def annotate_rows(
+    rows: list[dict],
+    record_type: str,
+    verdicts: VerdictMap,
+    *,
+    on_verdict: Callable[[dict], None] | None = None,
+) -> list[dict]:
+    """Stamp each row of one section with the verdict that applies to it.
+
+    Rows are mutated **in place** and the same list is returned, so a caller may either
+    take the return value or ignore it. A row whose verdict resolves carries it under
+    :data:`CURATION_FIELD`; a row with no verdict is left exactly as it was — no key is
+    added — which is what keeps unannotated output byte-identical (Architecture.md's
+    additive-only rule). An empty ``verdicts`` short-circuits the whole pass.
+
+    Resolution is **per row**, not per family (issue #114), and runs solely through
+    :meth:`VerdictMap.for_row` so the row-over-family precedence rule is never restated.
+    That needs the row's own identity, so ``rows`` must come from a ``SELECT *``: a
+    projected row missing ``dedup_base``/``<record_type>_id`` silently degrades to family
+    scope, or to no verdict at all.
+
+    ``on_verdict`` fires once per stamped row (`render` passes ``_CurationPass.record``,
+    which files the verdict into the appendix / open-questions sections). It is called
+    for **every** resolved verdict, including one bound for the appendix — the caller
+    decides what leaves the live view, via :func:`is_appendix`.
+    """
+    if not verdicts:
+        return rows
+    pk = f"{record_type}_id"
+    for row in rows:
+        verdict = verdicts.for_row(record_type, row.get("dedup_base"), row.get(pk))
+        if verdict is None:
+            continue
+        if on_verdict is not None:
+            on_verdict(verdict)
+        row[CURATION_FIELD] = verdict
+    return rows
+
+
+def annotate_events(
+    events: list[dict],
+    verdicts: VerdictMap,
+    *,
+    on_verdict: Callable[[dict], None] | None = None,
+) -> list[dict]:
+    """:func:`annotate_rows` for timeline events.
+
+    Same rule, different carrier: an event is a rendered sentence rather than a row, and
+    it carries ``record_type``/``dedup_base``/``record_id`` only when
+    :func:`query.query_timeline` was asked for them (``with_identity=True``). An event
+    without identity passes through untouched — that is also the no-verdicts fast path,
+    where no caller asks for the extra keys in the first place.
+    """
+    if not verdicts:
+        return events
+    for event in events:
+        base = event.get("dedup_base")
+        if base is None:
+            continue
+        verdict = verdicts.for_row(
+            event["record_type"], base, event.get("record_id")
+        )
+        if verdict is None:
+            continue
+        if on_verdict is not None:
+            on_verdict(verdict)
+        event[CURATION_FIELD] = verdict
+    return events
+
+
+def verdict_of(carrier: dict) -> dict | None:
+    """The verdict :func:`annotate_rows`/:func:`annotate_events` stamped, or None."""
+    return carrier.get(CURATION_FIELD) if isinstance(carrier, dict) else None
+
+
+def is_appendix(carrier: dict) -> bool:
+    """Whether a stamped carrier leaves the live view — the one predicate every front
+    door asks.
+
+    True for exactly the :data:`APPENDIX_STATUSES`. ``disputed`` is deliberately false:
+    it renders in place, marked, because a disputed fact that vanished from a clinical
+    list would be worse than an unmarked one.
+    """
+    verdict = verdict_of(carrier)
+    return verdict is not None and verdict.get("status") in APPENDIX_STATUSES
 
 
 def row_verdicts_for(

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -32,6 +32,7 @@ from typing import Any
 # Engine modules are underscore-aliased so the public tool named `query` (and any future
 # tool sharing a module name) can't shadow the module it delegates to.
 from . import __version__, cli, db
+from . import curation as _curation
 from . import dedup as _dedup
 from . import documents as _documents
 from . import ingest as _ingest
@@ -391,14 +392,30 @@ def query(
 ) -> list[dict[str, Any]]:
     """[read] Structured reads over the record tables. ``kind`` is ``labs`` | ``meds`` |
     ``timeline`` (mirrors ``pemr query <kind>`` rather than fanning out to three tools).
+
+    Every row carries its curation verdict under ``_curation`` when a human recorded one
+    (issue #131), and **nothing is suppressed**: this payload is the structured contract,
+    the same call the CLI's ``--json`` makes, so it discloses the verdict and lets the
+    caller decide. The suppression rule is the human-readable view's alone.
     """
     try:
+        verdicts = _curation.load_verdicts(conn)
         if kind == "labs":
             rows = _query.query_labs(conn, person, test=test, since=since, dictionary=_dictionary())
+            _curation.annotate_rows(rows, "lab_result", verdicts)
         elif kind == "meds":
             rows = _query.query_meds(conn, person, active=active)
+            _curation.annotate_rows(rows, "medication", verdicts)
         elif kind == "timeline":
-            rows = _query.query_timeline(conn, person, since=since)
+            rows = _query.query_timeline(
+                conn, person, since=since, with_identity=bool(verdicts)
+            )
+            _curation.annotate_events(rows, verdicts)
+            # Resolution scaffolding, not payload — the CLI strips the same three keys.
+            rows = [
+                {k: v for k, v in e.items() if k not in cli._QUERY_IDENTITY_KEYS}
+                for e in rows
+            ]
         else:
             raise ToolError(f"unknown query kind '{kind}' (known: labs, meds, timeline)")
     except (db.NotMigratedError, _query.PersonNotFoundError) as exc:

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -205,7 +205,9 @@ def query_timeline(
     Opt-in and **default-off** on purpose: ``dedup_base`` is one of
     :data:`dedup.INTERNAL_COLUMNS`, deliberately stripped from the CLI ``--json`` and
     MCP read payloads, so widening the default event shape would leak an unstable key
-    into both contracts.
+    into both contracts. Since issue #131 the `pemr query timeline` CLI handler and the
+    MCP ``query`` tool turn it on too — the same overlay `render_journal` applies — and
+    both strip the three keys again before emitting anything.
     """
     person_id = resolve_person_id(conn, slug)
     events: list[dict] = []

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -248,23 +248,23 @@ def _apply_curation(
     Called immediately after each section's ``SELECT`` and **before** any latest-wins,
     grouping or top-N logic, so a superseded reading can neither win "latest" nor
     consume a slot in a truncated list.
+
+    The stamping itself is :func:`curation.annotate_rows` (issue #131) — shared with
+    `pemr query`, so the two verbs cannot drift apart about which rows carry which
+    verdict. What stays here is the *policy*: collect into the appendix, then drop. An
+    appendix-bound row is now stamped a moment before it is dropped, which is invisible
+    (the row is discarded) but is why this is a filter over stamped rows rather than a
+    stamp-only-survivors loop.
     """
     if cur is None or not cur.verdicts:
         return rows
-    out: list[dict] = []
-    for row in rows:
-        verdict = cur.verdicts.for_row(
-            record_type, row["dedup_base"], row.get(f"{record_type}_id")
+    return [
+        row
+        for row in curation.annotate_rows(
+            rows, record_type, cur.verdicts, on_verdict=cur.record
         )
-        if verdict is None:
-            out.append(row)
-            continue
-        cur.record(verdict)
-        if verdict["status"] in curation.APPENDIX_STATUSES:
-            continue
-        row[curation.CURATION_FIELD] = verdict
-        out.append(row)
-    return out
+        if not curation.is_appendix(row)
+    ]
 
 
 def _apply_curation_events(
@@ -277,26 +277,19 @@ def _apply_curation_events(
     :func:`query.query_timeline` was asked for them (``with_identity``). An event
     without identity is passed through -- that is the no-verdicts fast path, where the
     journal never asks for the extra keys in the first place.
+
+    Stamping is :func:`curation.annotate_events`, shared with `pemr query timeline`
+    (issue #131); the appendix policy stays here, as in :func:`_apply_curation`.
     """
     if cur is None or not cur.verdicts:
         return events
-    out: list[dict] = []
-    for event in events:
-        base = event.get("dedup_base")
-        if base is None:
-            out.append(event)
-            continue
-        record_type = event["record_type"]
-        verdict = cur.verdicts.for_row(record_type, base, event.get("record_id"))
-        if verdict is None:
-            out.append(event)
-            continue
-        cur.record(verdict)
-        if verdict["status"] in curation.APPENDIX_STATUSES:
-            continue
-        event[curation.CURATION_FIELD] = verdict
-        out.append(event)
-    return out
+    return [
+        event
+        for event in curation.annotate_events(
+            events, cur.verdicts, on_verdict=cur.record
+        )
+        if not curation.is_appendix(event)
+    ]
 
 
 def _dispute_suffix(row: dict) -> str:

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -7,7 +7,7 @@ import uuid
 
 import pytest
 
-from pemr import cli, db, dedup, persons
+from pemr import cli, curation, db, dedup, persons, render
 
 DICT_ARG = ["--dictionary", str(
     __import__("pathlib").Path(__file__).resolve().parent.parent
@@ -272,3 +272,203 @@ def test_query_on_unmigrated_db_is_friendly(tmp_path, capsys, unmigrated_db):
     rc = _run(tmp_path, "query", "labs", "--person", "jane-doe")
     assert rc == 1
     assert "migrate" in capsys.readouterr().err
+
+
+# --- the curation overlay reaches `query` too (issue #131) --------------------
+#
+# The defect: `render summary` consulted the overlay and `query` did not, so the two
+# verbs disagreed about which medications a person is on -- and the verb that overstated
+# the active list was the one a lookup reaches for. The overlay is still additive: with
+# no verdicts every one of these commands is unchanged (the regression test below).
+
+
+def _annotate(tmp_path, record_type, column, value, **kwargs):
+    """Record a family verdict on the family holding one seeded row."""
+    conn = db.connect(tmp_path / "cli.db")
+    base = conn.execute(
+        f"SELECT dedup_base FROM {record_type} WHERE {column} = ?", (value,)
+    ).fetchone()["dedup_base"]
+    curation.annotate_record(conn, record_type, base, apply=True, **kwargs)
+    conn.close()
+    return base
+
+
+@pytest.fixture()
+def curated(ready):
+    """`ready` plus the verdicts the overlay has to honour.
+
+    Medications: Breo Ellipta superseded (still 'current' by dates -- the issue's exact
+    shape), Prednisone a superseded 2016 course, Lisinopril disputed, Metformin
+    untouched. Labs: Ferritin superseded, TSH disputed, the two A1c draws untouched.
+    """
+    conn = db.connect(ready / "cli.db")
+    d = dedup.load_dictionary(DICT_ARG[1])
+    doc = conn.execute("SELECT document_id FROM document LIMIT 1").fetchone()["document_id"]
+    dedup.commit_extraction(conn, doc, {
+        "medication": [
+            {"name": "Breo Ellipta", "dose": "100mcg", "started_on": "2023-01-01"},
+            {"name": "Lisinopril", "dose": "10mg", "started_on": "2023-06-01"},
+            {"name": "Prednisone", "dose": "5mg", "started_on": "2016-01-01",
+             "ended_on": "2016-01-31"},
+        ],
+        "lab_result": [
+            {"test_name": "Ferritin", "collected_at": "2025-05-05", "value_num": 15.0,
+             "unit": "ng/mL"},
+            {"test_name": "TSH", "collected_at": "2025-05-05", "value_num": 3.0,
+             "unit": "mIU/L"},
+        ],
+    }, d)
+    conn.close()
+    _annotate(ready, "medication", "name", "Breo Ellipta", status="superseded",
+              note="stopped in 2024; not on the current list")
+    _annotate(ready, "medication", "name", "Prednisone", status="superseded",
+              note="a completed 30-day course")
+    _annotate(ready, "medication", "name", "Lisinopril", status="disputed",
+              note="two documents disagree")
+    _annotate(ready, "lab_result", "test_name", "Ferritin", status="superseded",
+              note="requisition coding artifact")
+    _annotate(ready, "lab_result", "test_name", "TSH", status="disputed",
+              note="value contested")
+    return ready
+
+
+def test_query_meds_suppresses_superseded_and_marks_disputed(curated, capsys):
+    """The issue's repro: a superseded med must stop printing as '(current)'."""
+    assert _run(curated, "query", "meds", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    assert "Breo Ellipta" not in out and "Prednisone" not in out
+    assert "Metformin" in out
+    lisinopril = next(line for line in out.splitlines() if "Lisinopril" in line)
+    assert "[DISPUTED: two documents disagree]" in lisinopril
+    # Disclosed, never silently shortened.
+    assert "(2 superseded/corrected medications hidden; --raw to include)" in out
+
+
+def test_query_meds_raw_restores_the_rows_and_says_why_they_were_hidden(curated, capsys):
+    assert _run(curated, "query", "meds", "--person", "jane-doe", "--raw") == 0
+    out = capsys.readouterr().out
+    breo = next(line for line in out.splitlines() if "Breo Ellipta" in line)
+    assert "[superseded - stopped in 2024; not on the current list]" in breo
+    assert "Prednisone" in out and "Metformin" in out
+    assert "[DISPUTED: two documents disagree]" in out   # unchanged by --raw
+    assert "hidden; --raw to include" not in out
+
+
+def test_query_meds_json_always_carries_the_verdict(curated, capsys):
+    """--json is the programmatic contract: nothing suppressed, verdict on every row
+    that has one, and unaffected by --raw."""
+    assert _run(curated, "query", "meds", "--person", "jane-doe", "--json") == 0
+    default = json.loads(capsys.readouterr().out)
+    by_name = {m["name"]: m for m in default}
+    assert {"Breo Ellipta", "Prednisone", "Lisinopril", "Metformin"} <= set(by_name)
+    assert by_name["Breo Ellipta"]["_curation"]["status"] == "superseded"
+    assert by_name["Lisinopril"]["_curation"]["status"] == "disputed"
+    assert "_curation" not in by_name["Metformin"]       # additive: no verdict, no key
+    assert "dedup_base" not in by_name["Metformin"]      # the read contract still holds
+
+    assert _run(curated, "query", "meds", "--person", "jane-doe", "--json", "--raw") == 0
+    assert json.loads(capsys.readouterr().out) == default
+
+
+def test_query_meds_hidden_note_survives_an_entirely_hidden_list(ready, capsys):
+    """Suppressing a clinical list into silence with no signal is the one failure this
+    must not introduce."""
+    _annotate(ready, "medication", "name", "Metformin", status="superseded",
+              note="stopped")
+    assert _run(ready, "query", "meds", "--person", "jane-doe", "--active") == 0
+    out = capsys.readouterr().out
+    assert "no active medications" in out
+    assert "(1 superseded/corrected medications hidden; --raw to include)" in out
+
+
+def test_query_labs_suppression_marking_and_json(curated, capsys):
+    assert _run(curated, "query", "labs", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    assert "Ferritin" not in out
+    assert "HbA1c" in out and "A1c" in out
+    tsh = next(line for line in out.splitlines() if "TSH" in line)
+    assert "[DISPUTED: value contested]" in tsh
+    assert "(1 superseded/corrected lab results hidden; --raw to include)" in out
+
+    assert _run(curated, "query", "labs", "--person", "jane-doe", "--raw") == 0
+    raw = capsys.readouterr().out
+    assert "[superseded - requisition coding artifact]" in raw
+
+    assert _run(curated, "query", "labs", "--person", "jane-doe", "--json") == 0
+    by_test = {r["test_name"]: r for r in json.loads(capsys.readouterr().out)}
+    assert by_test["Ferritin"]["_curation"]["status"] == "superseded"
+    assert by_test["TSH"]["_curation"]["status"] == "disputed"
+    assert "_curation" not in by_test["HbA1c"]
+
+
+def test_query_timeline_suppression_and_no_identity_leak(curated, capsys):
+    assert _run(curated, "query", "timeline", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    # Prednisone contributes med-start *and* med-stop; both go.
+    assert "Prednisone" not in out and "Breo Ellipta" not in out and "Ferritin" not in out
+    assert "started Metformin" in out
+    assert "[DISPUTED: two documents disagree]" in out
+    assert "superseded/corrected events hidden; --raw to include" in out
+
+    assert _run(curated, "query", "timeline", "--person", "jane-doe", "--raw") == 0
+    raw = capsys.readouterr().out
+    assert "started Prednisone" in raw and "stopped Prednisone" in raw
+    assert "[superseded - a completed 30-day course]" in raw
+
+    assert _run(curated, "query", "timeline", "--person", "jane-doe", "--json") == 0
+    events = json.loads(capsys.readouterr().out)
+    assert any(e.get("_curation", {}).get("status") == "superseded" for e in events)
+    assert any(e.get("_curation", {}).get("status") == "disputed" for e in events)
+    assert any("Prednisone" in e["summary"] for e in events)   # nothing suppressed here
+    # `with_identity=True` scaffolding must never reach the payload -- `dedup_base` is
+    # an internal column, and this is the only DB state where the keys exist at all.
+    for key in ("record_type", "dedup_base", "record_id"):
+        assert all(key not in e for e in events)
+
+
+def test_query_with_no_verdicts_is_unchanged(ready, capsys):
+    """The additive-only guard: an unannotated database sees the exact output it saw
+    before the overlay reached `query` -- no marker, no note, --raw a no-op."""
+    for argv in (
+        ["query", "meds", "--person", "jane-doe"],
+        ["query", "labs", "--person", "jane-doe"],
+        ["query", "timeline", "--person", "jane-doe"],
+    ):
+        assert _run(ready, *argv) == 0
+        plain = capsys.readouterr().out
+        assert "hidden; --raw to include" not in plain
+        assert "DISPUTED" not in plain
+        assert _run(ready, *argv, "--raw") == 0
+        assert capsys.readouterr().out == plain
+
+        assert _run(ready, *argv, "--json") == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload and all("_curation" not in row for row in payload)
+
+
+def test_query_meds_active_agrees_with_render_summary(curated, capsys):
+    """The actual defect: two verbs disagreeing about who is on what."""
+    assert _run(curated, "query", "meds", "--person", "jane-doe", "--active",
+                "--json") == 0
+    listed = {m["name"] for m in json.loads(capsys.readouterr().out)
+              if not curation.is_appendix(m)}
+
+    conn = db.connect(curated / "cli.db")
+    try:
+        md = render.render_summary(
+            conn, "jane-doe", dictionary=dedup.load_dictionary(DICT_ARG[1])
+        )
+    finally:
+        conn.close()
+    section = md.split("## Active Medications", 1)[1].split("\n## ", 1)[0]
+    rendered = {line[2:].split("  ")[0].split(" ")[0]
+                for line in section.splitlines() if line.startswith("- ")}
+
+    assert listed == {"Metformin", "Lisinopril"}
+    assert {name.split(" ")[0] for name in listed} == rendered
+    assert "Breo Ellipta" not in section and "Prednisone" not in section
+    # ... and the one the summary *would* have listed is accounted for, not lost.
+    # (Prednisone is absent from both sides: an ended 2016 course never reaches the
+    # Active Medications query in the first place, so nothing about it is suppressed.)
+    appendix = md.split("## Superseded / corrected", 1)[1]
+    assert "Breo Ellipta" in appendix

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -632,6 +632,131 @@ def test_re_annotating_a_row_after_a_rekey_collapses_the_stale_breadcrumb(seeded
     assert live["dedup_base"] == new_base and live["note"] == "after"
 
 
+# --- the read-time overlay helpers (issue #131) -------------------------------
+#
+# The stamping half of the overlay, lifted out of `render` so `pemr query` applies the
+# same rule. Renderer *policy* (appendix collection) stays in test_render.py; the CLI's
+# policy (suppression + --raw) is in test_cli_phase3.py.
+
+
+def _rows(conn, record_type):
+    return [dict(r) for r in conn.execute(f"SELECT * FROM {record_type}").fetchall()]
+
+
+def test_annotate_rows_stamps_a_family_verdict_on_every_row_of_the_family(seeded):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "HbA1c")
+    curation.annotate_record(conn, "lab_result", base, status="superseded",
+                             note="corrected by a later draw", apply=True)
+
+    rows = curation.annotate_rows(
+        _rows(conn, "lab_result"), "lab_result", curation.load_verdicts(conn)
+    )
+    stamped = {r["test_name"]: r.get(curation.CURATION_FIELD) for r in rows}
+    assert stamped["HbA1c"]["status"] == "superseded"
+    assert stamped["Glucose"] is None          # a different family: no key at all
+    assert curation.CURATION_FIELD not in [r for r in rows if r["test_name"] == "Glucose"][0]
+
+
+def test_annotate_rows_lets_a_row_verdict_beat_the_family_one_on_its_own_row(seeded):
+    """The #114 precedence rule, resolved solely through ``VerdictMap.for_row``."""
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "HbA1c")
+    # A second occurrence of the same family, so the two scopes can disagree.
+    conn.execute(
+        "INSERT INTO lab_result (person_id, document_id, test_name, collected_at, "
+        "value_num, unit, dedup_key, dedup_base, dedup_occurrence) "
+        "SELECT person_id, document_id, test_name, collected_at, 5.9, unit, "
+        "dedup_key || '#1', dedup_base, 1 FROM lab_result WHERE test_name = 'HbA1c'",
+    )
+    conn.commit()
+    sibling = int(conn.execute(
+        "SELECT lab_result_id FROM lab_result WHERE dedup_occurrence = 1"
+    ).fetchone()["lab_result_id"])
+    curation.annotate_record(conn, "lab_result", base, status="superseded",
+                             note="family ruling", apply=True)
+    curation.annotate_record(conn, "lab_result", str(sibling), status="disputed",
+                             note="row ruling", row=True, apply=True)
+
+    by_id = {
+        r["lab_result_id"]: curation.verdict_of(r)
+        for r in curation.annotate_rows(
+            _rows(conn, "lab_result"), "lab_result", curation.load_verdicts(conn)
+        )
+    }
+    assert by_id[sibling]["status"] == "disputed"          # row scope wins here
+    occ0 = _row_id(conn, "lab_result", "dedup_occurrence", 0)
+    assert by_id[occ0]["status"] == "superseded"           # ... and only here
+
+
+def test_annotate_rows_fires_on_verdict_once_per_stamped_row(seeded):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "Glucose")
+    curation.annotate_record(conn, "lab_result", base, status="confirmed",
+                             note="ruled", apply=True)
+    seen = []
+    curation.annotate_rows(
+        _rows(conn, "lab_result"), "lab_result", curation.load_verdicts(conn),
+        on_verdict=seen.append,
+    )
+    assert [v["status"] for v in seen] == ["confirmed"]
+
+
+def test_annotate_rows_with_no_verdicts_adds_no_key(seeded):
+    """The additive-only guarantee: an unannotated database is untouched, key-for-key."""
+    conn = seeded["conn"]
+    rows = _rows(conn, "lab_result")
+    before = [dict(r) for r in rows]
+    assert curation.annotate_rows(rows, "lab_result", curation.load_verdicts(conn)) is rows
+    assert rows == before
+    assert all(curation.CURATION_FIELD not in r for r in rows)
+
+
+def test_annotate_events_passes_an_identity_less_event_through(seeded):
+    conn = seeded["conn"]
+    curation.annotate_record(
+        conn, "lab_result", _base(conn, "lab_result", "test_name", "HbA1c"),
+        status="superseded", note="corrected", apply=True,
+    )
+    events = [{"date": "2026-01-02", "type": "lab", "summary": "HbA1c 5.7 %"}]
+    assert curation.annotate_events(events, curation.load_verdicts(conn)) == [
+        {"date": "2026-01-02", "type": "lab", "summary": "HbA1c 5.7 %"}
+    ]
+
+
+def test_annotate_events_stamps_an_event_carrying_identity(seeded):
+    conn = seeded["conn"]
+    base = _base(conn, "lab_result", "test_name", "HbA1c")
+    row_id = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    curation.annotate_record(conn, "lab_result", base, status="superseded",
+                             note="corrected", apply=True)
+    events = [{"date": "2026-01-02", "type": "lab", "summary": "HbA1c",
+               "record_type": "lab_result", "dedup_base": base, "record_id": row_id}]
+    curation.annotate_events(events, curation.load_verdicts(conn))
+    assert events[0][curation.CURATION_FIELD]["status"] == "superseded"
+
+
+@pytest.mark.parametrize("status, appendix", [
+    ("superseded", True),
+    ("erroneous-in-source", True),
+    ("merged-into", True),
+    ("confirmed", False),
+    ("disputed", False),
+    ("distinct", False),
+])
+def test_is_appendix_is_exactly_the_appendix_statuses(status, appendix):
+    """A live row must never silently leave its clinical section — the classification
+    behind that is one predicate, and this pins the whole vocabulary against it."""
+    carrier = {curation.CURATION_FIELD: {"status": status}}
+    assert curation.is_appendix(carrier) is appendix
+    assert curation.verdict_of(carrier)["status"] == status
+
+
+def test_is_appendix_and_verdict_of_on_an_unstamped_carrier():
+    assert curation.is_appendix({"name": "Metformin"}) is False
+    assert curation.verdict_of({"name": "Metformin"}) is None
+
+
 # --- the rekey collision seam (issue #116) -----------------------------------
 
 def _fusing_ids(conn):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,7 +17,9 @@ from pathlib import Path
 
 import pytest
 
-from pemr import __version__, db, dedup, ingest, mcp_server, persons, tombstones
+from pemr import (
+    __version__, curation, db, dedup, ingest, mcp_server, persons, tombstones,
+)
 
 REPO = Path(__file__).resolve().parent.parent
 DICT_PATH = REPO / "data" / "dictionary.example.toml"
@@ -99,6 +101,35 @@ def test_query_kinds(seeded):
 def test_query_unknown_kind_raises(seeded):
     with pytest.raises(mcp_server.ToolError, match="unknown query kind"):
         mcp_server.query(seeded, kind="bogus", person="jane-doe")
+
+
+def test_query_carries_the_verdict_and_suppresses_nothing(seeded):
+    """Issue #131: the structured payload mirrors the CLI's `--json`, not its human
+    view — it discloses the verdict and lets the caller decide."""
+    base = seeded.execute(
+        "SELECT dedup_base FROM medication WHERE name = 'Metformin'"
+    ).fetchone()["dedup_base"]
+    curation.annotate_record(seeded, "medication", base, status="superseded",
+                             note="stopped", apply=True)
+
+    meds = mcp_server.query(seeded, kind="meds", person="jane-doe")
+    assert [m["name"] for m in meds] == ["Metformin"]        # nothing hidden
+    assert meds[0]["_curation"]["status"] == "superseded"
+
+    labs = mcp_server.query(seeded, kind="labs", person="jane-doe")
+    assert all("_curation" not in r for r in labs)           # additive: no verdict, no key
+
+    events = mcp_server.query(seeded, kind="timeline", person="jane-doe")
+    assert any(e.get("_curation", {}).get("status") == "superseded" for e in events)
+    # `with_identity=True` scaffolding must not reach the payload.
+    for key in ("record_type", "dedup_base", "record_id"):
+        assert all(key not in e for e in events)
+
+
+def test_query_with_no_verdicts_carries_no_curation_key(seeded):
+    for kind in ("labs", "meds", "timeline"):
+        rows = mcp_server.query(seeded, kind=kind, person="jane-doe")
+        assert rows and all("_curation" not in r for r in rows)
 
 
 def test_find_and_trends(seeded):


### PR DESCRIPTION
## Summary

`query meds`/`labs`/`timeline` never consulted the curation overlay that `render summary`
already applies, so a medication marked `superseded` (or a lab/condition marked
`erroneous-in-source`/`merged-into`) still printed as current from `query` while `render`
correctly moved it to `## Superseded / corrected`. 

- Lifted the read-time overlay stamping out of `render._apply_curation`/`_apply_curation_events`
  into shared helpers in `pemr/curation.py` (`annotate_rows`/`annotate_events`/`is_appendix`);
  `render` now delegates to them (pure refactor, `tests/test_render.py` unedited and green).
- Applied the overlay at the front doors — the three `query` CLI handlers and the MCP `query`
  tool — not inside `pemr/query.py` (load-bearing: `render_summary` calls `query_meds` and
  applies the overlay itself to collect its appendix; a self-suppressing `query_meds` would
  silently empty that section).
- Default human-readable output now suppresses appendix-status rows the same way `render`
  does, with a disclosure line (`N superseded/corrected … hidden; --raw to include`) whenever
  anything is hidden — including when everything is hidden. `disputed` renders in place with
  the same `[DISPUTED: ...]` marker `render` uses.
- New `--raw` flag on all three `query` subcommands opts back into the unfiltered view, marked.
- `--json` on all three verbs (and the MCP `query` tool) always carries the verdict under
  `_curation`, regardless of suppression, so programmatic callers can filter for themselves.
  `query timeline`'s existing `with_identity` plumbing (#109/#114) supplies row identity; the
  identity keys are stripped again before either output path so `dedup_base` never reaches the
  `--json`/MCP contract as a bare row key.
- No-verdict output is byte-identical to before (proved by a dev-vs-branch byte comparison in
  verify, not just inspection).
- Docs fan-out: `docs/Architecture.md` §5 (tool surface — `--raw`, MCP `query` now carries
  `_curation`) and §6 (the "filtered at read time" rule now covers the three `query` verbs, plus
  a note that `_curation`/`dedup_base` is a breadcrumb, never a lookup key, in the `--json`/MCP
  contract); `AGENTS.md` clarifies that verdict *content* now travels on MCP `query` reads while
  the write verbs (`record annotate`/`reaffirm`/etc.) stay CLI-only, unchanged.

Closes #131

## Reports
- Verify: https://github.com/meridun/pemr/issues/131#issuecomment-5300276309
- Audit: https://github.com/meridun/pemr/issues/131#issuecomment-5300310204

## Test plan
- [x] Full `pytest`: 1093 passed (verify)
- [x] Targeted re-run after docs-only ship commit: `tests/test_curation.py test_cli_phase3.py
      test_render.py test_query.py test_mcp_server.py` — 302 passed
- [x] Real-run repro against the live archive (verify): superseded
      medication families  no longer list as active; `query meds
      --active` name set equals `render summary`'s Active Medications for all four persons in
      the roster
- [x] `--json`/MCP payload asserted free of `dedup_base`/`record_id`/`record_type` leak on a DB
      that has verdicts
- [x] Read-only purity: DB sha256 unchanged after running all three verbs (human, `--json`, `--raw`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)