### PR TITLE
fix(assert): make the collision check consult curation verdicts

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -400,6 +400,18 @@ one raises and names the stored row. Same reason `commit_extraction`'s pass 1 re
 colliding rows of one submission: the human is at the keyboard, and a conflict staged
 against oneself has no independent provenance to adjudicate.
 
+Since issue #133, that refusal first consults the `curation` overlay (§2): a colliding row
+already carrying a **releasing** verdict — `superseded` / `erroneous-in-source` /
+`merged-into` (row scope beats family scope, same precedence rule as §6) — no longer blocks.
+Only a `disputed` or unverdicted row still raises, and the error's remedy text only
+recommends `record annotate` when annotating that row could actually change the outcome —
+a row already released is never named. Once every colliding row is released the attestation
+proceeds as an ordinary new occurrence of the identity (the next free `dedup_occurrence`),
+not a replacement of what is stored. One consequence worth knowing: a **family**-scoped
+release covers that new occurrence too, so the freshly attested row itself renders in the
+`## Superseded / corrected` appendix (§6) until the verdict is re-scoped to the rows it
+meant or lifted — the CLI prints a note when this happens so it is not a silent surprise.
+
 `norm()` = lowercase, trim, collapse whitespace, drop parenthetical qualifiers, map
 synonyms via an **analyte/name dictionary** (`data/dictionary.toml`) — e.g. `A1c`,
 `HbA1c`, `Hemoglobin A1c` → one canonical `hba1c`. The dictionary is the one place fuzzy
@@ -950,6 +962,9 @@ pemr record assert <table> --person <slug> --attributed-to <who> --date <iso>
                    --field NAME=VALUE [--field ...] [--apply]
                                                          # commit a fact attested by a PERSON, with no
                                                          # source document (§2 attestation); dry run by default
+                                                         # a colliding family fully released by curation
+                                                         # verdicts no longer blocks (§3, issue #133);
+                                                         # disputed/unverdicted rows still refuse it
 pemr record assert --list [<table>] [--all] [--json]     # attested rows still needing a source document
 pemr document tombstone list [--json]                    # recorded intentional removals, newest first
 pemr document tombstone add (--file <path> | --sha256 <hex>) [--reason ...] [--note ...]

--- a/pemr/attestations.py
+++ b/pemr/attestations.py
@@ -27,7 +27,10 @@ disagreement, only for recording an agreement.
 
 **Refuse, don't stage.** The mirror case — asserting a fact the record already holds —
 never stages a conflict. An equal payload reports ``duplicate`` and writes nothing; a
-differing one raises :class:`AttestationCollisionError` naming the stored row. Precedent:
+differing one raises :class:`AttestationCollisionError` naming the stored row — *unless*
+every colliding row already carries a verdict that released the identity
+(:data:`curation.APPENDIX_STATUSES`, issue #133), in which case the human has already ruled
+the identity free and the attestation is an ordinary new occurrence. Precedent:
 ``commit_extraction``'s pass 1 already refuses two colliding rows of one submission,
 because the human is at the keyboard and a conflict staged against oneself has no
 independent provenance to adjudicate. A conflict would also have to carry
@@ -45,7 +48,7 @@ import sqlite3
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
-from . import db, dedup, query
+from . import curation, db, dedup, query
 
 
 class AttestationCollisionError(ValueError):
@@ -134,6 +137,73 @@ def _provenance(row: sqlite3.Row | dict) -> str:
     if row_map.get("document_id") is not None:
         return f"document #{row_map['document_id']}"
     return "attestation"
+
+
+def _blocking_rows(
+    conn: sqlite3.Connection, record_type: str, family: list[sqlite3.Row]
+) -> tuple[list[dict], list[dict]]:
+    """Split a colliding family into ``(blocking, released)`` — issue #133.
+
+    A row *releases* the identity when a human already ruled on it with one of
+    :data:`curation.APPENDIX_STATUSES` (``superseded`` / ``erroneous-in-source`` /
+    ``merged-into``); ``disputed`` and unverdicted rows keep blocking, because a disputed
+    row still holds the identity, it is merely flagged.
+
+    Resolution runs through :func:`curation.annotate_rows`, never a hand-rolled lookup, so
+    the row-beats-family precedence rule stays the single site :meth:`VerdictMap.for_row`
+    already is (issue #114) and "leaves the live view" stays :func:`curation.is_appendix`'s
+    vocabulary. Both lists keep the family's occurrence order.
+
+    The ``dict`` copy is required: ``annotate_rows`` stamps in place and ``sqlite3.Row`` is
+    immutable. The stamped key is inert for every reader downstream of here —
+    :func:`dedup._rows_equal` iterates its own field list, and ``_rekey_label`` /
+    ``_provenance`` read named columns.
+    """
+    rows = curation.annotate_rows(
+        [dict(row) for row in family], record_type, curation.load_verdicts(conn)
+    )
+    blocking = [row for row in rows if not curation.is_appendix(row)]
+    released = [row for row in rows if curation.is_appendix(row)]
+    return blocking, released
+
+
+def _collision_remedy(record_type: str, stored: dict, released: int) -> str:
+    """The half of the collision message that must stay honest — issue #133.
+
+    The defect this fixes was dead advice: the error recommended `record annotate` for a
+    row whose verdict could not change the outcome. A row already carrying a releasing
+    verdict is never in ``blocking``, so it can never be named here; what remains is a row
+    with no verdict (annotating it *would* unblock) or one carrying a non-releasing verdict
+    (say which, and name the ones that do release — interpolated from
+    :data:`curation.APPENDIX_STATUSES`, never hand-typed).
+
+    ``released`` discloses siblings already ruled on, rather than dropping them: an
+    operator who annotated three rows of four must not be left guessing why the fourth
+    still refuses.
+    """
+    pk = f"{record_type}_id"
+    row_id = stored[pk]
+    verdict = curation.verdict_of(stored)
+    releasing = ", ".join(f"`{status}`" for status in curation.APPENDIX_STATUSES)
+    if verdict is None:
+        remedy = (
+            f"Correct the stored row (`pemr record rm {record_type} {row_id}`, or "
+            f"`pemr record annotate {record_type} {row_id} --row --status superseded` "
+            "to rule on it) and retry"
+        )
+    else:
+        remedy = (
+            f"That row already carries the verdict '{verdict.get('status')}', which does "
+            f"not release the identity - only {releasing} do. Re-rule on it "
+            f"(`pemr record annotate {record_type} {row_id} --row --status superseded`) "
+            f"or remove it (`pemr record rm {record_type} {row_id}`) and retry"
+        )
+    if released:
+        remedy += (
+            f"; {released} other row(s) in this family already carry a releasing verdict "
+            "and no longer block"
+        )
+    return remedy + "; nothing was written"
 
 
 def assert_record(
@@ -233,29 +303,43 @@ def assert_record(
         )
         pk = f"{record_type}_id"
         if twin is None:
-            stored = family[0]
-            raise AttestationCollisionError(
-                f"{record_type} {stored[pk]} "
-                f"({dedup._rekey_label(record_type, stored)!r}, "
-                f"{_provenance(stored)}) already holds this identity with a different "
-                "value. An attestation is refused rather than staged as a conflict - "
-                "there is no second source to adjudicate against, only you. Correct the "
-                f"stored row (`pemr record rm {record_type} {stored[pk]}`, or "
-                "`pemr record annotate` to rule on it) and retry; nothing was written"
-            )
-        report.outcome = "duplicate"
-        report.row_id = int(twin[pk])
-        report.label = dedup._rekey_label(record_type, twin)
-        report.dedup_key = twin["dedup_key"]
-        report.dedup_occurrence = int(twin["dedup_occurrence"] or 0)
-        report.existing_provenance = _provenance(twin)
-        report.applied = apply
-        return report
+            # The identity only still holds if some family row is unreleased (#133):
+            # a family the human already ruled superseded/corrected is theirs to
+            # re-file. Falls through to the ordinary write path when none blocks.
+            blocking, released = _blocking_rows(conn, record_type, family)
+            if blocking:
+                stored = blocking[0]
+                raise AttestationCollisionError(
+                    f"{record_type} {stored[pk]} "
+                    f"({dedup._rekey_label(record_type, stored)!r}, "
+                    f"{_provenance(stored)}) already holds this identity with a "
+                    "different value. An attestation is refused rather than staged as a "
+                    "conflict - there is no second source to adjudicate against, only "
+                    f"you. {_collision_remedy(record_type, stored, len(released))}"
+                )
+        else:
+            report.outcome = "duplicate"
+            report.row_id = int(twin[pk])
+            report.label = dedup._rekey_label(record_type, twin)
+            report.dedup_key = twin["dedup_key"]
+            report.dedup_occurrence = int(twin["dedup_occurrence"] or 0)
+            report.existing_provenance = _provenance(twin)
+            report.applied = apply
+            return report
 
+    # Reachable with a non-empty family only via the released-identity fall-through
+    # above, and `dedup_key` is UNIQUE per table (migration 001) — so the new row takes
+    # the next free occurrence, the monotonic rule `dedup._resolve_keep_both` uses.
+    # An empty family gives occurrence 0, whose key *is* the base, exactly as before.
+    occurrence = max(
+        (int(f["dedup_occurrence"] or 0) for f in family), default=-1
+    ) + 1
+    report.dedup_occurrence = occurrence
+    report.dedup_key = dedup.occurrence_key(base, occurrence)
     if apply:
         with conn:
             report.row_id = dedup._insert_record(
-                conn, record_type, payload, person_id, None, base,
+                conn, record_type, payload, person_id, None, base, occurrence,
                 attestation=(who, when, stamp),
             )
     report.applied = apply

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -1740,6 +1740,36 @@ def _print_attest_report(report: "attestations.AttestReport") -> None:
         )
 
 
+def _print_released_identity_note(
+    conn, record_type: str, report: "attestations.AttestReport"
+) -> None:
+    """Disclose that this `new` landed into an already-populated family (issue #133).
+
+    Reachable only when curation verdicts released a colliding identity, so the operator
+    is told which occurrence the fact took — and, in the one genuinely surprising case,
+    that a **family**-scoped verdict covers the row just written too: a family verdict
+    applies to every row of its family, including the new one, so without this line
+    `record assert` would report success and `query`/`render` would show nothing.
+
+    Human output only — the ``--json`` / :class:`AttestReport` key set is unchanged, and
+    presentation stays with the front door while stamping stays in `curation` (#131).
+    """
+    verdict = curation.get_verdict(conn, record_type, report.dedup_base)
+    if verdict is not None and verdict["status"] in curation.APPENDIX_STATUSES:
+        print(
+            f"  note: this identity carries a family-scoped '{verdict['status']}' "
+            "verdict, which covers this row too - it renders in the superseded/corrected "
+            "appendix until the verdict is re-scoped to the rows it meant "
+            f"(`pemr record annotate {record_type} <row-id> --row ...`) or lifted "
+            f"(`pemr record annotate {record_type} <row-id> --clear`)"
+        )
+    else:
+        print(
+            "  note: earlier rows of this fact are superseded/corrected, so this one "
+            f"takes occurrence {report.dedup_occurrence} of the identity"
+        )
+
+
 def _cmd_record_assert(args: argparse.Namespace) -> int:
     """`record assert` — list attested rows, or commit one attested fact.
 
@@ -1800,6 +1830,8 @@ def _cmd_record_assert(args: argparse.Namespace) -> int:
             _print_json(report.as_dict())
             return 0
         _print_attest_report(report)
+        if report.outcome == "new" and report.dedup_occurrence:
+            _print_released_identity_note(conn, args.table, report)
         if report.outcome == "duplicate":
             print("nothing to do: the fact is already on record")
         elif report.applied:

--- a/tests/test_attestations.py
+++ b/tests/test_attestations.py
@@ -10,7 +10,7 @@ import json
 
 import pytest
 
-from pemr import attestations, cli, db, dedup, persons, query
+from pemr import attestations, cli, curation, db, dedup, persons, query
 
 MED = {"name": "Metformin", "dose": "500 mg", "started_on": "2025-06-01"}
 
@@ -203,6 +203,186 @@ def test_the_collision_message_names_an_attestation_as_such(conn, jane):
 
 
 # --------------------------------------------------------------------------- #
+# The collision check consults the curation overlay (issue #133)
+#
+# Before this, `record assert` resolved a collision from `dedup.load_family`'s raw SQL,
+# which never sees the `curation` table: a row the human had already ruled `superseded`
+# still blocked, and the error's own suggested remedy (`record annotate`) provably could
+# not work. Released rows now stop blocking; `disputed` and unverdicted ones do not.
+# --------------------------------------------------------------------------- #
+
+def _rule(conn, target, status="superseded", *, row=False, **kwargs):
+    """Record one verdict the way an operator would — `record annotate`'s API."""
+    return curation.annotate_record(
+        conn, "medication", str(target), status=status,
+        note="ruled on during the test", row=row, apply=True, **kwargs,
+    )
+
+
+def _base(conn, jane):
+    return dedup.dedup_key("medication", MED, jane.person_id)
+
+
+def _stored_row_id(conn, occurrence=0):
+    return int(conn.execute(
+        "SELECT medication_id FROM medication WHERE dedup_occurrence = ?",
+        (occurrence,),
+    ).fetchone()["medication_id"])
+
+
+def test_a_released_row_no_longer_blocks_a_differing_attestation(conn, jane):
+    """The defect, inverted: annotating the colliding row now does what the error said."""
+    _assert_med(conn, apply=True)
+    _rule(conn, _stored_row_id(conn), row=True)
+    report = _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+    assert report.outcome == "new"
+    assert report.applied is True
+    assert conn.execute("SELECT COUNT(*) AS n FROM medication").fetchone()["n"] == 2
+
+
+@pytest.mark.parametrize("status", curation.APPENDIX_STATUSES)
+def test_every_appendix_status_releases_the_identity(conn, jane, status):
+    """The vocabulary is `APPENDIX_STATUSES`, not three literals — a status added there
+    must release here too, or the two halves of "leaves the live view" have drifted."""
+    _assert_med(conn, apply=True)
+    extra = (
+        {"merged_into_base": _base(conn, jane)} if status == "merged-into" else {}
+    )
+    _rule(conn, _stored_row_id(conn), status=status, row=True, **extra)
+    assert _assert_med(
+        conn, payload=MED | {"frequency": "daily"}, apply=True
+    ).outcome == "new"
+
+
+def test_a_family_scoped_release_also_unblocks(conn, jane):
+    _assert_med(conn, apply=True)
+    _rule(conn, _base(conn, jane))
+    assert _assert_med(
+        conn, payload=MED | {"frequency": "daily"}, apply=True
+    ).outcome == "new"
+
+
+@pytest.mark.parametrize("scope_row", [True, False])
+def test_a_disputed_row_still_blocks(conn, jane, scope_row):
+    """`disputed` is deliberately not in APPENDIX_STATUSES: the row still holds the
+    identity, it is merely flagged."""
+    _assert_med(conn, apply=True)
+    target = _stored_row_id(conn) if scope_row else _base(conn, jane)
+    _rule(conn, target, status="disputed", row=scope_row)
+    with pytest.raises(attestations.AttestationCollisionError):
+        _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+
+
+def test_an_unverdicted_row_still_blocks(conn, jane):
+    _assert_med(conn, apply=True)
+    with pytest.raises(attestations.AttestationCollisionError):
+        _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+
+
+def test_one_unverdicted_sibling_still_blocks_a_released_family(conn, jane):
+    """A released row must not mask an unresolved one — and must not be the row the
+    error tells you to annotate."""
+    _assert_med(conn, apply=True)
+    first = _stored_row_id(conn)
+    _rule(conn, first, row=True)
+    _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+    second = _stored_row_id(conn, occurrence=1)
+
+    with pytest.raises(attestations.AttestationCollisionError) as exc:
+        _assert_med(conn, payload=MED | {"frequency": "TID"}, apply=True)
+    message = str(exc.value)
+    assert f"medication {second}" in message
+    assert f"medication {first}" not in message
+    assert "1 other row(s) in this family already carry a releasing verdict" in message
+
+
+def test_row_scope_beats_family_scope_in_the_collision_check(conn, jane):
+    """Both directions, through `VerdictMap.for_row` — no second precedence rule."""
+    _assert_med(conn, apply=True)
+    row_id, base = _stored_row_id(conn), _base(conn, jane)
+
+    _rule(conn, base, status="superseded")
+    _rule(conn, row_id, status="disputed", row=True)
+    with pytest.raises(attestations.AttestationCollisionError):
+        _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+
+    _rule(conn, base, status="disputed")
+    _rule(conn, row_id, status="superseded", row=True)
+    assert _assert_med(
+        conn, payload=MED | {"frequency": "daily"}, apply=True
+    ).outcome == "new"
+
+
+def test_the_collision_message_stays_honest(conn, jane):
+    """The bug this issue is about: never recommend a remedy that cannot work."""
+    _assert_med(conn, apply=True)
+    row_id = _stored_row_id(conn)
+
+    # Unverdicted: today's advice, which does work.
+    with pytest.raises(attestations.AttestationCollisionError) as bare:
+        _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+    assert f"pemr record rm medication {row_id}" in str(bare.value)
+    assert f"pemr record annotate medication {row_id} --row" in str(bare.value)
+
+    # Verdicted but not releasing: say which verdict it carries, and which ones release.
+    _rule(conn, row_id, status="disputed", row=True)
+    with pytest.raises(attestations.AttestationCollisionError) as ruled:
+        _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+    message = str(ruled.value)
+    assert "already carries the verdict 'disputed'" in message
+    for status in curation.APPENDIX_STATUSES:
+        assert f"`{status}`" in message
+
+
+def test_a_released_row_matching_the_payload_still_reports_duplicate(conn, jane):
+    """Twin semantics are untouched: matching stays `dedup._rows_equal`'s call."""
+    _assert_med(conn, apply=True)
+    _rule(conn, _stored_row_id(conn), row=True)
+    report = _assert_med(conn, apply=True)
+    assert report.outcome == "duplicate"
+    assert conn.execute("SELECT COUNT(*) AS n FROM medication").fetchone()["n"] == 1
+
+
+def test_the_unblocked_write_takes_the_next_free_occurrence(conn, jane):
+    """`dedup_key` is UNIQUE: an unblocked write at occurrence 0 would raise
+    IntegrityError against its released sibling instead of landing."""
+    _assert_med(conn, apply=True)
+    _rule(conn, _stored_row_id(conn), row=True)
+    _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+    _rule(conn, _stored_row_id(conn, occurrence=1), row=True)
+    base = _base(conn, jane)
+
+    dry = _assert_med(conn, payload=MED | {"frequency": "TID"})
+    assert dry.dedup_occurrence == 2
+    assert dry.dedup_key == dedup.occurrence_key(base, 2)
+    assert conn.execute("SELECT COUNT(*) AS n FROM medication").fetchone()["n"] == 2
+
+    written = _assert_med(conn, payload=MED | {"frequency": "TID"}, apply=True)
+    assert written.dedup_occurrence == 2
+    assert written.dedup_key == dedup.occurrence_key(base, 2)
+    row = conn.execute(
+        "SELECT * FROM medication WHERE medication_id = ?", (written.row_id,)
+    ).fetchone()
+    assert row["dedup_key"] == dedup.occurrence_key(base, 2)
+    assert row["dedup_base"] == base
+    assert len(dedup.load_family(conn, "medication", base)) == 3
+
+
+def test_an_unverdicted_database_is_byte_identical(conn, jane):
+    """The additive-only AC: with no verdicts at all, nothing about this path moved."""
+    report = _assert_med(conn, apply=True)
+    assert report.dedup_occurrence == 0
+    assert report.dedup_key == report.dedup_base
+    row = conn.execute("SELECT * FROM medication").fetchone()
+    assert row["dedup_key"] == row["dedup_base"]
+    assert int(row["dedup_occurrence"]) == 0
+    with pytest.raises(attestations.AttestationCollisionError) as exc:
+        _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+    assert "`pemr record rm medication 1`" in str(exc.value)
+    assert "already carries the verdict" not in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
 # list_attested — the "needs source" queue
 # --------------------------------------------------------------------------- #
 
@@ -352,6 +532,87 @@ def test_cli_assert_collision_fails_friendly(cli_ready, capsys):
     capsys.readouterr()
     assert _run(cli_ready, *_ASSERT_ARGV, "--field", "frequency=BID", "--apply") == 1
     assert "already holds this identity" in capsys.readouterr().err
+
+
+def _seed_cli_family(path, count):
+    """`count` document-sourced rows on one identity — the #130 repro's shape."""
+    conn = db.connect(path / "cli.db")
+    person_id = int(
+        conn.execute("SELECT person_id FROM person").fetchone()["person_id"]
+    )
+    doc = _document(conn, person_id, "cc33dd44")
+    base = dedup.dedup_key("medication", MED, person_id)
+    ids = [
+        dedup._insert_record(
+            conn, "medication", MED | {"frequency": f"{occ + 1}x daily"},
+            person_id, doc, base, occ,
+        )
+        for occ in range(count)
+    ]
+    conn.commit()
+    conn.close()
+    return ids
+
+
+def test_cli_annotating_every_colliding_row_unblocks_the_assert(cli_ready, capsys):
+    """The #130 repro end to end: four stored rows hold one identity, the assert is
+    refused, the error's own remedy is run on all four, and the identical assert lands.
+    Before the fix the second assert refused byte-identically to the first."""
+    ids = _seed_cli_family(cli_ready, 4)
+    argv = (*_ASSERT_ARGV, "--field", "status=discontinued")
+    assert _run(cli_ready, *argv, "--apply") == 1
+    assert "already holds this identity" in capsys.readouterr().err
+
+    for row_id in ids:
+        assert _run(
+            cli_ready, "record", "annotate", "medication", str(row_id), "--row",
+            "--status", "superseded", "--note", "replaced by the current order",
+            "--apply",
+        ) == 0
+    capsys.readouterr()
+
+    assert _run(cli_ready, *argv, "--apply") == 0
+    assert "wrote medication #5" in capsys.readouterr().out
+
+
+def test_cli_assert_discloses_a_family_scoped_release(cli_ready, capsys):
+    """The one surprising outcome of the fix: a *family* verdict covers the row just
+    written, so it must be disclosed rather than reported as a plain success."""
+    ids = _seed_cli_family(cli_ready, 1)
+    assert _run(
+        cli_ready, "record", "annotate", "medication", str(ids[0]),
+        "--status", "superseded", "--note", "family ruling", "--apply",
+    ) == 0
+    capsys.readouterr()
+    argv = (*_ASSERT_ARGV, "--field", "status=discontinued")
+    assert _run(cli_ready, *argv, "--apply") == 0
+    out = capsys.readouterr().out
+    assert "family-scoped 'superseded' verdict" in out
+    assert "wrote medication #2" in out
+
+    # A row-scoped release gets the plain occurrence note instead, not this one: re-scope
+    # the family ruling onto the two rows it meant, then lift it.
+    for row_id in (str(ids[0]), "2"):
+        assert _run(
+            cli_ready, "record", "annotate", "medication", row_id, "--row",
+            "--status", "superseded", "--note", "row ruling", "--apply",
+        ) == 0
+    assert _run(
+        cli_ready, "record", "annotate", "medication", str(ids[0]), "--clear", "--apply"
+    ) == 0
+    capsys.readouterr()
+    assert _run(cli_ready, *argv, "--field", "route=oral", "--apply") == 0
+    out = capsys.readouterr().out
+    assert "family-scoped" not in out
+    assert "takes occurrence 2 of the identity" in out
+
+    # The --json contract is unchanged on this path (the #110 key set).
+    assert _run(cli_ready, *argv, "--field", "route=oral", "--json") == 0
+    assert set(json.loads(capsys.readouterr().out)) == {
+        "record_type", "person", "person_id", "attributed_to", "attested_on",
+        "attested_at", "label", "fields", "dedup_key", "dedup_base",
+        "dedup_occurrence", "outcome", "row_id", "existing_provenance", "applied",
+    }
 
 
 def test_cli_walk_from_attestation_to_a_source_document(cli_ready, capsys):

--- a/tests/test_attestations.py
+++ b/tests/test_attestations.py
@@ -10,7 +10,7 @@ import json
 
 import pytest
 
-from pemr import attestations, cli, curation, db, dedup, persons, query
+from pemr import attestations, cli, curation, db, dedup, persons, query, records
 
 MED = {"name": "Metformin", "dose": "500 mg", "started_on": "2025-06-01"}
 
@@ -366,6 +366,31 @@ def test_the_unblocked_write_takes_the_next_free_occurrence(conn, jane):
     assert row["dedup_key"] == dedup.occurrence_key(base, 2)
     assert row["dedup_base"] == base
     assert len(dedup.load_family(conn, "medication", base)) == 3
+
+
+def test_an_unblocked_write_steps_over_a_hole_left_by_record_rm(conn, jane):
+    """The occupied-occurrence seam: `record rm` on a middle sibling leaves a hole, and
+    the next unblocked write must take `max + 1` over what is still stored — not the
+    hole, whose key belongs to no live row, and not a number a live sibling already
+    holds (that would be `UNIQUE(dedup_key)` instead of a landing). Same rule, same
+    idiom, as `dedup._resolve_keep_both`."""
+    base = _base(conn, jane)
+    for occurrence, frequency in enumerate((None, "daily", "TID")):
+        payload = MED if frequency is None else MED | {"frequency": frequency}
+        _assert_med(conn, payload=payload, apply=True)
+        _rule(conn, _stored_row_id(conn, occurrence=occurrence), row=True)
+
+    records.remove_record(
+        conn, "medication", _stored_row_id(conn, occurrence=1), apply=True
+    )
+    written = _assert_med(conn, payload=MED | {"frequency": "QID"}, apply=True)
+    assert written.dedup_occurrence == 3
+    assert written.dedup_key == dedup.occurrence_key(base, 3)
+    stored = {
+        int(row["dedup_occurrence"])
+        for row in dedup.load_family(conn, "medication", base)
+    }
+    assert stored == {0, 2, 3}
 
 
 def test_an_unverdicted_database_is_byte_identical(conn, jane):


### PR DESCRIPTION
## Summary

`record assert`'s collision check now consults the `curation` overlay before refusing: a
colliding family whose rows are all released (`superseded` / `erroneous-in-source` /
`merged-into`, row scope beating family scope per #114) no longer blocks the attestation.
`disputed` and unverdicted rows still refuse it, and the error's remedy text only recommends
`record annotate` when annotating could actually change the outcome — a row already released is
never named.

Fixes the dead-advice bug from #130/#126 (symptom 3a): annotating every colliding row with
`superseded` previously changed nothing the check could see; the identical assert still refused.

- Unblocked writes land as an ordinary new occurrence (`max(dedup_occurrence) + 1`) — not a
  replacement — avoiding a `UNIQUE(dedup_key)` collision against a released sibling.
- A **family**-scoped release covers the newly attested row too, so it renders straight into the
  `## Superseded / corrected` appendix until the verdict is re-scoped or lifted; the CLI's human
  output now discloses this so it isn't a silent surprise. `--json` / `AttestReport` field
  contract is unchanged.
- `dedup.load_family`, `_rows_equal` matching semantics, and the `rekey`/ingest
  collision-resolution path (#116/#122/#124) are untouched — read-only overlay consult only, no
  schema/migration change.

Docs updated in `docs/Architecture.md` (§3 dedup algorithm, §5 CLI reference table) to describe
the new release/block rule and the family-scoped-release consequence.

Closes #133

## Reports

- Verify: https://github.com/meridun/pemr/issues/133#issuecomment-5304386331
- Audit: https://github.com/meridun/pemr/issues/133#issuecomment-5304416927

## Test plan

- [x] Full `pytest` green in the worktree after merging `origin/dev` (no conflicts, no code
      overlap with the merged-in commits)
- [x] `npm run check:pii` clean (112 files)
- [x] `npm run check:meta-drift` clean
- [x] Targeted: `tests/test_attestations.py`, `tests/test_curation.py`, `tests/test_dedup.py`,
      `tests/test_records.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)