### PR TITLE
fix(privacy): stop the skip-list hiding tracked files from check:pii

### DIFF
--- a/scripts/pii-scan.mjs
+++ b/scripts/pii-scan.mjs
@@ -273,8 +273,17 @@ export function assertClean(text, what = 'text') {
   );
 }
 
-const SKIP_DIRS = new Set(['.git', 'node_modules', 'sources', 'exports', 'inbox', 'backups', 'data', 'vdm-diag', '.venv', 'pemr.egg-info']);
-const TEXT_EXT = new Set(['.py', '.mjs', '.js', '.ts', '.md', '.json', '.toml', '.yml', '.yaml', '.txt', '.csv', '.sql', '.cfg', '.ini']);
+// No directory skip-list. The sweep enumerates `git ls-files`, so the runtime
+// directories worth excluding (sources/, exports/, inbox/, backups/, the venv)
+// are gitignored and can never appear. An explicit list only ever hid *tracked*
+// files — `data/` and `vdm-diag/` sat behind it, unscanned, for exactly that
+// reason. Untracked content is not this check's problem; the pre-push hook and
+// CI both operate on what is committed.
+const TEXT_EXT = new Set([
+  '.py', '.mjs', '.js', '.ts', '.md', '.json', '.toml', '.yml', '.yaml',
+  '.txt', '.csv', '.tsv', '.sql', '.cfg', '.ini', '.ps1', '.sh', '.bat',
+  '.xml', '.html', '.rst', '.env-example', '.example',
+]);
 // This file and its test necessarily contain the shapes they describe, so the
 // scanner cannot scan them — which makes them the one blind spot in the repo.
 // Every identity used as an example here MUST therefore be invented: a given
@@ -359,9 +368,8 @@ function main(argv) {
     const norm = f.split(path.sep).join('/');
     if (SKIP_FILES.has(norm)) return false;
     // Explicit paths are a deliberate ask (a hook handing us .git/COMMIT_EDITMSG);
-    // only the default whole-tree sweep applies the directory/extension filters.
+    // only the default sweep applies the extension filter.
     if (explicit.length) return true;
-    if (norm.split('/').some((seg) => SKIP_DIRS.has(seg))) return false;
     return TEXT_EXT.has(path.extname(f));
   });
 


### PR DESCRIPTION
## Summary

A fresh audit pass over **every blob reachable from public refs** (1165 unique objects, 10 branches) found **no real identity anywhere** — the remaining hits are all the guard's own invented fixtures. It did surface a blind spot in the check itself.

`SKIP_DIRS` listed `data/` and `vdm-diag/`, which between them hold five **tracked** files. `check:pii` had never scanned them.

The list was also redundant. The sweep enumerates `git ls-files`, so the runtime directories it names — `sources/`, `exports/`, `inbox/`, `backups/`, the venv — are gitignored and can never appear in the first place. Its only real effect was hiding committed files from the check.

## Change

Drop `SKIP_DIRS`, and widen `TEXT_EXT` to the extensions those files actually use (`.ps1`, `.xml`, `.sh`, `.bat`, `.html`, `.tsv`, `.rst`). Without the second half the paths come into scope but the files still fall out on extension.

Scope goes **107 → 112 files**.

## Verification

- [x] All five formerly-hidden files scan clean, against the repo rules *and* a broader generic pattern set (emails, phones, addresses, postcodes, SSNs, cards, AWS/GitHub/Slack tokens, private keys, hardcoded secrets, home paths)
- [x] `npm test` — 168/168
- [x] `npm run check:pii` — clean, 112 files
- [x] `check:meta-drift` — pass
- [x] **Recall unchanged at 19/19** on the real leak corpus

## What else the audit covered

Clean: all historical blobs; every distinct DOB value ever committed (14, all synthetic); 1379 issue/PR text units; PR review comments; labels; milestones; releases; tags; wiki; repo description and topics; untracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
