### PR TITLE
fix(render): suppress fully-resulted panel orders in Orders & Referrals

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1089,7 +1089,12 @@ default to the same exclusion unless a human explicitly decides otherwise.
   A *compound* order key (one order naming several analytes, `cbc,cmp,ldh`) decomposes on
   `,`/`/` at parenthesis depth 0 into component tokens, each still matched exactly, and
   leaves the section only when **every** component resulted in window (issue #145) — the
-  order side alone decomposes, and a partially resulted panel is still outstanding.
+  order side alone decomposes, and a partially resulted panel is still outstanding. Those
+  separators are content, not structure, inside many single analytes' names (`Glucose,
+  fasting`, `Kappa/Lambda Ratio`), so two guards keep #128's behaviour reachable: a key
+  the dictionary declares as one analyte is never split, and the whole-key match is tried
+  before the per-component one — decomposition can only ever move an order from
+  "renders" toward "suppressed", never take away a suppression that already worked.
 - **appointment brief** — for a given upcoming appointment: relevant history for that
   specialty, recent labs/imaging, current meds, med-interaction flags, suggested
   questions. This is your "walk-in readiness" as a repeatable command.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1089,7 +1089,12 @@ default to the same exclusion unless a human explicitly decides otherwise.
   A *compound* order key (one order naming several analytes, `cbc,cmp,ldh`) decomposes on
   `,`/`/` at parenthesis depth 0 into component tokens, each still matched exactly, and
   leaves the section only when **every** component resulted in window (issue #145) — the
-  order side alone decomposes, and a partially resulted panel is still outstanding. Those
+  order side alone decomposes, and a partially resulted panel is still outstanding. A
+  decomposed component drops structural words that name no analyte (`panel`, `profile`,
+  `extensive`), so `Immunofixation Panel` can match an `Immunofixation` result; if that
+  leaves a component with nothing readable, the whole key is voided rather than the
+  component dropped, so the surviving analytes can't suppress an order still naming
+  something unread. Those
   separators are content, not structure, inside many single analytes' names (`Glucose,
   fasting`, `Kappa/Lambda Ratio`), so two guards keep #128's behaviour reachable: a key
   the dictionary declares as one analyte is never split, and the whole-key match is tried

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1086,6 +1086,10 @@ default to the same exclusion unless a human explicitly decides otherwise.
   edge-tested date window) and biased toward under-suppression, since age alone is never
   a signal and a hidden-but-still-open order would be the worse failure; the window
   constants are guarded by a pinned edge test so a casual widening doesn't slip through.
+  A *compound* order key (one order naming several analytes, `cbc,cmp,ldh`) decomposes on
+  `,`/`/` at parenthesis depth 0 into component tokens, each still matched exactly, and
+  leaves the section only when **every** component resulted in window (issue #145) — the
+  order side alone decomposes, and a partially resulted panel is still outstanding.
 - **appointment brief** — for a given upcoming appointment: relevant history for that
   specialty, recent labs/imaging, current meds, med-interaction flags, suggested
   questions. This is your "walk-in readiness" as a repeatable command.

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -599,7 +599,12 @@ def _order_tokens(
     parenthetical (see :func:`_split_components`).
 
     ``()`` for an empty or wholly unusable key, which :func:`_all_resulted` reads as
-    "nothing known" -> render.
+    "nothing known" -> render. Decomposition **fails closed** on the same rule: if any one
+    component tokenizes empty -- it was entirely noise words (``CBC, Extensive Panel``), or
+    whitespace-equivalent after normalization -- the whole key returns ``()``. Dropping just
+    that component would silently narrow all-or-nothing to all-*remaining* and let the
+    surviving analytes suppress an order naming something this layer could not read, which
+    is the one direction (#128's inversion) the section must never fail in.
     """
     if value is None:
         return ()
@@ -617,8 +622,9 @@ def _order_tokens(
                 w for w in part.split() if w.lower() not in _ORDER_NOISE_WORDS
             )
         token = key_token(part, dictionary)
-        if token:
-            tokens.append(token)
+        if not token:
+            return ()                            # one unreadable component -> render
+        tokens.append(token)
     return tuple(dict.fromkeys(tokens))          # de-dup, order preserved
 
 

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -82,6 +82,14 @@ ORDER_RESULT_WINDOW_DAYS = 30
 #: text. A result genuinely predating its order answers an *earlier* order, so this side
 #: stays tight.
 ORDER_RESULT_BACKDATE_DAYS = 1
+#: Separators a *compound* order key uses to name several analytes at once (issue #145),
+#: e.g. ``cbc,cmp,ldh`` or ``spep / immunofixation panel``. Only the two actually observed
+#: in order text; extended on evidence, never speculatively -- every extra separator is a
+#: new way to split an identity that was never compound.
+_ORDER_SEPARATORS = (",", "/")
+#: Structural words in a compound key that name no analyte, dropped so a component can
+#: match the result that answered it. Deliberately tiny, for the same reason.
+_ORDER_NOISE_WORDS = frozenset({"panel", "profile", "extensive"})
 
 # `condition.status` buckets, one rendered section each (family history last: it is
 # context about relatives, not the patient's own record).
@@ -515,6 +523,92 @@ def _is_resulted(
     )
 
 
+def _split_components(text: str) -> list[str]:
+    """``text`` split on :data:`_ORDER_SEPARATORS` occurring at parenthesis depth 0.
+
+    Parts are stripped and empties dropped, so a leading/trailing/doubled separator
+    contributes nothing. Depth is clamped at 0: a stray ``)`` (OCR loses brackets) must
+    not drive it negative and start splitting inside a later parenthetical. A
+    parenthetical is identity-bearing (issue #71), so a separator inside one is content,
+    not structure -- ``SLE Profile (Profile A, Scleroderma)`` is one component, not two.
+
+    Never raises: like :func:`_as_date`, a malformed key must render, not crash.
+    """
+    parts: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    for ch in text:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth = max(0, depth - 1)
+        elif depth == 0 and ch in _ORDER_SEPARATORS:
+            parts.append("".join(buf))
+            buf = []
+            continue
+        buf.append(ch)
+    parts.append("".join(buf))
+    return [p for p in (part.strip() for part in parts) if p]
+
+
+def _order_tokens(
+    value: object, dictionary: dict[str, str] | None = None
+) -> tuple[str, ...]:
+    """An order's identity token **set** -- one token per analyte it names (issue #145).
+
+    ``_is_resulted`` compares a single :func:`key_token`, so a *panel* order (one key
+    naming several analytes: ``cbc,cmp,ldh``) yields one token no single-analyte result
+    can ever equal, and the order never leaves the section however completely it was
+    resulted. Decomposing the order side fixes that without loosening the match itself:
+    every component is still compared exact-token, never by substring.
+
+    Only the **order** side decomposes. A ``lab_result.test_name`` names one analyte by
+    construction, so splitting it would invent components that were never ordered.
+
+    A key with no top-level separator returns exactly today's single token -- original
+    text, no word stripping -- so single-analyte behaviour is unchanged by construction,
+    not merely by test. Noise-word removal applies only to a key that actually
+    decomposed, and never inside a parenthetical (see :func:`_split_components`).
+
+    ``()`` for an empty or wholly unusable key, which :func:`_all_resulted` reads as
+    "nothing known" -> render.
+    """
+    if value is None:
+        return ()
+    text = str(value).strip()
+    if not text:
+        return ()
+    parts = _split_components(text)
+    if len(parts) <= 1:
+        token = key_token(text, dictionary)
+        return (token,) if token else ()
+    tokens: list[str] = []
+    for part in parts:
+        if "(" not in part:
+            part = " ".join(
+                w for w in part.split() if w.lower() not in _ORDER_NOISE_WORDS
+            )
+        token = key_token(part, dictionary)
+        if token:
+            tokens.append(token)
+    return tuple(dict.fromkeys(tokens))          # de-dup, order preserved
+
+
+def _all_resulted(
+    tokens: tuple[str, ...], observed_at: object, index: dict[str, list[date]]
+) -> bool:
+    """Is **every** analyte this order names already resulted? (issue #145)
+
+    All-or-nothing, composing :func:`_is_resulted` per component: one component still
+    outstanding keeps the whole panel rendering, because a partially resulted panel *is*
+    outstanding work. An empty token set answers no, on the same "ambiguity renders"
+    rule as an unusable single token.
+    """
+    if not tokens:
+        return False
+    return all(_is_resulted(token, observed_at, index) for token in tokens)
+
+
 def _grouped_orders(
     conn: sqlite3.Connection,
     person_id: int,
@@ -548,6 +642,12 @@ def _grouped_orders(
     ``group_count``/``+N earlier`` disclosure is unchanged for everything that still
     renders. Referral-type orders have no ``lab_result`` by construction and so are
     never suppressed by this; closing them needs a mechanism that does not exist yet.
+
+    A **compound** key -- one order naming several analytes (``cbc,cmp,ldh``) -- is asked
+    the same question per component (issue #145): the group's identity text decomposes to
+    a token *set* (:func:`_order_tokens`) and the order drops only when every one of them
+    resulted in window. Grouping still folds on the single :func:`key_token`, so #93's
+    ``+N earlier`` disclosure is untouched; only the suppression question changed.
     """
     rows = conn.execute(
         "SELECT * FROM observation WHERE person_id = ? AND obs_type = ? "
@@ -562,25 +662,33 @@ def _grouped_orders(
         token = key_token(r["key"], dictionary) or key_token(r["value_text"], dictionary)
         groups.setdefault(token or ("", r["observation_id"]), []).append(r)
 
-    # Carry each group's identity token alongside it: the suppression lookup needs the
-    # very token the fold grouped on, and a keyless group (identity is the
-    # `("", observation_id)` fallback tuple) has none -- so it is never suppressed.
-    folded: list[tuple[str, dict]] = []
+    # Carry each group's identity token *set* alongside it: the suppression lookup asks
+    # about the very text the fold grouped on, decomposed per analyte (issue #145), and a
+    # keyless group (identity is the `("", observation_id)` fallback tuple) has none --
+    # so it is never suppressed.
+    folded: list[tuple[tuple[str, ...], dict]] = []
     for identity, members in groups.items():
         latest = members[-1]                      # ascending -> last is the latest
         earlier = sorted(
             d for d in (_date_part(m["observed_at"]) for m in members[:-1]) if d
         )
+        tokens: tuple[str, ...] = ()
+        if isinstance(identity, str):
+            # Same test the fold used, so the decomposition speaks for the same text.
+            source = (latest["key"] if key_token(latest["key"], dictionary)
+                      else latest["value_text"])
+            tokens = _order_tokens(source, dictionary)
         folded.append((
-            identity if isinstance(identity, str) else "",
+            tokens,
             dict(latest, group_count=len(members),
                  group_first=earlier[0] if earlier else ""),
         ))
 
-    # Drop what a result already answered (issue #128), asking the group's latest row.
+    # Drop what a result already answered (issue #128), asking the group's latest row --
+    # and, for a compound key, only when every analyte it names resulted (issue #145).
     index = _result_index(conn, person_id, dictionary, cur) if folded else {}
-    out = [g for token, g in folded
-           if not _is_resulted(token, g["observed_at"], index)]
+    out = [g for tokens, g in folded
+           if not _all_resulted(tokens, g["observed_at"], index)]
 
     # Two stable passes: alphabetical, then order-date ascending (undated sorts last,
     # keeping its alphabetical order). This section diverges from the other event

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -64,7 +64,7 @@ import sqlite3
 from datetime import date, datetime
 
 from . import curation, db, query
-from .dedup import enum_token, is_attested, key_token
+from .dedup import enum_token, is_attested, key_token, norm
 
 # Observation obs_type conventions this layer reads (see module docstring).
 OBS_VITAL = "vital"
@@ -551,6 +551,32 @@ def _split_components(text: str) -> list[str]:
     return [p for p in (part.strip() for part in parts) if p]
 
 
+def _declared_analyte(text: str, dictionary: dict[str, str] | None) -> bool:
+    """Does the dictionary declare ``text`` -- separators and all -- as **one** analyte?
+
+    ``,`` and ``/`` are structure in a panel key (``cbc,cmp,ldh``) but *content* in many
+    single analytes' canonical labels: ``Glucose, fasting``, ``Cholesterol, Total``,
+    ``Kappa/Lambda Ratio``. Decomposing one of those asks for two analytes that were
+    never ordered and no result can answer, so the order never suppresses -- the #128
+    inversion, re-created for a different class of key. The dictionary already knows
+    which strings are whole names: this asks it before :func:`_split_components` runs.
+
+    The question is asked through :func:`norm`, not by looking keys up directly, because
+    :func:`identity`'s two synonym rules (a declared *full label*, else the
+    qualifier-stripped *stem*) are what decide the matter, and only ``norm`` speaks for
+    both -- so ``Cholesterol, Total (Calculated)`` is recognized by its declared stem.
+    A hit shows up as a canonical token the bare normalization would not have produced.
+    Qualifier-only synonyms deliberately do **not** count: ``norm`` drops the qualifier,
+    so ``Sodium, Potassium (POC)`` still decomposes as the panel it is.
+
+    Conservative both ways: no dictionary means nothing is declared (decompose, as
+    before), and a false positive only costs suppression -- which is the safe side.
+    """
+    if not dictionary:
+        return False
+    return norm(text, dictionary) != norm(text)
+
+
 def _order_tokens(
     value: object, dictionary: dict[str, str] | None = None
 ) -> tuple[str, ...]:
@@ -567,8 +593,10 @@ def _order_tokens(
 
     A key with no top-level separator returns exactly today's single token -- original
     text, no word stripping -- so single-analyte behaviour is unchanged by construction,
-    not merely by test. Noise-word removal applies only to a key that actually
-    decomposed, and never inside a parenthetical (see :func:`_split_components`).
+    not merely by test. So does a key the dictionary declares as one analyte despite its
+    separators (:func:`_declared_analyte`): ``Glucose, fasting`` is a name, not a panel.
+    Noise-word removal applies only to a key that actually decomposed, and never inside a
+    parenthetical (see :func:`_split_components`).
 
     ``()`` for an empty or wholly unusable key, which :func:`_all_resulted` reads as
     "nothing known" -> render.
@@ -579,7 +607,7 @@ def _order_tokens(
     if not text:
         return ()
     parts = _split_components(text)
-    if len(parts) <= 1:
+    if len(parts) <= 1 or _declared_analyte(text, dictionary):
         token = key_token(text, dictionary)
         return (token,) if token else ()
     tokens: list[str] = []
@@ -607,6 +635,30 @@ def _all_resulted(
     if not tokens:
         return False
     return all(_is_resulted(token, observed_at, index) for token in tokens)
+
+
+def _order_resulted(
+    source: object,
+    observed_at: object,
+    index: dict[str, list[date]],
+    dictionary: dict[str, str] | None = None,
+) -> bool:
+    """Has this order been answered -- as a whole, or analyte by analyte? (issues #128, #145)
+
+    The two questions are a **union**, asked whole-key first, and that order is the point:
+    the whole-key arm is #128's rule verbatim, so nothing it used to suppress can stop
+    suppressing here whatever the decomposition does with the same text. That matters for
+    any single analyte whose own name carries a ``,`` or ``/`` -- ``Ferritin, Serum``
+    ordered and ``Ferritin, Serum`` resulted -- including the ones no dictionary declares
+    (:func:`_declared_analyte` can only speak for the ones it knows) and every render that
+    runs without a dictionary at all.
+
+    Only when that fails does the panel question run, and only then can decomposition
+    change an outcome -- always from "renders" toward "suppressed", never the reverse.
+    """
+    if _is_resulted(key_token(source, dictionary), observed_at, index):
+        return True
+    return _all_resulted(_order_tokens(source, dictionary), observed_at, index)
 
 
 def _grouped_orders(
@@ -645,9 +697,11 @@ def _grouped_orders(
 
     A **compound** key -- one order naming several analytes (``cbc,cmp,ldh``) -- is asked
     the same question per component (issue #145): the group's identity text decomposes to
-    a token *set* (:func:`_order_tokens`) and the order drops only when every one of them
-    resulted in window. Grouping still folds on the single :func:`key_token`, so #93's
-    ``+N earlier`` disclosure is untouched; only the suppression question changed.
+    a token *set* (:func:`_order_tokens`) and the order drops when every one of them
+    resulted in window, *or* when the key as a whole did (:func:`_order_resulted`, which
+    keeps #128's rule reachable for a single analyte whose own name carries a separator).
+    Grouping still folds on the single :func:`key_token`, so #93's ``+N earlier``
+    disclosure is untouched; only the suppression question changed.
     """
     rows = conn.execute(
         "SELECT * FROM observation WHERE person_id = ? AND obs_type = ? "
@@ -662,24 +716,23 @@ def _grouped_orders(
         token = key_token(r["key"], dictionary) or key_token(r["value_text"], dictionary)
         groups.setdefault(token or ("", r["observation_id"]), []).append(r)
 
-    # Carry each group's identity token *set* alongside it: the suppression lookup asks
-    # about the very text the fold grouped on, decomposed per analyte (issue #145), and a
-    # keyless group (identity is the `("", observation_id)` fallback tuple) has none --
-    # so it is never suppressed.
-    folded: list[tuple[tuple[str, ...], dict]] = []
+    # Carry each group's identity *text* alongside it: the suppression lookup asks about
+    # the very text the fold grouped on -- as a whole (issue #128) and decomposed per
+    # analyte (issue #145). A keyless group (identity is the `("", observation_id)`
+    # fallback tuple) carries `None` and is never suppressed.
+    folded: list[tuple[object, dict]] = []
     for identity, members in groups.items():
         latest = members[-1]                      # ascending -> last is the latest
         earlier = sorted(
             d for d in (_date_part(m["observed_at"]) for m in members[:-1]) if d
         )
-        tokens: tuple[str, ...] = ()
+        source = None
         if isinstance(identity, str):
-            # Same test the fold used, so the decomposition speaks for the same text.
+            # Same test the fold used, so suppression speaks for the same text.
             source = (latest["key"] if key_token(latest["key"], dictionary)
                       else latest["value_text"])
-            tokens = _order_tokens(source, dictionary)
         folded.append((
-            tokens,
+            source,
             dict(latest, group_count=len(members),
                  group_first=earlier[0] if earlier else ""),
         ))
@@ -687,8 +740,9 @@ def _grouped_orders(
     # Drop what a result already answered (issue #128), asking the group's latest row --
     # and, for a compound key, only when every analyte it names resulted (issue #145).
     index = _result_index(conn, person_id, dictionary, cur) if folded else {}
-    out = [g for tokens, g in folded
-           if not _all_resulted(tokens, g["observed_at"], index)]
+    out = [g for source, g in folded
+           if source is None
+           or not _order_resulted(source, g["observed_at"], index, dictionary)]
 
     # Two stable passes: alphabetical, then order-date ascending (undated sorts last,
     # keeping its alphabetical order). This section diverges from the other event

--- a/tests/test_cli_phase4.py
+++ b/tests/test_cli_phase4.py
@@ -253,6 +253,46 @@ def test_render_summary_hides_fully_resulted_panel_order_end_to_end(ready, capsy
     assert out.isascii()          # cp1252/cp437 console contract
 
 
+def test_render_summary_keeps_panel_order_with_unreadable_component_end_to_end(
+    ready, capsys
+):
+    """Issue #145's fail-closed rule, pinned at the same command boundary: a compound key
+    with one component this layer cannot read (`Extensive Panel` is all noise words; `()`
+    normalizes away) is voided whole, so the analytes it *can* read never close it. The
+    `Sodium, CBC` control keeps the fix honest -- decomposition still suppresses a panel
+    whose every component is both readable and resulted, so this is a narrowing, not a
+    disabling."""
+    tmp_path, _ = ready
+    _commit_labs(tmp_path, "sha-u-labs", [
+        {"test_name": "CBC", "collected_at": "2026-03-05", "value_num": 1, "unit": "x"},
+        {"test_name": "Sodium", "collected_at": "2026-03-05",
+         "value_num": 140, "unit": "mmol/L"},
+    ])
+    _commit_orders(tmp_path, "sha-u-orders", [
+        # a lone CBC result must not suppress an order still naming something unread
+        {"key": "CBC, Extensive Panel", "observed_at": "2026-03-01"},
+        # both components readable and resulted -> still suppressed
+        {"key": "Sodium, CBC", "observed_at": "2026-03-01"},
+        # component that normalizes to nothing, same rule
+        {"key": "Sodium, ()", "observed_at": "2026-03-02"},
+    ])
+    capsys.readouterr()
+
+    assert _run(tmp_path, "render", "summary", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    section = out.split("## Orders & Referrals")[1].split("\n## ")[0]
+    assert [ln for ln in section.splitlines() if ln.startswith("- ")] == [
+        "- CBC, Extensive Panel  (ordered 2026-03-01)",
+        "- Sodium, ()  (ordered 2026-03-02)",
+    ]
+    conn = db.connect(tmp_path / "cli.db")
+    assert conn.execute(
+        "SELECT COUNT(*) AS n FROM observation WHERE obs_type='order'"
+    ).fetchone()["n"] == 3
+    conn.close()
+    assert out.isascii()
+
+
 def test_render_on_unmigrated_db_is_friendly(tmp_path, capsys, unmigrated_db):
     # Schema-less DB file, not an absent one - see issue #55's missing-database gate.
     unmigrated_db(tmp_path / "cli.db")

--- a/tests/test_cli_phase4.py
+++ b/tests/test_cli_phase4.py
@@ -111,6 +111,25 @@ def _commit_orders(tmp_path, sha, rows):
                 "--json", str(payload)) == 0
 
 
+def _commit_labs(tmp_path, sha, rows):
+    """`_commit_orders`'s sibling for `lab_result` rows, committed the same way."""
+    conn = db.connect(tmp_path / "cli.db")
+    pid = conn.execute(
+        "SELECT person_id FROM person WHERE slug='jane-doe'"
+    ).fetchone()["person_id"]
+    cur = conn.execute(
+        "INSERT INTO document (sha256, person_id, source_path, ingested_at) "
+        "VALUES (?, ?, 'aa/x.pdf', '2026-01-01T00:00:00')", (sha, pid)
+    )
+    conn.commit()
+    doc = cur.lastrowid
+    conn.close()
+    payload = tmp_path / f"extract-{sha}.json"
+    payload.write_text(json.dumps({"lab_result": rows}), encoding="utf-8")
+    assert _run(tmp_path, "commit-extraction", "--document", str(doc),
+                "--json", str(payload)) == 0
+
+
 def test_render_summary_groups_repeated_orders_end_to_end(ready, capsys):
     """Issue #93, walked through the real CLI: an order restated by three documents is
     one bullet carrying the latest detail plus the `+N earlier` disclosure; distinct and
@@ -182,6 +201,56 @@ def test_render_summary_hides_resulted_order_end_to_end(ready, capsys):
         "SELECT COUNT(*) AS n FROM observation WHERE obs_type='order' AND key='LDL'"
     ).fetchone()["n"] == 1
     conn.close()
+
+
+def test_render_summary_hides_fully_resulted_panel_order_end_to_end(ready, capsys):
+    """Issue #145 through the real CLI, for the same reason #128 is pinned here: the
+    decomposition helpers are private, so the only honest proof that a *panel* order
+    leaves the section is the command boundary. Rendered **without** `--dictionary`,
+    which is also the path where a separator-bearing single analyte (`Ferritin, Serum`)
+    can only be rescued by the whole-key arm of the match, never by the dictionary."""
+    tmp_path, _ = ready
+    _commit_labs(tmp_path, "sha-p-labs", [
+        {"test_name": "Sodium", "collected_at": "2026-03-05",
+         "value_num": 140, "unit": "mmol/L"},
+        {"test_name": "Potassium", "collected_at": "2026-03-05",
+         "value_num": 4.1, "unit": "mmol/L"},
+        {"test_name": "Chloride", "collected_at": "2026-03-05",
+         "value_num": 101, "unit": "mmol/L"},
+        {"test_name": "Calcium", "collected_at": "2026-03-05",
+         "value_num": 9.4, "unit": "mg/dL"},
+        {"test_name": "Ferritin, Serum", "collected_at": "2026-03-05",
+         "value_num": 120, "unit": "ng/mL"},
+    ])
+    _commit_orders(tmp_path, "sha-p-orders", [
+        # every analyte resulted in window -> gone (issue #145)
+        {"key": "Sodium, Potassium, Chloride", "observed_at": "2026-03-01"},
+        # only Calcium resulted -> all-or-nothing keeps the panel outstanding
+        {"key": "Calcium, Phosphorus", "observed_at": "2026-03-01"},
+        # a comma is part of *this* analyte's name, not structure: #128's whole-key
+        # match still reaches it, with no dictionary to declare it
+        {"key": "Ferritin, Serum", "observed_at": "2026-03-01"},
+        # no separator, so no decomposition: a Sodium result must not close it
+        {"key": "Sodium Chloride Infusion", "observed_at": "2026-03-01"},
+        {"key": "cervical collar", "observed_at": "2026-03-01"},   # referral: still open
+    ])
+    capsys.readouterr()
+
+    assert _run(tmp_path, "render", "summary", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    section = out.split("## Orders & Referrals")[1].split("\n## ")[0]
+    assert [ln for ln in section.splitlines() if ln.startswith("- ")] == [
+        "- Calcium, Phosphorus  (ordered 2026-03-01)",
+        "- cervical collar  (ordered 2026-03-01)",
+        "- Sodium Chloride Infusion  (ordered 2026-03-01)",
+    ]
+    # render-only: every order row, suppressed or not, is untouched in the DB
+    conn = db.connect(tmp_path / "cli.db")
+    assert conn.execute(
+        "SELECT COUNT(*) AS n FROM observation WHERE obs_type='order'"
+    ).fetchone()["n"] == 5
+    conn.close()
+    assert out.isascii()          # cp1252/cp437 console contract
 
 
 def test_render_on_unmigrated_db_is_friendly(tmp_path, capsys, unmigrated_db):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -908,11 +908,14 @@ def _annotate(conn, record_type, column, value, **kwargs):
 
 
 def _renders(conn):
+    # `now` is pinned: every header carries a second-resolution `Generated:` stamp, so a
+    # before/after byte-identity check straddling a second boundary fails spuriously.
     d = dedup.load_dictionary(DICT_PATH)
+    now = datetime(2026, 6, 1)
     return {
-        "summary": render.render_summary(conn, "jane-doe", dictionary=d),
-        "brief": render.render_brief(conn, _upcoming_appt_id(conn), dictionary=d),
-        "journal": render.render_journal(conn, "jane-doe"),
+        "summary": render.render_summary(conn, "jane-doe", dictionary=d, now=now),
+        "brief": render.render_brief(conn, _upcoming_appt_id(conn), dictionary=d, now=now),
+        "journal": render.render_journal(conn, "jane-doe", now=now),
     }
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -226,8 +226,17 @@ def _seed_orders(conn, rows):
     }, dedup.load_dictionary(DICT_PATH))
 
 
-def _orders_section(conn):
-    md = render.render_summary(conn, "jane-doe")
+def _seed_results(conn, rows):
+    """Extra `lab_result` rows on jane, committed as their own document. The `seeded`
+    fixture's four results are a year apart, so no two of them share one 31-day window
+    and a panel case has to seed its own."""
+    dedup.commit_extraction(conn, _doc(conn, "jane-doe"), {
+        "lab_result": list(rows),
+    }, dedup.load_dictionary(DICT_PATH))
+
+
+def _orders_section(conn, dictionary=None):
+    md = render.render_summary(conn, "jane-doe", dictionary=dictionary)
     return md.split("## Orders & Referrals")[1].split("\n## ")[0]
 
 
@@ -411,6 +420,133 @@ def test_summary_orders_suppression_is_render_only(seeded):
     assert seeded.execute(
         "SELECT COUNT(*) AS n FROM observation WHERE obs_type='order' AND key='HbA1c'"
     ).fetchone()["n"] == 1
+
+
+# --- issue #145: compound / panel orders ---------------------------------------
+#
+# #128 compares one `key_token` per order, so a *panel* order -- one key naming several
+# analytes (`cbc,cmp,ldh`) -- yields a token no single-analyte result can ever equal and
+# never leaves the section, however completely it was resulted. The order side now
+# decomposes to a token *set*; the match itself is unchanged (still exact-token, never
+# substring) and the rule is all-or-nothing, so a partially resulted panel keeps
+# rendering. #128's stance is preserved throughout: every ambiguity resolves to render.
+
+def test_summary_orders_fully_resulted_panel_is_suppressed(seeded):
+    """AC1: every analyte a compound order names has an in-window result, so the panel
+    is done and the section stops claiming it is outstanding."""
+    _seed_orders(seeded, [{"key": "Sodium, Potassium", "observed_at": "2026-03-01"}])
+    _seed_results(seeded, [
+        {"test_name": "Sodium", "collected_at": "2026-03-01", "value_num": 140},
+        {"test_name": "Potassium", "collected_at": "2026-03-05", "value_num": 4.1},
+    ])
+    section = _orders_section(seeded)
+    assert "Sodium" not in section and "Potassium" not in section
+    assert "cervical collar" in section          # control: unresulted rows untouched
+
+
+def test_summary_orders_partially_resulted_panel_still_renders(seeded):
+    """AC2: all-or-nothing. One component still outstanding *is* outstanding work, so the
+    bullet stays -- with #93's `+N earlier` disclosure intact, since the fold is unchanged."""
+    _seed_orders(seeded, [
+        {"key": "Sodium, Potassium", "observed_at": "2026-03-01"},
+        {"key": "Sodium, Potassium", "observed_at": "2026-02-01"},
+    ])
+    _seed_results(seeded, [
+        {"test_name": "Sodium", "collected_at": "2026-03-01", "value_num": 140},
+    ])
+    section = _orders_section(seeded)
+    assert ("- Sodium, Potassium  "
+            "(ordered 2026-03-01; +1 earlier, first 2026-02-01)") in section
+
+
+def test_summary_orders_single_component_is_unchanged_by_decomposition(seeded):
+    """AC3: a key with no top-level separator never decomposes, so it is never
+    word-stripped either -- `Lipid Panel` keeps today's whole-string token and a bare
+    `Lipid` result does not close it. The #128 block above runs unmodified for the rest."""
+    _seed_orders(seeded, [{"key": "Lipid Panel", "observed_at": "2026-03-01"}])
+    _seed_results(seeded, [
+        {"test_name": "Lipid", "collected_at": "2026-03-01", "value_num": 1.0},
+    ])
+    assert "- Lipid Panel  (ordered 2026-03-01)" in _orders_section(seeded)
+
+
+def test_summary_orders_panel_is_never_suppressed_by_a_substring_result(seeded):
+    """AC4: components are matched exact-token, never by substring, in either direction --
+    a `Sodium Level` result does not answer the `Sodium` component, and an unrelated
+    panel-named result answers nothing."""
+    _seed_orders(seeded, [{"key": "Sodium, Potassium", "observed_at": "2026-03-01"}])
+    _seed_results(seeded, [
+        {"test_name": "Sodium Level", "collected_at": "2026-03-01", "value_num": 140},
+        {"test_name": "Comprehensive Metabolic Panel", "collected_at": "2026-03-02",
+         "value_num": 1.0},
+    ])
+    assert "- Sodium, Potassium  (ordered 2026-03-01)" in _orders_section(seeded)
+
+
+def test_summary_orders_slash_separated_panel_drops_noise_words(seeded):
+    """`/` splits like `,` does, and a structural word that names no analyte (`panel`) is
+    dropped from a component -- otherwise `Immunofixation Panel` could never match the
+    `Immunofixation` result that answered it."""
+    _seed_orders(seeded, [
+        {"key": "Serum Protein Electrophoresis / Immunofixation Panel",
+         "observed_at": "2026-03-01"},
+    ])
+    _seed_results(seeded, [
+        {"test_name": "Serum Protein Electrophoresis", "collected_at": "2026-03-01",
+         "value_num": 1.0},
+        {"test_name": "Immunofixation", "collected_at": "2026-03-02", "value_num": 2.0},
+    ])
+    assert "Immunofixation" not in _orders_section(seeded)
+
+
+def test_summary_orders_panel_components_map_through_the_dictionary(seeded):
+    """Each component runs through the *same* dictionary the fold and the result index
+    use, so synonyms agree per analyte: `Sed Rate` -> esr, `Mg` -> magnesium."""
+    _seed_orders(seeded, [{"key": "Sed Rate, Mg", "observed_at": "2026-03-01"}])
+    _seed_results(seeded, [
+        {"test_name": "ESR", "collected_at": "2026-03-01", "value_num": 12},
+        {"test_name": "Magnesium", "collected_at": "2026-03-02", "value_num": 2.0},
+    ])
+    section = _orders_section(seeded, dictionary=dedup.load_dictionary(DICT_PATH))
+    assert "Sed Rate" not in section
+    assert "cervical collar" in section
+
+
+def test_summary_orders_parenthetical_component_is_not_split(seeded):
+    """A parenthetical is identity-bearing (#71), so a separator inside one is content:
+    the qualifier stays one opaque component and nothing inside it is word-stripped.
+    Results named after its innards therefore close nothing, and the order still renders."""
+    _seed_orders(seeded, [
+        {"key": "Sed Rate, SLE Profile (Profile A, Scleroderma)",
+         "observed_at": "2026-03-01"},
+    ])
+    _seed_results(seeded, [
+        {"test_name": "ESR", "collected_at": "2026-03-01", "value_num": 12},
+        {"test_name": "Profile A", "collected_at": "2026-03-02", "value_num": 1.0},
+        {"test_name": "Scleroderma", "collected_at": "2026-03-02", "value_num": 2.0},
+    ])
+    section = _orders_section(seeded, dictionary=dedup.load_dictionary(DICT_PATH))
+    assert ("- Sed Rate, SLE Profile (Profile A, Scleroderma)  "
+            "(ordered 2026-03-01)") in section
+
+
+def test_summary_orders_malformed_compound_key_renders(seeded):
+    """The never-raises contract: separator-only, unbalanced-bracket and trailing-separator
+    keys all reach this layer from OCR'd documents. None may crash a summary, and each
+    degrades to "still open" -- including `HbA1c,`, which has no *second* component and so
+    keeps today's whole-string token rather than gaining a match it never had."""
+    _seed_orders(seeded, [
+        {"key": ",", "observed_at": "2026-03-01"},
+        {"key": "a) b, c", "observed_at": "2026-03-02"},
+        {"key": "HbA1c,", "observed_at": "2026-03-03"},
+    ])
+    _seed_results(seeded, [
+        {"test_name": "HbA1c", "collected_at": "2026-03-03", "value_num": 5.5},
+    ])
+    section = _orders_section(seeded)
+    assert "- ,  (ordered 2026-03-01)" in section
+    assert "- a) b, c  (ordered 2026-03-02)" in section
+    assert "- HbA1c,  (ordered 2026-03-03)" in section
 
 
 def test_summary_latest_vitals_pick(seeded):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -549,6 +549,66 @@ def test_summary_orders_malformed_compound_key_renders(seeded):
     assert "- HbA1c,  (ordered 2026-03-03)" in section
 
 
+# A `,` or `/` is structure in a panel key but *content* in many single analytes' names
+# (`Glucose, fasting`, `Kappa/Lambda Ratio`). Decomposing one of those asks for analytes
+# that were never ordered, so the order stops suppressing -- #128's inversion, re-created
+# for a different class of key. Two guards, tested below: the dictionary is asked whether
+# the whole string is one declared analyte before any split, and the whole-key match of
+# #128 is tried first regardless, so no suppression that worked before can be lost.
+
+def test_summary_orders_declared_comma_bearing_analyte_is_not_decomposed(seeded):
+    """AC3: `data/dictionary.example.toml:37` declares `glucose, fasting` a single
+    analyte, so the order asks for *that* result, not for `glucose` plus `fasting`."""
+    _seed_orders(seeded, [{"key": "Glucose, fasting", "observed_at": "2026-03-01"}])
+    _seed_results(seeded, [
+        {"test_name": "Glucose, fasting", "collected_at": "2026-03-02", "value_num": 92},
+    ])
+    section = _orders_section(seeded, dictionary=dedup.load_dictionary(DICT_PATH))
+    assert "Glucose" not in section
+    assert "cervical collar" in section          # control: unresulted rows untouched
+
+
+def test_summary_orders_declared_analyte_is_not_closed_by_one_component(seeded):
+    """The guard restores a *name*, it does not become a looser match: a bare `Glucose`
+    result answers `glucose`, which is not the `glucose_fasting` that was ordered."""
+    _seed_orders(seeded, [{"key": "Glucose, fasting", "observed_at": "2026-03-01"}])
+    _seed_results(seeded, [
+        {"test_name": "Glucose", "collected_at": "2026-03-02", "value_num": 92},
+    ])
+    section = _orders_section(seeded, dictionary=dedup.load_dictionary(DICT_PATH))
+    assert "- Glucose, fasting  (ordered 2026-03-01)" in section
+
+
+def test_summary_orders_declared_analyte_holds_for_a_slash_and_a_stem(seeded):
+    """The same guard for the `/` spelling (`kappa/lambda ratio`, whose first component
+    would otherwise map to a *different* analyte) and for a declared **stem** carrying a
+    qualifier -- `identity` looks the stem up, so `norm` sees the hit either way."""
+    _seed_orders(seeded, [
+        {"key": "Kappa/Lambda Ratio", "observed_at": "2026-03-01"},
+        {"key": "Cholesterol, Total (Calculated)", "observed_at": "2026-03-01"},
+    ])
+    _seed_results(seeded, [
+        {"test_name": "Kappa/Lambda Ratio", "collected_at": "2026-03-02", "value_num": 1.2},
+        {"test_name": "Cholesterol, Total (Calculated)", "collected_at": "2026-03-02",
+         "value_num": 180},
+    ])
+    section = _orders_section(seeded, dictionary=dedup.load_dictionary(DICT_PATH))
+    assert "Kappa" not in section and "Cholesterol" not in section
+
+
+def test_summary_orders_comma_bearing_name_suppresses_without_a_dictionary(seeded):
+    """AC3 for the case no dictionary can speak for: an undeclared analyte whose name
+    carries a comma, rendered with no dictionary at all. #128's whole-key match is asked
+    first, so an identically-named result still closes it."""
+    _seed_orders(seeded, [{"key": "Ferritin, Serum", "observed_at": "2026-03-01"}])
+    _seed_results(seeded, [
+        {"test_name": "Ferritin, Serum", "collected_at": "2026-03-02", "value_num": 30},
+    ])
+    section = _orders_section(seeded)
+    assert "Ferritin" not in section
+    assert "cervical collar" in section
+
+
 def test_summary_latest_vitals_pick(seeded):
     md = render.render_summary(seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH))
     assert "blood_pressure: 118.0 mmHg" in md   # most recent per key

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -549,6 +549,25 @@ def test_summary_orders_malformed_compound_key_renders(seeded):
     assert "- HbA1c,  (ordered 2026-03-03)" in section
 
 
+def test_summary_orders_unreadable_component_does_not_let_the_rest_suppress(seeded):
+    """Decomposition fails **closed**: a component that tokenizes empty -- all noise words
+    (`Extensive Panel`), or whitespace-equivalent after normalization -- is not dropped from
+    the set, it voids the whole key. Dropping it would narrow all-or-nothing to
+    all-*remaining* and let a lone `CBC` result suppress an order still naming something this
+    layer could not read, which is the one direction the section must never fail in."""
+    _seed_orders(seeded, [
+        {"key": "CBC, Extensive Panel", "observed_at": "2026-03-01"},
+        {"key": "Sodium, ()", "observed_at": "2026-03-02"},
+    ])
+    _seed_results(seeded, [
+        {"test_name": "CBC", "collected_at": "2026-03-01", "value_num": 1.0},
+        {"test_name": "Sodium", "collected_at": "2026-03-02", "value_num": 140},
+    ])
+    section = _orders_section(seeded)
+    assert "- CBC, Extensive Panel  (ordered 2026-03-01)" in section
+    assert "- Sodium, ()  (ordered 2026-03-02)" in section
+
+
 # A `,` or `/` is structure in a panel key but *content* in many single analytes' names
 # (`Glucose, fasting`, `Kappa/Lambda Ratio`). Decomposing one of those asks for analytes
 # that were never ordered, so the order stops suppressing -- #128's inversion, re-created


### PR DESCRIPTION
## Summary

Follow-up on #128: `_is_resulted`/`_result_index` compared a single `key_token(order.key)`
against an index of single-analyte result tokens, so a **panel order** (`key` naming several
analytes as one compound string, e.g. `cbc,cmp,ldh`) never equalled any individual result token
and never left `render summary`'s "Orders & Referrals" section, even when every component analyte
had resulted.

- Orders decompose their `key` into component tokens on `,`/`/` at parenthesis depth 0 (after the
  existing `key_token` normalisation), dropping structural noise words (`panel`, `profile`,
  `extensive`) that name no analyte. A key with no top-level separator returns exactly today's
  single token — #128's behaviour is unchanged by construction for single-analyte orders.
- An order suppresses only when **every** decomposed component has a matching `lab_result` in the
  existing window (`ORDER_RESULT_BACKDATE_DAYS`/`ORDER_RESULT_WINDOW_DAYS`, both untouched) — a
  partially-resulted panel still renders as outstanding.
- Matching stays exact-token throughout; no substring/contains matching was introduced, so an
  unrelated nearby analyte can't suppress a genuinely open order.
- Fail-closed: if a component is unreadable, the whole key is voided (renders) rather than
  suppressing on the readable remainder — decomposition can only ever move an order from
  "renders" toward "suppressed," never remove a suppression #128 already produced.
- **Not in scope:** `render brief` has no "Orders & Referrals" section — `_grouped_orders`'s only
  caller is `render_summary`, so the brief never had order suppression to extend. AC1's `render
  brief` clause is therefore vacuous by design (confirmed independently across all verify passes).
  Extending the brief is a #128-scope question left for its own issue.
- `pemr/dedup.py` and both dictionary TOMLs are byte-identical to `dev` — no stored `dedup_key`
  moves, no `pemr rekey` implied.
- `docs/Architecture.md` §6 gains one paragraph stating the decomposition rule and its three
  under-suppression-biased guards (whole-key match tried first, all-or-nothing across components,
  fail-closed on an unreadable component) — the canonical statement of this seam going forward.

Closes #145

## Test plan

- [x] `pytest` full suite green (1321 passed, at HEAD `22c74f1`)
- [x] `npm test` (planner/CLI) 168 passed
- [x] `npm run check:pii` clean (115 files)
- [x] `npm run check:meta-drift` clean
- [x] `npm run sync:claude-config:check` in sync
- [x] Real CLI run (`migrate --create` → `person add` → `commit-extraction` → `render summary` →
      `verify`): compound/panel orders from the issue's own evidence (`cbc,cmp,ldh`, the SPEP /
      Immunofixation panel) suppress once every component resulted; partially-resulted panels and
      degenerate/malformed keys (`,`, `a) b, c`) still render without raising; `pemr verify`
      reports `integrity ok`
- [x] Two CLI-boundary specs in `tests/test_cli_phase4.py` pin the fail-closed rule at the command
      boundary (fail on the pre-fix commit, pass on the fix)
- [x] Security review: no shell/filesystem/query/format-string surface introduced, no regex (no
      ReDoS), 45-key + 9 non-string adversarial sweep never raises, `person_id` scoping and
      appendix-status filtering untouched, read-only/no-I/O; empirically confirmed the #136
      (canonical display units) merge cannot influence a suppression decision — display conversion
      is a leaf, suppression is a pure function of stored identity

This branch merged `origin/dev` (bringing in PR #163 `feat/136` canonical display units and PR
#162 `fix/155` OOXML DOCTYPE guard) and gained a test-only flake pin since first opened; both were
re-verified and re-audited clean at current HEAD.

See the verify report
(https://github.com/meridun/pemr/issues/145#issuecomment-5308761971) and audit report
(https://github.com/meridun/pemr/issues/145#issuecomment-5308800086) for full detail at HEAD
`22c74f1`, including the re-walked AC coverage ledger and the `dev`-merge/units-coexistence
analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
