### PR TITLE
feat(ingest): native CCDA/C-CDA text extraction for find + owner verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,8 @@ to `find` (FTS5); an ingest without it is silently unsearchable.
   beats tesseract on messy scans.
 - **Fallback:** `ocr=true` (CLI: `--ocr auto`) only when you cannot read the file type yourself.
   It extracts by whatever route the type allows — plaintext/`.csv`/`.json` read directly,
-  `.docx`/`.xlsx` parsed from their OOXML, everything else (images, unknown suffixes)
+  `.docx`/`.xlsx` parsed from their OOXML, a CCDA `.xml` (a portal "download my record"
+  export) rendered from its section narrative, everything else (images, unknown suffixes)
   through tesseract. A `.pdf` is read page by page — embedded text layer where there is one, a
   300-dpi render OCR'd where there isn't (first 20 pages, joined by `\f`); that route needs the
   optional `pip install pemr[ocr]` extra, and without it a PDF stores no text and says so on
@@ -229,7 +230,8 @@ ingest-time owner check: it scans that text for the claimed person's name/DOB an
 carry a signal — their absence from the text is ignorance, not evidence). `mismatch`/`suspect`
 **refuse the ingest** before anything is written. `suspect` is scoped by **route**: it applies to
 the text you supply and to a tesseract pass, and never to anything `--ocr auto` extracts natively
-— the whole `.txt`/`.md`/`.csv`/`.tsv`/`.json`/`.log`/`.docx`/`.xlsx` set — because in a
+— the whole `.txt`/`.md`/`.csv`/`.tsv`/`.json`/`.log`/`.docx`/`.xlsx` set, CCDA `.xml`
+included — because in a
 structured export `Patient`/`DOB`/`MRN` are column labels rather than an identity header. The
 route is the line, not how prose-like the format is: a transcript you save as `.txt` and ingest
 with `--ocr auto` gets no identity-header check either, so pass your transcription as `ocr_text` /

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -797,11 +797,22 @@ tables as tab-delimited rows, prefixed with the `recordTarget` patient name and 
 time so the owner check has an identity to match. Detection is the parsed **root element**
 (`{urn:hl7-org:v3}ClinicalDocument`), never the suffix — `.xml` is a container, so any
 other XML keeps the OCR route. A `<!DOCTYPE` is refused before parsing (stdlib
-`ElementTree` expands internal entities, and the size cap does not bound expansion) — the
-refusal scans the **whole prolog**, stepping over comments and PIs rather than a fixed
-head window, because a leading comment pads the DOCTYPE past any window while the CCDA
-markers stay inside it. A malformed file is simply "not detectably a CCDA" and falls
-through. The narrative walk
+`ElementTree` expands internal entities, and the size cap does not bound expansion: a
+1.4 KB file rendered 1 MB of text, a 2 MB one 210 MB). That refusal is **encoding-agnostic
+by construction** — it asks expat, through a probe that aborts at whichever comes first,
+the DOCTYPE declaration or the root start tag, rather than scanning for byte patterns.
+Two hand-rolled scanners were bypassed before it: a fixed head window (a leading comment
+pads the DOCTYPE past it while the CCDA markers stay inside), then a whole-prolog ASCII
+scan (in UTF-16 every marker is `<\x00!\x00…`, so the scan read the first `<` as a start
+tag and never saw the DOCTYPE, while ASCII marker bytes smuggled into a CJK comment kept
+the file sniffing as a CCDA). Establishing the encoding is exactly what a byte scanner
+must re-implement to be correct, and expat has already done it — from the BOM and the
+`encoding=` pseudo-attribute — before it reports either event, so asking it is both
+cheaper and the version that cannot be re-bypassed. Detection itself stays a *cheap ASCII
+negative* over the first 8 KB, which means a genuine UTF-16 CCDA is not read natively and
+keeps today's OCR route: a deliberate narrowing, since a negative filter can be
+conservative for free while the refusal cannot. A malformed file is simply "not detectably
+a CCDA" and falls through. The narrative walk
 is **iterative, not recursive**: nesting depth is document-controlled and ~1500 levels fit
 in 30 KB, so a recursive walk hit `RecursionError` — a `RuntimeError`, outside the
 best-effort handler — and cost the whole document. `RecursionError` is caught there now

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -798,7 +798,11 @@ time so the owner check has an identity to match. Detection is the parsed **root
 (`{urn:hl7-org:v3}ClinicalDocument`), never the suffix — `.xml` is a container, so any
 other XML keeps the OCR route. A `<!DOCTYPE` is refused before parsing (stdlib
 `ElementTree` expands internal entities, and the size cap does not bound expansion), and
-a malformed file is simply "not detectably a CCDA" and falls through. Only the narrative
+a malformed file is simply "not detectably a CCDA" and falls through. The narrative walk
+is **iterative, not recursive**: nesting depth is document-controlled and ~1500 levels fit
+in 30 KB, so a recursive walk hit `RecursionError` — a `RuntimeError`, outside the
+best-effort handler — and cost the whole document. `RecursionError` is caught there now
+as well, since the stdlib's own `itertext()` walk is a recursive generator. Only the narrative
 is read: CCDA's coded entries are out of scope, since in real exports they are only
 selectively trustworthy (medication codes arrive `nullFlavor="UNK"` with the drug name
 only in the narrative, and historical entries carry a synthetic placeholder prescriber).

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -797,8 +797,11 @@ tables as tab-delimited rows, prefixed with the `recordTarget` patient name and 
 time so the owner check has an identity to match. Detection is the parsed **root element**
 (`{urn:hl7-org:v3}ClinicalDocument`), never the suffix — `.xml` is a container, so any
 other XML keeps the OCR route. A `<!DOCTYPE` is refused before parsing (stdlib
-`ElementTree` expands internal entities, and the size cap does not bound expansion), and
-a malformed file is simply "not detectably a CCDA" and falls through. The narrative walk
+`ElementTree` expands internal entities, and the size cap does not bound expansion) — the
+refusal scans the **whole prolog**, stepping over comments and PIs rather than a fixed
+head window, because a leading comment pads the DOCTYPE past any window while the CCDA
+markers stay inside it. A malformed file is simply "not detectably a CCDA" and falls
+through. The narrative walk
 is **iterative, not recursive**: nesting depth is document-controlled and ~1500 levels fit
 in 30 KB, so a recursive walk hit `RecursionError` — a `RuntimeError`, outside the
 best-effort handler — and cost the whole document. `RecursionError` is caught there now

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -22,7 +22,10 @@ re-inventing logic each request.
 
 ## Non-goals
 
-- No HIPAA/PHI compliance layer, no provider interoperability (HL7/FHIR/CCD).
+- No HIPAA/PHI compliance layer, no HL7/FHIR message exchange or provider-system
+  integration. Reading a clinical export *file* is not interoperability: document-level
+  **text extraction** from formats like CCDA/CCD is in scope (issue #138) — one more
+  document format feeding `find` and the owner check.
 - No always-on server, no multi-writer concurrency (family scale, one machine).
 - No clinical decision-making — the system assists prep/research, doesn't advise.
 
@@ -788,6 +791,18 @@ type allows (issue #66), with only the image and PDF routes reaching outside the
 parsed, **everything else** through `tesseract` (a soft dependency) — no image-suffix
 allowlist, so `.jfif`, `.jpe` and extension-less scans OCR like any other image.
 
+A **CCDA** `.xml` (C-CDA / HL7 CDA R2 — what a US portal's "download my record" produces)
+is read natively too (issue #138): each `structuredBody` section's title and narrative,
+tables as tab-delimited rows, prefixed with the `recordTarget` patient name and birth
+time so the owner check has an identity to match. Detection is the parsed **root element**
+(`{urn:hl7-org:v3}ClinicalDocument`), never the suffix — `.xml` is a container, so any
+other XML keeps the OCR route. A `<!DOCTYPE` is refused before parsing (stdlib
+`ElementTree` expands internal entities, and the size cap does not bound expansion), and
+a malformed file is simply "not detectably a CCDA" and falls through. Only the narrative
+is read: CCDA's coded entries are out of scope, since in real exports they are only
+selectively trustworthy (medication codes arrive `nullFlavor="UNK"` with the drug name
+only in the narrative, and historical entries carry a synthetic placeholder prescriber).
+
 `.pdf` takes its own branch inside `run_ocr` (issue #70), because `tesseract` alone cannot
 read a PDF at all — its Leptonica backend has no PDF decoder, so a scanned PDF is no better
 off than a text-layer one. Instead a PDF is read page by page: a page with an embedded text
@@ -809,14 +824,18 @@ gigabyte of `word/document.xml`).
 
 Extraction route feeds the owner check: the identity-anchor (`suspect`) verdict is applied
 only to an agent transcription or a tesseract pass, never to natively-extracted text —
-the whole `.txt/.md/.csv/.tsv/.json/.log/.docx/.xlsx` set. In a structured export
+the whole `.txt/.md/.csv/.tsv/.json/.log/.docx/.xlsx` set, CCDA `.xml` included. In a
+structured export
 `Patient`/`DOB`/`MRN` are column labels and field keys, and counting them as an identity
 header refuses ordinary lab exports as belonging to a stranger. The line is the *route*
 rather than how prose-like the format is, because the route is what the extractor actually
 knows; the cost is that a prose transcript saved as `.txt` and ingested with `--ocr auto`
 loses the anchor check too. That is no worse than before native extraction existed (such a
 file went to tesseract, which declined, so there was no text and no check either), and the
-`--ocr-text-file` path keeps full coverage. `mismatch` — an affirmative name/DOB match on a
+`--ocr-text-file` path keeps full coverage. A CCDA is the same trade with a better floor:
+its rendered `recordTarget` header is an affirmative name/DOB signal, so an export naming
+the person ingesting it verdicts `match` — only the "names a stranger nobody on the roster
+knows" case softens to `unverified`. `mismatch` — an affirmative name/DOB match on a
 *different* roster person — is the half that actually prevents misfiling, and it blocks on
 every route.
 

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -3255,7 +3255,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_ingest.add_argument(
         "--ocr",
         choices=["auto"],
-        help="pre-fill ocr_text: text/.docx/.xlsx read natively, PDF page by page "
+        help="pre-fill ocr_text: text/.docx/.xlsx/CCDA .xml read natively, "
+             "PDF page by page "
              "(text layer + rendered-page OCR), other files via tesseract "
              "(soft dependency)",
     )

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -53,7 +53,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Callable, Sequence
+from typing import Callable, Iterator, Sequence
 from urllib.parse import urlsplit
 
 from . import db, study as _study, tombstones as _tombstones
@@ -391,8 +391,14 @@ _CCDA_SNIFF_BYTES = 8192
 # Errors an OOXML/plaintext read can legitimately produce on a malformed or truncated
 # file. Extraction is best-effort: any of these degrades to "no ocr_text", never a lost
 # document — the same contract `run_ocr` already has for a missing tesseract.
+# `RecursionError` is in the list because element nesting depth is document-controlled
+# and the stdlib's own walkers recurse: `Element.itertext()` is a recursive generator,
+# so a pathologically nested narrative can exhaust the stack even though our own walk
+# is iterative. It is a `RuntimeError`, so it would otherwise escape the "never raises"
+# contract and cost the document (issue #138 audit).
 _EXTRACT_ERRORS = (
-    OSError, ValueError, KeyError, IndexError, zipfile.BadZipFile, ET.ParseError,
+    OSError, ValueError, KeyError, IndexError, RecursionError,
+    zipfile.BadZipFile, ET.ParseError,
 )
 
 _SHEET_NUM = re.compile(r"(\d+)")
@@ -541,22 +547,41 @@ def _ccda_table_rows(table: ET.Element) -> list[str]:
 
 
 def _ccda_narrative(node: ET.Element) -> list[str]:
-    """One section's `<text>` narrative block, rendered as lines."""
+    """One section's `<text>` narrative block, rendered as lines.
+
+    Walked with an explicit stack rather than recursion: nesting depth is whatever the
+    document says it is (~1000 levels of `<content>` fits in 20 KB, far under the
+    extraction cap), and a `RecursionError` here is a `RuntimeError` — it would escape
+    :func:`extract_text_routed`'s "never raises" contract and cost the document.
+    """
     lines: list[str] = []
     if (node.text or "").strip():
         lines.append(" ".join(node.text.split()))
-    for child in node:
+    # Each frame is (remaining children, that element's tail) — the tail is emitted
+    # when the frame pops, i.e. *after* its subtree, exactly as the recursion did.
+    stack: list[tuple[Iterator[ET.Element], str | None]] = [(iter(node), None)]
+    while stack:
+        children, tail = stack[-1]
+        child = next(children, None)
+        if child is None:
+            stack.pop()
+            if (tail or "").strip():
+                lines.append(" ".join(tail.split()))
+            continue
         name = _localname(child.tag)
         if name == "table":
             lines.extend(_ccda_table_rows(child))
         elif name in ("paragraph", "item", "caption"):
-            # Nested inline markup is already flattened by `_ccda_flat`; recursing
+            # Nested inline markup is already flattened by `_ccda_flat`; descending
             # would emit its text a second time.
             flat = _ccda_flat(child)
             if flat:
                 lines.append(flat)
         elif name != "renderMultiMedia":   # an image reference has no text to give
-            lines.extend(_ccda_narrative(child))
+            if (child.text or "").strip():
+                lines.append(" ".join(child.text.split()))
+            stack.append((iter(child), child.tail))
+            continue                       # its tail is emitted when that frame pops
         if (child.tail or "").strip():
             lines.append(" ".join(child.tail.split()))
     return lines
@@ -646,8 +671,9 @@ def _extract_ccda(path: Path) -> str | None:
         for section in body.iter(f"{_CDA_NS}section"):
             block: list[str] = []
             title = section.find(f"{_CDA_NS}title")
-            if title is not None and _ccda_flat(title):
-                block.append(_ccda_flat(title))
+            heading = _ccda_flat(title) if title is not None else ""
+            if heading:
+                block.append(heading)
             narrative = section.find(f"{_CDA_NS}text")
             if narrative is not None:
                 block.extend(_ccda_narrative(narrative))

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -20,6 +20,9 @@ Issue #66 adds two intake-format guards, both stdlib-only (the engine has no run
 dependencies): a pre-write refusal of Google Drive **pointer stubs** (see
 :func:`is_pointer_stub`) and a text-extraction dispatcher (:func:`extract_text`) so
 `.txt`/`.docx`/`.xlsx` and friends become findable instead of landing as opaque blobs.
+Issue #138 adds one more native route to that dispatcher, **CCDA** (C-CDA / HL7 CDA R2)
+XML — what every US portal's "download my record" produces — whose narrative was
+previously handed to tesseract, which cannot decode XML.
 
 Issue #70 closes that dispatcher's last hole, **PDFs**. They fall through to
 :func:`run_ocr`, and tesseract cannot decode a PDF at all (its Leptonica backend has
@@ -367,8 +370,9 @@ def run_ocr(path: str | Path) -> str | None:
 # this file type allows", not "shell out to tesseract". `run_ocr` keeps its name and
 # its tesseract semantics and becomes the image/PDF branch of the dispatcher below.
 #
-# Hard constraint: **zero new dependencies.** Everything here is stdlib, which is what
-# draws the scope line — `.rtf`, `.msg`, `.doc` and PDF *text-layer* extraction all
+# Hard constraint: **zero new dependencies.** Everything here is stdlib (CCDA included —
+# `xml.etree.ElementTree` is enough for it), which is what draws the scope line —
+# `.rtf`, `.msg`, `.doc` and PDF *text-layer* extraction all
 # need a third-party parser and stay out, covered by the agent transcription path
 # (`--ocr-text-file`) that `AGENTS.md` §3 already makes the default.
 # --------------------------------------------------------------------------- #
@@ -377,6 +381,12 @@ _PLAINTEXT_SUFFIXES = frozenset({".txt", ".md", ".csv", ".tsv", ".json", ".log"}
 
 _WORD_NS = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
 _SHEET_NS = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+
+# CCDA / C-CDA (HL7 CDA R2) — issue #138. `.xml` is a *container* suffix, so unlike
+# `.docx`/`.xlsx` the detection is on the parsed root element, never the extension.
+_CDA_NS = "{urn:hl7-org:v3}"
+_CDA_ROOT = f"{_CDA_NS}ClinicalDocument"
+_CCDA_SNIFF_BYTES = 8192
 
 # Errors an OOXML/plaintext read can legitimately produce on a malformed or truncated
 # file. Extraction is best-effort: any of these degrades to "no ocr_text", never a lost
@@ -483,11 +493,182 @@ def _extract_xlsx(path: Path) -> str:
     return "\n".join(lines)
 
 
+_CDA_TS_DIGITS = re.compile(r"\d+")
+
+
+def _localname(tag: str) -> str:
+    """Element name without its `{namespace}` prefix."""
+    return tag.rpartition("}")[2]
+
+
+def _ccda_flat(el: ET.Element) -> str:
+    """One element → one whitespace-collapsed line.
+
+    The single flattening primitive: it is what turns `<content>`, `<linkHtml>`,
+    `<sub>`/`<sup>` and any unknown inline markup inside a narrative block into text.
+    """
+    return " ".join("".join(el.itertext()).split())
+
+
+def _ccda_name(el: ET.Element) -> str:
+    """A CDA `<name>` as one line, one space per element boundary.
+
+    Not `_ccda_flat`: that concatenates (right for narrative, where markup splits
+    *inside* a word), and `<given>Jane</given><family>Doe</family>` carries no
+    whitespace of its own, so concatenating yields `JaneDoe` — a single token the
+    owner check can never match against "Jane Doe".
+    """
+    return " ".join(
+        " ".join(chunk.split()) for chunk in el.itertext() if chunk.strip()
+    )
+
+
+def _ccda_table_rows(table: ET.Element) -> list[str]:
+    """Narrative `<table>` as one tab-delimited line per `<tr>` (`thead` and `tbody`
+    alike, document order). Tab is what `_extract_xlsx` already uses for tabular text,
+    and it is what keeps a header cell on the same line as its value."""
+    rows: list[str] = []
+    for tr in table.iter():
+        if _localname(tr.tag) != "tr":
+            continue
+        cells = [
+            _ccda_flat(cell) for cell in tr
+            if _localname(cell.tag) in ("th", "td")
+        ]
+        if any(cells):
+            rows.append("\t".join(cells))
+    return rows
+
+
+def _ccda_narrative(node: ET.Element) -> list[str]:
+    """One section's `<text>` narrative block, rendered as lines."""
+    lines: list[str] = []
+    if (node.text or "").strip():
+        lines.append(" ".join(node.text.split()))
+    for child in node:
+        name = _localname(child.tag)
+        if name == "table":
+            lines.extend(_ccda_table_rows(child))
+        elif name in ("paragraph", "item", "caption"):
+            # Nested inline markup is already flattened by `_ccda_flat`; recursing
+            # would emit its text a second time.
+            flat = _ccda_flat(child)
+            if flat:
+                lines.append(flat)
+        elif name != "renderMultiMedia":   # an image reference has no text to give
+            lines.extend(_ccda_narrative(child))
+        if (child.tail or "").strip():
+            lines.append(" ".join(child.tail.split()))
+    return lines
+
+
+def _ccda_date(value: str | None) -> str | None:
+    """A CDA `TS/@value` (`"19620314000000-0600"`) as an ISO-ish date string.
+
+    The 8-digit → `YYYY-MM-DD` reformat is load-bearing: :func:`dob_candidates`
+    recognises `1962-03-14` and friends but not the raw `19620314` form, so without
+    it the DOB half of the owner check could never fire on a CCDA.
+    """
+    digits = _CDA_TS_DIGITS.match((value or "").strip())
+    if digits is None:
+        return None
+    raw = digits.group()
+    if len(raw) >= 8:
+        return f"{raw[:4]}-{raw[4:6]}-{raw[6:8]}"
+    if len(raw) >= 6:
+        return f"{raw[:4]}-{raw[4:6]}"
+    if len(raw) >= 4:
+        return raw[:4]
+    return None
+
+
+def _ccda_header(root: ET.Element) -> list[str]:
+    """`recordTarget` identity lines, prepended so the #61 owner check has an anchor.
+
+    A CCDA's own header is the most reliable identity in the document, and without it
+    the check degrades to "filed on your say-so" — the symptom issue #138 reports.
+    """
+    lines: list[str] = []
+    patient = root.find(
+        f"{_CDA_NS}recordTarget/{_CDA_NS}patientRole/{_CDA_NS}patient"
+    )
+    if patient is None:
+        return lines
+    for name in patient.findall(f"{_CDA_NS}name"):
+        flat = _ccda_name(name)   # `given`/`given`/`family` → "Jane A Doe"
+        if flat:
+            lines.append(f"Patient: {flat}")
+    birth = patient.find(f"{_CDA_NS}birthTime")
+    if birth is not None:
+        dob = _ccda_date(birth.get("value"))
+        if dob:
+            lines.append(f"DOB: {dob}")
+    return lines
+
+
+def _extract_ccda(path: Path) -> str | None:
+    """CCDA narrative text, or ``None`` when the file is **not** a CCDA.
+
+    ``None`` is the caller's signal to fall through to :func:`run_ocr` unchanged:
+    `.xml` is a container suffix, so an ordinary XML file must keep today's route.
+    """
+    size = path.stat().st_size
+    if size > _MAX_EXTRACT_BYTES:
+        # Deliberately a raise, not a fall-through: the honest "past the extraction
+        # cap" note beats handing a 40 MB XML to tesseract to fail on.
+        raise ValueError(
+            f"{size} bytes, past the {_MAX_EXTRACT_BYTES}-byte extraction cap"
+        )
+    with path.open("rb") as fh:
+        head = fh.read(_CCDA_SNIFF_BYTES)
+    # A conformant CCDA has no internal subset, and stdlib `ET` *does* expand internal
+    # entities — so a `<!DOCTYPE` is refused here rather than parsed (billion-laughs on
+    # a file whose bytes are well under the cap). Falling through costs nothing: today
+    # such a file goes to tesseract anyway.
+    if b"<!doctype" in head.lower():
+        return None
+    # Cheap negative first, so an ordinary `.xml` is never fully parsed.
+    if b"urn:hl7-org:v3" not in head or b"ClinicalDocument" not in head:
+        return None
+    try:
+        root = ET.parse(path).getroot()
+    except ET.ParseError:
+        # Malformed XML is not *detectably* a CCDA, so it takes today's path.
+        return None
+    if root.tag != _CDA_ROOT:
+        return None
+
+    lines = _ccda_header(root)
+    body = root.find(f"{_CDA_NS}component/{_CDA_NS}structuredBody")
+    if body is not None:
+        # `.iter` so a nested section is rendered too; the narrative is read from each
+        # section's *direct* `<text>` child, or a nested one would be emitted twice.
+        for section in body.iter(f"{_CDA_NS}section"):
+            block: list[str] = []
+            title = section.find(f"{_CDA_NS}title")
+            if title is not None and _ccda_flat(title):
+                block.append(_ccda_flat(title))
+            narrative = section.find(f"{_CDA_NS}text")
+            if narrative is not None:
+                block.extend(_ccda_narrative(narrative))
+            if block:
+                if lines:
+                    lines.append("")
+                lines.extend(block)
+    # No `structuredBody` (a `nonXMLBody` CDA) still returns the header alone: strictly
+    # better than today, since it restores owner verification.
+    return "\n".join(lines)
+
+
 def extract_text_routed(path: str | Path) -> tuple[str | None, str]:
     """:func:`extract_text` plus the **route** that produced the text.
 
     Dispatches on suffix: plaintext-ish formats are read directly and `.docx`/`.xlsx`
-    are unzipped and their OOXML parsed with the stdlib (route ``"native"``).
+    are unzipped and their OOXML parsed with the stdlib (route ``"native"``). A CCDA
+    `.xml` (issue #138) is rendered natively too — sections' narrative plus a
+    `recordTarget` identity header — but on the parsed **root element**, not the
+    suffix: a non-CCDA or malformed `.xml` falls through to the OCR route exactly as
+    it did before that branch existed.
     **Everything else falls through to :func:`run_ocr`** (route ``"ocr"``) — the same
     thing `ocr=True` did before this dispatcher existed. Deliberately not a suffix
     allowlist: image extensions vary far too widely (`.jfif`, `.jpe`, extension-less
@@ -521,6 +702,11 @@ def extract_text_routed(path: str | Path) -> tuple[str | None, str]:
             text = _extract_docx(src)
         elif suffix == ".xlsx":
             text = _extract_xlsx(src)
+        # `.xml` deliberately stays out of `_PLAINTEXT_SUFFIXES`: only a file whose
+        # root element is `{urn:hl7-org:v3}ClinicalDocument` is read natively, and
+        # every other `.xml` falls through to the `run_ocr` branch below unchanged.
+        elif suffix == ".xml" and (ccda := _extract_ccda(src)) is not None:
+            text = ccda
         else:
             ocr_text = run_ocr(src)
             if ocr_text is None:

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -48,6 +48,7 @@ import subprocess
 import sqlite3
 import sys
 import xml.etree.ElementTree as ET
+import xml.parsers.expat as expat
 import zipfile
 import uuid
 from dataclasses import dataclass
@@ -631,36 +632,56 @@ def _ccda_header(root: ET.Element) -> list[str]:
     return lines
 
 
+class _DoctypeFound(Exception):
+    """Sentinel: the prolog probe reached a ``<!DOCTYPE`` declaration."""
+
+
+class _PrologOver(Exception):
+    """Sentinel: the prolog probe reached the root element's start tag."""
+
+
 def _xml_declares_doctype(data: bytes) -> bool:
     """True when a ``<!DOCTYPE`` sits in the XML **prolog**.
 
     The prolog — everything before the root element's start tag — is the only place a
-    DOCTYPE may legally appear, and comments and processing instructions are the only
-    other markup allowed there, so the scan steps over those and stops at the first
-    element. Scanning a fixed head window instead is not enough: a leading comment pads
-    the DOCTYPE past any window while the CCDA markers stay inside it, and the internal
-    subset it smuggles through is an entity-amplification bomb the byte cap does not
-    bound (a 2 MB file rendered 197 MB of text; issue #138 audit). Stepping over
-    comments rather than stopping at the first ``<`` matters for the same reason: a
-    comment may itself contain something that looks like a start tag.
+    DOCTYPE may legally appear, and the internal subset it can carry is an
+    entity-amplification bomb the byte cap does not bound (a 1.4 KB file rendered 1 MB
+    of text, a 2 MB one 210 MB; issue #138 audit).
+
+    The check is **encoding-agnostic by construction**: it asks expat — the same parser
+    :func:`_extract_ccda` is about to hand the bytes to — rather than scanning for byte
+    patterns. Two hand-rolled byte scanners were bypassed before this one: a fixed head
+    window (a leading comment pads the DOCTYPE past it while the CCDA markers stay
+    inside), and a whole-prolog scan for ASCII ``<!--``/``<?``/``<!doctype`` (in a
+    UTF-16 document every marker is ``<\\x00!\\x00…``, so the scan mistook the first
+    ``<`` for a start tag and the DOCTYPE was never seen). Establishing the encoding is
+    exactly the work a scanner has to re-implement to be correct, and expat has already
+    done it — from the BOM and the ``encoding=`` pseudo-attribute — by the time it
+    reports either event.
+
+    Nothing expands: expat fires ``StartDoctypeDeclHandler`` *before* it reads the
+    internal subset, and the probe aborts out of the parse there. A document with no
+    DOCTYPE costs only the prolog — the parse aborts at the root start tag rather than
+    reading the body. A parse error means expat cannot read the file at all, so the
+    :func:`ET.fromstring` below cannot either (same parser): ``False`` sends it down the
+    unchanged non-CCDA route.
     """
-    i = 0
-    while (start := data.find(b"<", i)) >= 0:
-        if data.startswith(b"<!--", start):
-            end = data.find(b"-->", start + 4)
-            if end < 0:
-                return False           # unterminated: no root element follows either
-            i = end + 3
-        elif data.startswith(b"<?", start):
-            end = data.find(b"?>", start + 2)
-            if end < 0:
-                return False
-            i = end + 2
-        elif data[start:start + 9].lower() == b"<!doctype":
-            return True
-        else:
-            return False               # a start tag (or junk) — the prolog is over
-    return False
+    def _doctype(*_args: object) -> None:
+        raise _DoctypeFound
+
+    def _element(*_args: object) -> None:
+        raise _PrologOver
+
+    parser = expat.ParserCreate()
+    parser.StartDoctypeDeclHandler = _doctype
+    parser.StartElementHandler = _element
+    try:
+        parser.Parse(data, True)
+    except _DoctypeFound:
+        return True
+    except (_PrologOver, expat.ExpatError):
+        return False
+    return False                       # no root element at all — `ET` will reject it too
 
 
 def _extract_ccda(path: Path) -> str | None:
@@ -678,7 +699,13 @@ def _extract_ccda(path: Path) -> str | None:
         )
     with path.open("rb") as fh:
         head = fh.read(_CCDA_SNIFF_BYTES)
-    # Cheap negative first, so an ordinary `.xml` is never read whole or parsed.
+    # Cheap negative first, so an ordinary `.xml` is never read whole or parsed. The
+    # markers are matched as raw ASCII, so a CCDA in an encoding that is not
+    # ASCII-compatible (UTF-16/UTF-32) sniffs as non-CCDA and keeps today's tesseract
+    # route. That narrowing is deliberate: US portal exports are UTF-8, and the sniff
+    # is a *negative* filter — being conservative here costs nothing beyond the status
+    # quo, whereas the DOCTYPE refusal below has to be right for every encoding, which
+    # is why it asks expat instead of matching bytes.
     if b"urn:hl7-org:v3" not in head or b"ClinicalDocument" not in head:
         return None
     data = path.read_bytes()           # bounded by the cap checked above

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -631,6 +631,38 @@ def _ccda_header(root: ET.Element) -> list[str]:
     return lines
 
 
+def _xml_declares_doctype(data: bytes) -> bool:
+    """True when a ``<!DOCTYPE`` sits in the XML **prolog**.
+
+    The prolog — everything before the root element's start tag — is the only place a
+    DOCTYPE may legally appear, and comments and processing instructions are the only
+    other markup allowed there, so the scan steps over those and stops at the first
+    element. Scanning a fixed head window instead is not enough: a leading comment pads
+    the DOCTYPE past any window while the CCDA markers stay inside it, and the internal
+    subset it smuggles through is an entity-amplification bomb the byte cap does not
+    bound (a 2 MB file rendered 197 MB of text; issue #138 audit). Stepping over
+    comments rather than stopping at the first ``<`` matters for the same reason: a
+    comment may itself contain something that looks like a start tag.
+    """
+    i = 0
+    while (start := data.find(b"<", i)) >= 0:
+        if data.startswith(b"<!--", start):
+            end = data.find(b"-->", start + 4)
+            if end < 0:
+                return False           # unterminated: no root element follows either
+            i = end + 3
+        elif data.startswith(b"<?", start):
+            end = data.find(b"?>", start + 2)
+            if end < 0:
+                return False
+            i = end + 2
+        elif data[start:start + 9].lower() == b"<!doctype":
+            return True
+        else:
+            return False               # a start tag (or junk) — the prolog is over
+    return False
+
+
 def _extract_ccda(path: Path) -> str | None:
     """CCDA narrative text, or ``None`` when the file is **not** a CCDA.
 
@@ -646,17 +678,18 @@ def _extract_ccda(path: Path) -> str | None:
         )
     with path.open("rb") as fh:
         head = fh.read(_CCDA_SNIFF_BYTES)
+    # Cheap negative first, so an ordinary `.xml` is never read whole or parsed.
+    if b"urn:hl7-org:v3" not in head or b"ClinicalDocument" not in head:
+        return None
+    data = path.read_bytes()           # bounded by the cap checked above
     # A conformant CCDA has no internal subset, and stdlib `ET` *does* expand internal
     # entities — so a `<!DOCTYPE` is refused here rather than parsed (billion-laughs on
     # a file whose bytes are well under the cap). Falling through costs nothing: today
     # such a file goes to tesseract anyway.
-    if b"<!doctype" in head.lower():
-        return None
-    # Cheap negative first, so an ordinary `.xml` is never fully parsed.
-    if b"urn:hl7-org:v3" not in head or b"ClinicalDocument" not in head:
+    if _xml_declares_doctype(data):
         return None
     try:
-        root = ET.parse(path).getroot()
+        root = ET.fromstring(data)     # the bytes already in hand, not a second read
     except ET.ParseError:
         # Malformed XML is not *detectably* a CCDA, so it takes today's path.
         return None

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -183,7 +183,8 @@ def ingest_document(
     ``ocr_text`` is the agent's own transcription — the ``AGENTS.md`` default path.
     The response's ``ocr_text_populated`` lets the agent self-check the FTS-visibility
     contract without a follow-up read. ``ocr=true`` is the fallback: it extracts by
-    whatever route the file type allows (plaintext/`.docx`/`.xlsx` natively, everything
+    whatever route the file type allows (plaintext/`.docx`/`.xlsx` and CCDA `.xml`
+    natively, everything
     else via tesseract), and stores nothing when nothing could be read — `.pdf`, `.rtf`,
     `.msg` and `.doc` have no route at all (tesseract does not accept PDF input), so
     transcribe those yourself.
@@ -203,7 +204,8 @@ def ingest_document(
     go-ahead before retrying with ``force=true``. ``suspect`` (a patient-identity
     header naming nobody on the roster) is scoped by route: it applies to the text you
     supply and to a tesseract pass, never to anything ``ocr=true`` extracts natively
-    (``.txt``/``.md``/``.csv``/``.tsv``/``.json``/``.log``/``.docx``/``.xlsx``), where
+    (``.txt``/``.md``/``.csv``/``.tsv``/``.json``/``.log``/``.docx``/``.xlsx``, CCDA
+    ``.xml``), where
     those words are column labels — so pass your transcription as ``ocr_text`` rather
     than saving it to a ``.txt`` and re-reading that. ``mismatch`` holds on every route.
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -952,6 +952,48 @@ def test_malformed_ccda_xml_does_not_raise(conn, tmp_path, sources, capsys, monk
     assert "--ocr-text-file" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize("wrapper", ["content", "list", "paragraph"])
+def test_deeply_nested_ccda_narrative_does_not_raise(
+    conn, tmp_path, sources, wrapper
+):
+    """Nesting depth is document-controlled and unbounded, and ~1500 levels fits in
+    30 KB — far under the extraction cap. A recursive walk raised `RecursionError`
+    (a `RuntimeError`, so outside `_EXTRACT_ERRORS`) straight out of
+    `extract_text_routed`, breaking its "never raises" contract and losing the
+    document entirely."""
+    narrative = "Ferritin 201 ng/mL"
+    for _ in range(1500):
+        narrative = f"<{wrapper}>{narrative}</{wrapper}>"
+    src = _make_ccda(
+        tmp_path,
+        sections=(f"<section><title>Results</title><text>{narrative}</text></section>",),
+    )
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.status == "new"                       # the document still lands
+    assert "Ferritin 201 ng/mL" in result.document.ocr_text   # ...and is readable
+
+
+def test_recursion_error_degrades_like_any_other_extraction_failure(
+    conn, tmp_path, sources, capsys, monkeypatch
+):
+    """Our own walk is iterative, but the stdlib's are not (`Element.itertext()` is a
+    recursive generator), so the best-effort handler has to cover `RecursionError`
+    too — it is a `RuntimeError` and would otherwise escape the contract."""
+    def boom(_):
+        raise RecursionError("maximum recursion depth exceeded")
+
+    def never(path):  # pragma: no cover - the degrade is native, not a fallback to OCR
+        raise AssertionError(f"run_ocr must not be called for {path}")
+
+    monkeypatch.setattr(ingest, "_extract_ccda", boom)
+    monkeypatch.setattr(ingest, "run_ocr", never)
+    src = _make_ccda(tmp_path)
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.status == "new"                # the document still lands
+    assert result.document.ocr_text is None
+    assert "text extraction failed" in capsys.readouterr().err
+
+
 def test_ccda_doctype_is_not_parsed_natively(conn, tmp_path, sources, monkeypatch):
     """stdlib `ET` expands internal entities, so a `<!DOCTYPE` is refused before the
     parse rather than after — a billion-laughs file is small enough to clear the cap."""

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2,6 +2,7 @@
 
 import json
 import sqlite3
+import time
 import zipfile
 import subprocess
 
@@ -1187,6 +1188,100 @@ def test_a_doctype_the_probe_cannot_reach_still_falls_through(tmp_path):
     src.write_text(doc, encoding="utf-8")
     assert ingest._xml_declares_doctype(src.read_bytes()) is False
     assert ingest._extract_ccda(src) is None    # refused all the same
+
+
+# --- the guard's equivalence class, not just its fixtures (issue #138 verify) ----- #
+#
+# Three shapes the UTF-16 pair does not cover: a 4-byte encoding, a BOM that contradicts
+# the declaration, and a DOCTYPE with no internal subset at all. Each is refused, and the
+# point of pinning them is that all three arrive at that refusal by a *different* arm.
+
+
+def test_ccda_doctype_in_a_utf32_document_never_reaches_the_parser(
+    conn, tmp_path, sources, monkeypatch
+):
+    """UTF-32 is refused by the *sniff*, not the DOCTYPE probe — and that is fine.
+
+    A 4-byte encoding cannot smuggle a contiguous ASCII run (every character carries two
+    zero bytes), so the marker sniff fails and the file keeps today's OCR route before
+    anything is parsed. Pinned because the safety of the whole design rests on the sniff
+    being a *negative* filter: it is free for it to be conservative, so a shape it cannot
+    read must fall through rather than be special-cased into the native path."""
+    seen: list[str] = []
+    monkeypatch.setattr(ingest, "run_ocr", lambda p: seen.append(str(p)) or "scanned")
+    doctype, levels = _entity_bomb_doctype()
+    body = _make_ccda(tmp_path, name="utf32-src.XML").read_text(encoding="utf-8")
+    doc = (
+        body.replace('encoding="UTF-8"', 'encoding="UTF-32"', 1)
+        .replace("?>", f"?>{doctype}", 1)
+        .replace("Ferritin 201 ng/mL", f"&e{levels};")
+    )
+    src = tmp_path / "utf32-doctype.xml"
+    src.write_bytes(b"\xff\xfe\x00\x00" + doc.encode("utf-32-le"))
+
+    head = src.read_bytes()[:ingest._CCDA_SNIFF_BYTES]
+    assert b"urn:hl7-org:v3" not in head       # the sniff is what stops it here
+    assert ingest._extract_ccda(src) is None
+
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert seen == [str(src)]
+    assert result.document.ocr_text == "scanned"
+
+
+def test_ccda_whose_bom_contradicts_its_declaration_is_not_parsed_natively(
+    conn, tmp_path, sources, monkeypatch
+):
+    """A UTF-8 BOM under an ``encoding="UTF-16"`` declaration: the file sniffs as a CCDA
+    (its bytes are ASCII-compatible) but no parser can agree with it.
+
+    This is the ``ExpatError`` arm rather than the DOCTYPE arm, and it is safe for the
+    reason that arm exists: the probe is the same expat the `ET.fromstring` below it uses,
+    so a file the probe cannot read is one the parse cannot read either — the DOCTYPE it
+    carries is never expanded because the document is never parsed at all."""
+    seen: list[str] = []
+    monkeypatch.setattr(ingest, "run_ocr", lambda p: seen.append(str(p)) or "scanned")
+    doctype, levels = _entity_bomb_doctype()
+    body = _make_ccda(tmp_path, name="bom-src.XML").read_text(encoding="utf-8")
+    doc = (
+        body.replace('encoding="UTF-8"', 'encoding="UTF-16"', 1)
+        .replace("?>", f"?>{doctype}", 1)
+        .replace("Ferritin 201 ng/mL", f"&e{levels};")
+    )
+    src = tmp_path / "bom-mismatch.xml"
+    src.write_bytes(b"\xef\xbb\xbf" + doc.encode("utf-8"))   # BOM says UTF-8
+
+    raw = src.read_bytes()
+    assert b"urn:hl7-org:v3" in raw and b"ClinicalDocument" in raw   # sniffs as CCDA
+    assert ingest._xml_declares_doctype(raw) is False                # the parse-error arm
+    assert ingest._extract_ccda(src) is None
+
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert seen == [str(src)]
+    assert result.document.ocr_text == "scanned"
+    assert "A" * 200 not in (result.document.ocr_text or "")
+
+
+def test_an_external_doctype_is_refused_without_fetching_it(tmp_path):
+    """A DOCTYPE with an external ``SYSTEM`` id and **no** internal subset.
+
+    Two properties at once. It is still refused — the guard keys on the declaration, not
+    on whether a subset follows — and refusing it costs no network: the ``SYSTEM`` id
+    points at TEST-NET-1, which blackholes rather than refuses, so a resolver would stall
+    for seconds instead of returning. Local-first has no exception for a schema fetch."""
+    body = _make_ccda(tmp_path, name="external-src.XML").read_text(encoding="utf-8")
+    src = tmp_path / "external-doctype.xml"
+    src.write_text(
+        body.replace(
+            "?>",
+            '?><!DOCTYPE ClinicalDocument SYSTEM "http://192.0.2.1/CDA.dtd">',
+            1,
+        ),
+        encoding="utf-8",
+    )
+    started = time.monotonic()
+    assert ingest._xml_declares_doctype(src.read_bytes()) is True
+    assert ingest._extract_ccda(src) is None
+    assert time.monotonic() - started < 2.0     # nothing was dereferenced
 
 
 def test_ccda_owner_check_matches_record_target(conn, tmp_path, sources):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -7,7 +7,7 @@ import subprocess
 
 import pytest
 
-from pemr import db, ingest, persons
+from pemr import db, ingest, persons, query
 from pemr.models import Person
 
 
@@ -739,6 +739,45 @@ def _make_xlsx(tmp_path, name="labs.xlsx", rows=(("test", "value"), ("sodium", "
     return p
 
 
+_CCDA_SECTIONS = (
+    "<section><title>Allergies</title><text>"
+    "<paragraph>No known drug allergies</paragraph>"
+    "</text></section>",
+    "<section><title>Results</title><text><table>"
+    "<thead><tr><th>Test</th><th>Value</th></tr></thead>"
+    "<tbody><tr><td>Ferritin</td><td>201 ng/mL</td></tr></tbody>"
+    "</table></text></section>",
+)
+
+
+def _make_ccda(
+    tmp_path,
+    name="DOC0001.XML",
+    patient=("Jane", "Doe"),
+    birth="19620314",
+    sections=_CCDA_SECTIONS,
+):
+    given, family = patient
+    birth_el = f'<birthTime value="{birth}"/>' if birth else ""
+    body = (
+        f"<component><structuredBody>"
+        + "".join(f"<component>{s}</component>" for s in sections)
+        + "</structuredBody></component>"
+    ) if sections else ""
+    doc = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<ClinicalDocument xmlns="urn:hl7-org:v3">'
+        "<recordTarget><patientRole><patient>"
+        f"<name><given>{given}</given><family>{family}</family></name>"
+        f"{birth_el}"
+        "</patient></patientRole></recordTarget>"
+        f"{body}</ClinicalDocument>"
+    )
+    p = tmp_path / name
+    p.write_text(doc, encoding="utf-8")
+    return p
+
+
 def test_pointer_stub_is_refused_pre_write(conn, tmp_path, sources):
     stub = _make_stub(tmp_path)
     with pytest.raises(ingest.IngestError) as excinfo:
@@ -797,6 +836,146 @@ def test_extract_text_reads_xlsx(conn, tmp_path, sources):
     src = _make_xlsx(tmp_path)
     result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
     assert result.document.ocr_text == "test\tvalue\nsodium\t140"
+
+
+# --- CCDA (issue #138) ---------------------------------------------------------
+# `.xml` used to reach tesseract, which cannot decode it, so every portal export
+# ("download my record" produces CCDA) landed with no `ocr_text` *and* an unverified
+# owner. Detection is on the parsed root element, never the suffix.
+
+
+def test_extract_text_reads_ccda_xml(conn, tmp_path, sources):
+    src = _make_ccda(tmp_path)
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    text = result.document.ocr_text
+    assert result.ocr_text_populated
+    assert text.startswith("Patient: Jane Doe\nDOB: 1962-03-14")
+    assert "Allergies\nNo known drug allergies" in text
+    # header and value survive on one tab-delimited line each
+    assert "Test\tValue" in text
+    assert "Ferritin\t201 ng/mL" in text
+
+
+def test_ccda_never_shells_out(conn, tmp_path, sources, monkeypatch):
+    def boom(path):  # pragma: no cover - the assertion is that this never runs
+        raise AssertionError(f"run_ocr must not be called for {path}")
+
+    monkeypatch.setattr(ingest, "run_ocr", boom)
+    src = _make_ccda(tmp_path)
+    assert ingest.ingest_document(
+        conn, src, "jane-doe", sources, ocr=True
+    ).ocr_text_populated
+
+
+@pytest.mark.parametrize(
+    "name, payload",
+    [
+        # an IHE_XDM manifest sitting beside the documents
+        ("METADATA.XML",
+         '<?xml version="1.0"?><Manifest><Doc>DOC0001.XML</Doc></Manifest>'),
+        ("plain.xml", "<root><a>1</a></root>"),
+        # right namespace, wrong root: the parsed root tag is the authority
+        ("other.xml", '<Bundle xmlns="urn:hl7-org:v3"><ClinicalDocument/></Bundle>'),
+    ],
+)
+def test_non_ccda_xml_still_reaches_tesseract(
+    conn, tmp_path, sources, monkeypatch, name, payload
+):
+    seen: list[str] = []
+
+    def fake_run_ocr(path):
+        seen.append(str(path))
+        return "Ferritin 201 nanograms"
+
+    monkeypatch.setattr(ingest, "run_ocr", fake_run_ocr)
+    src = _make_file(tmp_path, name, payload.encode("utf-8"))
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert seen == [str(src)]
+    assert result.document.ocr_text == "Ferritin 201 nanograms"
+
+
+def test_malformed_ccda_xml_does_not_raise(conn, tmp_path, sources, capsys, monkeypatch):
+    monkeypatch.setattr(ingest, "run_ocr", lambda _: None)   # tesseract declines
+    src = _make_file(
+        tmp_path, "broken.xml",
+        b'<?xml version="1.0"?><ClinicalDocument xmlns="urn:hl7-org:v3">'
+        b"<recordTarget><patientRole",
+    )
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.status == "new"           # the document still lands
+    assert result.document.ocr_text is None
+    assert "--ocr-text-file" in capsys.readouterr().err
+
+
+def test_ccda_doctype_is_not_parsed_natively(conn, tmp_path, sources, monkeypatch):
+    """stdlib `ET` expands internal entities, so a `<!DOCTYPE` is refused before the
+    parse rather than after — a billion-laughs file is small enough to clear the cap."""
+    seen: list[str] = []
+    monkeypatch.setattr(ingest, "run_ocr", lambda p: seen.append(str(p)) or "scanned")
+    body = _make_ccda(tmp_path, name="doctype-src.XML").read_text(encoding="utf-8")
+    src = tmp_path / "doctype.xml"
+    src.write_text(
+        body.replace(
+            "?>", '?><!DOCTYPE ClinicalDocument [<!ENTITY a "aaaa">]>', 1
+        ),
+        encoding="utf-8",
+    )
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert seen == [str(src)]
+    assert result.document.ocr_text == "scanned"
+
+
+def test_ccda_owner_check_matches_record_target(conn, tmp_path, sources):
+    """The point of the issue: `recordTarget` is an identity the check can use, so a
+    CCDA no longer degrades to "filed on your say-so"."""
+    _seed_roster(conn)
+    # no `birthTime`, so the name is the only signal — `<given>`/`<family>` have no
+    # whitespace of their own and must not flatten into one unmatchable token
+    src = _make_ccda(tmp_path, birth="")
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.owner_check.verdict == "match"
+    assert result.owner_check.blocks is False
+    # ...and the protective half still fires on this route.
+    other = _make_ccda(tmp_path, name="DOC0002.XML", patient=("Robert Alan", "Roe"),
+                       birth="")
+    with pytest.raises(ingest.OwnerMismatchError) as excinfo:
+        ingest.ingest_document(conn, other, "jane-doe", sources, ocr=True)
+    assert excinfo.value.check.verdict == "mismatch"
+    assert excinfo.value.check.matched_slug == "bob-roe"
+
+
+def test_ccda_birth_time_is_rendered_matchably(conn, tmp_path, sources):
+    """`19620314` is not a form `dob_candidates` knows; the ISO reformat is what makes
+    the DOB half of the check work at all."""
+    _seed_roster(conn)
+    src = _make_ccda(tmp_path, patient=("Unreadable", "Smudge"))
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.owner_check.verdict == "match"
+
+
+def test_ccda_stranger_is_unverified_not_suspect(conn, tmp_path, sources):
+    """Route-scoped anchors, same as `.docx`/`.xlsx`: a CCDA naming a non-roster
+    stranger is `unverified`. No regression — it used to yield no text at all."""
+    _seed_roster(conn)
+    src = _make_ccda(tmp_path, patient=("Karen", "Fields"), birth="19710909")
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.owner_check.verdict == "unverified"
+    assert result.status == "new"
+
+
+def test_find_sees_ccda_narrative(conn, tmp_path, sources):
+    """The headline symptom: `find` was blind to every CCDA."""
+    ingest.ingest_document(conn, _make_ccda(tmp_path), "jane-doe", sources, ocr=True)
+    hits = query.find(conn, "jane-doe", "ferritin")
+    assert [hit["person"] for hit in hits] == ["jane-doe"]
+
+
+def test_ccda_without_structured_body_still_yields_identity(conn, tmp_path, sources):
+    _seed_roster(conn)
+    src = _make_ccda(tmp_path, sections=())
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.document.ocr_text == "Patient: Jane Doe\nDOB: 1962-03-14"
+    assert result.owner_check.verdict == "match"
 
 
 def test_extract_text_has_no_route_for_msg(conn, tmp_path, sources, capsys, monkeypatch):
@@ -1075,7 +1254,7 @@ def test_ocr_route_still_produces_suspect(conn, tmp_path, sources, monkeypatch):
 # `word/document.xml`). Over the cap degrades like any other extraction failure.
 
 
-@pytest.mark.parametrize("kind", ["docx", "xlsx", "txt"])
+@pytest.mark.parametrize("kind", ["docx", "xlsx", "txt", "ccda"])
 def test_oversized_extraction_degrades_instead_of_reading_it(
     conn, tmp_path, sources, capsys, monkeypatch, kind
 ):
@@ -1084,6 +1263,10 @@ def test_oversized_extraction_degrades_instead_of_reading_it(
         src = _make_docx(tmp_path, paragraphs=("a" * 500,))
     elif kind == "xlsx":
         src = _make_xlsx(tmp_path)
+    elif kind == "ccda":
+        # over the cap degrades *native* with the cap note, rather than falling
+        # through to a tesseract failure that says nothing useful
+        src = _make_ccda(tmp_path)
     else:
         src = _make_file(tmp_path, "big.txt", b"x" * 500)
     result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1069,6 +1069,126 @@ def test_ccda_with_a_harmless_prolog_comment_still_reads_natively(
     assert "Ferritin" in result.document.ocr_text
 
 
+# --- the DOCTYPE guard has to be encoding-agnostic (issue #138 audit) ------------- #
+#
+# Two byte scanners were bypassed before the current expat probe. The second one
+# matched raw ASCII `<!--`/`<?`/`<!doctype`, which in UTF-16 are `<\x00!\x00...`: the
+# first `<` looked like a start tag, the scan declared the prolog over, and the DOCTYPE
+# went unseen. The file still *sniffed* as a CCDA because ASCII marker bytes are
+# trivially smuggled into a UTF-16 comment — one CJK character carries two of them —
+# so the bomb took the native route and a 1.4 KB file rendered 1 MB of text.
+
+def _utf16_smuggled(marker: str, big_endian: bool = False) -> str:
+    """Characters whose UTF-16 bytes spell ``marker`` in ASCII (for the sniff)."""
+    hi, lo = (0, 8) if big_endian else (8, 0)
+    return "".join(
+        chr((ord(marker[i]) << lo) | (ord(marker[i + 1]) << hi))
+        for i in range(0, len(marker), 2)
+    )
+
+
+def _entity_bomb_doctype(levels=7, width=4, leaf=64):
+    """A `<!DOCTYPE` whose internal subset amplifies ``&e{levels};`` ~1 MB."""
+    chain = "".join(
+        f'<!ENTITY e{n} "{f"&e{n - 1};" * width}">' for n in range(1, levels + 1)
+    )
+    return f'<!DOCTYPE ClinicalDocument [<!ENTITY e0 "{"A" * leaf}">{chain}]>', levels
+
+
+@pytest.mark.parametrize(
+    "encoding, bom, big_endian",
+    [
+        ("utf-16-le", b"\xff\xfe", False),
+        ("utf-16-be", b"\xfe\xff", True),
+    ],
+    ids=["utf-16-le", "utf-16-be"],
+)
+def test_ccda_doctype_in_a_utf16_document_is_not_parsed_natively(
+    conn, tmp_path, sources, monkeypatch, encoding, bom, big_endian
+):
+    """The refusal must hold in an encoding whose bytes no ASCII scan can read.
+
+    Non-vacuous by construction: the smuggled markers make the file pass the ASCII
+    sniff, so it *is* a CCDA candidate and only the DOCTYPE guard stands between it and
+    a parse that expands the internal subset."""
+    seen: list[str] = []
+    monkeypatch.setattr(ingest, "run_ocr", lambda p: seen.append(str(p)) or "scanned")
+    doctype, levels = _entity_bomb_doctype()
+    markers = _utf16_smuggled("urn:hl7-org:v3", big_endian) + _utf16_smuggled(
+        "ClinicalDocument", big_endian
+    )
+    body = _make_ccda(tmp_path, name="utf16-src.XML").read_text(encoding="utf-8")
+    doc = (
+        body.replace('encoding="UTF-8"', 'encoding="UTF-16"', 1)
+        .replace("?>", f"?><!-- {markers} -->{doctype}", 1)
+        .replace("Ferritin 201 ng/mL", f"&e{levels};")
+    )
+    src = tmp_path / "utf16-doctype.xml"
+    src.write_bytes(bom + doc.encode(encoding))
+
+    raw = src.read_bytes()
+    assert b"urn:hl7-org:v3" in raw and b"ClinicalDocument" in raw   # sniffs as CCDA
+    assert ingest._xml_declares_doctype(raw) is True
+
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert seen == [str(src)]                       # fell through to today's route
+    assert result.document.ocr_text == "scanned"    # no amplified text stored
+    assert "A" * 200 not in (result.document.ocr_text or "")
+
+
+def test_utf16_ccda_without_a_doctype_keeps_the_unchanged_ocr_route(
+    conn, tmp_path, sources, monkeypatch
+):
+    """The mirror case, pinned as a deliberate product decision rather than an accident.
+
+    The sniff matches ASCII marker bytes, so a *genuine* UTF-16 CCDA is not detected and
+    keeps today's tesseract route. Narrowing the negative filter costs nothing beyond
+    the status quo (US portal exports are UTF-8); it is the DOCTYPE refusal, not the
+    sniff, that has to be right for every encoding."""
+    seen: list[str] = []
+    monkeypatch.setattr(ingest, "run_ocr", lambda p: seen.append(str(p)) or "scanned")
+    body = _make_ccda(tmp_path, name="utf16-plain-src.XML").read_text(encoding="utf-8")
+    src = tmp_path / "utf16-plain.xml"
+    # a well-formed UTF-16 CCDA (declaration and BOM agree), not a mangled one
+    src.write_bytes(body.replace('encoding="UTF-8"', 'encoding="UTF-16"', 1)
+                    .encode("utf-16"))
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert seen == [str(src)]
+    assert result.document.ocr_text == "scanned"
+
+
+def test_doctype_probe_refuses_before_the_internal_subset_expands(tmp_path):
+    """Unit-level proof of *why* the probe is safe: expat reports the DOCTYPE before it
+    reads the subset, so the amplification never happens. A 1.4 KB file that would
+    render ~1 MB is refused, and refusing it does not cost the expansion."""
+    doctype, levels = _entity_bomb_doctype()
+    body = _make_ccda(tmp_path, name="bomb-src.XML").read_text(encoding="utf-8")
+    doc = body.replace("?>", f"?>{doctype}", 1).replace(
+        "Ferritin 201 ng/mL", f"&e{levels};"
+    )
+    src = tmp_path / "bomb.xml"
+    src.write_text(doc, encoding="utf-8")
+    assert src.stat().st_size < 4096            # small enough to clear the byte cap
+    assert ingest._xml_declares_doctype(src.read_bytes()) is True
+    assert ingest._extract_ccda(src) is None    # never rendered, so never amplified
+
+
+def test_a_doctype_the_probe_cannot_reach_still_falls_through(tmp_path):
+    """A parse error is the other ``False`` arm, and it is safe because it is the same
+    expat: whatever the probe cannot read, the `ET.fromstring` after it cannot read
+    either, so the file takes the unchanged non-CCDA route. Pinned on a lowercase
+    ``<!doctype``, which is not well-formed XML at all."""
+    doctype, levels = _entity_bomb_doctype()
+    body = _make_ccda(tmp_path, name="lower-src.XML").read_text(encoding="utf-8")
+    doc = body.replace(
+        "?>", f"?>{doctype.replace('<!DOCTYPE', '<!doctype')}", 1
+    ).replace("Ferritin 201 ng/mL", f"&e{levels};")
+    src = tmp_path / "lowercase-doctype.xml"
+    src.write_text(doc, encoding="utf-8")
+    assert ingest._xml_declares_doctype(src.read_bytes()) is False
+    assert ingest._extract_ccda(src) is None    # refused all the same
+
+
 def test_ccda_owner_check_matches_record_target(conn, tmp_path, sources):
     """The point of the issue: `recordTarget` is an identity the check can use, so a
     CCDA no longer degrades to "filed on your say-so"."""

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1023,8 +1023,13 @@ def test_ccda_owner_check_matches_record_target(conn, tmp_path, sources):
     assert result.owner_check.verdict == "match"
     assert result.owner_check.blocks is False
     # ...and the protective half still fires on this route.
-    other = _make_ccda(tmp_path, name="DOC0002.XML", patient=("Robert Alan", "Roe"),
-                       birth="")
+    # `pii-allow`: the roster placeholder "Robert Alan Roe" (see BOB above), split into
+    # CDA's `<given>`/`<family>` — the scanner reads the given half as first+last.
+    other = _make_ccda(
+        tmp_path, name="DOC0002.XML",
+        patient=("Robert Alan", "Roe"),  # pii-allow
+        birth="",
+    )
     with pytest.raises(ingest.OwnerMismatchError) as excinfo:
         ingest.ingest_document(conn, other, "jane-doe", sources, ocr=True)
     assert excinfo.value.check.verdict == "mismatch"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -856,6 +856,51 @@ def test_extract_text_reads_ccda_xml(conn, tmp_path, sources):
     assert "Ferritin\t201 ng/mL" in text
 
 
+# The shapes a real portal export carries that `_make_ccda` only approximates: a
+# multi-`<given>` legal name, a second `<name nullFlavor="UNK"/>`, a section nested
+# inside another section's `<component>`, `<list>/<item>` narrative, and inline
+# markup (`<content>`, `<sub>`) splitting text mid-cell.
+_CCDA_VENDOR = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<ClinicalDocument xmlns="urn:hl7-org:v3">'
+    "<recordTarget><patientRole><patient>"
+    '<name use="L"><given>Jane</given><given>Amelia</given><family>Doe</family></name>'
+    '<name use="P" nullFlavor="UNK"/>'
+    '<birthTime value="19620314000000-0600"/>'
+    "</patient></patientRole></recordTarget>"
+    "<component><structuredBody><component><section><title>Results</title><text>"
+    "<table><thead><tr><th>Test</th><th>Result</th></tr></thead>"
+    "<tbody><tr><td><content ID='res1'>Ferritin</content></td>"
+    "<td>11.<sub>2</sub></td></tr></tbody></table>"
+    '<renderMultiMedia referencedObject="MM1"/>'
+    "</text>"
+    "<component><section><title>Results Addendum</title><text>"
+    "<list><item>Repeat ferritin in 8 weeks.</item>"
+    "<item><content ID='med27'>Ferrous sulfate 325 MG</content> - 1 tablet daily</item>"
+    "</list></text></section></component>"
+    "</section></component></structuredBody></component>"
+    "</ClinicalDocument>"
+)
+
+
+def test_ccda_renders_real_vendor_export_shapes(conn, tmp_path, sources):
+    src = tmp_path / "DOC0003.XML"
+    src.write_text(_CCDA_VENDOR, encoding="utf-8")
+    text = ingest.ingest_document(
+        conn, src, "jane-doe", sources, ocr=True
+    ).document.ocr_text
+    # every `<given>` joins into the one name the owner check tokenises
+    assert text.startswith("Patient: Jane Amelia Doe\nDOB: 1962-03-14")
+    assert "Patient: \n" not in text   # the nullFlavor name contributes no line
+    # inline markup is flattened, not dropped, and does not split the cell
+    assert "Ferritin\t11.2" in text
+    # a nested section renders under its own title, exactly once
+    assert "Results Addendum" in text
+    assert text.count("Repeat ferritin in 8 weeks.") == 1
+    # `<list>` recurses, `<item>` flattens with its own tail text
+    assert "Ferrous sulfate 325 MG - 1 tablet daily" in text
+
+
 def test_ccda_never_shells_out(conn, tmp_path, sources, monkeypatch):
     def boom(path):  # pragma: no cover - the assertion is that this never runs
         raise AssertionError(f"run_ocr must not be called for {path}")

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1012,6 +1012,63 @@ def test_ccda_doctype_is_not_parsed_natively(conn, tmp_path, sources, monkeypatc
     assert result.document.ocr_text == "scanned"
 
 
+@pytest.mark.parametrize(
+    "prolog",
+    [
+        # the markers sit in a leading comment, so the file still sniffs as a CCDA
+        # while the DOCTYPE is padded past any fixed head window
+        '<!-- urn:hl7-org:v3 ClinicalDocument --><!-- ' + "x" * 9000 + " -->",
+        # a comment carrying something that *looks* like the root element: stopping at
+        # the first `<` instead of stepping over comments would end the scan here
+        '<!-- urn:hl7-org:v3 --><!-- <ClinicalDocument xmlns="urn:hl7-org:v3"> -->',
+    ],
+    ids=["padded-past-the-sniff-window", "comment-holding-a-fake-start-tag"],
+)
+def test_ccda_doctype_anywhere_in_the_prolog_is_not_parsed_natively(
+    conn, tmp_path, sources, monkeypatch, prolog
+):
+    """The DOCTYPE refusal scans the whole prolog, not a fixed head window.
+
+    A comment pushes the DOCTYPE past any window while the CCDA markers stay inside it,
+    and the internal subset it hides amplifies far past the byte cap — expat only checks
+    its ratio above 8 MiB of output, so everything under that expands silently."""
+    seen: list[str] = []
+    monkeypatch.setattr(ingest, "run_ocr", lambda p: seen.append(str(p)) or "scanned")
+    body = _make_ccda(tmp_path, name="prolog-src.XML").read_text(encoding="utf-8")
+    src = tmp_path / "prolog-doctype.xml"
+    src.write_text(
+        body.replace(
+            "?>",
+            f'?>{prolog}<!DOCTYPE ClinicalDocument [<!ENTITY a "aaaa">]>',
+            1,
+        ),
+        encoding="utf-8",
+    )
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert seen == [str(src)]
+    assert result.document.ocr_text == "scanned"
+
+
+def test_ccda_with_a_harmless_prolog_comment_still_reads_natively(
+    conn, tmp_path, sources, monkeypatch
+):
+    """The other half of the guard: stepping over prolog markup must not make the
+    scanner over-eager. A real CCDA behind a comment — including one quoting a start
+    tag — has no DOCTYPE and is still rendered rather than shipped to tesseract."""
+    def never(path):  # pragma: no cover - a CCDA never reaches the OCR route
+        raise AssertionError(f"run_ocr must not be called for {path}")
+
+    monkeypatch.setattr(ingest, "run_ocr", never)
+    body = _make_ccda(tmp_path, name="comment-src.XML").read_text(encoding="utf-8")
+    src = tmp_path / "commented.xml"
+    src.write_text(
+        body.replace("?>", "?><!-- exported <ClinicalDocument> 2026 -->", 1),
+        encoding="utf-8",
+    )
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert "Ferritin" in result.document.ocr_text
+
+
 def test_ccda_owner_check_matches_record_target(conn, tmp_path, sources):
     """The point of the issue: `recordTarget` is an identity the check can use, so a
     CCDA no longer degrades to "filed on your say-so"."""


### PR DESCRIPTION
## Summary

`pemr ingest` has no text extractor for CCDA (C-CDA / HL7 CDA R2) XML — such files fell through
to the tesseract branch, tesseract cannot decode XML, and the document was stored with no
`ocr_text` and an unverified owner. This adds a native extraction route:

- `_extract_ccda` (and helpers `_ccda_flat`, `_ccda_name`, `_ccda_table_rows`, `_ccda_narrative`,
  `_ccda_date`, `_ccda_header`) in `pemr/ingest.py`, wired into `extract_text_routed` beside the
  existing `.docx`/`.xlsx` native branches. Detection is gated on the parsed root element
  (`{urn:hl7-org:v3}ClinicalDocument`), not the `.xml` suffix — a non-CCDA `.xml` still falls
  through to the existing OCR/failure path unchanged.
- Narrative rendering walks `structuredBody/component/section` (title + text, tables as
  delimited rows, paragraphs/items/content flattened) using an **iterative** stack-based walk
  (not recursion — nesting depth is document-controlled and unbounded).
- `recordTarget/patientRole/patient` name + `birthTime` are prepended so the existing owner
  verification check has an identity anchor to match, the same way it already works for a
  scanned/transcribed document. Route reports `native`.
- A DOCTYPE guard (encoding-agnostic expat probe) refuses to fully parse any XML that declares
  a DOCTYPE, closing an entity-expansion/XXE surface before `ET.fromstring` ever sees the bytes.
- stdlib `xml.etree.ElementTree` / `xml.parsers.expat` only — no new dependency.
- `docs/Architecture.md`'s non-goal wording is tightened per the graduated in-thread decision:
  the "no HIPAA/PHI compliance layer, no provider interoperability (HL7/FHIR/CCD)" non-goal
  targets statutory compliance and bidirectional interop obligations, not local read-only
  document-format text extraction. `AGENTS.md`, `pemr/cli.py` (`--ocr` help), and
  `pemr/mcp_server.py` docstrings updated to match.

**Out of scope** (carried forward from the issue): structured/typed record extraction from
CCDA's coded entries, `nonXMLBody` payload extraction, IHE_XDM archive/manifest handling, and
any HL7/FHIR message exchange or provider-system integration.

Closes #138

## Test plan

- [x] `pytest` full suite green (1122 passed)
- [x] `pytest tests/test_ingest.py -k ccda` and DOCTYPE/prolog/recursion-focused subsets green
- [x] `npm test` (planner/CLI) 168 passed
- [x] `npm run check:pii` clean
- [x] `npm run check:meta-drift` clean
- [x] Real CLI run: CCDA ingests natively (no tesseract invocation), owner verified from
      `recordTarget`, `find` matches text from the rendered narrative
- [x] Deep-nesting and DOCTYPE/entity-expansion attack shapes (multiple encodings) confirmed
      refused/handled without raising, across three build↔audit round-trips

See the verify report (https://github.com/meridun/pemr/issues/138#issuecomment-5304097949) and
audit report (https://github.com/meridun/pemr/issues/138#issuecomment-5304142617) for full
detail, including the security review history (deep-recursion and DOCTYPE-bypass findings, both
closed and independently re-derived by audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
