### PR TITLE
feat(observation): add functional obs_type for caregiver-observed IADL/self-management facts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ report's verbatim label.
   edit for you to make in the payload.
 - MUST NOT invent abbreviations or "helpful" renames.
 
-### 2. Observation rows — vitals, orders, screenings, immunizations
+### 2. Observation rows — vitals, orders, screenings, immunizations, functional
 
 `render_summary` populates its **Orders & Referrals** and **Latest Vitals** sections purely from
 `observation` rows, keyed by `obs_type`. An extraction that omits them leaves those sections
@@ -133,10 +133,10 @@ also maps common synonyms (`bp` → `blood_pressure`), but agents SHOULD emit th
 directly. Set `observed_at` (ISO date) whenever the source gives one — it drives timeline order and
 the "latest" selection.
 
-Two more observation families capture care-gap inputs. They have **no dedicated summary section** —
-their structured consumer is the future `pemr due` (care-gap) command, so they surface only via the
-generic `observation` loop in the appointment brief and timeline. Commit them anyway; the last-done
-date is what phase 7 needs and re-extraction to recover it later is expensive:
+Three more observation families have **no dedicated summary section** — they surface only via the
+generic `observation` loop in the appointment brief and timeline. Commit them anyway: for the first
+two the structured consumer is the future `pemr due` (care-gap) command and the last-done date is
+what phase 7 needs; re-extraction to recover any of them later is expensive:
 
 - **Screening** → `obs_type='screening'`, `key=<snake_case screening name>` (e.g. `mammogram`,
   `colonoscopy`, `diabetes_screening`), `observed_at=<last-done ISO date>` (the load-bearing
@@ -145,6 +145,28 @@ date is what phase 7 needs and re-extraction to recover it later is expensive:
 - **Immunization** → `obs_type='immunization'`, `key=<snake_case vaccine name>` (e.g. `influenza`,
   `tdap`, `mmr`, `pneumococcal`), `observed_at=<date administered>`, optional `value_text=<detail:
   dose #, lot, site>`. One row per administration; multiple rows over time = vaccination history.
+
+- **Functional** → `obs_type='functional'`, `key=<snake_case IADL / self-management token>` (e.g.
+  `financial_self_management`, `meal_regularity`, `medication_self_administration`, `iadl_bathing`),
+  `observed_at=<ISO date the fact was observed>`, optional `value_num` (an ordinal/scale rating) or
+  `value_text` (the observed fact in words). This is the home for a caregiver-observed fact about
+  daily function — the class of evidence that is not a vital sign, not an order and not a diagnosis
+  (issue #132).
+  - `observed_at` is **required** here, unlike every other observation family: a functional
+    observation's entire value is being dated (a decline is a date, not a state), and an undated one
+    is the unqueryable prose this family exists to replace. A commit without it is **rejected**.
+  - Attribution: set `document_id` implicitly by committing against the source document when one
+    states the fact (e.g. a transcribed ledger or letter). A fact known only from family knowledge
+    with no document goes through `pemr record assert` (CLI-only, never an MCP tool — see the tool
+    surface above; issue #110) — **never** invent a document to hang it on.
+  - **MUST NOT imply a diagnosis.** A `functional` row records an observed fact ("stopped balancing
+    the register in July"), never a coded finding. Never promote one to a `condition` row and never
+    emit a paired `condition` because the pattern suggests one — no diagnostic code without
+    clinician documentation. The inverse rule lives in §3: conditions are typed rows, not
+    observations.
+  - `key` is lightly controlled: emit sensible `snake_case` tokens, no approval gate (same
+    discipline as screening/vaccine tokens). One row per observation date — a series of rows on the
+    same `key` over time *is* the trend.
 
 Vaccine overlap (influenza appears in both worlds): an **administered** vaccine → an `immunization`
 row; a health-screening-table *"due / last-done"* line → a `screening` row **only when the table is

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -278,8 +278,9 @@ CREATE TABLE observation (
   document_id    INTEGER REFERENCES document(document_id),
   obs_type       TEXT NOT NULL,           -- 'vital' (key = canonical vital token, e.g.
                                            -- 'blood_pressure'/'weight'), 'order',
-                                           -- 'screening', 'immunization'
-                                           -- (condition/allergy graduated in 006)
+                                           -- 'screening', 'immunization', 'functional'
+                                           -- ('functional' alone requires observed_at;
+                                           -- condition/allergy graduated in 006)
   observed_at    TEXT,
   key            TEXT,
   value_num      REAL,

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -147,6 +147,16 @@ ENUM_FIELDS: dict[str, dict[str, frozenset[str]]] = {
     },
 }
 
+# Per-`obs_type` required fields, enforced by validate_row after the per-field loop.
+# `observation`'s FIELD_SPECS entry marks `observed_at` optional because vitals and orders
+# legitimately arrive undated, but a `functional` row's whole value is being dated (issue
+# #132: "the running-balance column stops in July") — an undated one is exactly the
+# unqueryable prose that record type exists to eliminate. Scoped to `functional` alone:
+# widening it to the other families would reject already-valid extractions.
+OBS_TYPE_REQUIRED: dict[str, frozenset[str]] = {
+    "functional": frozenset({"observed_at"}),
+}
+
 _WS = re.compile(r"\s+")
 # Capturing group so the same pattern both removes a parenthetical (`sub`, giving the
 # bare analyte stem) and yields its contents (`findall`, giving the candidate qualifier).
@@ -572,6 +582,18 @@ def validate_row(record_type: str, row: object) -> None:
                 f"{record_type}.{name}: expected one of "
                 f"{', '.join(sorted(allowed))}, got {value!r}"
             )
+    if record_type == "observation":
+        # Runs after the per-field loop so a type/ISO-date error on a field that *is*
+        # present still reports first. `obs_type` is required=True, hence present here.
+        # Matched verbatim (not via enum_token): `obs_type` is stored as written and every
+        # reader selects on it with `=`, so a rule keyed to a normalized spelling would
+        # bind a value that then renders nowhere.
+        for field in sorted(OBS_TYPE_REQUIRED.get(row["obs_type"], frozenset())):
+            if row.get(field) is None:
+                raise ValidationError(
+                    f"observation: missing required field '{field}' "
+                    f"for obs_type={row['obs_type']!r}"
+                )
 
 
 def _type_names(types: object) -> str:

--- a/tests/test_attestations.py
+++ b/tests/test_attestations.py
@@ -426,3 +426,27 @@ def test_the_mcp_read_payload_uses_the_same_rule(conn, jane):
     at_cli = [_cli._clean(r) for r in query.query_meds(conn, "jane-doe")]
     assert over_mcp == at_cli
     assert over_mcp[0]["attested_by"] == "Mom"
+
+
+def test_cli_assert_a_functional_observation_without_a_document(cli_ready, capsys):
+    """Issue #132: AGENTS.md §2 names `record assert` as the home for a functional fact
+    known only from family knowledge, so that path has to honour the family's rules —
+    the row lands unsourced, and an undated one is refused like any other."""
+    argv = (
+        "record", "assert", "observation", "--person", "jane-doe",
+        "--attributed-to", "Daughter", "--date", "2026-08-09",
+        "--field", "obs_type=functional", "--field", "key=meal_regularity",
+        "--field", "observed_at=2026-08-01",
+        "--field", "value_text=one meal most days",
+    )
+    assert _run(cli_ready, *argv, "--apply") == 0
+    assert "wrote observation #1" in capsys.readouterr().out
+    assert _run(cli_ready, "record", "assert", "--list") == 0
+    assert "needs source" in capsys.readouterr().out
+
+    assert _run(
+        cli_ready, "record", "assert", "observation", "--person", "jane-doe",
+        "--attributed-to", "Daughter", "--date", "2026-08-09",
+        "--field", "obs_type=functional", "--field", "key=meal_regularity", "--apply",
+    ) == 1
+    assert "missing required field 'observed_at'" in capsys.readouterr().err

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -1535,3 +1535,69 @@ def test_rekey_is_the_migration_for_a_pre_change_database(ready, capsys):
     assert _run(tmp_path, "commit-extraction", "--document", str(doc),
                 "--json", str(payload)) == 0
     assert "0 new, 1 duplicate" in capsys.readouterr().out
+
+
+# --- functional observations end to end (issue #132) --------------------------
+
+def test_functional_observation_cli_roundtrip(ready, capsys):
+    """The #132 round trip through the real CLI: a caregiver-observed functional fact
+    stated by an ingested document commits, reaches `query timeline` and `render brief`
+    on the generic observation path, and stays out of `render summary`'s vitals/orders
+    sections and out of the problem list entirely."""
+    tmp_path = ready
+    register = tmp_path / "register.txt"
+    register.write_bytes(b"check register transcription, jane-doe: the running balance "
+                         b"column stops mid-page while checks keep being written")
+    assert _run(tmp_path, "ingest", str(register), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources")) == 0
+    capsys.readouterr()
+
+    payload = _write_json(tmp_path, "functional.json", {
+        "observation": [
+            {"obs_type": "functional", "key": "financial_self_management",
+             "observed_at": "2025-07-05",
+             "value_text": "stopped carrying the running balance forward"},
+            {"obs_type": "functional", "key": "meal_regularity",
+             "observed_at": "2025-07-19", "value_num": 2, "unit": "meals/day"},
+        ],
+        "appointment": [{"scheduled_for": "2099-02-01", "provider": "Dr. Smith",
+                         "specialty": "Geriatrics", "reason": "function review"}],
+    })
+    assert _run(tmp_path, "commit-extraction", "--document", "1",
+                "--json", str(payload)) == 0
+    assert "3 new" in capsys.readouterr().out
+
+    # An undated functional row is refused at the CLI boundary, not quietly stored.
+    undated = _write_json(tmp_path, "undated.json", {"observation": [
+        {"obs_type": "functional", "key": "meal_regularity",
+         "value_text": "skipping meals"},
+    ]})
+    assert _run(tmp_path, "commit-extraction", "--document", "1",
+                "--json", str(undated)) == 1
+    assert "missing required field 'observed_at'" in capsys.readouterr().err
+
+    assert _run(tmp_path, "query", "timeline", "--person", "jane-doe") == 0
+    timeline = capsys.readouterr().out
+    assert "functional financial_self_management" in timeline
+    assert "stopped carrying the running balance forward" in timeline
+    assert "2025-07-05" in timeline
+    assert "functional meal_regularity" in timeline and "meals/day" in timeline
+
+    assert _run(tmp_path, "render", "brief", "--appointment", "1") == 0
+    brief = capsys.readouterr().out
+    observations = brief.split("## Procedures & Observations")[1].split("\n## ")[0]
+    assert "functional financial_self_management" in observations
+    assert "## Active Problems\n\n_none recorded_" in brief   # never a diagnosis
+
+    assert _run(tmp_path, "render", "summary", "--person", "jane-doe") == 0
+    summary = capsys.readouterr().out
+    for section in ("## Latest Vitals", "## Orders & Referrals", "## Active Problems"):
+        assert "functional" not in summary.split(section)[1].split("\n## ")[0]
+
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        assert conn.execute("SELECT COUNT(*) AS n FROM observation "
+                            "WHERE obs_type='functional'").fetchone()["n"] == 2
+        assert conn.execute("SELECT COUNT(*) AS n FROM condition").fetchone()["n"] == 0
+    finally:
+        conn.close()

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -429,6 +429,57 @@ def test_validate_rejects_non_iso_date_across_record_types():
         dedup.validate_row("observation", {"obs_type": "vital", "observed_at": "2026/01/02"})
 
 
+@pytest.mark.parametrize("key", ["financial_self_management", "meal_regularity",
+                                  "medication_self_administration", "iadl_bathing"])
+def test_validate_accepts_functional_observation_keys(key):
+    # Issue #132: `functional` is a fifth obs_type and its `key` vocabulary is only
+    # lightly controlled — any sensible snake_case token validates, no dictionary gate.
+    dedup.validate_row(
+        "observation",
+        {"obs_type": "functional", "key": key, "observed_at": "2026-07-14",
+         "value_text": "stopped keeping the running balance mid-page"},
+    )
+
+
+def test_validate_accepts_functional_ordinal_value():
+    # An ordinal/scale rating is as legal as a free-text description.
+    dedup.validate_row(
+        "observation",
+        {"obs_type": "functional", "key": "meal_regularity",
+         "observed_at": "2026-07", "value_num": 2},
+    )
+
+
+def test_validate_rejects_functional_without_observed_at():
+    # The one field `functional` requires that the other families don't: an undated
+    # functional observation is the unqueryable prose the record type exists to replace.
+    with pytest.raises(dedup.ValidationError,
+                       match=r"missing required field 'observed_at'.*functional"):
+        dedup.validate_row(
+            "observation",
+            {"obs_type": "functional", "key": "financial_self_management",
+             "value_text": "stopped balancing the register"},
+        )
+
+
+@pytest.mark.parametrize("obs_type", ["vital", "order", "screening", "immunization"])
+def test_validate_still_accepts_other_obs_types_without_observed_at(obs_type):
+    # Scoping regression: the observed_at requirement is `functional`-only. Widening it
+    # would reject already-valid extractions (an undated vital or order is routine).
+    dedup.validate_row("observation", {"obs_type": obs_type, "key": "anything"})
+
+
+def test_validate_functional_date_check_runs_before_required_check():
+    # The new rule must not shadow DATE_FIELDS: a present-but-junk observed_at still
+    # reports as an ISO-date error, not as a missing field.
+    with pytest.raises(dedup.ValidationError, match=r"observed_at.*ISO date"):
+        dedup.validate_row(
+            "observation",
+            {"obs_type": "functional", "key": "meal_regularity",
+             "observed_at": "July 2026"},
+        )
+
+
 def test_commit_bad_date_rolls_back_whole_batch(conn):
     # End-to-end: a non-ISO date in a committed batch rolls the whole thing back.
     doc = _make_document(conn)
@@ -713,6 +764,66 @@ def test_serial_same_day_observations_are_distinct_rows(conn):
     summary = dedup.commit_extraction(conn, doc, {"observation": rows}, d)
     assert summary.counts == {"new": 2, "duplicate": 0, "enriched": 0, "conflict": 0, "promoted": 0}
     assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 2
+
+
+# --- functional observations (issue #132) -------------------------------------
+
+def _functional(observed_at, key="financial_self_management",
+                value_text="running balance column stops mid-page"):
+    return {"obs_type": "functional", "key": key, "observed_at": observed_at,
+            "value_text": value_text}
+
+
+def test_functional_observation_commits_without_a_migration(conn):
+    # A caregiver-observed functional fact stated by an ingested document lands as an
+    # ordinary observation row carrying that document as its provenance.
+    doc = _make_document(conn)
+    summary = dedup.commit_extraction(conn, doc, {"observation": [_functional("2026-07-14")]})
+    assert summary.counts["new"] == 1
+    row = conn.execute("SELECT * FROM observation WHERE obs_type='functional'").fetchone()
+    assert row["key"] == "financial_self_management"
+    assert row["observed_at"] == "2026-07-14"
+    assert row["document_id"] == doc
+
+
+def test_functional_observation_never_creates_a_condition(conn):
+    # The load-bearing invariant: no diagnostic code without clinician documentation.
+    # A functional observation records what was observed and stops there — nothing may
+    # promote it into the problem list.
+    doc = _make_document(conn)
+    dedup.commit_extraction(conn, doc, {"observation": [
+        _functional("2026-07-14"),
+        _functional("2026-08-02", key="meal_regularity",
+                    value_text="one meal most days, skipped others"),
+    ]})
+    assert conn.execute("SELECT COUNT(*) AS n FROM condition").fetchone()["n"] == 0
+    assert conn.execute("SELECT COUNT(*) AS n FROM allergy").fetchone()["n"] == 0
+
+
+def test_functional_series_keeps_one_row_per_date(conn):
+    # The dated series *is* the trend: same key on two dates = two rows, while a second
+    # document restating the same key+date collapses.
+    doc1 = _make_document(conn)
+    doc2 = _make_document(conn)
+    dedup.commit_extraction(conn, doc1, {"observation": [_functional("2026-07-14")]})
+    same = dedup.commit_extraction(conn, doc2, {"observation": [_functional("2026-07-14")]})
+    assert same.counts["duplicate"] == 1
+    later = dedup.commit_extraction(conn, doc2, {"observation": [_functional("2026-08-14")]})
+    assert later.counts["new"] == 1
+    assert conn.execute(
+        "SELECT COUNT(*) AS n FROM observation WHERE obs_type='functional'"
+    ).fetchone()["n"] == 2
+
+
+def test_functional_commit_without_observed_at_is_rejected(conn):
+    # The validation rule holds through the real commit path, and the batch is atomic.
+    doc = _make_document(conn)
+    with pytest.raises(dedup.ValidationError, match="missing required field 'observed_at'"):
+        dedup.commit_extraction(conn, doc, {"observation": [
+            {"obs_type": "functional", "key": "meal_regularity",
+             "value_text": "skipping meals"},
+        ]})
+    assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 0
 
 
 # --- intra-payload collisions (issue #58) -------------------------------------

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -232,6 +232,24 @@ def test_timeline_excludes_family_history(seeded):
     assert not any(e["date"] == "2001-01-01" for e in events)
 
 
+def test_timeline_surfaces_functional_observations(seeded):
+    """Issue #132: a caregiver-observed functional fact needs no new rendering — it rides
+    the generic observation loop, dated, with its `obs_type key` detail and its value."""
+    doc = _doc(seeded, "jane-doe", ocr="ledger transcription")
+    dedup.commit_extraction(seeded, doc, {"observation": [
+        {"obs_type": "functional", "key": "financial_self_management",
+         "observed_at": "2025-07-20",
+         "value_text": "running balance column stops mid-page"},
+    ]})
+    events = query.query_timeline(seeded, "jane-doe")
+    hit = [e for e in events if "functional" in e["summary"]]
+    assert len(hit) == 1
+    assert hit[0]["date"] == "2025-07-20"
+    assert hit[0]["type"] == "observation"
+    assert "financial_self_management" in hit[0]["summary"]
+    assert "running balance column stops mid-page" in hit[0]["summary"]
+
+
 def test_timeline_carries_provenance(seeded):
     events = query.query_timeline(seeded, "jane-doe")
     assert all("document_id" in e for e in events)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -513,6 +513,29 @@ def test_brief_scopes_to_appointment_and_person(seeded):
     assert "999" not in md           # john's lab must never leak in
 
 
+def test_functional_observation_surfaces_without_a_new_section(seeded):
+    """Issue #132: a functional observation reaches the brief through the generic
+    observation loop, and must stay out of the vitals/orders sections — those are scoped
+    by obs_type equality and widening them is not how this family surfaces."""
+    doc = _doc(seeded, "jane-doe", ocr="ledger transcription")
+    dedup.commit_extraction(seeded, doc, {"observation": [
+        {"obs_type": "functional", "key": "financial_self_management",
+         "observed_at": "2025-07-20",
+         "value_text": "running balance column stops mid-page"},
+    ]})
+    md = render.render_brief(seeded, _upcoming_appt_id(seeded))
+    ctx = md.split("## Procedures & Observations")[1].split("\n## ")[0]
+    assert "functional financial_self_management" in ctx
+    assert "running balance column stops mid-page" in ctx
+    assert "2025-07-20" in ctx
+
+    summary = render.render_summary(seeded, "jane-doe")
+    assert "financial_self_management" not in \
+        summary.split("## Latest Vitals")[1].split("\n## ")[0]
+    assert "financial_self_management" not in \
+        summary.split("## Orders & Referrals")[1].split("\n## ")[0]
+
+
 def test_brief_flags_abnormal_labs_with_marker_and_ref(seeded):
     """Recent Labs in the brief must not hide an abnormal value: each abnormal lab gets
     a marker + its reference interval, mirroring render summary; normal labs stay bare."""


### PR DESCRIPTION
## Summary

Adds `functional` as a fifth `obs_type` value on the `observation` table — a caregiver-observed
functional fact (IADL / self-management), dated, without implying a diagnosis. No schema
migration needed: the catch-all `observation` table already accepts any `obs_type` string; this
change adds the one genuine behavior — `functional` rows now *require* `observed_at` — plus the
AGENTS.md / Architecture.md documentation for the new family.

- `pemr/dedup.py` — `OBS_TYPE_REQUIRED = {"functional": frozenset({"observed_at"})}` and a
  `functional`-scoped required-field check in `validate_row`. `vital`/`order`/`screening`/
  `immunization` keep today's optional `observed_at` (unaffected — pinned by a scoping
  regression test).
- `AGENTS.md` §2 — documents the `functional` family: lightly-controlled `snake_case` key
  vocabulary, required `observed_at` (and why), optional `value_num`/`value_text`, attribution
  (`document_id` or `record assert` when there's no source document), and the **MUST NOT imply a
  diagnosis** rule (no promotion to `condition` without clinician documentation — pemr-data
  ledger #18 item 3).
- `docs/Architecture.md` §3 — `observation` DDL comment's `obs_type` list extended with
  `'functional'`. `migrations/001_init.sql` is untouched (shipped migrations are immutable
  history).
- Tests (`tests/test_dedup.py`, `test_query.py`, `test_render.py`, `test_cli_phase2.py`,
  `test_attestations.py`) pin: the four example keys, `observed_at` required with the scoping
  regression, `value_num`/`value_text`, the no-diagnosis invariant (`condition`/`allergy` counts
  stay 0), the dated-series dedup behavior, and end-to-end surfacing through `query timeline` /
  `render brief` while staying out of `render summary`'s Latest Vitals and Orders & Referrals.

No new render surface, no `trends` support, no closed key dictionary — all explicitly out of
scope per the reviewed implementation plan in the issue body.

Closes #132

## Verification

- Verify report: full `pytest` (1112 passed), `node --test` (168 passed), real-run CLI round
  trip against a scratch DB, full AC coverage ledger —
  https://github.com/meridun/pemr/issues/132#issuecomment-5304107604
- Audit report: read-only security/invariant review, no blocking findings, no-diagnosis
  invariant confirmed absent of any inference path, pii-scan clean —
  https://github.com/meridun/pemr/issues/132#issuecomment-5304133700

🤖 Generated with the pemr agentic SDLC pipeline (ship stage)
