### PR TITLE
feat(dedup): add operator-driven `--keep merge` to review-conflicts (#140)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,6 +312,9 @@ Agents never resolve staged conflicts silently.
   refuses the whole resolution and names the colliding fields. Report that refusal to the human and
   ask which side wins per field; `fields={"<field>": "existing"|"incoming"}` (CLI: `--field
   NAME=existing|incoming`) settles one, and only a field that genuinely collides may appear there.
+  Provenance moves the same way `keep incoming`'s does — the row takes the winning document's
+  `document_id`, which supersedes an existing attestation on that row (issue #110) even when merge
+  takes no field, because the row is now filed under a different document.
   On a standing-fact type merge always refuses, because a conflict there is present-and-different by
   construction — use `keep incoming` for those.
 - `commit_extraction` **rejects** two rows of one submission that derive the same key and disagree;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,8 +282,8 @@ Agents never resolve staged conflicts silently.
 
 - `review_conflicts` with no `resolve` id **lists** conflicts — call it freely.
 - **Resolution requires explicit human sign-off.** The human must have named the specific conflict
-  and the chosen resolution (`keep existing` / `keep incoming` / `keep both`) in the current
-  session. "Clean this up", silence, or a standing general instruction is **not** sign-off.
+  and the chosen resolution (`keep existing` / `keep incoming` / `keep both` / `keep merge`) in the
+  current session. "Clean this up", silence, or a standing general instruction is **not** sign-off.
 - Mechanically: `review_conflicts(resolve=…)` requires a non-empty `signoff` param quoting the
   human's instruction verbatim; the wrapper refuses the write otherwise and stores the sign-off
   text with the resolution.
@@ -305,6 +305,15 @@ Agents never resolve staged conflicts silently.
   disagreement (`criticality: high` vs `low`) does not also erase a `reaction` the incoming
   document simply didn't repeat. On the dated types an unstated field IS a clearing and is written
   as one.
+- `keep merge` is the field-level resolution for exactly that dated-type case: a document that
+  **refines** some fields and is silent about others (a portal export restating a medication with a
+  better sig and no prescriber). It takes what the incoming row states over a stored NULL, keeps
+  what it leaves unstated, and does **not** guess where both rows state different values — it
+  refuses the whole resolution and names the colliding fields. Report that refusal to the human and
+  ask which side wins per field; `fields={"<field>": "existing"|"incoming"}` (CLI: `--field
+  NAME=existing|incoming`) settles one, and only a field that genuinely collides may appear there.
+  On a standing-fact type merge always refuses, because a conflict there is present-and-different by
+  construction — use `keep incoming` for those.
 - `commit_extraction` **rejects** two rows of one submission that derive the same key and disagree;
   that is an extraction error, not a conflict. For `observation`, re-read the source for times; if
   there genuinely are none, submit them separately and ask the human about `keep both`. For

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -377,6 +377,31 @@ enrichment cannot launder a disagreement into a silent overwrite. The same readi
 `keep incoming` on these types: it writes the fields the incoming row states and leaves the
 rest as stored, so a one-field adjudication doesn't erase the row's other payload.
 
+**On the dated types that reading is deliberately unavailable at commit time, and deliberately
+available at review time** (issue #140). A cleared field on a lab or a medication IS news, so
+enrichment must not fire automatically there — otherwise a later document could blank-then-refill
+a column with nobody looking. But that left no field-level path at all: a portal export that
+refines a medication's `status` and sig while carrying no prescriber could only be resolved by
+dropping the refinement (`keep existing`), erasing the prescriber (`keep incoming`), or forking one
+prescription into two rows (`keep both`). `review-conflicts --resolve --keep merge` is the missing
+middle, and it is safe precisely because it is **operator-driven**: a human is already looking at
+both rows. Per payload column it takes what the incoming row states over a stored NULL, keeps what
+the incoming row is silent about, and leaves agreeing values alone (through the same normalization
+as the duplicate-vs-conflict comparison, so a `MG/DL`/`mg/dL` variant is agreement, not a
+disagreement).
+
+Where both rows state *different* values, merge **refuses the whole resolution** — nothing written,
+the conflict still open, the colliding field names reported. That is the only genuinely lossy
+decision in the shape, so it stays explicit rather than being smeared across every field:
+`--field NAME=existing|incoming` settles one collision and leaves every other column on the
+automatic rule. A field choice naming a column that does not collide is refused too, so a typo or a
+stale retry can't quietly leave the real collision unsettled. On the standing-fact types merge
+always refuses, and needs no type gate to: a conflict there is present-and-different by
+construction, because the NULL-vs-stated case was already absorbed at commit time as a gain.
+Provenance is unchanged from `keep incoming` — the row takes the winning document's `document_id`,
+and with it the attestation supersession above. The resolution text, the CLI success line and the
+MCP payload record which fields came from which side by **name only**, never value.
+
 **Document provenance outranks an attestation** (issue #110). An attested row keys exactly
 like a document-sourced one, so a later `commit-extraction` of the same fact lands in the
 same identity family and the ordinary duplicate/conflict split decides the outcome — no new
@@ -911,7 +936,8 @@ pemr person add|list|show|edit|deactivate|reactivate|remove
 pemr ingest <file> --person <slug> [--ocr auto] [--force]        # --force: skip owner verification
 pemr ingest <dir>  --person <slug> --study dicom [--allow-large] # a study folder as ONE document (§4)
 pemr commit-extraction --document <id> --json <file>
-pemr review-conflicts [--resolve <id> --keep existing|incoming|both [--note ...]] [--dictionary <toml>]
+pemr review-conflicts [--resolve <id> --keep existing|incoming|both|merge
+                       [--field NAME=existing|incoming ...] [--note ...]] [--dictionary <toml>]
 pemr document list [--person <slug>]                     # newest first; omit --person for everyone
 pemr document show <id> [--json | --text]                # one document's detail; --text dumps stored ocr_text
 pemr document edit <id> [--doc-date|--category|--provider ...]   # partial update; "" clears a field

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -2268,7 +2268,7 @@ def _cmd_review_conflicts(args: argparse.Namespace) -> int:
             if args.resolve is not None:
                 result = dedup.resolve_conflict(
                     conn, args.resolve, keep=args.keep, note=args.note,
-                    dictionary=dictionary,
+                    dictionary=dictionary, fields=_field_choices(args.fields),
                 )
                 print(f"resolved conflict #{args.resolve} ({_resolved_as(result)})")
                 return 0
@@ -2304,11 +2304,34 @@ def _cmd_review_conflicts(args: argparse.Namespace) -> int:
         count = occurrences.get(row["conflict_id"], 0)
         if count > 1:
             print(f"    occurrences: {count} rows already stored under this key")
+    # Built from KEEP_CHOICES so the hint cannot drift as modes are added.
     print(
         "\nresolve: `pemr review-conflicts --resolve <id> --keep "
-        "existing|incoming|both [--note ...]`"
+        f"{'|'.join(dedup.KEEP_CHOICES)} [--note ...]`"
+        "\n         merge = per field: take what the incoming row adds, keep what it "
+        "leaves unstated;"
+        "\n         settle a field both rows state differently with "
+        "`--field NAME=existing|incoming`"
     )
     return 0
+
+
+def _field_choices(items: list[str] | None) -> dict[str, str]:
+    """Parse repeated `--field NAME=SIDE` into the mapping `resolve_conflict` takes.
+
+    Only the *shape* is checked here; which fields are mergeable and which sides are
+    legal is `dedup`'s call, so the CLI and the MCP tool refuse identically. Both raise
+    ValueError, which `_cmd_review_conflicts` already renders as `error: ...` + exit 1.
+    """
+    choices: dict[str, str] = {}
+    for item in items or []:
+        name, sep, side = item.partition("=")
+        if not sep or not name.strip() or not side.strip():
+            raise ValueError(
+                f"--field expects NAME=existing|incoming, got {item!r}"
+            )
+        choices[name.strip()] = side.strip()
+    return choices
 
 
 def _resolved_as(result: dedup.ResolveResult) -> str:
@@ -2318,8 +2341,11 @@ def _resolved_as(result: dedup.ResolveResult) -> str:
     fills the matched sibling's NULL columns from the staged payload (issue #63). Naming
     those fields keeps the operator's line honest about the write, matching what
     `dedup._resolution_text` persists on the conflict. Field names only, never values --
-    the resolution text is an audit trail, not a place to echo clinical data.
+    the resolution text is an audit trail, not a place to echo clinical data. keep-merge
+    reports through `dedup.merge_summary`, the same wording it persists.
     """
+    if result.kept == "merge":
+        return dedup.merge_summary(result)
     if result.kept != "both":
         return f"keep-{result.kept}"
     if result.no_op:
@@ -3306,9 +3332,18 @@ def build_parser() -> argparse.ArgumentParser:
     p_review.add_argument(
         "--keep", choices=list(dedup.KEEP_CHOICES), default="existing",
         help="on --resolve: keep the stored row, overwrite it with the incoming one, "
-             "or 'both' = admit the incoming row alongside the stored one as a new "
+             "'both' = admit the incoming row alongside the stored one as a new "
              "occurrence of the same identity (use for a genuine repeat the source "
-             "cannot timestamp). Default existing",
+             "cannot timestamp), or 'merge' = per field, take what the incoming row "
+             "adds over a stored NULL and keep what it leaves unstated, refusing when "
+             "both rows state a different value (settle those with --field). "
+             "Default existing",
+    )
+    p_review.add_argument(
+        "--field", action="append", dest="fields", metavar="NAME=SIDE",
+        help="only with --keep merge; repeatable. Settles one field both rows state "
+             "differently: NAME=existing keeps the stored value, NAME=incoming takes "
+             "the document's. Fields that do not collide are rejected",
     )
     p_review.add_argument("--note", help="optional resolution note")
     p_review.add_argument(

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -728,6 +728,25 @@ def _norm_unit(value: object) -> str:
     return "" if value is None else str(value).strip().lower()
 
 
+def _values_agree(name: str, ev: object, iv: object) -> bool:
+    """Do two *stated* payload values for column ``name`` mean the same thing?
+
+    The single source of the normalization shared by the duplicate-vs-conflict decision
+    (:func:`_rows_equal`) and the operator-driven field merge (:func:`_merge_plan`), so
+    the two can never drift apart on what "the same value" means. It deliberately does
+    **not** implement the None rules: silence reads differently in each caller (sparse
+    types, and merge's take/preserve split), so that stays with them.
+    """
+    # Unit strings are compared case-insensitively so casing variants across
+    # documents don't stage a spurious conflict.
+    if name == "unit":
+        return _norm_unit(ev) == _norm_unit(iv)
+    # Numeric columns round-trip through SQLite as float; compare numerically.
+    if isinstance(ev, _NUM) and isinstance(iv, _NUM):
+        return float(ev) == float(iv)
+    return ev == iv
+
+
 def _rows_equal(
     record_type: str, existing: sqlite3.Row | dict, incoming: dict
 ) -> bool:
@@ -750,17 +769,7 @@ def _rows_equal(
         # Standing facts: one side simply not stating a field is silence, not a change.
         if sparse and (ev is None or iv is None):
             continue
-        # Unit strings are compared case-insensitively so casing variants across
-        # documents don't stage a spurious conflict.
-        if name == "unit":
-            if _norm_unit(ev) != _norm_unit(iv):
-                return False
-            continue
-        # Numeric columns round-trip through SQLite as float; compare numerically.
-        if isinstance(ev, _NUM) and isinstance(iv, _NUM):
-            if float(ev) != float(iv):
-                return False
-        elif ev != iv:
+        if not _values_agree(name, ev, iv):
             return False
     return True
 
@@ -1178,12 +1187,105 @@ class ResolveResult:
     dedup_key: str | None = None
     dedup_base: str | None = None
     no_op: bool = False          # keep-both that matched an existing sibling
-    # Sparse-type fields the matched sibling was missing and the staged payload
-    # supplies; filled in place so a no-op still can't drop stated data (issue #63).
+    # Fields written from the staged payload: on a keep-both no-op the sparse-type
+    # columns the matched sibling was missing (issue #63), on keep-merge the columns
+    # the stored row left NULL (or the operator settled toward incoming) - the same
+    # meaning either way, so `_resolution_text` audits both by field name.
     gains: dict = field(default_factory=dict)
+    # keep-merge only: columns left as stored because the incoming row is silent about
+    # them (or the operator settled toward existing).
+    preserved: list = field(default_factory=list)
+    # keep-merge only: field -> 'existing'|'incoming', the collisions the operator ruled
+    # on explicitly. Everything else on a merge was decided by the silence rule alone.
+    settled: dict = field(default_factory=dict)
 
 
-KEEP_CHOICES = ("existing", "incoming", "both")
+@dataclass
+class MergePlan:
+    """What a ``keep='merge'`` resolution would do to one stored row, field by field.
+
+    Computed before the transaction opens so a collision refuses without a partial
+    write (same discipline as :func:`_plan_keep_both`).
+    """
+    taken: dict = field(default_factory=dict)       # field -> incoming value to write
+    preserved: list = field(default_factory=list)   # stored value kept as-is
+    settled: dict = field(default_factory=dict)     # field -> side, from an override
+    collisions: list = field(default_factory=list)  # both stated, differing, unsettled
+
+
+def _merge_plan(
+    record_type: str,
+    stored: sqlite3.Row | dict,
+    incoming: dict,
+    overrides: dict[str, str],
+) -> MergePlan:
+    """Plan a field-level merge of ``incoming`` onto ``stored``.
+
+    The rule, per payload column: the incoming row's statement fills a stored NULL, the
+    stored value survives a silent incoming row, agreeing values are left alone, and a
+    genuine disagreement is a **collision** unless ``overrides`` names the winning side.
+    An absent key and a ``None`` value are the same thing ("not stated"), matching
+    :func:`_sparse_gains`.
+
+    Why this only exists as an *operator* path: at commit time a stored NULL under a
+    stated value is news for the dated types (see :data:`_SPARSE_TYPES`), so an automatic
+    merge would let a later document blank-then-refill a column unwatched. At
+    ``review-conflicts`` time a human is already adjudicating both rows, which is exactly
+    when "take the refinement, keep what the incoming row is silent about" is safe.
+    """
+    stored_map = dict(stored)
+    plan = MergePlan()
+    for name in _COMPARE_FIELDS[record_type]:
+        ev = stored_map.get(name)
+        iv = incoming.get(name)
+        if ev is None and iv is None:
+            continue
+        if ev is None:              # the document supplies what the record lacked
+            plan.taken[name] = iv
+            continue
+        if iv is None:              # the document is silent: do not erase the record
+            plan.preserved.append(name)
+            continue
+        if _values_agree(name, ev, iv):
+            continue
+        side = overrides.get(name)
+        if side is None:
+            plan.collisions.append(name)
+        elif side == "incoming":
+            plan.settled[name] = side
+            plan.taken[name] = iv
+        else:
+            plan.settled[name] = side
+            plan.preserved.append(name)
+    return plan
+
+
+def _merge_overrides(
+    record_type: str, fields: dict[str, str] | None
+) -> dict[str, str]:
+    """Validate the operator's per-field choices against the type's payload columns.
+
+    A typo'd field name or an unrecognized side is refused by name rather than ignored:
+    silently dropping one would leave the collision it was meant to settle unsettled, and
+    the merge would refuse for a reason the operator thought they had already answered.
+    """
+    overrides = dict(fields or {})
+    valid = _COMPARE_FIELDS[record_type]
+    for name, side in overrides.items():
+        if name not in valid:
+            raise ValueError(
+                f"field choice {name!r}: not a mergeable {record_type} field - "
+                f"choose from {', '.join(valid)}"
+            )
+        if side not in ("existing", "incoming"):
+            raise ValueError(
+                f"field choice {name!r}: side must be 'existing' or 'incoming', "
+                f"got {side!r}"
+            )
+    return overrides
+
+
+KEEP_CHOICES = ("existing", "incoming", "both", "merge")
 
 
 def resolve_conflict(
@@ -1192,12 +1294,24 @@ def resolve_conflict(
     keep: str,
     note: str | None = None,
     dictionary: dict[str, str] | None = None,
+    fields: dict[str, str] | None = None,
 ) -> ResolveResult:
     """Resolve a staged conflict. ``keep`` is 'existing' (drop the incoming row),
-    'incoming' (overwrite the stored record's payload fields with the incoming row) or
+    'incoming' (overwrite the stored record's payload fields with the incoming row),
     'both' (admit the incoming row *alongside* the stored one as the next occurrence of
     that identity — the recovery path for a genuine repeat the source cannot timestamp,
-    issue #58).
+    issue #58) or 'merge' (field-level rather than row-level, issue #140).
+
+    ``keep='merge'`` takes each field the incoming row states over a stored NULL, keeps
+    each field the incoming row is silent about, and **refuses the whole resolution**
+    when both rows state different values for a field — naming those fields, writing
+    nothing, leaving the conflict open. That is the case where something genuinely has to
+    be lost, so it stays an explicit operator decision: ``fields`` maps one colliding
+    field to the side that wins (``'existing'`` | ``'incoming'``), and only fields that
+    actually collide may appear there. On a :data:`_SPARSE_TYPES` row a merge always
+    refuses, because a conflict there is present-and-different by construction (the
+    NULL-vs-stated case never gets that far — :func:`_sparse_gains` absorbs it at commit
+    time).
 
     Overwriting touches only the payload columns (``_COMPARE_FIELDS``) whose
     disagreement defined the conflict, plus provenance ``document_id``. Identity
@@ -1216,7 +1330,15 @@ def resolve_conflict(
     """
     db.require_migrated(conn)
     if keep not in KEEP_CHOICES:
-        raise ValueError("keep must be 'existing', 'incoming' or 'both'")
+        raise ValueError(
+            "keep must be " + " or ".join(
+                (", ".join(repr(c) for c in KEEP_CHOICES[:-1]), repr(KEEP_CHOICES[-1]))
+            )
+        )
+    if fields and keep != "merge":
+        raise ValueError(
+            f"per-field choices only apply to keep 'merge', not {keep!r}"
+        )
 
     row = conn.execute(
         "SELECT * FROM conflict WHERE conflict_id = ?", (conflict_id,)
@@ -1239,6 +1361,8 @@ def resolve_conflict(
             occurrence=int(anchor["dedup_occurrence"]),
             dedup_key=anchor["dedup_key"], dedup_base=anchor["dedup_base"],
         )
+    elif keep == "merge":
+        result = _plan_keep_merge(conn, row, dictionary, fields)
     else:
         result = ResolveResult(
             kept=keep, record_type=record_type, dedup_key=row["dedup_key"]
@@ -1250,6 +1374,10 @@ def resolve_conflict(
             incoming = json.loads(row["incoming_json"])
             _overwrite_record(
                 conn, record_type, int(result.row_id), row["document_id"], incoming
+            )
+        elif keep == "merge":
+            _merge_record(
+                conn, record_type, int(result.row_id), row["document_id"], result.gains
             )
         elif keep == "both" and result.no_op:
             if result.gains:
@@ -1271,9 +1399,33 @@ def resolve_conflict(
     return result
 
 
+def merge_summary(result: ResolveResult) -> str:
+    """How a keep-merge resolution describes itself, for the audit trail *and* the CLI
+    success line — one wording so the stored resolution and what the operator was told
+    can't drift.
+
+    Field **names** and sides only, never values: this is an audit trail, not a place to
+    echo clinical data (same rule as the sparse-gains reporting).
+    """
+    parts = [f"keep-merge -> {result.record_type} #{result.row_id}"]
+    if result.gains:
+        parts.append(f"from incoming: {', '.join(sorted(result.gains))}")
+    if result.preserved:
+        parts.append(f"kept: {', '.join(sorted(result.preserved))}")
+    if result.settled:
+        parts.append(
+            "settled: "
+            + ", ".join(f"{n}={s}" for n, s in sorted(result.settled.items()))
+        )
+    return "; ".join(parts)
+
+
 def _resolution_text(result: ResolveResult) -> str:
     """The auditable resolution string stored on the conflict row. keep-both records
-    which row it admitted (or matched) so the decision stays reconstructable."""
+    which row it admitted (or matched), keep-merge which fields came from which side, so
+    the decision stays reconstructable."""
+    if result.kept == "merge":
+        return merge_summary(result)
     if result.kept != "both":
         return f"keep-{result.kept}"
     if result.no_op:
@@ -1427,6 +1579,53 @@ def _plan_keep_both(
     return ResolveResult(
         kept="both", record_type=record_type, occurrence=occurrence,
         dedup_key=occurrence_key(base, occurrence), dedup_base=base,
+    )
+
+
+def _plan_keep_merge(
+    conn: sqlite3.Connection,
+    conflict: sqlite3.Row,
+    dictionary: dict[str, str] | None,
+    fields: dict[str, str] | None,
+) -> ResolveResult:
+    """Validate + plan the field-level write a ``keep='merge'`` resolution would make.
+
+    Everything that can refuse the resolution happens here, before the transaction opens.
+
+    Planned against the **live anchor row**, never ``conflict.existing_json``: that
+    snapshot is frozen at staging time, so an enrichment or a sibling resolution since
+    then would make the plan re-NULL columns the stored row has meanwhile gained - the
+    exact loss keep-merge exists to prevent.
+    """
+    record_type = conflict["record_type"]
+    overrides = _merge_overrides(record_type, fields)
+    # Same anchor (and same empty-family refusal) as keep-incoming: a family with no
+    # rows left can no longer be merged onto.
+    anchor = _anchor_row(conn, conflict, dictionary)
+    plan = _merge_plan(
+        record_type, anchor, json.loads(conflict["incoming_json"]), overrides
+    )
+    stale = sorted(set(overrides) - set(plan.settled))
+    if stale:
+        raise ValueError(
+            f"conflict {conflict['conflict_id']}: nothing to settle for "
+            f"{', '.join(stale)} - a field choice applies only where both rows state a "
+            "different value, and these do not. Nothing was written"
+        )
+    if plan.collisions:
+        raise ValueError(
+            f"conflict {conflict['conflict_id']}: keep-merge cannot decide "
+            f"{', '.join(plan.collisions)} - both rows state a different value there, "
+            "and choosing is a human call. Settle each with a field choice "
+            "(`--field NAME=existing|incoming`), or resolve the row as a whole with "
+            "keep 'existing', 'incoming' or 'both'. Nothing was written"
+        )
+    return ResolveResult(
+        kept="merge", record_type=record_type,
+        row_id=int(anchor[f"{record_type}_id"]),
+        occurrence=int(anchor["dedup_occurrence"]),
+        dedup_key=anchor["dedup_key"], dedup_base=anchor["dedup_base"],
+        gains=plan.taken, preserved=plan.preserved, settled=plan.settled,
     )
 
 
@@ -2068,4 +2267,42 @@ def _overwrite_record(
         raise ValueError(
             f"keep-incoming matched no {record_type} row (id {row_id}) - refusing to "
             "resolve the conflict, the incoming row would have been discarded"
+        )
+
+
+def _merge_record(
+    conn: sqlite3.Connection,
+    record_type: str,
+    row_id: int,
+    document_id: int | None,
+    values: dict,
+) -> None:
+    """Apply a :func:`_merge_plan`'s ``taken`` fields to one stored row, by primary key.
+
+    Only the planned columns are assigned, so every field the incoming row was silent
+    about keeps its stored value - the whole point of keep-merge. Identity fields,
+    ``dedup_key``, ``dedup_base`` and ``dedup_occurrence`` are never touched.
+
+    ``document_id`` is written unconditionally, exactly as :func:`_overwrite_record`
+    does, even when ``values`` is empty: provenance handling is deliberately unchanged
+    from keep-incoming, and so therefore is the attestation supersession it carries
+    (issue #110). The ``rowcount`` guard mirrors that function's for the same reason - a
+    zero-row UPDATE would stamp the conflict resolved having written nothing.
+    """
+    assignments = ["document_id = ?"]
+    params: list[object] = [document_id]
+    for name in _COMPARE_FIELDS[record_type]:      # planned column names only
+        if name in values:
+            assignments.append(f"{name} = ?")
+            params.append(values[name])
+    params.append(row_id)
+    cur = conn.execute(
+        f"UPDATE {record_type} SET {', '.join(assignments)} "
+        f"WHERE {record_type}_id = ?",
+        params,
+    )
+    if cur.rowcount != 1:
+        raise ValueError(
+            f"keep-merge matched no {record_type} row (id {row_id}) - refusing to "
+            "resolve the conflict, the merged fields would have been discarded"
         )

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -326,21 +326,28 @@ def review_conflicts(
     keep: str = "existing",
     signoff: str | None = None,
     note: str | None = None,
+    fields: dict[str, str] | None = None,
     all: bool = False,
 ) -> Any:
     """[read to list / write to resolve] List or resolve staged dedup conflicts.
 
     Listing is free, and reports ``occurrences`` — how many rows are already stored
     under the conflict's identity. Resolution takes ``keep`` = ``"existing"`` (drop the
-    incoming row), ``"incoming"`` (overwrite the stored one) or ``"both"`` (admit the
+    incoming row), ``"incoming"`` (overwrite the stored one), ``"both"`` (admit the
     incoming row *alongside* the stored one as a new occurrence of that identity — for a
-    genuine repeat, e.g. two same-day draws on a report that prints no collection times).
+    genuine repeat, e.g. two same-day draws on a report that prints no collection times)
+    or ``"merge"`` (field level: take what the incoming row states over a stored NULL,
+    keep what it leaves unstated, so accepting a refinement doesn't erase the fields the
+    document is simply silent about). ``"merge"`` **refuses** when both rows state a
+    different value for a field, naming those fields and writing nothing; pass
+    ``fields`` = ``{"<field>": "existing"|"incoming"}`` to settle one, and only for a
+    field that actually collides.
 
     Listing is free. **Resolution requires explicit human sign-off** (``AGENTS.md``
-    conflict discipline) — ``"both"`` included, it admits a row rather than choosing one:
-    ``signoff`` must quote the human's instruction verbatim, or the write is refused. The
-    sign-off text is threaded into the stored resolution note so the record shows who
-    authorized it.
+    conflict discipline) — ``"both"`` and ``"merge"`` included, and a ``fields`` choice is
+    itself a decision the human has to have made: ``signoff`` must quote the human's
+    instruction verbatim, or the write is refused. The sign-off text is threaded into the
+    stored resolution note so the record shows who authorized it.
     """
     if resolve is not None:
         if not (signoff and signoff.strip()):
@@ -352,7 +359,8 @@ def review_conflicts(
         merged_note = f"signoff: {signoff.strip()}" + (f" — {note}" if note else "")
         try:
             result = _dedup.resolve_conflict(
-                conn, resolve, keep=keep, note=merged_note, dictionary=_dictionary()
+                conn, resolve, keep=keep, note=merged_note, dictionary=_dictionary(),
+                fields=fields,
             )
         # ValueError covers ValidationError, raised when a keep-both payload no longer
         # validates as a row.
@@ -365,6 +373,16 @@ def review_conflicts(
                 "row_id": result.row_id,
                 "occurrence": result.occurrence,
                 "no_op": result.no_op,
+            }
+        elif keep == "merge":
+            # Field names and sides only, never values - same rule as the stored
+            # resolution text (this payload is an audit trail too).
+            payload |= {
+                "record_type": result.record_type,
+                "row_id": result.row_id,
+                "taken": sorted(result.gains),
+                "preserved": sorted(result.preserved),
+                "settled": result.settled,
             }
         return payload
 
@@ -612,9 +630,10 @@ def build_server():  # pragma: no cover - exercised only with the mcp SDK instal
     @server.tool(name="review_conflicts", annotations=rw)
     def review_conflicts_tool(resolve: int | None = None, keep: str = "existing",
                               signoff: str | None = None, note: str | None = None,
+                              fields: dict[str, str] | None = None,
                               all: bool = False) -> object:
         return _run(review_conflicts, resolve=resolve, keep=keep, signoff=signoff,
-                    note=note, all=all)
+                    note=note, fields=fields, all=all)
 
     return server
 

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -112,8 +112,9 @@ def test_review_conflicts_listing_shows_occurrences_and_the_both_hint(ready, cap
     _stage_repeat_draw(tmp_path, capsys)
     assert _run(tmp_path, "review-conflicts") == 0
     out = capsys.readouterr().out
-    assert "--keep existing|incoming|both" in out
+    assert "--keep existing|incoming|both|merge" in out
     assert "occurrences:" not in out          # family of 1 -> nothing to say yet
+    assert "--field NAME=existing|incoming" in out
 
     assert _run(tmp_path, "review-conflicts", "--resolve", "1", "--keep", "both") == 0
     scan = tmp_path / "g3.txt"
@@ -131,6 +132,102 @@ def test_review_conflicts_listing_shows_occurrences_and_the_both_hint(ready, cap
     out = capsys.readouterr().out
     assert "occurrences: 2 rows already stored under this key" in out
     assert out.isascii()
+
+
+# --- keep merge through the CLI (issue #140) ---------------------------------
+
+def _stage_med_refinement(tmp_path, capsys, stored: dict, incoming: dict):
+    """The issue's shape end to end: a stored medication row, then a portal export
+    that refines some fields and is silent about others -> one open conflict."""
+    identity = {"name": "metformin", "dose": "500 mg", "started_on": "2024-01-05"}
+    for i, payload in enumerate((stored, incoming), start=1):
+        scan = tmp_path / f"m{i}.txt"
+        scan.write_bytes(f"metformin {i}".encode())
+        assert _run(tmp_path, "ingest", str(scan), "--person", "jane-doe",
+                    "--sources", str(tmp_path / "sources")) == 0
+        doc = _write_json(tmp_path, f"m{i}.json",
+                          {"medication": [identity | payload]})
+        assert _run(tmp_path, "commit-extraction", "--document", str(i),
+                    "--json", str(doc)) == 0
+    capsys.readouterr()
+
+
+def test_review_conflicts_merge_writes_and_names_the_fields(ready, capsys):
+    tmp_path = ready
+    _stage_med_refinement(
+        tmp_path, capsys,
+        {"prescriber": "Dr Who", "route": "oral"},
+        {"route": "oral", "status": "active"},
+    )
+
+    assert _run(tmp_path, "review-conflicts", "--resolve", "1", "--keep", "merge",
+                "--note", "Jane confirms the portal list") == 0
+    out = capsys.readouterr().out
+    assert "resolved conflict #1 (keep-merge -> medication #1" in out
+    assert "from incoming: status" in out and "kept: prescriber" in out
+    assert "Dr Who" not in out                 # field names only, never values
+    assert out.isascii()
+
+    assert _run(tmp_path, "query", "meds", "--person", "jane-doe", "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload) == 1                   # merged in place, not forked
+    assert payload[0]["status"] == "active"    # the refinement landed
+    assert payload[0]["prescriber"] == "Dr Who"   # and the silent field survived
+
+
+def test_review_conflicts_merge_collision_exits_1_and_leaves_it_open(ready, capsys):
+    tmp_path = ready
+    _stage_med_refinement(
+        tmp_path, capsys,
+        {"status": "ordered", "prescriber": "Dr Who"},
+        {"status": "completed"},
+    )
+
+    assert _run(tmp_path, "review-conflicts", "--resolve", "1", "--keep", "merge") == 1
+    captured = capsys.readouterr()
+    assert "error: " in captured.err and "status" in captured.err
+    assert "ordered" not in captured.err and "completed" not in captured.err
+    assert captured.err.isascii()
+
+    assert _run(tmp_path, "review-conflicts") == 0
+    assert "[open]" in capsys.readouterr().out
+
+
+def test_review_conflicts_merge_field_override_resolves(ready, capsys):
+    tmp_path = ready
+    _stage_med_refinement(
+        tmp_path, capsys,
+        {"status": "ordered", "prescriber": "Dr Who"},
+        {"status": "completed"},
+    )
+
+    assert _run(tmp_path, "review-conflicts", "--resolve", "1", "--keep", "merge",
+                "--field", "status=incoming") == 0
+    assert "settled: status=incoming" in capsys.readouterr().out
+
+    assert _run(tmp_path, "query", "meds", "--person", "jane-doe", "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert (payload[0]["status"], payload[0]["prescriber"]) == ("completed", "Dr Who")
+
+
+def test_review_conflicts_malformed_field_argument_exits_1(ready, capsys):
+    tmp_path = ready
+    _stage_med_refinement(
+        tmp_path, capsys, {"status": "ordered"}, {"status": "completed"})
+
+    assert _run(tmp_path, "review-conflicts", "--resolve", "1", "--keep", "merge",
+                "--field", "status") == 1
+    assert "NAME=existing|incoming" in capsys.readouterr().err
+
+
+def test_review_conflicts_field_without_merge_exits_1(ready, capsys):
+    tmp_path = ready
+    _stage_med_refinement(
+        tmp_path, capsys, {"status": "ordered"}, {"status": "completed"})
+
+    assert _run(tmp_path, "review-conflicts", "--resolve", "1", "--keep", "incoming",
+                "--field", "status=incoming") == 1
+    assert "only apply to keep 'merge'" in capsys.readouterr().err
 
 
 def test_keep_both_after_a_rekey_does_not_wedge_rekey(ready, capsys):

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -524,3 +524,251 @@ def test_keep_existing_and_incoming_still_return_a_result(conn, staged):
     result = dedup.resolve_conflict(conn, staged, keep="existing")
     assert (result.kept, result.row_id, result.occurrence) == ("existing", None, None)
     assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 1
+
+
+# --- keep merge: field-level resolution (issue #140) --------------------------
+#
+# The shape the row-level keeps cannot express: a portal export restates a current
+# medication list, refining `status` and the sig while carrying no prescriber. `keep
+# existing` drops the refinement, `keep incoming` erases the prescriber the record
+# already had, `keep both` forks one prescription into two rows.
+
+def _med(**payload):
+    """One medication identity (name/dose/started_on), payload fields per call."""
+    return {"name": "metformin", "dose": "500 mg", "started_on": "2024-01-05"} | payload
+
+
+def _stage_med(conn, stored: dict, incoming: dict) -> int:
+    """One open medication conflict from two documents; returns its conflict_id."""
+    dedup.commit_extraction(conn, _doc(conn, "med-a"), {"medication": [_med(**stored)]})
+    summary = dedup.commit_extraction(
+        conn, _doc(conn, "med-b"), {"medication": [_med(**incoming)]}
+    )
+    assert summary.counts["conflict"] == 1
+    return dedup.list_conflicts(conn)[-1]["conflict_id"]
+
+
+def _med_row(conn):
+    return conn.execute("SELECT * FROM medication").fetchone()
+
+
+def test_merge_fills_a_stored_null_from_incoming(conn):
+    cid = _stage_med(conn, {"route": "oral"}, {"route": "oral", "status": "active"})
+    result = dedup.resolve_conflict(conn, cid, keep="merge")
+
+    assert conn.execute("SELECT COUNT(*) AS n FROM medication").fetchone()["n"] == 1
+    assert _med_row(conn)["status"] == "active"
+    assert (result.kept, result.gains) == ("merge", {"status": "active"})
+
+
+def test_merge_preserves_a_field_the_incoming_row_leaves_null(conn):
+    """The headline regression: the incoming row is *silent* about prescriber, which
+    keep-incoming would write as a clearing on a dated type."""
+    cid = _stage_med(
+        conn,
+        {"prescriber": "Dr Who", "frequency": "1 tablet twice a day"},
+        {"prescriber": None, "frequency": "1 tablet twice a day", "status": "active"},
+    )
+    result = dedup.resolve_conflict(conn, cid, keep="merge")
+
+    row = _med_row(conn)
+    assert (row["prescriber"], row["status"]) == ("Dr Who", "active")
+    assert result.preserved == ["prescriber"]
+
+
+def test_merge_leaves_agreeing_fields_unchanged(conn):
+    cid = _stage_med(
+        conn,
+        {"route": "oral", "prescriber": "Dr Who"},
+        {"route": "oral", "prescriber": "Dr Who", "status": "active"},
+    )
+    result = dedup.resolve_conflict(conn, cid, keep="merge")
+
+    assert _med_row(conn)["route"] == "oral"
+    assert "route" not in result.gains and "route" not in result.preserved
+
+
+def test_merge_inherits_the_duplicate_comparisons_unit_normalization(conn):
+    """`_values_agree` is shared with `_rows_equal`, so a casing variant of a stated
+    unit is agreement here too - not a collision to refuse over."""
+    dedup.commit_extraction(conn, _doc(conn, "u-a"), {"lab_result": [
+        {"test_name": "glucose", "collected_at": "2026-02-01",
+         "value_num": 99, "unit": "mg/dL"}]})
+    dedup.commit_extraction(conn, _doc(conn, "u-b"), {"lab_result": [
+        {"test_name": "glucose", "collected_at": "2026-02-01",
+         "value_num": 99, "unit": "MG/DL", "flag": "normal"}]})
+    cid = dedup.list_conflicts(conn)[-1]["conflict_id"]
+
+    result = dedup.resolve_conflict(conn, cid, keep="merge")
+    row = conn.execute("SELECT * FROM lab_result").fetchone()
+    assert row["unit"] == "mg/dL"            # stored display casing untouched
+    assert (row["flag"], result.gains) == ("normal", {"flag": "normal"})
+
+
+def test_merge_refuses_a_true_collision(conn):
+    """The issue's second case: `ordered` -> `completed` is a real disagreement, so
+    keep-merge refuses rather than picking a side."""
+    cid = _stage_med(
+        conn,
+        {"status": "ordered", "prescriber": "Dr Who", "ended_on": "2024-11-11"},
+        {"status": "completed", "prescriber": None},
+    )
+    with pytest.raises(ValueError, match="keep-merge cannot decide status"):
+        dedup.resolve_conflict(conn, cid, keep="merge")
+
+    row = _med_row(conn)
+    assert (row["status"], row["prescriber"], row["ended_on"]) == (
+        "ordered", "Dr Who", "2024-11-11")
+    assert row["document_id"] == 1            # provenance untouched too
+    conflict = conn.execute(
+        "SELECT * FROM conflict WHERE conflict_id=?", (cid,)
+    ).fetchone()
+    assert (conflict["status"], conflict["resolved_at"]) == ("open", None)
+
+
+def test_merge_collision_error_names_every_colliding_field_and_no_values(conn):
+    cid = _stage_med(
+        conn,
+        {"status": "ordered", "route": "oral"},
+        {"status": "completed", "route": "subcutaneous"},
+    )
+    with pytest.raises(ValueError) as exc:
+        dedup.resolve_conflict(conn, cid, keep="merge")
+    message = str(exc.value)
+    assert "route, status" in message or "status, route" in message
+    assert "ordered" not in message and "subcutaneous" not in message
+    assert message.isascii()                  # printed by the CLI (issue #23)
+
+
+def test_merge_settles_a_collision_with_an_explicit_field_choice(conn):
+    """The issue's first case end to end: status is a gain, the sig a settled
+    collision, the prescriber preserved."""
+    cid = _stage_med(
+        conn,
+        {"prescriber": "Dr Who", "frequency": "1 tablet twice a day"},
+        {"status": "active",
+         "frequency": "Take 1 tablet by mouth in the morning and 1 before bedtime."},
+    )
+    result = dedup.resolve_conflict(
+        conn, cid, keep="merge", fields={"frequency": "incoming"}
+    )
+
+    assert conn.execute("SELECT COUNT(*) AS n FROM medication").fetchone()["n"] == 1
+    row = _med_row(conn)
+    assert row["status"] == "active"
+    assert row["frequency"].startswith("Take 1 tablet by mouth")
+    assert row["prescriber"] == "Dr Who"
+    assert sorted(result.gains) == ["frequency", "status"]
+    assert (result.preserved, result.settled) == (
+        ["prescriber"], {"frequency": "incoming"})
+
+
+def test_merge_field_choice_can_keep_the_stored_side(conn):
+    cid = _stage_med(conn, {"status": "ordered"}, {"status": "completed"})
+    result = dedup.resolve_conflict(
+        conn, cid, keep="merge", fields={"status": "existing"}
+    )
+    assert _med_row(conn)["status"] == "ordered"
+    assert (result.gains, result.preserved) == ({}, ["status"])
+
+
+def test_merge_field_choice_rejects_an_unknown_field(conn):
+    cid = _stage_med(conn, {"status": "ordered"}, {"status": "completed"})
+    with pytest.raises(ValueError, match="not a mergeable medication field"):
+        dedup.resolve_conflict(conn, cid, keep="merge", fields={"dose": "incoming"})
+
+
+def test_merge_field_choice_rejects_a_non_colliding_field(conn):
+    """A stale retry or a typo'd name must not be silently absorbed - it would leave
+    the collision the operator meant to settle still unsettled."""
+    cid = _stage_med(conn, {"status": "ordered"}, {"status": "completed"})
+    with pytest.raises(ValueError, match="nothing to settle for route"):
+        dedup.resolve_conflict(conn, cid, keep="merge", fields={"route": "incoming"})
+    assert conn.execute(
+        "SELECT status FROM conflict WHERE conflict_id=?", (cid,)
+    ).fetchone()["status"] == "open"
+
+
+def test_merge_field_choice_rejects_an_invalid_side(conn):
+    cid = _stage_med(conn, {"status": "ordered"}, {"status": "completed"})
+    with pytest.raises(ValueError, match="side must be"):
+        dedup.resolve_conflict(conn, cid, keep="merge", fields={"status": "newest"})
+
+
+def test_field_choices_are_rejected_for_the_other_keeps(conn, staged):
+    with pytest.raises(ValueError, match="only apply to keep 'merge'"):
+        dedup.resolve_conflict(
+            conn, staged, keep="incoming", fields={"unit": "incoming"}
+        )
+    assert conn.execute(
+        "SELECT status FROM conflict WHERE conflict_id=?", (staged,)
+    ).fetchone()["status"] == "open"
+
+
+def test_merge_records_an_auditable_resolution(conn):
+    cid = _stage_med(
+        conn,
+        {"prescriber": "Dr Who", "status": "ordered"},
+        {"status": "completed", "route": "oral"},
+    )
+    dedup.resolve_conflict(
+        conn, cid, keep="merge", fields={"status": "incoming"}, note="Jane confirmed"
+    )
+    resolution = conn.execute(
+        "SELECT resolution FROM conflict WHERE conflict_id=?", (cid,)
+    ).fetchone()["resolution"]
+
+    assert resolution.startswith("keep-merge -> medication #1")
+    assert "from incoming: route, status" in resolution
+    assert "kept: prescriber" in resolution
+    assert "settled: status=incoming" in resolution
+    assert "Jane confirmed" in resolution
+    for value in ("Dr Who", "ordered", "completed", "oral"):
+        assert value not in resolution.split("Jane confirmed")[0]
+
+
+def test_merge_takes_provenance_like_keep_incoming(conn):
+    """Deliberately unchanged from keep-incoming: the human ruled for the document, so
+    the row takes its document_id (and with it the issue #110 supersession)."""
+    cid = _stage_med(conn, {"route": "oral"}, {"route": "oral", "status": "active"})
+    dedup.resolve_conflict(conn, cid, keep="merge")
+    assert _med_row(conn)["document_id"] == 2
+
+
+def test_merge_never_touches_identity_or_key_columns(conn):
+    cid = _stage_med(conn, {"route": "oral"}, {"route": "oral", "status": "active"})
+    before = dict(_med_row(conn))
+    dedup.resolve_conflict(conn, cid, keep="merge")
+    after = dict(_med_row(conn))
+    for column in ("name", "dose", "started_on",
+                   "dedup_key", "dedup_base", "dedup_occurrence"):
+        assert after[column] == before[column]
+
+
+def test_merge_refuses_when_the_family_is_empty(conn, orphaned_family):
+    """Same anchor rule as keep-incoming: nothing left to merge onto is a refusal, not
+    a success that wrote nothing."""
+    _drop_occurrence(conn, 1)
+    with pytest.raises(ValueError, match="no stored lab_result row left"):
+        dedup.resolve_conflict(conn, orphaned_family, keep="merge")
+    assert conn.execute(
+        "SELECT status FROM conflict WHERE conflict_id=?", (orphaned_family,)
+    ).fetchone()["status"] == "open"
+
+
+def test_merge_on_a_sparse_type_always_refuses(conn):
+    """No type gate, and none needed: a conflict on a standing-fact type is
+    present-and-different by construction (the NULL-vs-stated case is absorbed at commit
+    time as an `enriched` gain), so the collision rule refuses it truthfully."""
+    dedup.commit_extraction(conn, _doc(conn, "al-a"), {"allergy": [
+        {"substance": "penicillin", "criticality": "high"}]})
+    summary = dedup.commit_extraction(conn, _doc(conn, "al-b"), {"allergy": [
+        {"substance": "penicillin", "criticality": "low", "reaction": "hives"}]})
+    assert summary.counts["conflict"] == 1
+    cid = dedup.list_conflicts(conn)[-1]["conflict_id"]
+
+    with pytest.raises(ValueError, match="keep-merge cannot decide criticality"):
+        dedup.resolve_conflict(conn, cid, keep="merge")
+    assert conn.execute(
+        "SELECT criticality FROM allergy"
+    ).fetchone()["criticality"] == "high"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -444,6 +444,79 @@ def test_review_conflicts_listing_reports_family_size(seeded, tmp_path, monkeypa
     assert mcp_server.review_conflicts(seeded)[0]["occurrences"] == 2
 
 
+def _stage_med_conflict(seeded, tmp_path, monkeypatch, stored, incoming) -> int:
+    """One open medication conflict on a single identity (issue #140's shape: a portal
+    export refining some fields and silent about others); returns its conflict id."""
+    monkeypatch.setenv("PEMR_SOURCES", str(tmp_path / "sources"))
+    identity = {"name": "metformin", "dose": "500 mg", "started_on": "2024-01-05"}
+    for name, payload in (("m1.txt", stored), ("m2.txt", incoming)):
+        scan = tmp_path / name
+        scan.write_bytes(name.encode())
+        doc = mcp_server.ingest_document(
+            seeded, file=str(scan), person="jane-doe", ocr_text="metformin",
+        )["document"]["document_id"]
+        mcp_server.commit_extraction(seeded, document_id=doc, records={
+            "medication": [identity | payload],
+        })
+    return mcp_server.review_conflicts(seeded)[0]["conflict_id"]
+
+
+def test_review_conflicts_merge_requires_signoff_and_reports_fields(
+    seeded, tmp_path, monkeypatch
+):
+    """`merge` writes, so it goes through the *same* sign-off gate - no new bypass -
+    and its payload names the fields per side without echoing any value."""
+    cid = _stage_med_conflict(
+        seeded, tmp_path, monkeypatch,
+        {"prescriber": "Dr Who", "route": "oral"},
+        {"route": "oral", "status": "active"},
+    )
+    with pytest.raises(mcp_server.ToolError, match="sign-off"):
+        mcp_server.review_conflicts(seeded, resolve=cid, keep="merge")
+    assert seeded.execute(
+        "SELECT status FROM conflict WHERE conflict_id=?", (cid,)
+    ).fetchone()["status"] == "open"
+
+    res = mcp_server.review_conflicts(
+        seeded, resolve=cid, keep="merge",
+        signoff="Jane said take the portal status and keep the prescriber",
+    )
+    assert res["keep"] == "merge" and res["record_type"] == "medication"
+    assert (res["taken"], res["preserved"], res["settled"]) == (
+        ["status"], ["prescriber"], {})
+    assert "Dr Who" not in str(res)
+    row = seeded.execute(
+        "SELECT * FROM medication WHERE medication_id = ?", (res["row_id"],)
+    ).fetchone()
+    assert (row["status"], row["prescriber"]) == ("active", "Dr Who")
+
+
+def test_review_conflicts_merge_collision_refuses_until_a_field_is_settled(
+    seeded, tmp_path, monkeypatch
+):
+    cid = _stage_med_conflict(
+        seeded, tmp_path, monkeypatch,
+        {"status": "ordered", "prescriber": "Dr Who"},
+        {"status": "completed"},
+    )
+    with pytest.raises(mcp_server.ToolError, match="status"):
+        mcp_server.review_conflicts(seeded, resolve=cid, keep="merge",
+                                    signoff="Jane said merge them")
+    assert seeded.execute(
+        "SELECT status FROM conflict WHERE conflict_id=?", (cid,)
+    ).fetchone()["status"] == "open"
+
+    res = mcp_server.review_conflicts(
+        seeded, resolve=cid, keep="merge", fields={"status": "incoming"},
+        signoff="Jane said the portal status wins",
+    )
+    assert res["settled"] == {"status": "incoming"}
+    row = seeded.execute(
+        "SELECT * FROM medication WHERE medication_id = ?", (res["row_id"],)
+    ).fetchone()
+    assert (row["status"], row["prescriber"]) == ("completed", "Dr Who")
+
+
 def test_review_conflicts_rejects_an_unknown_keep(seeded, tmp_path, monkeypatch):
     cid = _stage_repeat_draw(seeded, tmp_path, monkeypatch)
     with pytest.raises(mcp_server.ToolError, match="keep must be"):


### PR DESCRIPTION
## Summary

Adds a third `review-conflicts --resolve` mode, `--keep merge`, for the non-sparse record types
(`medication`, `lab_result`, `procedure`, `appointment`, `observation`). Today `keep existing` /
`keep incoming` / `keep both` each force a loss on the common portal-export shape — a document that
refines some fields while staying silent on others. `keep merge` is field-level:

- incoming states a value, stored is NULL -> take incoming
- stored states a value, incoming is silent -> keep stored
- both state the same value (normalized) -> unchanged
- both state different values -> refuse the whole resolution, name the colliding field(s); settle
  with repeatable `--field NAME=existing|incoming`

On standing-fact types (`allergy`, `condition`) merge always refuses — a conflict there is
present-and-different by construction, so `keep incoming` is the tool for those.

Provenance follows `keep incoming`: the row takes the winning document's `document_id`, which
supersedes an existing attestation on that row (issue #110) — including when merge takes no field,
because the row is now filed under a different document even though its content didn't change.

## Docs fan-out (this PR)

- `pemr/cli.py`, `pemr/mcp_server.py`, `pemr/dedup.py` — implementation (`--field`, `_field_choices`,
  `MergePlan`/`_merge_plan`, `_plan_keep_merge`, `_merge_record`, `dedup.merge_summary`).
- `docs/Architecture.md` — conflict-resolution section + CLI synopsis (added during build).
- `AGENTS.md` §5 — `keep merge` semantics (added during build), plus one sentence added here at
  ship closing an audit advisory: the provenance-move/attestation-supersession behavior was in
  Architecture.md but not in AGENTS.md, so an agent reading only AGENTS.md wouldn't know a
  no-field-taken merge can still flip an attestation to `superseded`.

## Non-blocking advisories from audit (not addressed here, logged for a possible follow-up)

- The asymmetry between `_merge_record`'s unconditional `document_id` write and `_enrich_record`'s
  opposite choice is intentional (merge is adjudication, enrichment is automatic) but was flagged as
  worth a dedicated follow-up issue if anyone wants it revisited.
- CLI `--field` edge cases (repeated `--field NAME=` for the same name last-wins silently;
  `--field` silently ignored without `--resolve`) are cosmetic — neither can cause a wrong write.

## Reports

- Verify: https://github.com/meridun/pemr/issues/140#issuecomment-5304588850
- Audit: https://github.com/meridun/pemr/issues/140#issuecomment-5304608812

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)