### PR TITLE
feat(privacy): gate every publishing surface, not just the tree

### DIFF
--- a/.claude/hooks/pii-guard.py
+++ b/.claude/hooks/pii-guard.py
@@ -1,0 +1,103 @@
+"""PreToolUse hook: stop an agent publishing a real identity to GitHub.
+
+The repo-side hooks (.githooks/) cover commits and pushes, and CI covers the
+tree and the PR body. None of them see an agent calling `gh pr create` or
+`gh issue comment` straight from a shell — which is exactly how the identities
+this guard exists for got republished three times in one session, each time in
+the act of *describing* the leak.
+
+Blocks a Bash command when the command text itself carries a patient identity.
+Delegates every pattern decision to scripts/pii-scan.mjs so there is one source
+of truth, not a Python reimplementation that drifts.
+
+Fails open on any internal error: a broken hook must not wedge the session.
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+SCANNER = os.path.join("scripts", "pii-scan.mjs")
+
+# Only gate commands that actually publish. Reads (`gh pr view`, `git log`)
+# legitimately surface the old content and must stay usable for remediation.
+PUBLISHING = re.compile(
+    r"""\b(
+        gh\s+(issue|pr)\s+(create|comment|edit|review)
+      | gh\s+api\b(?=.*-X\s*(POST|PATCH|PUT))
+      | git\s+commit\b
+      | git\s+tag\b(?!.*-l)
+    )""",
+    re.VERBOSE | re.IGNORECASE,
+)
+
+
+def allow():
+    sys.exit(0)
+
+
+def deny(reason):
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
+        )
+    )
+    sys.exit(0)
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        allow()
+
+    if payload.get("tool_name") != "Bash":
+        allow()
+
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    if not command or not PUBLISHING.search(command):
+        allow()
+
+    cwd = payload.get("cwd") or os.getcwd()
+    scanner = os.path.join(cwd, SCANNER)
+    if not os.path.exists(scanner):
+        allow()
+
+    node = shutil.which("node")
+    if not node:
+        allow()
+
+    try:
+        proc = subprocess.run(
+            [node, scanner, "--stdin", "this command"],
+            input=command,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=15,
+        )
+    except Exception:
+        allow()
+
+    if proc.returncode == 0:
+        allow()
+
+    detail = (proc.stderr or proc.stdout or "").strip()
+    deny(
+        "Blocked: this command would publish a real identity to a public repo.\n\n"
+        f"{detail}\n\n"
+        "AGENTS.md §\"Privacy posture\": describe the shape, never the value. "
+        "Rewrite the message/body without the identifier, or use a roster persona."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": "python3 .claude/hooks/graphify-nudge.py 2>/dev/null || python .claude/hooks/graphify-nudge.py 2>/dev/null || true"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/pii-guard.py || python .claude/hooks/pii-guard.py"
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Block a commit message that names a real identity.
+#
+# This repo is public and the message is as public as the diff. The incident
+# that motivated the guard leaked partly through commit messages written to
+# *describe* the leak — so the rule is: describe the shape, never the value.
+#
+# Installed via `npm run setup:hooks` (sets core.hooksPath to .githooks).
+# Bypass, if you are certain: `git commit --no-verify`.
+
+[ -z "$SKIP_PII_HOOK" ] || exit 0
+
+command -v node >/dev/null 2>&1 || {
+  echo "pii-guard: node not found; cannot check the commit message." >&2
+  exit 1
+}
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+scanner="$repo_root/scripts/pii-scan.mjs"
+[ -f "$scanner" ] || exit 0
+
+if ! node "$scanner" --stdin "this commit message" < "$1"; then
+  echo "" >&2
+  echo "pii-guard: commit blocked — the message above names a real identity." >&2
+  echo "Rewrite it to describe the shape rather than the value." >&2
+  exit 1
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -44,9 +44,12 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
     fi
   done
 
-  if ! git diff "$range" 2>/dev/null | node "$scanner" --stdin "the outgoing diff" >/dev/null 2>&1; then
-    echo "pii-guard: push blocked — the outgoing diff carries a real identity:" >&2
-    git diff "$range" 2>/dev/null | node "$scanner" --stdin "the outgoing diff" >&2 2>&1
+  # --diff scans only introduced lines, so a scrub commit is not blocked by the
+  # old value sitting on its own removal lines, and the scanner's own exempt
+  # files stay exempt. A guard that cries wolf gets bypassed.
+  if ! git diff "$range" 2>/dev/null | node "$scanner" --diff >/dev/null 2>&1; then
+    echo "pii-guard: push blocked — the outgoing diff introduces a real identity:" >&2
+    git diff "$range" 2>/dev/null | node "$scanner" --diff >&2 2>&1
     status=1
   fi
 done

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Last gate before anything leaves the machine: scan the commit messages and
+# the diff of everything about to be pushed.
+#
+# commit-msg catches a message as it is written, but not one written before the
+# hooks were installed, amended elsewhere, or merged in from another branch.
+# This is the check that actually stands between a real identity and GitHub,
+# where a later scrub cannot reach refs/pull/*.
+#
+# Bypass, if you are certain: `git push --no-verify`.
+
+[ -z "$SKIP_PII_HOOK" ] || exit 0
+
+command -v node >/dev/null 2>&1 || exit 0
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+scanner="$repo_root/scripts/pii-scan.mjs"
+[ -f "$scanner" ] || exit 0
+
+z40=0000000000000000000000000000000000000000
+status=0
+
+# stdin: <local-ref> <local-sha> <remote-ref> <remote-sha>
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ "$local_sha" = "$z40" ] && continue   # branch deletion
+
+  if [ "$remote_sha" = "$z40" ]; then
+    # New branch: only what it adds on top of the upstream default branch.
+    base=$(git merge-base "$local_sha" origin/dev 2>/dev/null \
+        || git merge-base "$local_sha" origin/main 2>/dev/null)
+    range=${base:+$base..$local_sha}
+    range=${range:-$local_sha}
+  else
+    range="$remote_sha..$local_sha"
+  fi
+
+  commits=$(git rev-list "$range" 2>/dev/null) || continue
+  [ -z "$commits" ] && continue
+
+  for sha in $commits; do
+    if ! git log -1 --format=%B "$sha" | node "$scanner" --stdin "commit $(git rev-parse --short "$sha") message" >/dev/null 2>&1; then
+      echo "pii-guard: push blocked — commit $(git rev-parse --short "$sha") names a real identity in its message:" >&2
+      git log -1 --format=%B "$sha" | node "$scanner" --stdin "commit message" >&2 2>&1
+      status=1
+    fi
+  done
+
+  if ! git diff "$range" 2>/dev/null | node "$scanner" --stdin "the outgoing diff" >/dev/null 2>&1; then
+    echo "pii-guard: push blocked — the outgoing diff carries a real identity:" >&2
+    git diff "$range" 2>/dev/null | node "$scanner" --stdin "the outgoing diff" >&2 2>&1
+    status=1
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  echo "" >&2
+  echo "Nothing was pushed. Fix the history, or re-run with --no-verify if this is genuinely synthetic." >&2
+fi
+exit $status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       # This repo is public: fail the build before a real identity lands in it.
       # See AGENTS.md §"Privacy posture".
       - run: npm run check:pii
+      # `core.hooksPath` is per-clone, so CI checks the hook scripts are valid
+      # rather than that this runner installed them.
+      - run: sh -n .githooks/commit-msg && sh -n .githooks/pre-push
       - run: npm test
 
   # The tree is only one surface. A PR's title and body are just as public, are

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,20 @@ jobs:
       # See AGENTS.md §"Privacy posture".
       - run: npm run check:pii
       - run: npm test
+
+  # The tree is only one surface. A PR's title and body are just as public, are
+  # not covered by check:pii, and are where the identities this guard exists for
+  # were republished twice — while describing the fix.
+  pii-pr-text:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Scan PR title and body
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" | node scripts/pii-scan.mjs --stdin "this pull request's title/body"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,8 +336,26 @@ This repository is **public**. It is framework + documentation only.
   not after — a later scrub cannot reach `refs/pull/*`, which GitHub keeps permanently.
 - **The roster is the allowlist.** `SYNTHETIC_ROSTER` in `scripts/pii-scan.mjs` is the complete set
   of identities permitted in this repo. Need another persona? Add it there — that edit is the
-  review point. `npm run check:pii` enforces this in CI, and the same check gates every outbound
-  `gh` write in `scripts/sdlc.mjs`, so a lane physically cannot post an identity it invented.
+  review point.
+- **Describe the shape, never the value.** Writing *about* a leak is how one keeps spreading: a
+  fix's own commit message, PR body, and test fixtures are as public as the code. Say "a person
+  slug whose surname is not a placeholder", never the slug itself. The one place this is
+  unenforceable is `scripts/pii-scan.mjs` and its test, which the scanner must exempt — every
+  example identity there has to be invented.
+- **Every publishing surface is gated** (`npm run setup:hooks` installs the git ones; `npm install`
+  does it automatically):
+
+  | surface | gate |
+  |---|---|
+  | tracked files | `npm run check:pii`, in CI |
+  | commit message | `.githooks/commit-msg` |
+  | push (messages + introduced lines) | `.githooks/pre-push` |
+  | PR title and body | `pii-pr-text` CI job |
+  | agent shell commands | `.claude/hooks/pii-guard.py` |
+  | SDLC lane comments | `guardOutboundBody` in `scripts/sdlc.mjs` |
+
+  All of them shell out to `scripts/pii-scan.mjs`, so there is one set of patterns rather than six
+  that drift. Bypass is `--no-verify` and should be rare enough to notice.
 - MCP responses stay on the local machine. Agents MUST NOT relay record contents into any remote
   channel (issue comments, PRs, external APIs) beyond what the human explicitly asks for.
 - The live database and blobs stay out of git: `pemr.db` (and `*-wal`/`*-shm`), `sources/`,

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "check:pii": "node scripts/pii-scan.mjs",
     "setup:hooks": "node scripts/setup-hooks.mjs",
     "check:hooks": "node scripts/setup-hooks.mjs --check",
+    "prepare": "node scripts/setup-hooks.mjs",
     "sdlc": "node scripts/sdlc.mjs",
     "test": "node --test"
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "sync:claude-config:check": "node scripts/sync-claude-config.mjs --check",
     "check:meta-drift": "node scripts/check-meta-drift.mjs",
     "check:pii": "node scripts/pii-scan.mjs",
+    "setup:hooks": "node scripts/setup-hooks.mjs",
+    "check:hooks": "node scripts/setup-hooks.mjs --check",
     "sdlc": "node scripts/sdlc.mjs",
     "test": "node --test"
   }

--- a/scripts/pii-scan.mjs
+++ b/scripts/pii-scan.mjs
@@ -290,13 +290,47 @@ function trackedFiles() {
   }
 }
 
+function report(all, whatScanned) {
+  if (all.length === 0) {
+    console.log(`pii-scan: clean (${whatScanned})`);
+    return 0;
+  }
+  console.error(`pii-scan: ${all.length} finding(s)\n`);
+  for (const f of all) {
+    console.error(`${f.label}:${f.line}  [${f.rule}] ${f.message}`);
+    console.error(`    ${f.excerpt}`);
+  }
+  console.error('\nAGENTS.md §"Privacy posture": describe the shape, never the value.');
+  console.error('Add the persona to SYNTHETIC_ROSTER in scripts/pii-scan.mjs, or mark the line `pii-allow`.');
+  return 1;
+}
+
 function main(argv) {
+  const flags = argv.slice(2).filter((a) => a.startsWith('-'));
   const explicit = argv.slice(2).filter((a) => !a.startsWith('-'));
+
+  // `--stdin` scans arbitrary text — a commit message, a PR body, a shell
+  // command line. This is what the git and Claude Code hooks use, so every
+  // surface shares exactly one set of patterns.
+  if (flags.includes('--stdin')) {
+    const label = explicit[0] || '<stdin>';
+    let text = '';
+    try {
+      text = fs.readFileSync(0, 'utf8');
+    } catch {
+      text = '';
+    }
+    return report(scanText(text, label), label);
+  }
+
   const files = (explicit.length ? explicit : trackedFiles()).filter((f) => {
     const norm = f.split(path.sep).join('/');
     if (SKIP_FILES.has(norm)) return false;
+    // Explicit paths are a deliberate ask (a hook handing us .git/COMMIT_EDITMSG);
+    // only the default whole-tree sweep applies the directory/extension filters.
+    if (explicit.length) return true;
     if (norm.split('/').some((seg) => SKIP_DIRS.has(seg))) return false;
-    return explicit.length ? true : TEXT_EXT.has(path.extname(f));
+    return TEXT_EXT.has(path.extname(f));
   });
 
   let all = [];
@@ -310,18 +344,7 @@ function main(argv) {
     all = all.concat(scanText(text, f));
   }
 
-  if (all.length === 0) {
-    console.log(`pii-scan: clean (${files.length} files)`);
-    return 0;
-  }
-  console.error(`pii-scan: ${all.length} finding(s)\n`);
-  for (const f of all) {
-    console.error(`${f.label}:${f.line}  [${f.rule}] ${f.message}`);
-    console.error(`    ${f.excerpt}`);
-  }
-  console.error('\nAGENTS.md §"Privacy posture": fixtures are synthetic only.');
-  console.error('Add the persona to SYNTHETIC_ROSTER in scripts/pii-scan.mjs, or mark the line `pii-allow`.');
-  return 1;
+  return report(all, `${files.length} files`);
 }
 
 if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('pii-scan.mjs')) {

--- a/scripts/pii-scan.mjs
+++ b/scripts/pii-scan.mjs
@@ -309,6 +309,38 @@ function main(argv) {
   const flags = argv.slice(2).filter((a) => a.startsWith('-'));
   const explicit = argv.slice(2).filter((a) => !a.startsWith('-'));
 
+  // `--diff` reads a unified diff and scans only the lines it *introduces*,
+  // skipping the files the scanner necessarily exempts. Without both of those
+  // every scrub commit trips its own guard — a removal line still carries the
+  // old value — and a guard that cries wolf just teaches people --no-verify.
+  if (flags.includes('--diff')) {
+    let raw = '';
+    try {
+      raw = fs.readFileSync(0, 'utf8');
+    } catch {
+      raw = '';
+    }
+    let file = '<diff>';
+    let skipping = false;
+    const added = [];
+    for (const line of raw.split(/\r?\n/)) {
+      const hdr = /^\+\+\+ b\/(.+)$/.exec(line);
+      if (hdr) {
+        file = hdr[1].trim();
+        skipping = SKIP_FILES.has(file);
+        continue;
+      }
+      if (line.startsWith('---') || line.startsWith('+++')) continue;
+      if (!line.startsWith('+') || skipping) continue;
+      added.push({ file, text: line.slice(1) });
+    }
+    const found = [];
+    for (const a of added) {
+      for (const f of scanText(a.text, a.file)) found.push(f);
+    }
+    return report(found, `${added.length} added line(s)`);
+  }
+
   // `--stdin` scans arbitrary text — a commit message, a PR body, a shell
   // command line. This is what the git and Claude Code hooks use, so every
   // surface shares exactly one set of patterns.

--- a/scripts/setup-hooks.mjs
+++ b/scripts/setup-hooks.mjs
@@ -44,7 +44,15 @@ if (check) {
 }
 
 if (current !== DIR) {
-  git(['config', 'core.hooksPath', DIR]);
+  try {
+    git(['config', 'core.hooksPath', DIR]);
+  } catch {
+    // Runs from `prepare`, so it fires in tarball installs and sandboxes with
+    // no git repo. Not being able to install hooks is not a reason to fail an
+    // install; CI checks the hook scripts separately.
+    console.log('setup-hooks: not a git repo, skipping');
+    process.exit(0);
+  }
 }
 
 // core.hooksPath ignores the executable bit on Windows, but honours it on

--- a/scripts/setup-hooks.mjs
+++ b/scripts/setup-hooks.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Point git at the versioned hooks in .githooks/.
+//
+// Hooks in .git/hooks are per-clone and untracked, so they are exactly the
+// thing a fresh clone silently lacks. `core.hooksPath` keeps them in the repo
+// and under review.
+//
+//   npm run setup:hooks          # install
+//   npm run setup:hooks -- --check   # verify (used by CI)
+
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const DIR = '.githooks';
+const HOOKS = ['commit-msg', 'pre-push'];
+const check = process.argv.includes('--check');
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+const missing = HOOKS.filter((h) => !fs.existsSync(path.join(DIR, h)));
+if (missing.length) {
+  console.error(`setup-hooks: missing hook script(s): ${missing.join(', ')}`);
+  process.exit(1);
+}
+
+let current = '';
+try {
+  current = git(['config', '--get', 'core.hooksPath']);
+} catch {
+  current = '';
+}
+
+if (check) {
+  if (current !== DIR) {
+    console.error(`setup-hooks: core.hooksPath is '${current || '(unset)'}', expected '${DIR}'.`);
+    console.error('Run: npm run setup:hooks');
+    process.exit(1);
+  }
+  console.log(`setup-hooks: ok (core.hooksPath=${DIR})`);
+  process.exit(0);
+}
+
+if (current !== DIR) {
+  git(['config', 'core.hooksPath', DIR]);
+}
+
+// core.hooksPath ignores the executable bit on Windows, but honours it on
+// POSIX — set it where the filesystem supports it.
+for (const h of HOOKS) {
+  const p = path.join(DIR, h);
+  try {
+    fs.chmodSync(p, 0o755);
+  } catch {
+    /* windows: no-op */
+  }
+}
+
+console.log(`setup-hooks: core.hooksPath=${DIR} (${HOOKS.join(', ')})`);

--- a/test/pii-scan.test.mjs
+++ b/test/pii-scan.test.mjs
@@ -9,6 +9,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 
 import { scanText, assertClean, SYNTHETIC_ROSTER } from '../scripts/pii-scan.mjs';
 import { guardOutboundBody } from '../scripts/sdlc.mjs';
@@ -103,6 +104,47 @@ describe('assertClean', () => {
 
   it('passes clean text through silently', () => {
     assert.doesNotThrow(() => assertClean('sdlc:claim dispatch-20260815-0407 design'));
+  });
+});
+
+describe('diff mode: only what a change introduces', () => {
+  const run = (diff) => {
+    const r = spawnSync(process.execPath, ['scripts/pii-scan.mjs', '--diff'], {
+      input: diff, encoding: 'utf8',
+    });
+    return { code: r.status, out: (r.stdout || '') + (r.stderr || '') };
+  };
+
+  it('flags an identity on an added line', () => {
+    const diff = '--- a/x.md\n+++ b/x.md\n@@\n+repro for melanie-ashworth medication\n';
+    assert.equal(run(diff).code, 1);
+  });
+
+  it('ignores an identity that a change is REMOVING', () => {
+    // Otherwise every scrub commit trips its own guard and people learn to
+    // pass --no-verify, which is worse than having no hook.
+    const diff = '--- a/x.md\n+++ b/x.md\n@@\n-repro for melanie-ashworth medication\n+repro for jane-doe\n';
+    assert.equal(run(diff).code, 0);
+  });
+
+  it('ignores the files the scanner necessarily exempts', () => {
+    const diff = '--- a/test/pii-scan.test.mjs\n+++ b/test/pii-scan.test.mjs\n@@\n+  const t = "melanie-ashworth medication";\n';
+    assert.equal(run(diff).code, 0);
+  });
+});
+
+describe('stdin mode: arbitrary text surfaces', () => {
+  const run = (text) => spawnSync(
+    process.execPath, ['scripts/pii-scan.mjs', '--stdin', 'a message'],
+    { input: text, encoding: 'utf8' },
+  ).status;
+
+  it('rejects a commit message naming an identity', () => {
+    assert.equal(run('fix: repro for melanie-ashworth meds'), 1);
+  });
+
+  it('accepts an ordinary message', () => {
+    assert.equal(run('fix(render): suppress resulted orders'), 0);
   });
 });
 


### PR DESCRIPTION
## Summary

The guard from #146 covered the tracked tree and the SDLC dispatcher. It did not cover commit messages, pushes, PR titles/bodies, or an agent shelling out to `gh` — and every re-leak in this incident travelled through one of those, each time while *describing* the fix. Three in one session, none caught.

This closes the four uncovered surfaces.

| surface | gate |
|---|---|
| commit message | `.githooks/commit-msg` |
| push — messages + introduced lines | `.githooks/pre-push` |
| PR title and body | `pii-pr-text` CI job |
| agent shell commands | `.claude/hooks/pii-guard.py` |

All four shell out to `scripts/pii-scan.mjs`, so there is one set of patterns rather than four that drift apart. Two new scanner modes support them: `--stdin` for arbitrary text, and `--diff` for a unified diff.

## What testing changed

The agent hook fired on its own author mid-session, blocking a `git commit` whose message carried an identifier — the exact class of leak that motivated the work.

The `pre-push` diff scan initially flagged its own scrub commit. A removal line still carries the old value, and the scanner's exempt files are only exempt in the file sweep, not in raw diff text. As written it would have fired on every remediation commit, and a guard that cries wolf just teaches people `--no-verify`. Hence `--diff`: parse the diff, track the file, skip exempt paths, scan **only added lines**.

Hooks install via npm's `prepare`, because `core.hooksPath` is per-clone and a fresh clone is precisely what silently lacks them. CI syntax-checks the hook scripts rather than asserting the runner installed them.

## Test plan

- [x] `npm test` — 168/168 (5 new, covering both scanner modes and all three diff cases)
- [x] `npm run check:pii` — clean, 107 files
- [x] `check:meta-drift`, `sync:claude-config:check` — pass
- [x] `commit-msg` verified both ways: blocks a message naming an identity, passes a clean one
- [x] `pre-push` verified against a branch carrying a dirty commit message — blocked, nothing pushed
- [x] `--diff` matrix: introduces identity → blocks; removal-only → passes; exempt file → passes
- [x] **Recall still 19/19** against the real leak corpus

## Note

Bypass remains `--no-verify`, which is deliberate — it should be rare enough to be conspicuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
