### PR TITLE
fix(privacy): scope the pre-push message scan to a branch's own commits

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,6 +7,11 @@
 # This is the check that actually stands between a real identity and GitHub,
 # where a later scrub cannot reach refs/pull/*.
 #
+# The message scan skips commits already reachable from origin/dev or
+# origin/main — CI gates those trees, and re-scanning them means every branch
+# that merges the integration branch inherits their verdict. Nothing wider is
+# exempt: a commit that escaped onto some other origin ref never earns a pass.
+#
 # Bypass, if you are certain: `git push --no-verify`.
 
 [ -z "$SKIP_PII_HOOK" ] || exit 0
@@ -29,11 +34,16 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
         || git merge-base "$local_sha" origin/main 2>/dev/null)
     range=${base:+$base..$local_sha}
     range=${range:-$local_sha}
+    commits=$(git rev-list "$range" 2>/dev/null)
   else
     range="$remote_sha..$local_sha"
+    # Same range, minus what origin/dev and origin/main already carry. Falls
+    # back to the whole range if those refs are absent — a missing ref must
+    # scan more, never less.
+    commits=$(git rev-list "$local_sha" --not "$remote_sha" origin/dev origin/main 2>/dev/null) \
+      || commits=$(git rev-list "$range" 2>/dev/null)
   fi
 
-  commits=$(git rev-list "$range" 2>/dev/null) || continue
   [ -z "$commits" ] && continue
 
   for sha in $commits; do


### PR DESCRIPTION
## The bug

For an existing remote branch, `.githooks/pre-push` computed `range="$remote_sha..$local_sha"` and
ran the per-commit **message** scan over every commit in that range. A `git merge dev` therefore
pulled the integration branch's own history into the scan.

One commit on `dev` (ae6b4ba) is a fix to the PII scanner itself, and its message necessarily
discusses the scanner's deliberately off-roster tripwire examples — the ones kept off
`SYNTHETIC_ROSTER` precisely so the rules fire. Result: every feature branch that merged `dev`
was blocked at push time on history it did not author and cannot rewrite. This parked the push
for issue #138 on 2026-08-15.

## The fix

The message scan now excludes commits already reachable from `origin/dev` or `origin/main`:

- same set as before, minus what the integration branches already carry;
- the **diff** scan (`git diff "$range"`) is unchanged in code, with one behavioral consequence:
  when *every* commit in the range is already reachable from the integration branches, the loop now
  skips the iteration before the diff scan runs (the old hook ran it). That case means `local_sha`'s
  tree is itself an integration-branch tree, so it is covered by the same CI-`check:pii` rationale
  as the message exclusion. For any range containing at least one genuinely new commit, the diff
  scan runs over the full original `remote..local` range exactly as before;
- the new-branch (`merge-base`) arm is untouched;
- if neither integration ref resolves (shallow or single-branch clone), the hook falls back to the
  whole range. A missing ref must scan more, never less — the exclusion must not fail open.

## Why the exemption is `origin/dev` + `origin/main` only

- Those two trees are gated by `check:pii` in CI, so re-scanning them only re-litigates a verdict
  that already passed on a branch that cannot act on it.
- `--not --remotes=origin` was rejected. It would exempt anything that ever landed on any origin
  ref — including commits pushed with `--no-verify` or from a clone with no hooks installed — so a
  single escape would launder itself into a permanent bypass of the last gate. It also opens a
  stale-ref window: after a history-rewrite scrub, leftover remote-tracking refs would keep
  vouching for the very commits being removed.
- The stakes are asymmetric here: a scrub cannot reach `refs/pull/*`, which GitHub keeps
  permanently. The exemption is deliberately the narrowest set that fixes the false positive.

## Verification

- `sh -n .githooks/pre-push` passes (CI's POSIX check).
- **Regression repro, proven failing first.** Fed the hook a stdin line with `local` = `origin/dev`
  tip and `remote` = `origin/dev~12` (older than ae6b4ba, so ae6b4ba falls inside the range).
  Pre-fix: exit 1, blocked on ae6b4ba's message. Post-fix: exit 0, silent.
- **Guard still fires.** Made a throwaway commit on a temp branch whose message contained a freshly
  invented, non-roster person slug of the flagging shape, and fed the hook `local` = that commit,
  `remote` = its parent. Exit 1, correctly attributed to that commit. Temp branch deleted; the
  invented slug appears in no surviving commit, message, or file on this branch (verified with
  `git log -p` and `git grep` over the tree).
- `npm run check:pii` clean; `npm test` 168/168 passing. No Python touched, so `pytest` was not run.
- This branch was pushed without `--no-verify`.

Unblocks the parked push on #138. Referenced commits are given by SHA only, per
AGENTS.md §"Privacy posture" — describe the shape, never the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


