### PR TITLE
feat(document): re-run text extraction against a stored blob (#143)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -997,6 +997,8 @@ pemr document tombstone add (--file <path> | --sha256 <hex>) [--reason ...] [--n
                                                          # pre-emptive exclusion; ingests and copies nothing
 pemr document tombstone rm <sha256>                      # lift one (full hash only)
 pemr document set-text <id> --ocr-text-file <path> [--force]     # attach/replace ocr_text after ingest; FTS follows via trigger
+pemr document reocr [<id>...] [--where-empty [--person <slug>]] [--dry-run] [--force]
+                                                         # re-derive ocr_text from the stored blob using the ingest dispatch
 pemr query labs --person jane --test hba1c --since 2023-01-01 [--raw]
 pemr query meds --person jane --active [--raw]
 pemr query timeline --person jane --since 2024-01-01 [--raw] # merged event stream

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -895,6 +895,18 @@ knows" case softens to `unverified`. `mismatch` — an affirmative name/DOB matc
 *different* roster person — is the half that actually prevents misfiling, and it blocks on
 every route.
 
+`document reocr` (issue #143) re-runs this same dispatch against a blob already in
+`sources/`, closing the gap for documents ingested before an extractor fix (#70, #138)
+landed — same routing, so the two paths cannot drift. Its `--force` carries two meanings at
+once: it overrides both the has-text refusal (replace a populated `ocr_text`) *and* a
+`mismatch` owner-check refusal on the recovered text, and the exit code stays 0 when the
+latter fires. The verb's own backlog use case, `--where-empty`, needs neither sense of
+`--force` — the population is unpopulated by definition, so a `mismatch` there still
+refuses on its own and names `document reassign` as the remedy. `suspect` (no roster match
+either way) stores and warns rather than refusing, since the recovered text cannot name the
+wrong household member — refusing would only withhold the evidence that the document is
+misfiled at the row level.
+
 ### Study directories (issue #69)
 
 A burned imaging disc is clinically *one* document but physically one folder holding

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -544,6 +544,145 @@ def _cmd_document_set_text(args: argparse.Namespace) -> int:
     return _with_document_conn(args, work)
 
 
+def _reocr_json(result: "ingest.ReocrResult") -> dict:
+    """One :class:`ingest.ReocrResult` as a stable-key JSON dict.
+
+    ``owner_check`` is nested (or null) in the shape MCP's `ingest` already returns it,
+    so a caller that parses one parses both.
+    """
+    check = result.owner_check
+    return {
+        "document_id": result.document_id,
+        "status": result.status,
+        "chars": result.chars,
+        "previous_chars": result.previous_chars,
+        "route": result.route,
+        "pages": result.pages,
+        "truncated": result.truncated,
+        "blob_path": result.blob_path,
+        "owner_check": None if check is None else {
+            "verdict": check.verdict,
+            "matched_slug": check.matched_slug,
+            "evidence": check.evidence,
+        },
+    }
+
+
+def _print_reocr_result(result: "ingest.ReocrResult") -> None:
+    """One human line per document, plus the two things a sweep must not miss:
+    truncation against `OCR_MAX_PAGES`, and any owner verdict that isn't reassuring."""
+    was = (
+        f"was {result.previous_chars} chars"
+        if result.previous_chars
+        else "was empty"
+    )
+    route = f"  route {result.route}" if result.route else ""
+    if result.status == "written":
+        line = f"written      {result.chars} chars ({was}){route}"
+    elif result.status == "would-write":
+        line = f"would write  {result.chars} chars ({was}){route}  [dry run]"
+    elif result.status == "has-text":
+        line = (
+            f"skipped      already has ocr_text ({result.previous_chars} chars) - "
+            "pass --force to replace it"
+        )
+    elif result.status == "no-text":
+        line = f"no text      nothing could be extracted from the blob{route}"
+    elif result.status == "owner-mismatch":
+        line = "refused      owner verification failed - nothing written"
+    elif result.status == "missing-blob":
+        line = f"missing blob {result.blob_path}"
+    else:  # study-blob
+        line = (
+            "skipped      packed DICOM study; its ocr_text is a header summary, "
+            "not extracted text"
+        )
+    print(f"#{result.document_id}  {line}")
+
+    if result.truncated:
+        print(
+            f"    pages: {result.pages} (over the {ingest.OCR_MAX_PAGES}-page cap - "
+            "text is truncated)"
+        )
+    check = result.owner_check
+    if check is not None and check.verdict not in ("match", "unverified"):
+        if check.verdict == "mismatch":
+            print(
+                f"    owner: text matches '{check.matched_slug}', "
+                "not this document's owner"
+            )
+            print(
+                f"    fix with `pemr document reassign {result.document_id} "
+                f"--person {check.matched_slug}`, or store anyway with --force"
+            )
+        else:  # suspect - stored, but the operator should look
+            print(
+                "    owner: warning - the text carries an identity header naming "
+                "nobody on the roster"
+            )
+        if check.evidence:
+            print(f'    found in document text: "{check.evidence}"')
+
+
+def _cmd_document_reocr(args: argparse.Namespace) -> int:
+    # Exactly one selector, and `--person` only scopes the filter. An argparse error
+    # (usage + rc=2) rather than a silent guess, following `document rm`'s
+    # parser-on-the-namespace pattern - a sweep that selects the wrong set is worse
+    # than one that refuses to start.
+    if args.document_ids and args.where_empty:
+        args.parser.error(
+            "pass document ids or --where-empty, not both; nothing was written"
+        )
+    if not args.document_ids and not args.where_empty:
+        args.parser.error(
+            "nothing selected - pass document ids or --where-empty; "
+            "nothing was written"
+        )
+    if args.person and not args.where_empty:
+        args.parser.error(
+            "--person only scopes --where-empty; nothing was written"
+        )
+    sources_dir = _resolve_sources_dir(args)
+
+    def work(conn):
+        document_ids = args.document_ids or documents.list_documents_without_text(
+            conn, args.person
+        )
+        if not document_ids:
+            if args.json:
+                _print_json([])
+                return 0
+            print("no documents with empty ocr_text - nothing to do")
+            return 0
+        try:
+            results = ingest.reocr_documents(
+                conn, document_ids, sources_dir,
+                force=args.force, dry_run=args.dry_run,
+            )
+        except ingest.IngestError as exc:
+            # Not in `_with_document_conn`'s catch list (it is an engine-side
+            # RuntimeError, not one of the `documents` refusals), so translate it here
+            # to the same friendly rc=1 every other `document` verb gives.
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+
+        if args.json:
+            _print_json([_reocr_json(r) for r in results])
+        else:
+            for result in results:
+                _print_reocr_result(result)
+            counts: dict[str, int] = {}
+            for result in results:
+                counts[result.status] = counts.get(result.status, 0) + 1
+            summary = ", ".join(f"{n} {status}" for status, n in sorted(counts.items()))
+            print(f"{len(results)} document(s): {summary}")
+        # rc=1 when work the operator asked for was refused (see ReocrResult.refused);
+        # `no-text` stays rc=0 so a sweep does not exit non-zero on expected outcomes.
+        return 1 if any(r.refused for r in results) else 0
+
+    return _with_document_conn(args, work)
+
+
 def _cmd_document_edit(args: argparse.Namespace) -> int:
     # A flag left unset is None -> not part of the update; an explicit empty string
     # (e.g. --category "") clears that column (documents.py), same as `person edit`.
@@ -3025,6 +3164,38 @@ def build_parser() -> argparse.ArgumentParser:
     )
     d_set_text.add_argument("--json", action="store_true", help="machine-readable output")
     d_set_text.set_defaults(func=_cmd_document_set_text)
+
+    # --- re-run extraction against the stored blob (issue #143) -----------
+    d_reocr = document_sub.add_parser(
+        "reocr",
+        help="re-derive ocr_text from a document's stored blob, using the same "
+             "extraction dispatch as `ingest`",
+    )
+    d_reocr.add_argument(
+        "document_ids", nargs="*", type=int, metavar="ID",
+        help="document id(s) to re-extract; omit and pass --where-empty instead",
+    )
+    d_reocr.add_argument(
+        "--where-empty", dest="where_empty", action="store_true",
+        help="select every document whose ocr_text is empty (the repair sweep)",
+    )
+    d_reocr.add_argument(
+        "--person", help="scope --where-empty to one owner slug"
+    )
+    d_reocr.add_argument(
+        "--dry-run", dest="dry_run", action="store_true",
+        help="report the character count that would be stored; write nothing",
+    )
+    d_reocr.add_argument(
+        "--force", action="store_true",
+        help="replace existing ocr_text, and store despite an owner mismatch "
+             "(both refused without this, same as `ingest --force`)",
+    )
+    d_reocr.add_argument("--sources", help="sources blob dir (overrides config)")
+    d_reocr.add_argument("--json", action="store_true", help="machine-readable output")
+    # `parser` rides along for the selector-combination checks in the handler, so the
+    # usage line names `pemr document reocr` (same pattern as `document rm`).
+    d_reocr.set_defaults(func=_cmd_document_reocr, parser=d_reocr)
 
     d_edit = document_sub.add_parser(
         "edit", help="correct a document's date/category/provider (partial)"

--- a/pemr/documents.py
+++ b/pemr/documents.py
@@ -276,6 +276,43 @@ def list_documents(
     return [_document_view(conn, row) for row in rows]
 
 
+def list_documents_without_text(
+    conn: sqlite3.Connection, person_slug: str | None = None
+) -> list[int]:
+    """Ids of documents whose ``ocr_text`` is empty, ascending (`reocr --where-empty`).
+
+    Ascending rather than :func:`list_documents`' newest-first: this feeds a repair
+    sweep, where the useful property is that it works forward through the backlog and a
+    partially-completed run is resumable by eye.
+
+    Emptiness is :func:`normalize_document_text`'s predicate, applied in Python rather
+    than in SQL: `TRIM()` knows about whitespace and nothing about zero-width or other
+    invisible characters, and the invisible-only rows of issue #87 are part of exactly
+    the population this selector exists to find.
+
+    Raises :class:`pemr.persons.PersonNotFoundError` for an unknown ``person_slug``,
+    matching :func:`list_documents` — an unknown slug is a typo, not an empty result.
+    """
+    db.require_migrated(conn)
+    params: list[object] = []
+    where = ""
+    if person_slug is not None:
+        person = get_person(conn, person_slug)
+        if person is None:
+            raise PersonNotFoundError(f"no person with slug '{person_slug}'")
+        where = " WHERE person_id = ?"
+        params.append(person.person_id)
+    return [
+        row["document_id"]
+        for row in conn.execute(
+            f"SELECT document_id, ocr_text FROM document{where} "
+            "ORDER BY document_id ASC",
+            params,
+        )
+        if not normalize_document_text(row["ocr_text"])
+    ]
+
+
 def _show_view(conn: sqlite3.Connection, row: sqlite3.Row) -> dict:
     """The :func:`_document_view` fields plus the two `document show` extras.
 

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -29,6 +29,12 @@ Issue #70 closes that dispatcher's last hole, **PDFs**. They fall through to
 no PDF reader), so every PDF ingest used to store an empty `ocr_text`. See
 :func:`_ocr_pdf`.
 
+Issue #143 adds the *backwards* half of those extractor fixes: :func:`reocr_documents`
+re-runs today's dispatch against a blob already in `sources/`, so a document ingested
+before an extractor improved can gain the text it never got. It calls the same
+:func:`extract_text_routed` `ingest` calls (so the two paths cannot drift) and writes
+through the same :func:`pemr.documents.set_document_text` guard.
+
 Issue #69 adds a second entry point, :func:`ingest_study_dir`: a DICOM study
 *directory* becomes one document whose blob is a canonical zip of its slices (see
 :mod:`pemr.study`). It reuses every rail above — same person lookup, same layer-1
@@ -58,7 +64,7 @@ from typing import Callable, Iterator, Sequence
 from urllib.parse import urlsplit
 
 from . import db, study as _study, tombstones as _tombstones
-from .documents import normalize_document_text
+from .documents import normalize_document_text, set_document_text
 from .models import Document, Person
 
 
@@ -314,6 +320,39 @@ def _ocr_pdf(src: Path) -> str | None:
     finally:
         doc.close()
     return normalize_document_text(_PAGE_SEPARATOR.join(pages)) or None
+
+
+def pdf_page_count(src: Path) -> int | None:
+    """How many pages a PDF has, or ``None`` when that cannot be known.
+
+    ``None`` covers every "don't know" — the ``pemr[ocr]`` extra is absent, the file is
+    not a PDF, or it is unreadable/password-protected — so a caller can only ever say
+    "this document is over the cap" on positive evidence. Never raises, same contract
+    as :func:`_ocr_pdf`.
+
+    Deliberately a second, tiny open rather than a refactor of :func:`_ocr_pdf` (which
+    needs the page handles it already holds): both read the one ``OCR_MAX_PAGES``
+    constant, so there is nothing here to drift. Exists for `document reocr` (issue
+    #143), where the operator is not looking at the source document and so cannot see
+    the truncation note `_ocr_pdf` prints.
+    """
+    if src.suffix.lower() != ".pdf":
+        return None
+    backend = _load_pdf_backend()
+    if backend is None:
+        return None
+    try:
+        doc = backend.open(str(src))
+    except _PDF_ERRORS:
+        return None
+    try:
+        if getattr(doc, "needs_pass", False):
+            return None
+        return int(doc.page_count)
+    except _PDF_ERRORS:
+        return None
+    finally:
+        doc.close()
 
 
 def run_ocr(path: str | Path) -> str | None:
@@ -1140,6 +1179,21 @@ def _person_for_slug(conn: sqlite3.Connection, slug: str) -> Person:
     return Person.from_row(row)
 
 
+def _person_for_id(conn: sqlite3.Connection, person_id: int | None) -> Person | None:
+    """The claimed owner of an already-filed document, or ``None`` when unowned.
+
+    Sibling of :func:`_person_for_slug` for the re-run path (issue #143), where the
+    owner comes from the stored row rather than a `--person` flag. Unowned is not an
+    error here — there is simply nobody to check the recovered text against.
+    """
+    if person_id is None:
+        return None
+    row = conn.execute(
+        "SELECT * FROM person WHERE person_id = ?", (person_id,)
+    ).fetchone()
+    return Person.from_row(row) if row is not None else None
+
+
 def _roster(conn: sqlite3.Connection) -> list[Person]:
     """Everyone on the roster, **including deactivated people** — a deactivated person
     is still a real person whose documents must not land on someone else."""
@@ -1503,3 +1557,174 @@ def ingest_study_dir(
     return IngestResult(
         status="new", document=document, owner_check=owner_check, tombstone=tombstone
     )
+
+
+# --------------------------------------------------------------------------- #
+# Re-extraction against an already-stored blob (issue #143)
+# --------------------------------------------------------------------------- #
+#
+# `ingest` writes `ocr_text` once, from whatever the extractor could read that day.
+# Every later extractor fix (#70's PDF route, #138's CCDA route) therefore only helps
+# documents ingested *after* it landed; the ones already on file keep the empty column
+# they got. `document set-text` cannot close that gap — it takes text derived
+# out-of-band, which is a transcription path, not a re-run.
+#
+# `reocr_documents` is the missing verb's engine: a selector and a policy layer over
+# two functions that already exist. It calls `extract_text_routed` (the one `ingest`
+# calls, not a copy) and writes through `set_document_text` (the one `set-text` calls),
+# so the re-run cannot drift from the ingest path and cannot bypass the overwrite guard.
+
+
+@dataclass(frozen=True)
+class ReocrResult:
+    """What a re-extraction did — or refused to do — for one document.
+
+    Same shape and spirit as :class:`IngestResult`: one frozen row per document, so a
+    262-document sweep is a list a caller can print, count and serialise without a
+    second pass over the database.
+
+    ``status``:
+
+    * ``written`` — the recovered text is stored.
+    * ``would-write`` — ``dry_run``; ``chars`` is what *would* have been stored.
+    * ``has-text`` — the column already holds visible text and ``force`` was off.
+      Refused **before** extraction, so the skip is cheap.
+    * ``no-text`` — extraction ran and recovered nothing. A warning, not an error.
+    * ``owner-mismatch`` — the recovered text affirmatively names a *different* roster
+      person (issue #61's check, re-run against text that did not exist at ingest).
+    * ``missing-blob`` — ``source_path`` does not resolve under ``sources_dir``.
+    * ``study-blob`` — a packed DICOM study, whose ``ocr_text`` is a derived header
+      summary rather than extracted text (see :func:`ingest_study_dir`).
+    """
+
+    document_id: int
+    status: str
+    chars: int = 0
+    previous_chars: int = 0
+    route: str | None = None
+    pages: int | None = None
+    truncated: bool = False
+    owner_check: OwnerCheck | None = None
+    blob_path: str | None = None
+
+    @property
+    def wrote(self) -> bool:
+        return self.status == "written"
+
+    @property
+    def refused(self) -> bool:
+        """Whether the caller asked for work that was declined (drives the exit code).
+
+        ``no-text`` is deliberately excluded: a document that genuinely has no readable
+        text is an expected outcome of a sweep, and a sweep that exits non-zero on
+        expected outcomes trains `|| true` — the same reasoning as
+        :attr:`IngestResult.is_tombstoned`.
+        """
+        return self.status in ("has-text", "owner-mismatch", "missing-blob",
+                               "study-blob")
+
+
+def reocr_documents(
+    conn: sqlite3.Connection,
+    document_ids: Sequence[int],
+    sources_dir: str | Path,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+) -> list[ReocrResult]:
+    """Re-derive ``ocr_text`` for each document from its stored blob (`document reocr`).
+
+    Every id is resolved **before** any extraction runs: an unknown id is a typo, and a
+    sweep must not half-run on one. After that, each document is independent — there is
+    deliberately **no transaction across the sweep** (each write is
+    :func:`pemr.documents.set_document_text`'s own), so an interrupted 262-document run
+    leaves the finished documents committed and is safely re-runnable.
+
+    ``force`` means both "replace existing ``ocr_text``" and "store despite an owner
+    mismatch", matching what ``--force`` already means on `ingest`. ``dry_run`` reports
+    what would be stored and writes nothing.
+
+    Raises :class:`IngestError` for an unknown document id.
+    """
+    db.require_migrated(conn)
+    root = Path(sources_dir)
+
+    rows: list[Document] = []
+    for document_id in document_ids:
+        row = get_document_by_id(conn, document_id)
+        if row is None:
+            raise IngestError(
+                f"no document with id {document_id} - see `pemr document list`"
+            )
+        rows.append(row)
+
+    roster = _roster(conn)
+    results: list[ReocrResult] = []
+    for row in rows:
+        previous = normalize_document_text(row.ocr_text)
+        common = {"document_id": row.document_id, "previous_chars": len(previous)}
+
+        if row.source_path.endswith(STUDY_EXT):
+            # A study's `ocr_text` is a DICOM-header summary built from the unpacked
+            # slices, not text extracted from the blob. Re-deriving it is a different
+            # pipeline (see `ingest_study_dir`), so this verb reports and skips.
+            results.append(ReocrResult(status="study-blob", **common))
+            continue
+
+        # Before extraction, not after: the skip has to be cheap, or a sweep across a
+        # mostly-populated corpus pays for OCR it then discards. Same normalised
+        # predicate `set_document_text` uses, so an invisible-characters-only row
+        # (issue #87) correctly counts as empty and gets repaired.
+        if previous and not force:
+            results.append(ReocrResult(status="has-text", **common))
+            continue
+
+        blob = root / row.source_path
+        # Recorded even when it does not resolve — a `missing-blob` result is only
+        # actionable if it names the path that was looked for.
+        common["blob_path"] = str(blob)
+        if not blob.is_file():
+            results.append(ReocrResult(status="missing-blob", **common))
+            continue
+
+        text, route = extract_text_routed(blob)
+        # What `set_document_text` would actually store, so `--dry-run`'s character
+        # count is the number the write reports and not one character more.
+        text = normalize_document_text(text)
+        pages = pdf_page_count(blob)
+        common.update(
+            route=route, pages=pages,
+            truncated=pages is not None and pages > OCR_MAX_PAGES,
+        )
+        if not text:
+            results.append(ReocrResult(status="no-text", **common))
+            continue
+
+        person = _person_for_id(conn, row.person_id)
+        owner_check = None
+        if person is not None:
+            owner_check = check_owner(
+                text, person, roster, trust_anchors=(route != "native")
+            )
+        common["owner_check"] = owner_check
+        # Only `mismatch` refuses here, unlike ingest where `suspect` blocks too: this
+        # document is *already filed* under that owner, so withholding the text does
+        # not un-file it — it only hides the evidence and keeps the document invisible
+        # to `find`, which is the bug this verb exists to close. `mismatch` is
+        # affirmative evidence of a cross-owner leak, so it still earns the refusal.
+        if owner_check is not None and owner_check.verdict == "mismatch" and not force:
+            results.append(ReocrResult(status="owner-mismatch", **common))
+            continue
+
+        if dry_run:
+            results.append(
+                ReocrResult(status="would-write", chars=len(text), **common)
+            )
+            continue
+
+        # `force=True` unconditionally: this call is only reached once the `has-text`
+        # guard above has already applied the caller's own force policy, and re-testing
+        # it here would refuse the invisible-only rows that guard deliberately admits.
+        set_document_text(conn, row.document_id, text, force=True)
+        results.append(ReocrResult(status="written", chars=len(text), **common))
+    return results

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -9,7 +9,7 @@ import json
 
 import pytest
 
-from pemr import cli, db, dedup, documents, persons
+from pemr import cli, db, dedup, documents, ingest, persons
 
 RECORDS = {
     "lab_result": [
@@ -1186,3 +1186,301 @@ def test_cli_document_output_is_console_safe(cli_ready, capsys):
         for text in (captured.out, captured.err):
             assert text.isascii(), repr(text)
             text.encode("cp437")
+
+
+# --- re-extraction from the stored blob: `document reocr` (issue #143) -------
+
+
+def _sources(tmp_path):
+    return str(tmp_path / "sources")
+
+
+def _ingest_textless(tmp_path, name, content, person="jane-doe"):
+    """Ingest a blob with no ocr_text - the population `reocr` exists to repair."""
+    src = tmp_path / name
+    src.write_bytes(content)
+    assert _run(tmp_path, "ingest", str(src), "--person", person,
+                "--sources", _sources(tmp_path)) == 0
+
+
+def _ocr_text_of(tmp_path, document_id):
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        return conn.execute(
+            "SELECT ocr_text FROM document WHERE document_id = ?", (document_id,)
+        ).fetchone()["ocr_text"]
+    finally:
+        conn.close()
+
+
+def test_list_documents_without_text_uses_the_invisible_aware_predicate(conn):
+    """The #87 rows are the target population: raw truthiness calls them populated,
+    `normalize_document_text` calls them empty, and only the second one is right."""
+    jane = persons.add_person(conn, "jane-doe", "Jane Doe")
+    john = persons.add_person(conn, "john-doe", "John Doe")
+    populated = _insert_document(conn, jane.person_id, "aa11", ocr_text="real text")
+    empty = _insert_document(conn, jane.person_id, "bb22", ocr_text=None)
+    invisible = _insert_document(conn, jane.person_id, "cc33", ocr_text="​﻿")
+    johns = _insert_document(conn, john.person_id, "dd44", ocr_text="")
+
+    ids = documents.list_documents_without_text(conn)
+
+    assert ids == sorted([empty, invisible, johns])   # ascending, resumable by eye
+    assert populated not in ids
+    assert documents.list_documents_without_text(conn, "jane-doe") == sorted(
+        [empty, invisible]
+    )
+
+
+def test_list_documents_without_text_unknown_slug_raises(seeded):
+    with pytest.raises(persons.PersonNotFoundError):
+        documents.list_documents_without_text(seeded["conn"], "nobody")
+
+
+def test_cli_document_reocr_fills_an_empty_document_and_find_sees_it(
+    cli_ready, capsys
+):
+    _ingest_textless(cli_ready, "scan2.txt", b"acute pericarditis noted on review")
+    capsys.readouterr()
+    assert _run(cli_ready, "find", "--person", "jane-doe", "pericarditis") == 0
+    assert "pericarditis" not in capsys.readouterr().out
+
+    assert _run(cli_ready, "document", "reocr", "2",
+                "--sources", _sources(cli_ready)) == 0
+    out = capsys.readouterr().out
+    assert "#2  written" in out
+    assert "34 chars (was empty)" in out
+    assert "route native" in out
+    assert out.isascii(), repr(out)
+
+    # No explicit reindex anywhere: the FTS trigger followed the ocr_text write.
+    assert _run(cli_ready, "find", "--person", "jane-doe", "pericarditis") == 0
+    assert "pericarditis" in capsys.readouterr().out.lower()
+
+
+def test_cli_document_reocr_refuses_a_populated_document_without_force(
+    cli_ready, capsys
+):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "reocr", "1",
+                "--sources", _sources(cli_ready)) == 1
+    out = capsys.readouterr().out
+    assert "#1  skipped" in out and "--force" in out
+    assert _ocr_text_of(cli_ready, 1) == "hba1c 5.7 percent"
+
+
+def test_cli_document_reocr_force_replaces_existing_text(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "reocr", "1", "--force",
+                "--sources", _sources(cli_ready)) == 0
+    assert "was 17 chars" in capsys.readouterr().out
+    # The blob is the same bytes the transcription came from, so this is a no-change
+    # replace - what matters is that force got past the guard at all.
+    assert _ocr_text_of(cli_ready, 1) == "hba1c 5.7 percent"
+
+
+def test_cli_document_reocr_dry_run_prints_char_count_and_names_truncation(
+    cli_ready, capsys, monkeypatch
+):
+    _ingest_textless(cli_ready, "scan2.txt", b"a long scanned bundle of pages")
+    # The page count is the extractor's business; here the unit under test is whether
+    # the operator is *told* about the cap without having to read the write path.
+    monkeypatch.setattr(ingest, "pdf_page_count", lambda src: 21)
+    capsys.readouterr()
+
+    assert _run(cli_ready, "document", "reocr", "2", "--dry-run",
+                "--sources", _sources(cli_ready)) == 0
+    out = capsys.readouterr().out
+    assert "#2  would write  30 chars (was empty)" in out
+    assert "[dry run]" in out
+    assert f"pages: 21 (over the {ingest.OCR_MAX_PAGES}-page cap" in out
+    assert out.isascii(), repr(out)
+    assert _ocr_text_of(cli_ready, 2) is None
+
+
+def test_cli_document_reocr_where_empty_selects_only_textless_documents(
+    cli_ready, capsys
+):
+    _ingest_textless(cli_ready, "scan2.txt", b"second document text")
+    capsys.readouterr()
+
+    assert _run(cli_ready, "document", "reocr", "--where-empty",
+                "--sources", _sources(cli_ready)) == 0
+    out = capsys.readouterr().out
+    assert "#2  written" in out
+    assert "#1" not in out                 # already populated -> never selected
+    assert "1 document(s): 1 written" in out
+
+
+def test_cli_document_reocr_where_empty_scoped_by_person(cli_ready, capsys):
+    _ingest_textless(cli_ready, "jane2.txt", b"jane's untranscribed scan")
+    _ingest_textless(cli_ready, "john2.txt", b"john's untranscribed scan", "john-doe")
+    capsys.readouterr()
+
+    assert _run(cli_ready, "document", "reocr", "--where-empty",
+                "--person", "john-doe", "--sources", _sources(cli_ready)) == 0
+    out = capsys.readouterr().out
+    assert "#3  written" in out and "#2" not in out
+    assert _ocr_text_of(cli_ready, 2) is None
+    assert _ocr_text_of(cli_ready, 3) == "john's untranscribed scan"
+
+
+def test_cli_document_reocr_where_empty_on_a_clean_archive_is_a_noop(
+    cli_ready, capsys
+):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "reocr", "--where-empty",
+                "--sources", _sources(cli_ready)) == 0
+    assert "nothing to do" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("argv", [
+    ("document", "reocr", "1", "--where-empty"),        # both selectors
+    ("document", "reocr"),                              # neither
+    ("document", "reocr", "1", "--person", "jane-doe"),  # --person without the filter
+])
+def test_cli_document_reocr_rejects_bad_flag_combinations(cli_ready, argv):
+    with pytest.raises(SystemExit) as exc:
+        _run(cli_ready, *argv, "--sources", _sources(cli_ready))
+    assert exc.value.code == 2
+
+
+def test_cli_document_reocr_multi_id_summary_and_exit_code(cli_ready, capsys):
+    _ingest_textless(cli_ready, "scan2.txt", b"recovered from the blob")
+    capsys.readouterr()
+
+    # One written, one refused: the write still lands, and the refusal still sets rc=1.
+    assert _run(cli_ready, "document", "reocr", "1", "2",
+                "--sources", _sources(cli_ready)) == 1
+    out = capsys.readouterr().out
+    assert "#1  skipped" in out and "#2  written" in out
+    assert "2 document(s): 1 has-text, 1 written" in out
+    assert _ocr_text_of(cli_ready, 2) == "recovered from the blob"
+
+
+def test_cli_document_reocr_json_carries_a_stable_key_set(cli_ready, capsys):
+    _ingest_textless(cli_ready, "scan2.txt", b"Patient: Jane  findings here")
+    capsys.readouterr()
+
+    assert _run(cli_ready, "document", "reocr", "1", "2", "--json",
+                "--sources", _sources(cli_ready)) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert [row["document_id"] for row in payload] == [1, 2]
+    assert set(payload[0]) == {
+        "document_id", "status", "chars", "previous_chars", "route", "pages",
+        "truncated", "blob_path", "owner_check",
+    }
+    assert payload[0]["status"] == "has-text"
+    assert payload[0]["owner_check"] is None            # refused before any check
+    assert payload[1]["status"] == "written"
+    assert set(payload[1]["owner_check"]) == {"verdict", "matched_slug", "evidence"}
+
+
+def test_cli_document_reocr_missing_blob_is_reported_not_crashed(cli_ready, capsys):
+    _ingest_textless(cli_ready, "scan2.txt", b"about to vanish from sources")
+    conn = db.connect(cli_ready / "cli.db")
+    try:
+        source_path = conn.execute(
+            "SELECT source_path FROM document WHERE document_id = 2"
+        ).fetchone()["source_path"]
+    finally:
+        conn.close()
+    (cli_ready / "sources" / source_path).unlink()
+    capsys.readouterr()
+
+    assert _run(cli_ready, "document", "reocr", "2",
+                "--sources", _sources(cli_ready)) == 1
+    out = capsys.readouterr().out
+    assert "#2  missing blob" in out
+    assert out.isascii(), repr(out)
+
+
+def test_cli_document_reocr_owner_mismatch_refuses_and_names_the_remedy(
+    cli_ready, capsys
+):
+    # A roster person with a usable multi-token name: `name_tokens` deliberately
+    # ignores mononyms, so the fixture's "Jane"/"John" can never produce a verdict.
+    assert _run(cli_ready, "person", "add", "--slug", "bob-roe",
+                "--name", "Robert Alan Roe") == 0
+    _ingest_textless(cli_ready, "scan2.txt", b"Patient: ROE, ROBERT ALAN  summary")
+    capsys.readouterr()
+
+    assert _run(cli_ready, "document", "reocr", "2",
+                "--sources", _sources(cli_ready)) == 1
+    out = capsys.readouterr().out
+    assert "#2  refused" in out
+    assert "text matches 'bob-roe'" in out
+    assert "pemr document reassign 2 --person bob-roe" in out
+    assert out.isascii(), repr(out)
+    assert _ocr_text_of(cli_ready, 2) is None
+
+    # ...and --force is the documented way past it.
+    assert _run(cli_ready, "document", "reocr", "2", "--force",
+                "--sources", _sources(cli_ready)) == 0
+    assert _ocr_text_of(cli_ready, 2) == "Patient: ROE, ROBERT ALAN  summary"
+
+
+def test_cli_document_reocr_unknown_id_is_a_friendly_error(cli_ready, capsys):
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "reocr", "999",
+                "--sources", _sources(cli_ready)) == 1
+    assert "no document with id" in capsys.readouterr().err
+
+
+def test_cli_document_reocr_without_a_sources_dir_is_a_friendly_error(
+    cli_ready, monkeypatch
+):
+    monkeypatch.delenv("PEMR_SOURCES", raising=False)
+    monkeypatch.delenv("PEMR_CONFIG", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        cli.main([
+            "--db", str(cli_ready / "cli.db"),
+            "--config", str(cli_ready / "absent.toml"),
+            "document", "reocr", "1",
+        ])
+    assert "no sources dir" in str(exc.value.code)
+
+
+def test_cli_document_reocr_leaves_records_and_keys_untouched(cli_ready, capsys):
+    """`reocr` touches one column. Record rows, dedup keys and the blob are not its
+    business, and extraction against a repaired document behaves normally."""
+    conn = db.connect(cli_ready / "cli.db")
+    try:
+        before = conn.execute(
+            "SELECT lab_result_id, dedup_key FROM lab_result ORDER BY lab_result_id"
+        ).fetchall()
+    finally:
+        conn.close()
+    _ingest_textless(cli_ready, "scan2.txt", b"repaired document text")
+    blob_bytes = sorted(p.read_bytes() for p in (cli_ready / "sources").rglob("*.txt"))
+    capsys.readouterr()
+
+    assert _run(cli_ready, "document", "reocr", "2",
+                "--sources", _sources(cli_ready)) == 0
+    capsys.readouterr()
+
+    payload = cli_ready / "extract2.json"
+    payload.write_text(json.dumps({"lab_result": [
+        {"test_name": "Sodium", "collected_at": "2026-02-02", "value_num": 140,
+         "unit": "mmol/L"},
+    ]}), encoding="utf-8")
+    assert _run(cli_ready, "commit-extraction", "--document", "2",
+                "--json", str(payload)) == 0
+
+    conn = db.connect(cli_ready / "cli.db")
+    try:
+        after = conn.execute(
+            "SELECT lab_result_id, dedup_key FROM lab_result WHERE document_id = 1 "
+            "ORDER BY lab_result_id"
+        ).fetchall()
+        added = conn.execute(
+            "SELECT COUNT(*) AS n FROM lab_result WHERE document_id = 2"
+        ).fetchone()["n"]
+    finally:
+        conn.close()
+    assert [tuple(row) for row in after] == [tuple(row) for row in before]
+    assert added == 1
+    # The blob store is read-only to this verb.
+    assert sorted(
+        p.read_bytes() for p in (cli_ready / "sources").rglob("*.txt")
+    ) == blob_bytes

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1484,3 +1484,58 @@ def test_cli_document_reocr_leaves_records_and_keys_untouched(cli_ready, capsys)
     assert sorted(
         p.read_bytes() for p in (cli_ready / "sources").rglob("*.txt")
     ) == blob_bytes
+
+
+def test_cli_document_reocr_names_truncation_on_the_write_path_too(
+    cli_ready, capsys, monkeypatch
+):
+    """The dry-run names an over-cap document; so must the run that writes for real.
+    A sweep is exactly where the operator is *not* looking at the document, so a
+    truncation notice that only appears under `--dry-run` is a notice nobody sees."""
+    _ingest_textless(cli_ready, "bundle.txt", b"a long scanned bundle of pages")
+    monkeypatch.setattr(ingest, "pdf_page_count", lambda src: 21)
+    capsys.readouterr()
+
+    assert _run(cli_ready, "document", "reocr", "2",
+                "--sources", _sources(cli_ready)) == 0
+    out = capsys.readouterr().out
+    assert "#2  written" in out
+    assert f"pages: 21 (over the {ingest.OCR_MAX_PAGES}-page cap" in out
+    assert out.isascii(), repr(out)
+    assert _ocr_text_of(cli_ready, 2) == "a long scanned bundle of pages"
+
+
+def test_cli_document_reocr_stores_what_ingest_would_have_stored(cli_ready, capsys):
+    """The anti-drift claim at the operator's surface: the same bytes ingested with
+    `--ocr auto` today, and ingested textless then repaired with `reocr`, end up with
+    byte-identical `ocr_text`. Two archives, because layer-1 dedup rightly refuses the
+    same sha twice inside one."""
+    content = b"MERIDIAN FAMILY CLINIC\nSodium 140 mmol/L\nrepeat panel in six months\n"
+    blob = cli_ready / "panel.txt"
+    blob.write_bytes(content)
+
+    # Archive A - ingested after the extractor could read it.
+    other = cli_ready / "other"
+    other.mkdir()
+    assert cli.main(["--db", str(other / "cli.db"), "migrate", "--create"]) == 0
+    assert cli.main(["--db", str(other / "cli.db"), "person", "add",
+                     "--slug", "jane-doe", "--name", "Jane"]) == 0
+    assert cli.main(["--db", str(other / "cli.db"), "ingest", str(blob),
+                     "--person", "jane-doe", "--sources", str(other / "sources"),
+                     "--ocr", "auto"]) == 0
+
+    # Archive B - the #143 population: same bytes, ingested before it could.
+    _ingest_textless(cli_ready, "panel-copy.txt", content)
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "reocr", "2",
+                "--sources", _sources(cli_ready)) == 0
+
+    conn = db.connect(other / "cli.db")
+    try:
+        at_ingest = conn.execute(
+            "SELECT ocr_text FROM document WHERE document_id = 1"
+        ).fetchone()["ocr_text"]
+    finally:
+        conn.close()
+    assert at_ingest, "the --ocr auto ingest stored nothing; the comparison is vacuous"
+    assert _ocr_text_of(cli_ready, 2) == at_ingest

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1664,3 +1664,328 @@ def test_extraction_cap_is_one_budget_shared_across_the_archive(
     assert result.status == "new"
     assert result.document.ocr_text is None
     assert "sheet2.xml" in capsys.readouterr().err
+
+
+# --- re-extraction against a stored blob (issue #143) --------------------------
+#
+# `reocr_documents` is a selector plus a policy layer over `extract_text_routed` and
+# `documents.set_document_text`. These tests exercise the policy; the extraction fakes
+# above stand in for PyMuPDF/tesseract, so the CI contract (neither installed) holds.
+
+
+def _file_document(conn, tmp_path, sources, name="scan.txt", content=b"stored blob",
+                   person="jane-doe", ocr_text=None, force=False):
+    """Ingest a real blob into `sources` and return its `document` row."""
+    src = _make_file(tmp_path, name, content)
+    result = ingest.ingest_document(
+        conn, src, person, sources, ocr_text=ocr_text, force=force
+    )
+    return result.document
+
+
+def _stored_text(conn, document_id):
+    return conn.execute(
+        "SELECT ocr_text FROM document WHERE document_id = ?", (document_id,)
+    ).fetchone()["ocr_text"]
+
+
+def _forbid_extraction(monkeypatch):
+    """Fail loudly if extraction runs at all - proves a skip happened before the work."""
+    def boom(path):
+        raise AssertionError(f"extraction must not run: {path}")
+    monkeypatch.setattr(ingest, "extract_text_routed", boom)
+    monkeypatch.setattr(ingest, "pdf_page_count", boom)
+
+
+def test_reocr_fills_an_empty_document_from_its_stored_blob(conn, tmp_path, sources):
+    doc = _file_document(conn, tmp_path, sources, content=b"acute pericarditis noted")
+    assert doc.ocr_text is None
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources)
+
+    assert result.status == "written"
+    assert result.route == "native"
+    assert result.previous_chars == 0
+    assert result.chars == len("acute pericarditis noted")
+    assert _stored_text(conn, doc.document_id) == "acute pericarditis noted"
+
+
+def test_reocr_refuses_a_populated_document_without_force(
+    conn, tmp_path, sources, monkeypatch
+):
+    doc = _file_document(conn, tmp_path, sources, ocr_text="human transcription")
+    _forbid_extraction(monkeypatch)
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources)
+
+    assert result.status == "has-text"
+    assert result.previous_chars == len("human transcription")
+    assert _stored_text(conn, doc.document_id) == "human transcription"
+
+
+def test_reocr_force_replaces_existing_text(conn, tmp_path, sources):
+    doc = _file_document(
+        conn, tmp_path, sources, content=b"machine text", ocr_text="old transcription"
+    )
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources, force=True)
+
+    assert result.status == "written"
+    assert result.previous_chars == len("old transcription")
+    assert _stored_text(conn, doc.document_id) == "machine text"
+
+
+def test_reocr_dry_run_reports_chars_and_writes_nothing(conn, tmp_path, sources):
+    doc = _file_document(conn, tmp_path, sources, content=b"twenty four characters!!")
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources, dry_run=True)
+
+    assert result.status == "would-write"
+    assert result.chars == 24
+    assert _stored_text(conn, doc.document_id) is None
+
+
+def test_reocr_dry_run_names_a_pdf_over_the_page_cap(
+    conn, tmp_path, sources, monkeypatch
+):
+    doc = _file_document(
+        conn, tmp_path, sources, name="long.pdf", content=b"%PDF-1.4 fake bytes"
+    )
+    pages = [
+        _FakePage(text="page text long enough to skip ocr entirely")
+        for _ in range(21)
+    ]
+    _install_backend(monkeypatch, _FakeBackend(_FakeDoc(pages)))
+    _install_tesseract(monkeypatch)
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources, dry_run=True)
+
+    assert result.status == "would-write"
+    assert result.pages == 21
+    assert result.truncated is True
+    assert _stored_text(conn, doc.document_id) is None
+
+
+def test_reocr_under_the_page_cap_is_not_flagged_as_truncated(
+    conn, tmp_path, sources, monkeypatch
+):
+    doc = _file_document(
+        conn, tmp_path, sources, name="short.pdf", content=b"%PDF-1.4 fake bytes"
+    )
+    pages = [
+        _FakePage(text="page text long enough to skip ocr entirely") for _ in range(3)
+    ]
+    _install_backend(monkeypatch, _FakeBackend(_FakeDoc(pages)))
+    _install_tesseract(monkeypatch)
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources)
+
+    assert result.pages == 3
+    assert result.truncated is False
+
+
+def test_reocr_routes_a_pdf_through_the_same_dispatch_as_ingest(
+    conn, tmp_path, sources, monkeypatch
+):
+    """The anti-drift guarantee: re-run text is `extract_text_routed`'s text, because
+    it *is* `extract_text_routed` - not a second extraction path that can rot apart."""
+    doc = _file_document(
+        conn, tmp_path, sources, name="mixed.pdf", content=b"%PDF-1.4 fake bytes"
+    )
+    pages = [
+        _FakePage(text="searchable page with a real embedded text layer"),
+        _FakePage(text="", scanned="rasterized page read by tesseract"),
+    ]
+    _install_backend(monkeypatch, _FakeBackend(_FakeDoc(pages)))
+    _install_tesseract(monkeypatch)
+    blob = sources / doc.source_path
+    expected_text, expected_route = ingest.extract_text_routed(blob)
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources)
+
+    assert result.route == expected_route == "ocr"
+    assert _stored_text(conn, doc.document_id) == expected_text
+    assert "searchable page" in expected_text and "rasterized page" in expected_text
+
+
+def test_reocr_reports_an_owner_mismatch_and_writes_nothing(conn, tmp_path, sources):
+    _seed_roster(conn)
+    doc = _file_document(conn, tmp_path, sources, content=b"Patient: ROE, ROBERT ALAN")
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources)
+
+    assert result.status == "owner-mismatch"
+    assert result.owner_check.verdict == "mismatch"
+    assert result.owner_check.matched_slug == "bob-roe"
+    assert _stored_text(conn, doc.document_id) is None
+
+
+def test_reocr_force_stores_despite_an_owner_mismatch(conn, tmp_path, sources):
+    _seed_roster(conn)
+    doc = _file_document(conn, tmp_path, sources, content=b"Patient: ROE, ROBERT ALAN")
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources, force=True)
+
+    assert result.status == "written"
+    assert result.owner_check.verdict == "mismatch"
+    assert _stored_text(conn, doc.document_id) == "Patient: ROE, ROBERT ALAN"
+
+
+def test_reocr_stores_and_warns_on_a_suspect_verdict(
+    conn, tmp_path, sources, monkeypatch
+):
+    """The recorded design call: unlike ingest, a `suspect` verdict does not refuse.
+
+    The document is already filed under that owner, so withholding the text does not
+    un-file it - it only keeps the document invisible to `find`, which is the bug this
+    verb exists to close. The text names nobody on the roster, so nothing leaks across
+    household members either.
+    """
+    _seed_roster(conn)
+    # `.png`, not `.txt`: `suspect` is only reachable on the OCR route, where a
+    # `Patient:` header is a printed identity claim rather than a column label.
+    doc = _file_document(conn, tmp_path, sources, name="scan.png", content=b"pixels")
+    monkeypatch.setattr(ingest.shutil, "which", lambda _: "/usr/bin/tesseract")
+    monkeypatch.setattr(
+        ingest.subprocess, "run",
+        _fake_tesseract(b"Patient: SMITH, KAREN  DOB: 09/09/1971"),
+    )
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources)
+
+    assert result.status == "written"
+    assert result.route == "ocr"
+    assert result.owner_check.verdict == "suspect"
+    assert result.owner_check.evidence
+    assert _stored_text(conn, doc.document_id).startswith("Patient: SMITH")
+
+
+def test_reocr_native_route_does_not_trust_anchors(conn, tmp_path, sources):
+    """A `Patient ID` column header is a label, not an identity claim - the same
+    `trust_anchors` rule ingest applies, reached through the same route value."""
+    _seed_roster(conn)
+    doc = _file_document(
+        conn, tmp_path, sources, name="labs.csv",
+        content=b"Patient ID,Test,Value\n1,HbA1c,5.7\n",
+    )
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources)
+
+    assert result.route == "native"
+    assert result.status == "written"
+    assert result.owner_check.verdict == "unverified"
+
+
+def test_reocr_reports_a_missing_blob_without_writing(conn, tmp_path, sources):
+    doc = _file_document(conn, tmp_path, sources, content=b"about to vanish")
+    (sources / doc.source_path).unlink()
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources)
+
+    assert result.status == "missing-blob"
+    assert result.blob_path and doc.sha256 in result.blob_path
+    assert _stored_text(conn, doc.document_id) is None
+
+
+def test_reocr_skips_a_study_blob(conn, tmp_path, sources, monkeypatch):
+    """A study's ocr_text is a DICOM-header summary, not text extracted from the blob -
+    re-deriving it is a different pipeline, so `reocr` reports and leaves it alone."""
+    doc = _file_document(conn, tmp_path, sources, content=b"packed study stand-in")
+    with conn:
+        conn.execute(
+            "UPDATE document SET source_path = ? WHERE document_id = ?",
+            (f"aa/{doc.sha256}{ingest.STUDY_EXT}", doc.document_id),
+        )
+    _forbid_extraction(monkeypatch)
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources)
+
+    assert result.status == "study-blob"
+    assert _stored_text(conn, doc.document_id) is None
+
+
+def test_reocr_recovering_nothing_is_a_warning_not_an_error(conn, tmp_path, sources):
+    doc = _file_document(conn, tmp_path, sources, name="blank.txt", content=b"   \n")
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources)
+
+    assert result.status == "no-text"
+    assert result.refused is False       # an expected sweep outcome, not a refusal
+    assert _stored_text(conn, doc.document_id) is None
+
+
+def test_reocr_unknown_document_id_raises_before_any_work(conn, tmp_path, sources):
+    doc = _file_document(conn, tmp_path, sources, content=b"never touched")
+
+    with pytest.raises(ingest.IngestError) as excinfo:
+        ingest.reocr_documents(conn, [doc.document_id, 999], sources)
+
+    assert "999" in str(excinfo.value)
+    # A typo in one id must not half-run the sweep.
+    assert _stored_text(conn, doc.document_id) is None
+
+
+def test_reocr_sweeps_several_documents_independently(conn, tmp_path, sources):
+    empty = _file_document(conn, tmp_path, sources, name="a.txt", content=b"recovered")
+    populated = _file_document(
+        conn, tmp_path, sources, name="b.txt", content=b"other bytes",
+        ocr_text="already transcribed",
+    )
+
+    results = ingest.reocr_documents(
+        conn, [empty.document_id, populated.document_id], sources
+    )
+
+    assert [r.status for r in results] == ["written", "has-text"]
+    # Each write is its own transaction, so a refusal later in the list cannot roll
+    # back an earlier success.
+    assert _stored_text(conn, empty.document_id) == "recovered"
+    assert _stored_text(conn, populated.document_id) == "already transcribed"
+
+
+def test_reocr_repairs_an_invisible_only_row_without_force(conn, tmp_path, sources):
+    """Issue #87's invisible-character rows are part of the target population: they
+    read as populated to raw truthiness and as empty to `normalize_document_text`."""
+    doc = _file_document(conn, tmp_path, sources, content=b"real text at last")
+    with conn:
+        conn.execute(
+            "UPDATE document SET ocr_text = ? WHERE document_id = ?",
+            ("​﻿", doc.document_id),
+        )
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources)
+
+    assert result.status == "written"
+    assert result.previous_chars == 0
+    assert _stored_text(conn, doc.document_id) == "real text at last"
+
+
+def test_reocr_on_an_unmigrated_db_raises(tmp_path, sources):
+    raw = db.connect(tmp_path / "empty.db")
+    try:
+        with pytest.raises(db.NotMigratedError):
+            ingest.reocr_documents(raw, [1], sources)
+    finally:
+        raw.close()
+
+
+def test_pdf_page_count_counts_pages_and_degrades_to_none(tmp_path, monkeypatch):
+    src = _pdf(tmp_path)
+    _install_backend(monkeypatch, _FakeBackend(_FakeDoc([_FakePage(), _FakePage()])))
+    assert ingest.pdf_page_count(src) == 2
+
+    # Not a PDF -> not a question this function answers.
+    assert ingest.pdf_page_count(_make_file(tmp_path, "notes.txt")) is None
+
+    # Encrypted and unreadable are both "don't know", never a raise: a caller may only
+    # claim truncation on positive evidence.
+    _install_backend(
+        monkeypatch, _FakeBackend(_FakeDoc([_FakePage()], needs_pass=True))
+    )
+    assert ingest.pdf_page_count(src) is None
+    _install_backend(monkeypatch, _FakeBackend(error=RuntimeError("broken pdf")))
+    assert ingest.pdf_page_count(src) is None
+
+    # Backend absent (no `pemr[ocr]` extra) -> also None, no note, no crash.
+    _install_backend(monkeypatch, None)
+    assert ingest.pdf_page_count(src) is None


### PR DESCRIPTION
## What shipped

A new verb, `pemr document reocr [<id>...] [--where-empty [--person <slug>]] [--dry-run] [--force]`,
that re-runs today's text-extraction pipeline (`extract_text_routed` -> `_ocr_pdf` / native
route -> `run_ocr`, the exact dispatch `ingest` uses) against a document's already-stored blob.
Closes the gap #70 and #138 could not reach backwards: a document ingested before an extractor
fix keeps whatever `ocr_text` it got at ingest time, with no route back except deriving text
out-of-band and handing it in through `document set-text --ocr-text-file`.

- Refuses to overwrite a populated `ocr_text` without `--force` (matching `set-text`).
- `--dry-run` reports the character count it would store, without writing, and names any
  document over `OCR_MAX_PAGES` on both the dry-run and the write path.
- Re-runs the #61 owner-verification check against the recovered text: a `mismatch` refuses
  and names `document reassign` as the remedy; a `suspect` verdict (text anchored to nobody on
  the roster) stores and warns, since it cannot name the wrong household member and refusing
  would only withhold the evidence that the document is misfiled.
- Selects by explicit id(s) or `--where-empty [--person <slug>]`, so the reported 262-document
  backlog is one invocation.

**Security-relevant note for anyone reading this before merge:** `--force` carries two meanings
at once — it overrides *both* the has-text refusal (replace existing `ocr_text`) *and* a
`mismatch` owner-check refusal on the recovered text, and the exit code stays 0 when the latter
fires. The verb's own backlog use case, `--where-empty`, needs neither sense of it: an
unpopulated document can't collide with has-text, and a `mismatch` there still refuses on its
own with rc 1. This is now written into `docs/Architecture.md` (Ingestion pipeline, §4) as well
as the `decision:` comments on the issue.

## Testing

- `pytest` (full suite): 1222 passed, including 36 new tests across `tests/test_ingest.py`
  (engine, faked I/O seams) and `tests/test_documents.py` (CLI wiring + real-file integration).
- Verify additionally ran the OCR route for real (PyMuPDF + tesseract present locally) against a
  scratch archive: image-only PDFs, a 21-page text-layer PDF, an owner-mismatch case, and
  whitespace-only text — see the verify report for the per-AC ledger.
- Audit reviewed the six-file diff read-only against the plan: no blocking findings. Four
  advisories noted (a stale code comment, a forced-mismatch tally gap, a cosmetic remedy-message
  reuse, and one untested-but-safe-by-construction `person_id IS NULL` path) — none blocking,
  left for a human/follow-up call.

No schema change, no migration, no new MCP tool (`document_reocr` is deliberately CLI-only, same
reasoning that already denies `document_set_text` a `force` over MCP).

## Reports

- Design (implementation plan + decision log): in the issue body / comments.
- Build: https://github.com/meridun/pemr/issues/143#issuecomment-5304752963
- Verify: https://github.com/meridun/pemr/issues/143#issuecomment-5304817077
- Audit: https://github.com/meridun/pemr/issues/143#issuecomment-5304849829

Closes #143

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
