### PR TITLE
fix(privacy): use invented identities in the PII guard's own fixtures

### DIFF
--- a/scripts/pii-scan.mjs
+++ b/scripts/pii-scan.mjs
@@ -145,7 +145,7 @@ const RULES = [
   {
     id: 'bare-slug',
     // A `given-surname` token in prose, with no `--person` in front of it. This
-    // is how the real leak actually travelled: "Real repro (charlotte-dickinson,
+    // is how the real leak actually travelled: "Real repro (melanie-ashworth,
     // medication omeprazole)". Context-gated so ordinary hyphenated compounds
     // (`fan-out`, `byte-identical`) stay quiet.
     re: /\b([a-z]{3,15})-([a-z]{3,15})\b/g,
@@ -163,7 +163,7 @@ const RULES = [
   },
   {
     id: 'full-name',
-    // `Michael Dickinson` in prose — the same identity as the slug, but spelled
+    // `Gregory Ashworth` in prose — the same identity as the slug, but spelled
     // out. Gated on person context so ordinary Capitalised Pairs stay quiet.
     // Match the whole capitalised run, so a middle name (`Robert Alan Roe`)
     // cannot hide the placeholder surname that ends it.
@@ -275,7 +275,11 @@ export function assertClean(text, what = 'text') {
 
 const SKIP_DIRS = new Set(['.git', 'node_modules', 'sources', 'exports', 'inbox', 'backups', 'data', 'vdm-diag', '.venv', 'pemr.egg-info']);
 const TEXT_EXT = new Set(['.py', '.mjs', '.js', '.ts', '.md', '.json', '.toml', '.yml', '.yaml', '.txt', '.csv', '.sql', '.cfg', '.ini']);
-// This file and its test necessarily contain the shapes they describe.
+// This file and its test necessarily contain the shapes they describe, so the
+// scanner cannot scan them — which makes them the one blind spot in the repo.
+// Every identity used as an example here MUST therefore be invented: a given
+// name from the list above plus a surname that belongs to nobody. Never
+// illustrate a rule with the real identity that motivated it.
 const SKIP_FILES = new Set(['scripts/pii-scan.mjs', 'test/pii-scan.test.mjs']);
 
 function trackedFiles() {

--- a/test/pii-scan.test.mjs
+++ b/test/pii-scan.test.mjs
@@ -17,31 +17,31 @@ const rules = (text) => scanText(text).map((f) => f.rule);
 
 describe('pii-scan: catches real identities', () => {
   it('flags a person slug that is not on the roster', () => {
-    assert.ok(rules('pemr ingest scan.pdf --person charlotte-dickinson').includes('person-slug'));
+    assert.ok(rules('pemr ingest scan.pdf --person melanie-ashworth').includes('person-slug'));
   });
 
   it('flags a bare given-surname slug in prose — how the leak actually travelled', () => {
-    const t = 'Real repro (charlotte-dickinson, medication omeprazole): four stored rows.';
+    const t = 'Real repro (melanie-ashworth, medication omeprazole): four stored rows.';
     assert.ok(rules(t).includes('bare-slug'));
   });
 
   it('flags a full name spelled out in prose', () => {
-    const t = 'The patient record was filed under Michael Dickinson by mistake.';
+    const t = 'The patient record was filed under Gregory Ashworth by mistake.';
     assert.ok(rules(t).includes('full-name'));
   });
 
   it('flags a DOB that is not an allowlisted synthetic date', () => {
-    assert.ok(rules('Patient: DOE, JOHN Q   DOB: 1978-05-04').includes('dob'));
+    assert.ok(rules('Patient: DOE, JOHN Q   DOB: 1968-02-11').includes('dob'));
   });
 
   it('sees through a literal \\n escape gluing the label to the previous token', () => {
     // `...^\nDOB:` reads as `nDOB` and defeats a naive word boundary.
-    const t = 'PatientName = "STRANGER^SAM^\\nDOB: 1978-05-04"';
+    const t = 'PatientName = "STRANGER^SAM^\\nDOB: 1968-02-11"';
     assert.ok(rules(t).includes('dob'));
   });
 
   it('flags a patient name whose surname is not a placeholder', () => {
-    assert.ok(rules('Patient: DICKINSON, MICHAEL J').includes('patient-name'));
+    assert.ok(rules('Patient: ASHWORTH, GREGORY J').includes('patient-name'));
   });
 
   it('flags SSNs, concrete MRNs and card numbers outright', () => {
@@ -92,13 +92,13 @@ describe('pii-scan: stays quiet on synthetic and technical text', () => {
   });
 
   it('honours the pii-allow escape hatch', () => {
-    assert.deepEqual(scanText('DOB: 1978-05-04  # pii-allow'), []);
+    assert.deepEqual(scanText('DOB: 1968-02-11  # pii-allow'), []);
   });
 });
 
 describe('assertClean', () => {
   it('throws with the offending rule named', () => {
-    assert.throws(() => assertClean('Patient: DOE, JOHN Q  DOB: 1978-05-04', 'a comment'), /dob/);
+    assert.throws(() => assertClean('Patient: DOE, JOHN Q  DOB: 1968-02-11', 'a comment'), /dob/);
   });
 
   it('passes clean text through silently', () => {
@@ -109,7 +109,7 @@ describe('assertClean', () => {
 describe('guardOutboundBody: the dispatcher cannot republish an identity', () => {
   it('refuses an issue comment carrying a real identity', () => {
     assert.throws(
-      () => guardOutboundBody(['issue', 'comment', '61', '--body', 'repro: charlotte-dickinson meds']),
+      () => guardOutboundBody(['issue', 'comment', '61', '--body', 'repro: melanie-ashworth meds']),
       /patient identity/,
     );
   });


### PR DESCRIPTION
## Summary

The guard shipped in #146 illustrated its rules with the real identities that motivated them, in scanner comments and test fixtures. **Eleven occurrences**, straight back into the public repo the scrub had just cleared. My error, caught on a post-merge sweep.

`check:pii` could not catch it. `scripts/pii-scan.mjs` and `test/pii-scan.test.mjs` are in `SKIP_FILES`, because a scanner that scanned its own pattern definitions would flag every rule it defines. That exemption is the single blind spot in the repo, and the fixtures walked straight into it.

## Change

Every example identity is now invented — a given name from the list plus a surname belonging to nobody — so each rule is still exercised without carrying a real identity:

- the person-slug and bare-slug examples
- the full-name and patient-name examples
- the DOB examples

The constraint is now documented next to `SKIP_FILES` so the exemption cannot be re-abused.

## Test plan

- [x] `npm test` — 21/21 in this file, no change to assertions
- [x] `npm run check:pii` — clean, 105 files
- [x] **Recall unchanged at 19/19** against the real leak corpus — confirms the tests exercise the rules rather than passing on hardcoded strings

## Note

The forward fix clears the tip. The identifiers remain in #146's history and its `refs/pull` diff, which is the same permanent residue already accepted for the original scrub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
