### PR TITLE
fix(ingest): refuse DOCTYPE-bearing OOXML members before parsing (#155)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -827,7 +827,13 @@ from instead of re-reading the source every time. It extracts by whatever route 
 type allows (issue #66), with only the image and PDF routes reaching outside the stdlib:
 `.txt/.md/.csv/.tsv/.json/.log` read directly, `.docx`/`.xlsx` unzipped and their OOXML
 parsed, **everything else** through `tesseract` (a soft dependency) — no image-suffix
-allowlist, so `.jfif`, `.jpe` and extension-less scans OCR like any other image.
+allowlist, so `.jfif`, `.jpe` and extension-less scans OCR like any other image. Every
+OOXML member goes through one guarded parse helper that applies the same encoding-agnostic
+`<!DOCTYPE` refusal described for CCDA below before `ElementTree` sees the bytes (issue
+#155): the byte cap bounds a member's *declared* uncompressed size, not entity expansion,
+so a 355-byte `.docx` expanded to 4,194,304 stored chars before the guard. A DOCTYPE on
+any member refuses the whole file, degrading exactly like a malformed one — stderr note,
+no `ocr_text`, document kept.
 
 A **CCDA** `.xml` (C-CDA / HL7 CDA R2 — what a US portal's "download my record" produces)
 is read natively too (issue #138): each `structuredBody` section's title and narrative,

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -481,11 +481,33 @@ def _member_reader(zf: zipfile.ZipFile) -> Callable[[str], bytes]:
     return read
 
 
+def _parse_ooxml_member(read: Callable[[str], bytes], name: str) -> ET.Element:
+    """Read one OOXML member and parse it — refusing a `<!DOCTYPE` first (issue #155).
+
+    The only convenient way to parse a zip member, deliberately: `_member_reader`'s cap
+    bounds a member's *declared* uncompressed size, which does not bound entity
+    expansion — an internal subset expands after that check passes (a 355-byte `.docx`
+    rendered 4,194,304 chars). A future extractor that reaches for a fourth member must
+    not be able to forget the probe, so the probe lives here rather than inline at each
+    call site.
+
+    The probe is :func:`_xml_declares_doctype` (encoding-agnostic by construction — the
+    argument is on that function; do not reimplement it as a byte scan), and it runs on
+    the exact bytes handed to `ET.fromstring`, with no re-read between them. `ValueError`
+    is what a malformed member already raises, so :func:`extract_text_routed` degrades a
+    refusal to "no ocr_text" at exactly the cost of today's malformed-file path.
+    """
+    data = read(name)
+    if _xml_declares_doctype(data):
+        raise ValueError(f"{name} declares a DOCTYPE; refusing to parse")
+    return ET.fromstring(data)
+
+
 def _extract_docx(path: Path) -> str:
     """`.docx` body text: concat `w:t` runs, one line per `w:p` paragraph."""
     with zipfile.ZipFile(path) as zf:
         read_member = _member_reader(zf)
-        root = ET.fromstring(read_member("word/document.xml"))
+        root = _parse_ooxml_member(read_member, "word/document.xml")
     return "\n".join(
         _xml_text(para, f"{_WORD_NS}t") for para in root.iter(f"{_WORD_NS}p")
     )
@@ -519,7 +541,7 @@ def _extract_xlsx(path: Path) -> str:
         names = zf.namelist()
         shared: list[str] = []
         if "xl/sharedStrings.xml" in names:
-            root = ET.fromstring(read_member("xl/sharedStrings.xml"))
+            root = _parse_ooxml_member(read_member, "xl/sharedStrings.xml")
             shared = [
                 _xml_text(si, f"{_SHEET_NS}t") for si in root.iter(f"{_SHEET_NS}si")
             ]
@@ -531,7 +553,10 @@ def _extract_xlsx(path: Path) -> str:
         )
         lines: list[str] = []
         for name in sheets:
-            root = ET.fromstring(read_member(name))
+            # A DOCTYPE on any one member refuses the whole workbook: the `ValueError`
+            # propagates out to `extract_text_routed`, deliberately not caught per sheet
+            # (all-or-nothing degrade, as on the CCDA route — not a best-effort result).
+            root = _parse_ooxml_member(read_member, name)
             for row in root.iter(f"{_SHEET_NS}row"):
                 lines.append("\t".join(
                     _cell_text(cell, shared) for cell in row.iter(f"{_SHEET_NS}c")

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -954,6 +954,59 @@ def test_ocr_auto_makes_a_docx_findable(ready, capsys):
     assert "#1" in capsys.readouterr().out
 
 
+def _ooxml_entity_bomb(root, levels=7, width=4, leaf=64):
+    """A `<!DOCTYPE` whose internal subset amplifies ``&e{levels};`` ~1 MB."""
+    chain = "".join(
+        f'<!ENTITY e{n} "{f"&e{n - 1};" * width}">' for n in range(1, levels + 1)
+    )
+    return f'<!DOCTYPE {root} [<!ENTITY e0 "{"A" * leaf}">{chain}]>', levels
+
+
+@pytest.mark.parametrize("kind", ["docx", "xlsx"])
+def test_ocr_auto_refuses_a_doctype_bearing_ooxml_end_to_end(ready, capsys, kind):
+    """Issue #155 through the CLI: a DOCTYPE member is refused before parsing, and
+    the refusal costs a note — never the document. Pre-fix these ~800-byte files
+    stored 1,048,576 chars of `AAAA…` as `native` text."""
+    tmp_path = ready
+    if kind == "docx":
+        ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        doctype, levels = _ooxml_entity_bomb("w:document")
+        member = "word/document.xml"
+        body = (
+            f'<?xml version="1.0" encoding="UTF-8"?>{doctype}'
+            f'<w:document xmlns:w="{ns}"><w:body>'
+            f"<w:p><w:r><w:t>&e{levels};</w:t></w:r></w:p>"
+            "</w:body></w:document>"
+        )
+    else:
+        ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+        doctype, levels = _ooxml_entity_bomb("worksheet")
+        member = "xl/worksheets/sheet1.xml"
+        body = (
+            f'{doctype}<worksheet xmlns="{ns}"><sheetData>'
+            f'<row><c t="str"><v>&e{levels};</v></c></row>'
+            "</sheetData></worksheet>"
+        )
+    src = tmp_path / f"bomb.{kind}"
+    with zipfile.ZipFile(src, "w") as zf:
+        zf.writestr("[Content_Types].xml", "<Types/>")
+        zf.writestr(member, body)
+    assert src.stat().st_size < 4096          # well under the extraction byte cap
+
+    assert _run(tmp_path, "ingest", str(src), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources"), "--ocr", "auto",
+                "--force") == 0
+    out = capsys.readouterr()
+    assert "ingested document #1" in out.out          # the document is kept
+    assert f"{member} declares a DOCTYPE" in out.err   # named, before any parse
+    assert "no ocr_text stored" in out.err
+    assert "A" * 200 not in out.err
+
+    # nothing expanded into the archive: the amplified text is unfindable
+    assert _run(tmp_path, "find", "--person", "jane-doe", "AAAA") == 0
+    assert "no matches" in capsys.readouterr().out
+
+
 def test_ocr_tesseract_is_rejected(ready, capsys):
     """Issue #91: the misleading `tesseract` alias is gone; argparse names `auto`."""
     tmp_path = ready

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -697,7 +697,10 @@ def _make_stub(tmp_path, name="budget.gsheet", payload=None):
     return p
 
 
-def _make_docx(tmp_path, name="note.docx", paragraphs=("HbA1c 5.7 percent",)):
+def _make_docx(
+    tmp_path, name="note.docx", paragraphs=("HbA1c 5.7 percent",), doctype=""
+):
+    """A minimal `.docx`; `doctype` injects one into `word/document.xml`'s prolog."""
     body = "".join(
         f"<w:p><w:r><w:t>{part}</w:t></w:r></w:p>" for part in paragraphs
     )
@@ -706,6 +709,8 @@ def _make_docx(tmp_path, name="note.docx", paragraphs=("HbA1c 5.7 percent",)):
         '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/'
         f'2006/main"><w:body>{body}</w:body></w:document>'
     )
+    if doctype:
+        document = document.replace("?>", f"?>{doctype}", 1)
     p = tmp_path / name
     with zipfile.ZipFile(p, "w") as zf:
         zf.writestr("[Content_Types].xml", "<Types/>")
@@ -713,7 +718,13 @@ def _make_docx(tmp_path, name="note.docx", paragraphs=("HbA1c 5.7 percent",)):
     return p
 
 
-def _make_xlsx(tmp_path, name="labs.xlsx", rows=(("test", "value"), ("sodium", "140"))):
+def _make_xlsx(
+    tmp_path,
+    name="labs.xlsx",
+    rows=(("test", "value"), ("sodium", "140")),
+    doctype="",
+    doctype_member="xl/sharedStrings.xml",
+):
     strings: list[str] = []
     for row in rows:
         for cell in row:
@@ -732,11 +743,16 @@ def _make_xlsx(tmp_path, name="labs.xlsx", rows=(("test", "value"), ("sodium", "
         for row in rows
     )
     sheet = f'<worksheet xmlns="{ns}"><sheetData>{body}</sheetData></worksheet>'
+    members = {"xl/sharedStrings.xml": shared, "xl/worksheets/sheet1.xml": sheet}
+    if doctype:
+        # These fixtures carry no XML declaration, so the prolog *is* the leading
+        # DOCTYPE — well-formed, and the same position the CCDA tests inject at.
+        members[doctype_member] = doctype + members[doctype_member]
     p = tmp_path / name
     with zipfile.ZipFile(p, "w") as zf:
         zf.writestr("[Content_Types].xml", "<Types/>")
-        zf.writestr("xl/sharedStrings.xml", shared)
-        zf.writestr("xl/worksheets/sheet1.xml", sheet)
+        for member, content in members.items():
+            zf.writestr(member, content)
     return p
 
 
@@ -1088,12 +1104,15 @@ def _utf16_smuggled(marker: str, big_endian: bool = False) -> str:
     )
 
 
-def _entity_bomb_doctype(levels=7, width=4, leaf=64):
-    """A `<!DOCTYPE` whose internal subset amplifies ``&e{levels};`` ~1 MB."""
+def _entity_bomb_doctype(levels=7, width=4, leaf=64, root="ClinicalDocument"):
+    """A `<!DOCTYPE` whose internal subset amplifies ``&e{levels};`` ~1 MB.
+
+    ``root`` names the declared root element so the OOXML reuses (issue #155) can
+    build a bomb that is a plausible `.docx`/`.xlsx` member, not just a CCDA one."""
     chain = "".join(
         f'<!ENTITY e{n} "{f"&e{n - 1};" * width}">' for n in range(1, levels + 1)
     )
-    return f'<!DOCTYPE ClinicalDocument [<!ENTITY e0 "{"A" * leaf}">{chain}]>', levels
+    return f'<!DOCTYPE {root} [<!ENTITY e0 "{"A" * leaf}">{chain}]>', levels
 
 
 @pytest.mark.parametrize(
@@ -1424,6 +1443,88 @@ def test_malformed_docx_degrades_instead_of_losing_the_document(
     result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
     assert result.status == "new"
     assert result.document.ocr_text is None
+    assert "extraction failed" in capsys.readouterr().err
+
+
+# --- OOXML DOCTYPE refusal (issue #155) ------------------------------------------
+# `_member_reader`'s cap bounds a member's *declared* uncompressed size, which is not a
+# bound on entity expansion: a 355-byte `.docx` expanded to 4,194,304 chars and was
+# stored as `native` text. The CCDA route was guarded in #138; these pin the same guard
+# on the OOXML route, all-or-nothing per file.
+
+
+def _explode_on_parse(monkeypatch):
+    """Make any `ET.fromstring` a test failure — refusal must precede the parse."""
+    def _explode(*_args, **_kwargs):
+        raise AssertionError("ET.fromstring reached a DOCTYPE-bearing member")
+    monkeypatch.setattr(ingest.ET, "fromstring", _explode)
+
+
+def test_docx_doctype_is_refused_before_parsing(tmp_path, monkeypatch):
+    doctype, levels = _entity_bomb_doctype(root="w:document")
+    src = _make_docx(
+        tmp_path, name="bomb.docx", paragraphs=(f"&e{levels};",), doctype=doctype
+    )
+    assert src.stat().st_size < 4096            # well under the byte cap
+    _explode_on_parse(monkeypatch)
+    # refused, not merely empty: the parse that would amplify never runs
+    assert ingest.extract_text_routed(src) == (None, "native")
+
+
+def test_xlsx_doctype_in_shared_strings_is_refused(tmp_path, monkeypatch):
+    doctype, levels = _entity_bomb_doctype(root="sst")
+    src = _make_xlsx(tmp_path, name="bomb-shared.xlsx", doctype=doctype)
+    _explode_on_parse(monkeypatch)
+    assert ingest.extract_text_routed(src) == (None, "native")
+
+
+def test_xlsx_doctype_in_a_worksheet_refuses_the_whole_workbook(tmp_path, capsys):
+    """All-or-nothing: benign shared strings do not buy a best-effort partial result."""
+    doctype, _levels = _entity_bomb_doctype(root="worksheet")
+    src = _make_xlsx(
+        tmp_path,
+        name="bomb-sheet.xlsx",
+        doctype=doctype,
+        doctype_member="xl/worksheets/sheet1.xml",
+    )
+    assert ingest.extract_text_routed(src) == (None, "native")
+    err = capsys.readouterr().err
+    # refused at that member, and nothing expanded on the way there
+    assert "xl/worksheets/sheet1.xml declares a DOCTYPE" in err
+    assert "A" * 200 not in err
+
+
+def test_ooxml_doctype_refusal_is_encoding_agnostic(tmp_path, monkeypatch):
+    """A UTF-16 member with the DOCTYPE padded behind a comment — the two bypass
+    classes documented against the CCDA probe must not reopen on this route."""
+    doctype, levels = _entity_bomb_doctype(root="w:document")
+    document = (
+        '<?xml version="1.0" encoding="UTF-16" standalone="yes"?>'
+        f"<!-- padding so no fixed head window sees it -->{doctype}"
+        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/'
+        f'2006/main"><w:body><w:p><w:r><w:t>&e{levels};</w:t></w:r></w:p>'
+        "</w:body></w:document>"
+    )
+    src = tmp_path / "utf16-bomb.docx"
+    with zipfile.ZipFile(src, "w") as zf:
+        zf.writestr("[Content_Types].xml", "<Types/>")
+        zf.writestr("word/document.xml", b"\xff\xfe" + document.encode("utf-16-le"))
+    _explode_on_parse(monkeypatch)
+    assert ingest.extract_text_routed(src) == (None, "native")
+
+
+def test_docx_doctype_stores_the_document_without_ocr_text(
+    conn, tmp_path, sources, capsys
+):
+    """The "never costs you the document" contract, at the level the caller sees."""
+    doctype, levels = _entity_bomb_doctype(root="w:document")
+    src = _make_docx(
+        tmp_path, name="bomb2.docx", paragraphs=(f"&e{levels};",), doctype=doctype
+    )
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.status == "new"                # the document itself is kept
+    assert result.document.ocr_text is None
+    assert not result.ocr_text_populated
     assert "extraction failed" in capsys.readouterr().err
 
 


### PR DESCRIPTION
## Summary
- Adds a `_parse_ooxml_member` helper in `pemr/ingest.py` that probes zip-member bytes with the existing `_xml_declares_doctype` (added in #138 for CCDA) before handing them to `ET.fromstring`, closing an entity-amplification path in `_extract_docx`/`_extract_xlsx` that the size cap on `_member_reader` does not bound (declared-size cap != post-parse entity expansion).
- All three OOXML parse sites (`word/document.xml`, `xl/sharedStrings.xml`, each `xl/worksheets/sheetN.xml`) route through the helper; a DOCTYPE on any one refuses the whole workbook (all-or-nothing, no partial per-sheet result).
- Refusal raises `ValueError`, already caught by `extract_text_routed`'s `_EXTRACT_ERRORS`, so it degrades exactly like today's malformed-file path: `(None, "native")`, a stderr note, no exception escaping, and the document row is still stored — no ocr_text.
- `docs/Architecture.md`'s OOXML paragraph now states the same DOCTYPE guard, consistent with the adjacent CCDA paragraph.
- Regression tests: crafted entity-amplification `.docx`/`.xlsx` (including a UTF-16 + comment-padded DOCTYPE variant proving the encoding-agnostic bypass classes stay closed), an `ingest_document` integration test pinning the never-raises/no-ocr_text contract, and a CLI-level end-to-end smoke (`tests/test_cli_phase2.py`) driving `pemr ingest --ocr auto` through refusal. Existing benign `.docx`/`.xlsx` fixtures and the byte-cap tests are untouched and green.

Origin: audit advisory on #138 (dispatch cycle `dispatch-20260815-1954-8ba1`).

Closes #155

## Verify + audit reports
- Verify: https://github.com/meridun/pemr/issues/155#issuecomment-5305743074
- Audit: https://github.com/meridun/pemr/issues/155#issuecomment-5305759309

## Test plan
- [x] `pytest tests/test_ingest.py tests/test_cli_phase2.py` — 225 passed (per verify/audit)
- [x] Full suite: `pytest` — 1229 passed (per verify)
- [x] `npm run check:pii` clean, `npm run check:meta-drift` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)