### PR TITLE
chore(privacy): enforce the no-PHI rule instead of only stating it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,7 @@ jobs:
           node-version: "22"
       - run: npm run sync:claude-config:check
       - run: npm run check:meta-drift
+      # This repo is public: fail the build before a real identity lands in it.
+      # See AGENTS.md §"Privacy posture".
+      - run: npm run check:pii
       - run: npm test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,14 @@ This repository is **public**. It is framework + documentation only.
 
 - **No PHI anywhere in the repo** — no real names, DOBs, values, encounter dates, or personal-name
   filenames in issues, commits, logs, PRs, or test fixtures. Fixtures are synthetic only.
+- **A real identifier reaches GitHub more than once.** The SDLC lanes quote diffs, repro steps and
+  issue text back into issue comments, so one real name in a fixture or a repro write-up gets
+  republished across every downstream thread. Substitute the persona *before* it is written down,
+  not after — a later scrub cannot reach `refs/pull/*`, which GitHub keeps permanently.
+- **The roster is the allowlist.** `SYNTHETIC_ROSTER` in `scripts/pii-scan.mjs` is the complete set
+  of identities permitted in this repo. Need another persona? Add it there — that edit is the
+  review point. `npm run check:pii` enforces this in CI, and the same check gates every outbound
+  `gh` write in `scripts/sdlc.mjs`, so a lane physically cannot post an identity it invented.
 - MCP responses stay on the local machine. Agents MUST NOT relay record contents into any remote
   channel (issue comments, PRs, external APIs) beyond what the human explicitly asks for.
 - The live database and blobs stay out of git: `pemr.db` (and `*-wal`/`*-shm`), `sources/`,

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "pemr",
   "version": "0.0.1",
   "private": true,
-  "description": "Personal EMR — SDLC tooling wrapper around the Python engine (SQLite is truth)",
+  "description": "Personal EMR \u2014 SDLC tooling wrapper around the Python engine (SQLite is truth)",
   "type": "module",
   "scripts": {
     "sync:claude-config": "node scripts/sync-claude-config.mjs",
     "sync:claude-config:check": "node scripts/sync-claude-config.mjs --check",
     "check:meta-drift": "node scripts/check-meta-drift.mjs",
+    "check:pii": "node scripts/pii-scan.mjs",
     "sdlc": "node scripts/sdlc.mjs",
     "test": "node --test"
   }

--- a/scripts/pii-scan.mjs
+++ b/scripts/pii-scan.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+// PII/PHI guard for a public repo. Enforces AGENTS.md §"Privacy posture":
+// fixtures are synthetic only, and no real identity reaches code, commits, or
+// issue/PR text.
+//
+// Allowlist-first, deliberately: real names are unguessable, but the synthetic
+// cast is a short fixed list. Anything claiming to be a patient identity that
+// is NOT on the roster is treated as a violation. Adding a persona is then a
+// visible, reviewable edit to SYNTHETIC_ROSTER rather than a silent new name.
+//
+//   node scripts/pii-scan.mjs [paths...]   # CI mode; exit 1 on any finding
+//   import { scanText } from './pii-scan.mjs'
+//
+// Escape hatch for a genuine false positive: put `pii-allow` on the same line.
+
+import fs from 'fs';
+import path from 'path';
+import { execFileSync } from 'child_process';
+
+/** The only identities permitted to appear in this repository. */
+export const SYNTHETIC_ROSTER = {
+  slugs: [
+    'jane-doe', 'john-doe', 'kid-doe', 'bob-roe', 'john-roe', 'robert-roe',
+    'ann-poe', 'ann-zed', 'jane-smith', 'karen-smith', 'michael-vu',
+    'alex-carter', 'dana-roe', 'stranger-sam',
+  ],
+  // Surnames that mark a name as a placeholder (Doe/Roe/Poe/Zed family).
+  surnames: [
+    'doe', 'roe', 'poe', 'zed', 'smith', 'vu', 'carter', 'stranger', 'last',
+    'fields',
+  ],
+  dobs: [
+    '1962-03-14', '1971-09-09', '1955-11-02', '1900-03-14', '1990-09-09',
+    '1981-03-07', '1980-01-01', '1890-01-01', '1955-01-02', '1900-01-01',
+    // Day-first trap dates: deliberately NOT anyone's DOB. They exist so the
+    // digit-boundary guard in `_person_matches` is actually exercised.
+    '1981-07-23', '1981-07-13',
+  ],
+};
+
+/**
+ * Common given names. A `given-surname` token is what a person slug looks like,
+ * and "starts with a given name" discriminates far better than any attempt to
+ * enumerate technical vocabulary — that set is unbounded, this one is not.
+ * Names that double as technical words (mark, bill, will, may, art, page) are
+ * deliberately omitted; the `--person` rule still catches those in slug position.
+ */
+const GIVEN_NAMES = new Set([
+  'aaron', 'abigail', 'adam', 'adrian', 'aiden', 'alan', 'albert', 'alex',
+  'alexander', 'alexis', 'alice', 'alicia', 'allison', 'amanda', 'amber',
+  'amelia', 'amy', 'andrea', 'andrew', 'angela', 'anna', 'anne', 'anthony',
+  'antonio', 'ariana', 'arthur', 'ashley', 'aubrey', 'audrey', 'austin',
+  'ava', 'barbara', 'beatrice', 'benjamin', 'bernard', 'beth', 'betty',
+  'beverly', 'blake', 'bradley', 'brandon', 'brenda', 'brian', 'brianna',
+  'bridget', 'brittany', 'brooke', 'bruce', 'bryan', 'caleb', 'cameron',
+  'camila', 'carl', 'carlos', 'carol', 'caroline', 'carolyn', 'catherine',
+  'charles', 'charlotte', 'chelsea', 'cheryl', 'chloe', 'christian',
+  'christina', 'christine', 'christopher', 'claire', 'clara', 'colin',
+  'connor', 'courtney', 'craig', 'crystal', 'cynthia', 'daniel', 'danielle',
+  'david', 'deborah', 'debra', 'declan', 'denise', 'dennis', 'derek',
+  'diana', 'diane', 'dominic', 'donald', 'donna', 'dorothy', 'douglas',
+  'dylan', 'edward', 'eleanor', 'elena', 'eli', 'elijah', 'elizabeth',
+  'ella', 'ellen', 'emily', 'emma', 'eric', 'erica', 'erin', 'ethan',
+  'eugene', 'evelyn', 'felix', 'fiona', 'frances', 'francis', 'frank',
+  'gabriel', 'gabriella', 'gary', 'george', 'gerald', 'gloria', 'gordon',
+  'gregory', 'hannah', 'harold', 'harper', 'harry', 'hazel', 'heather',
+  'helen', 'henry', 'holly', 'howard', 'hunter', 'ian', 'irene', 'isaac',
+  'isabella', 'isaiah', 'ivan', 'jack', 'jackson', 'jacob', 'jacqueline',
+  'james', 'jamie', 'jane', 'janet', 'janice', 'jared', 'jasmine', 'jason',
+  'jeffrey', 'jennifer', 'jeremy', 'jerry', 'jesse', 'jessica', 'joan',
+  'joanne', 'joel', 'john', 'jonathan', 'jordan', 'joseph', 'joshua',
+  'joyce', 'juan', 'judith', 'judy', 'julia', 'julian', 'julie', 'justin',
+  'kaitlyn', 'karen', 'katherine', 'kathleen', 'kathryn', 'katie', 'kayla',
+  'keith', 'kelly', 'kenneth', 'kevin', 'kimberly', 'kyle', 'larry', 'laura',
+  'lauren', 'lawrence', 'leah', 'leo', 'leonard', 'leslie', 'liam', 'lillian',
+  'lily', 'linda', 'lisa', 'logan', 'lois', 'lorraine', 'louis', 'lucas',
+  'lucy', 'luke', 'lydia', 'madison', 'marcus', 'margaret', 'maria',
+  'marie', 'marilyn', 'mario', 'marjorie', 'martha', 'martin', 'mary',
+  'mason', 'matthew', 'maureen', 'megan', 'melanie', 'melissa', 'micah',
+  'michael', 'michelle', 'mildred', 'molly', 'monica', 'nancy', 'naomi',
+  'natalie', 'nathan', 'neil', 'nicholas', 'nicole', 'noah', 'nora',
+  'norman', 'olivia', 'oscar', 'owen', 'pamela', 'patricia', 'patrick',
+  'paul', 'paula', 'pauline', 'peter', 'philip', 'phillip', 'phoebe',
+  'rachel', 'ralph', 'randy', 'raymond', 'rebecca', 'regina', 'renee',
+  'richard', 'robert', 'roberta', 'roger', 'ronald', 'rosemary', 'roy',
+  'russell', 'ruth', 'ryan', 'samantha', 'samuel', 'sandra', 'sara',
+  'sarah', 'scott', 'sean', 'sebastian', 'shannon', 'sharon', 'shawn',
+  'sheila', 'shirley', 'sidney', 'simon', 'sophia', 'sophie', 'stanley',
+  'stephanie', 'stephen', 'steven', 'susan', 'sylvia', 'tamara', 'tara',
+  'teresa', 'terrance', 'thelma', 'theodore', 'theresa', 'thomas',
+  'tiffany', 'timothy', 'tina', 'todd', 'tracy', 'travis', 'tyler',
+  'valerie', 'vanessa', 'veronica', 'victor', 'victoria', 'vincent',
+  'virginia', 'vivian', 'walter', 'wanda', 'wayne', 'wendy', 'wesley',
+  'william', 'wyatt', 'xavier', 'yolanda', 'yvonne', 'zachary', 'zoe',
+]);
+
+/** Words that mark a line as talking about a person/record. */
+const PERSON_CONTEXT = /\b(patient|person|roster|medication|meds|dob|repro|owner|family|slug|ingest|misfil|archive|record|chart|encounter)/i;
+
+const ALLOW_MARKER = /pii-allow/;
+
+const slugSet = new Set(SYNTHETIC_ROSTER.slugs);
+const surnameSet = new Set(SYNTHETIC_ROSTER.surnames);
+const dobSet = new Set(SYNTHETIC_ROSTER.dobs);
+
+/** Normalize any of the renderings `dob_candidates` emits to ISO, else null. */
+function isoDate(raw) {
+  let m = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(raw);
+  if (m) return `${m[1]}-${String(m[2]).padStart(2, '0')}-${String(m[3]).padStart(2, '0')}`;
+  m = /^(\d{1,2})[/-](\d{1,2})[/-](\d{4})$/.exec(raw);
+  if (!m) return null;
+  const [, a, b, y] = m;
+  // Ambiguous month/day: accept either reading as allowlisted.
+  const mm = String(a).padStart(2, '0');
+  const dd = String(b).padStart(2, '0');
+  return [`${y}-${mm}-${dd}`, `${y}-${dd}-${mm}`];
+}
+
+function dobAllowed(raw) {
+  const iso = isoDate(raw);
+  if (!iso) return false;
+  return Array.isArray(iso) ? iso.some((d) => dobSet.has(d)) : dobSet.has(iso);
+}
+
+const RULES = [
+  {
+    id: 'person-slug',
+    // `--person X`, `person add X`, `add_person(conn, "X"`
+    // A literal slug only — `<slug>`/`$VAR` placeholders and prose after
+    // `--person` (as in "omit --person for everyone") are not identities.
+    re: /(?:--person\s+|person add\s+|add_person\(\s*conn\s*,\s*["'])(?![<${])([a-z][a-z0-9-]{2,40})/g,
+    check: (m) => {
+      const slug = m[1];
+      if (slugSet.has(slug)) return null;
+      // Single-token slugs (`jane`, `zoe`, `typo`) are conventional test stubs and
+      // carry no surname, so they cannot identify anyone. Only `first-last` shapes
+      // assert a full identity — those must land on a placeholder surname.
+      const parts = slug.split('-');
+      if (parts.length < 2) return null;
+      const surname = parts[parts.length - 1];
+      if (surnameSet.has(surname)) return null;
+      return `person slug '${slug}' is not on the synthetic roster`;
+    },
+  },
+  {
+    id: 'bare-slug',
+    // A `given-surname` token in prose, with no `--person` in front of it. This
+    // is how the real leak actually travelled: "Real repro (charlotte-dickinson,
+    // medication omeprazole)". Context-gated so ordinary hyphenated compounds
+    // (`fan-out`, `byte-identical`) stay quiet.
+    re: /\b([a-z]{3,15})-([a-z]{3,15})\b/g,
+    check: (m, line, inPersonDoc) => {
+      const [full, given, surname] = m;
+      if (slugSet.has(full)) return null;
+      if (surnameSet.has(surname)) return null;
+      if (!GIVEN_NAMES.has(given)) return null;
+      // A path or filename (`exports/jane-journal.md`) is not a person reference.
+      const before = line[m.index - 1];
+      const after = line[m.index + full.length];
+      if (before === '/' || before === '.' || before === '_' || after === '.' || after === '/') return null;
+      return `'${full}' reads as a real person slug (surname '${surname}' is not a roster placeholder)`;
+    },
+  },
+  {
+    id: 'full-name',
+    // `Michael Dickinson` in prose — the same identity as the slug, but spelled
+    // out. Gated on person context so ordinary Capitalised Pairs stay quiet.
+    // Match the whole capitalised run, so a middle name (`Robert Alan Roe`)
+    // cannot hide the placeholder surname that ends it.
+    re: /\b([A-Z][a-z]{2,14}(?:\s+[A-Z][a-z]{2,14}){1,3})\b/g,
+    check: (m, line, inPersonDoc) => {
+      const tokens = m[1].split(/\s+/);
+      const given = tokens[0].toLowerCase();
+      if (!GIVEN_NAMES.has(given)) return null;
+      if (tokens.some((t) => surnameSet.has(t.toLowerCase()))) return null;
+      if (!inPersonDoc) return null;
+      const surname = tokens[tokens.length - 1];
+      return `'${m[1]}' reads as a real person's name (surname '${surname}' is not a roster placeholder)`;
+    },
+  },
+  {
+    id: 'patient-name',
+    // `Patient: SURNAME, FIRST` / `Patient Name: SURNAME, FIRST`
+    re: /Patient(?:\s+Name)?\s*:\s*([A-Za-z'-]{2,20})\s*[,^]\s*([A-Za-z'-]{2,20})/g,
+    check: (m) => (surnameSet.has(m[1].toLowerCase())
+      ? null
+      : `patient name '${m[1]}, ${m[2]}' is not a roster placeholder`),
+  },
+  {
+    id: 'dob',
+    re: /\b(?:DOB|D\.O\.B\.?|date of birth|birth ?date)\b\s*[:=]?\s*(\d{4}-\d{1,2}-\d{1,2}|\d{1,2}[/-]\d{1,2}[/-]\d{4})/gi,
+    check: (m) => (dobAllowed(m[1]) ? null : `DOB '${m[1]}' is not an allowlisted synthetic date`),
+  },
+  {
+    id: 'ssn',
+    re: /\b\d{3}-\d{2}-\d{4}\b/g,
+    check: (m) => `looks like a US SSN: ${m[0]}`,
+  },
+  {
+    id: 'mrn',
+    re: /\bMRN\s*[:=#]\s*([0-9]{4,12})\b/gi,
+    check: (m) => `MRN with a concrete value: ${m[0]}`,
+  },
+  {
+    id: 'card',
+    re: /\b(?:4\d{3}|5[1-5]\d{2}|3[47]\d{2}|6011)[ -]?\d{4}[ -]?\d{4}[ -]?\d{2,4}\b/g,
+    check: (m) => `looks like a payment card number: ${m[0]}`,
+  },
+  {
+    id: 'nhs',
+    // Requires the label: a bare 10-digit run passes the checksum often enough
+    // that GitHub comment IDs trip it, which would train people to ignore this.
+    re: /\bNHS(?:\s*(?:number|no\.?))?\s*[:=#]?\s*(\d{3})[ -]?(\d{3})[ -]?(\d{4})\b/gi,
+    check: (m) => {
+      const d = (m[1] + m[2] + m[3]);
+      let t = 0;
+      for (let i = 0; i < 9; i++) t += Number(d[i]) * (10 - i);
+      let c = 11 - (t % 11);
+      if (c === 11) c = 0;
+      if (c === 10 || c !== Number(d[9])) return null;
+      return `passes the NHS-number checksum: ${m[0]}`;
+    },
+  },
+];
+
+/**
+ * @param {string} text
+ * @param {string} [label] file path or description, echoed in findings
+ * @returns {{rule:string, line:number, message:string, excerpt:string}[]}
+ */
+export function scanText(text, label = '<text>') {
+  const findings = [];
+  if (!text) return findings;
+  const lines = String(text).split(/\r?\n/);
+  // Person context is judged over the whole document, not the single line: a
+  // write-up names the patient in one sentence and the repro three lines down.
+  const inPersonDoc = PERSON_CONTEXT.test(text);
+  lines.forEach((line, i) => {
+    if (ALLOW_MARKER.test(line)) return;
+    // A literal `\n` in quoted source text glues to the next word (`...^\nDOB:`)
+    // and defeats \b. Blank the escape to two spaces — same length, so match
+    // offsets still line up with the original for the adjacency checks.
+    const scanLine = line.replace(/\\[nrt]/g, '  ');
+    for (const rule of RULES) {
+      rule.re.lastIndex = 0;
+      let m;
+      while ((m = rule.re.exec(scanLine)) !== null) {
+        const message = rule.check(m, scanLine, inPersonDoc);
+        if (message) {
+          findings.push({
+            rule: rule.id,
+            label,
+            line: i + 1,
+            message,
+            excerpt: line.trim().slice(0, 160),
+          });
+        }
+      }
+    }
+  });
+  return findings;
+}
+
+/** Throws if `text` carries a patient identity. Used to gate outbound writes. */
+export function assertClean(text, what = 'text') {
+  const findings = scanText(text, what);
+  if (findings.length === 0) return;
+  const detail = findings.map((f) => `  [${f.rule}] line ${f.line}: ${f.message}`).join('\n');
+  throw new Error(
+    `refusing to publish ${what}: it contains a patient identity.\n${detail}\n` +
+    'See AGENTS.md §"Privacy posture". Substitute a roster persona, or add `pii-allow` ' +
+    'to the line if this is genuinely synthetic.',
+  );
+}
+
+const SKIP_DIRS = new Set(['.git', 'node_modules', 'sources', 'exports', 'inbox', 'backups', 'data', 'vdm-diag', '.venv', 'pemr.egg-info']);
+const TEXT_EXT = new Set(['.py', '.mjs', '.js', '.ts', '.md', '.json', '.toml', '.yml', '.yaml', '.txt', '.csv', '.sql', '.cfg', '.ini']);
+// This file and its test necessarily contain the shapes they describe.
+const SKIP_FILES = new Set(['scripts/pii-scan.mjs', 'test/pii-scan.test.mjs']);
+
+function trackedFiles() {
+  try {
+    return execFileSync('git', ['ls-files'], { encoding: 'utf8' }).split(/\r?\n/).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function main(argv) {
+  const explicit = argv.slice(2).filter((a) => !a.startsWith('-'));
+  const files = (explicit.length ? explicit : trackedFiles()).filter((f) => {
+    const norm = f.split(path.sep).join('/');
+    if (SKIP_FILES.has(norm)) return false;
+    if (norm.split('/').some((seg) => SKIP_DIRS.has(seg))) return false;
+    return explicit.length ? true : TEXT_EXT.has(path.extname(f));
+  });
+
+  let all = [];
+  for (const f of files) {
+    let text;
+    try {
+      text = fs.readFileSync(f, 'utf8');
+    } catch {
+      continue;
+    }
+    all = all.concat(scanText(text, f));
+  }
+
+  if (all.length === 0) {
+    console.log(`pii-scan: clean (${files.length} files)`);
+    return 0;
+  }
+  console.error(`pii-scan: ${all.length} finding(s)\n`);
+  for (const f of all) {
+    console.error(`${f.label}:${f.line}  [${f.rule}] ${f.message}`);
+    console.error(`    ${f.excerpt}`);
+  }
+  console.error('\nAGENTS.md §"Privacy posture": fixtures are synthetic only.');
+  console.error('Add the persona to SYNTHETIC_ROSTER in scripts/pii-scan.mjs, or mark the line `pii-allow`.');
+  return 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('pii-scan.mjs')) {
+  process.exit(main(process.argv));
+}

--- a/scripts/sdlc.mjs
+++ b/scripts/sdlc.mjs
@@ -58,6 +58,8 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { assertClean } from './pii-scan.mjs';
+
 // --- Adapt to your repo -------------------------------------------------------
 // These are the only project-specific knobs. `<DEFAULT_BRANCH>` is the
 // integration branch PRs target; `<PROD_BRANCH>` is the release branch no
@@ -935,7 +937,34 @@ export function scoreDupCandidates(query, issues, opts = {}) {
 
 // --- I/O boundary: gh / git executors (injectable for tests) -------------------
 
-const defaultGh = (args) => execFileSync('gh', args, { encoding: 'utf8' });
+/**
+ * Every outbound `gh` write funnels through here, so the privacy guard lives
+ * here too rather than at each `issue comment` call site — a new call site
+ * cannot forget it.
+ *
+ * This matters because the dispatcher's whole job is quoting diffs, repro steps
+ * and issue text back into comments: a real identifier that reaches the repo
+ * once gets republished by the lanes many times over. See AGENTS.md
+ * §"Privacy posture".
+ */
+export function guardOutboundBody(args, scan = assertClean) {
+  const isComment = args.includes('comment') || args.includes('create') || args.includes('edit');
+  if (!isComment) return;
+  const bodyIdx = args.indexOf('--body');
+  if (bodyIdx !== -1 && args[bodyIdx + 1] != null) {
+    scan(String(args[bodyIdx + 1]), 'this issue comment');
+  }
+  const fileIdx = args.indexOf('--body-file');
+  if (fileIdx !== -1 && args[fileIdx + 1] != null) {
+    const p = String(args[fileIdx + 1]);
+    if (p !== '-' && fs.existsSync(p)) scan(fs.readFileSync(p, 'utf8'), `this comment body (${p})`);
+  }
+}
+
+const defaultGh = (args) => {
+  guardOutboundBody(args);
+  return execFileSync('gh', args, { encoding: 'utf8' });
+};
 const defaultGit = (args) => execFileSync('git', args, { encoding: 'utf8' });
 
 /** Fetch an issue's label names via gh. */

--- a/test/pii-scan.test.mjs
+++ b/test/pii-scan.test.mjs
@@ -1,0 +1,128 @@
+// Tests for scripts/pii-scan.mjs — the privacy guard behind AGENTS.md
+// §"Privacy posture". Run with `npm test` (node --test).
+//
+// The positive cases below are the *shapes* that actually leaked into this
+// public repo's issue tracker and test fixtures, reduced to minimal form. The
+// negative cases are the shapes that tripped earlier drafts of the scanner —
+// a guard nobody trusts is a guard people switch off, so false positives are
+// treated as bugs with the same weight as misses.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { scanText, assertClean, SYNTHETIC_ROSTER } from '../scripts/pii-scan.mjs';
+import { guardOutboundBody } from '../scripts/sdlc.mjs';
+
+const rules = (text) => scanText(text).map((f) => f.rule);
+
+describe('pii-scan: catches real identities', () => {
+  it('flags a person slug that is not on the roster', () => {
+    assert.ok(rules('pemr ingest scan.pdf --person charlotte-dickinson').includes('person-slug'));
+  });
+
+  it('flags a bare given-surname slug in prose — how the leak actually travelled', () => {
+    const t = 'Real repro (charlotte-dickinson, medication omeprazole): four stored rows.';
+    assert.ok(rules(t).includes('bare-slug'));
+  });
+
+  it('flags a full name spelled out in prose', () => {
+    const t = 'The patient record was filed under Michael Dickinson by mistake.';
+    assert.ok(rules(t).includes('full-name'));
+  });
+
+  it('flags a DOB that is not an allowlisted synthetic date', () => {
+    assert.ok(rules('Patient: DOE, JOHN Q   DOB: 1978-05-04').includes('dob'));
+  });
+
+  it('sees through a literal \\n escape gluing the label to the previous token', () => {
+    // `...^\nDOB:` reads as `nDOB` and defeats a naive word boundary.
+    const t = 'PatientName = "STRANGER^SAM^\\nDOB: 1978-05-04"';
+    assert.ok(rules(t).includes('dob'));
+  });
+
+  it('flags a patient name whose surname is not a placeholder', () => {
+    assert.ok(rules('Patient: DICKINSON, MICHAEL J').includes('patient-name'));
+  });
+
+  it('flags SSNs, concrete MRNs and card numbers outright', () => {
+    assert.ok(rules('SSN 123-45-6789').includes('ssn'));
+    assert.ok(rules('MRN: 88213').includes('mrn'));
+    assert.ok(rules('card 4111 1111 1111 1111').includes('card'));
+  });
+});
+
+describe('pii-scan: stays quiet on synthetic and technical text', () => {
+  it('accepts every roster persona', () => {
+    for (const slug of SYNTHETIC_ROSTER.slugs) {
+      assert.deepEqual(scanText(`--person ${slug}`), [], `roster slug ${slug} should pass`);
+    }
+  });
+
+  it('accepts roster DOBs in any rendering dob_candidates emits', () => {
+    for (const t of ['DOB: 1962-03-14', 'DOB 03/14/1962', 'DOB: 3/14/1962', 'DOB 03-14-1962']) {
+      assert.deepEqual(scanText(t), [], `${t} should pass`);
+    }
+  });
+
+  it('ignores ordinary hyphenated compounds even in person context', () => {
+    const t = 'The patient record is byte-identical: fan-out, read-only, pre-existing, row-scoped.';
+    assert.deepEqual(scanText(t), []);
+  });
+
+  it('ignores single-token test stubs, which identify nobody', () => {
+    assert.deepEqual(scanText('persons.add_person(conn, "zoe", "Zoe")'), []);
+    assert.deepEqual(scanText('pemr query meds --person jane --active'), []);
+  });
+
+  it('ignores placeholders and prose after --person', () => {
+    assert.deepEqual(scanText('pemr document list [--person <slug>]'), []);
+    assert.deepEqual(scanText('omit --person for everyone'), []);
+  });
+
+  it('ignores a path that merely contains a name', () => {
+    assert.deepEqual(scanText('pemr render journal --person jane > exports/jane-journal.md'), []);
+  });
+
+  it('does not let a middle name hide the placeholder surname', () => {
+    assert.deepEqual(scanText('BOB = Person(slug="bob-roe", full_name="Robert Alan Roe")'), []);
+  });
+
+  it('does not treat a 10-digit comment id as an NHS number', () => {
+    assert.deepEqual(scanText('see issues/131#issuecomment-5300310204 for the audit'), []);
+  });
+
+  it('honours the pii-allow escape hatch', () => {
+    assert.deepEqual(scanText('DOB: 1978-05-04  # pii-allow'), []);
+  });
+});
+
+describe('assertClean', () => {
+  it('throws with the offending rule named', () => {
+    assert.throws(() => assertClean('Patient: DOE, JOHN Q  DOB: 1978-05-04', 'a comment'), /dob/);
+  });
+
+  it('passes clean text through silently', () => {
+    assert.doesNotThrow(() => assertClean('sdlc:claim dispatch-20260815-0407 design'));
+  });
+});
+
+describe('guardOutboundBody: the dispatcher cannot republish an identity', () => {
+  it('refuses an issue comment carrying a real identity', () => {
+    assert.throws(
+      () => guardOutboundBody(['issue', 'comment', '61', '--body', 'repro: charlotte-dickinson meds']),
+      /patient identity/,
+    );
+  });
+
+  it('allows an ordinary dispatcher status comment', () => {
+    assert.doesNotThrow(
+      () => guardOutboundBody(['issue', 'comment', '138', '--body', 'sdlc:claim run-1 verify']),
+    );
+  });
+
+  it('ignores read-only gh invocations', () => {
+    assert.doesNotThrow(
+      () => guardOutboundBody(['issue', 'view', '61', '--json', 'labels']),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`AGENTS.md` §"Privacy posture" already forbade real identities anywhere in this public repo. Nothing checked, so a real name and DOB reached test fixtures and spread to 19 issue/PR locations. Restating the rule would not have caught any of them — this adds the thing that does.

`scripts/pii-scan.mjs` is an **allowlist-first** detector: `SYNTHETIC_ROSTER` is the complete set of identities permitted in the repo, and anything claiming to be a patient identity that is not on it is a violation. That inversion is the point — real names are unguessable, and a denylist of them could not live in a public repo in the first place. Adding a persona means editing `SYNTHETIC_ROSTER`, which is a visible, reviewable act.

## Why the detector looks the way it does

Telling a person slug from a hyphenated technical term is the whole problem. A stopword list of technical prefixes produced **687 false positives** against this repo's own issue corpus — technical vocabulary is unbounded, given names are not. Gating on "first token is a given name" plus document-level person context is what works.

Tuned against ground truth rather than judgement: the 19 real leaks as positives, the scrubbed live corpus and the repo tree as negatives.

| | result |
|---|---|
| Recall on the 19 actual leaks | **19/19** |
| Scrubbed text still flagged | **0** |
| False positives across 1371 live units | **2** (both the same synthetic MRN) |
| Repo scan | clean, 105 files |

Two real evasions surfaced while tuning, both now regression-tested:

- a literal `\n` before a DOB label glues to it and defeats `\b`
- a middle name hid the placeholder surname that followed it

## Enforcement

- **CI** — `npm run check:pii` in the `meta` job, failing the build before an identity lands.
- **The dispatcher** — `guardOutboundBody` sits at `defaultGh`, the single funnel for every outbound `gh` write, rather than at each `issue comment` call site, so a new call site cannot forget it.

`AGENTS.md` gains the mechanism it was missing: a real identifier reaches GitHub **more than once**, because the lanes quote diffs and issue text back into comments. That is how one fixture became 19 locations, and it is why substitution has to happen before the identifier is written down — a later scrub cannot reach `refs/pull/*`, which GitHub keeps permanently.

## Test plan

- [x] `npm test` — 163/163 pass (21 new)
- [x] `npm run check:pii` — clean, 105 files
- [x] `npm run check:meta-drift`, `npm run sync:claude-config:check` — pass
- [x] `node scripts/sdlc.mjs` still loads; guard verified end-to-end
- [x] `pytest` — 7 failures, **identical on pristine `dev`** (same three files, zero introduced). Pre-existing CLI drills picking up a local `config.toml`; a fresh clone passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
