### PR TITLE
feat(medication): store the CCDA discontinue reason (#159)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,6 +387,13 @@ resurrecting a stopped drug.
 Re-ingesting the same medication with a *different* `status_reason` stages a **conflict** (§5), like
 a differing `status` does — it is a real disagreement between documents, not noise to be smoothed.
 
+**Rows committed before migration 014 have `status_reason IS NULL`** — there is no automated
+backfill, because matching an `ocr_text` table line back to an already-committed row is a name/date
+heuristic over PHI and belongs to a human-in-the-loop curation pass, not a migration. The reason is
+not lost, though: it still sits verbatim in `document.ocr_text` for any already-ingested CCDA, and is
+recoverable per row with `pemr record edit medication <id> --set status_reason="Reorder"` (this does
+not move `dedup_key` — §5's identity guarantee holds for this field like any other editable one).
+
 ## Privacy posture
 
 This repository is **public**. It is framework + documentation only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,6 +360,33 @@ day or month the source didn't state, and never fall back to stashing an impreci
   second stages a conflict. Emitting a time you invented is never the fix — the recovery path is
   `keep both` under human sign-off (§5).
 
+### 8. Medication discontinue reason
+
+A med-list status cell often states **why** a drug stopped, in the same cell as the status word:
+`Discontinued (Reorder)`, `Discontinued (Therapy Completed)`, `Discontinued (Patient Stopped
+Taking)`, `Discontinued (Substitution/Alternate Therapy Placed)`. The two halves go to two fields.
+
+- The **lifecycle word** goes in `medication.status` (`discontinued`), exactly as today.
+- The **parenthetical** goes in `medication.status_reason`, **verbatim, parentheses stripped**
+  (`Reorder`, `Therapy Completed`, ...). Preserve the source's own casing and spacing.
+- NEVER concatenate the two into `status` (`discontinued (reorder)`, `discontinued-reorder`) —
+  `status` stays a lifecycle word, and the reason is the read layer's own axis.
+- OMIT `status_reason` when the source states no reason. Never invent one and never write `none` /
+  `n/a` — a bare `Discontinued` row is absent-reason, and behaves exactly as it always has.
+- The field is **free text**, not a closed vocabulary: a reason this list doesn't name (`Never
+  Started`, `Provider Discontinued`, ...) is emitted **as stated** rather than forced into a
+  familiar one.
+
+Why it is worth a field of its own: `(Reorder)` and `(Therapy Completed)` are **opposites**. A
+reorder means the prescription was renewed and therapy continues, so its `ended_on` is the end of an
+authorization period; a therapy-completed row is a genuine end. The read layer treats only a
+*renewal* reason as non-terminal (`query.RENEWAL_MED_REASONS`) and every other reason — recognized
+or not — as ending the course, so an unfamiliar reason degrades safely rather than silently
+resurrecting a stopped drug.
+
+Re-ingesting the same medication with a *different* `status_reason` stages a **conflict** (§5), like
+a differing `status` does — it is a real disagreement between documents, not noise to be smoothed.
+
 ## Privacy posture
 
 This repository is **public**. It is framework + documentation only.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -249,7 +249,9 @@ CREATE TABLE medication (
   started_on    TEXT,
   ended_on      TEXT,                     -- NULL = current
   prescriber    TEXT,
-  status        TEXT,                     -- active|discontinued|prn
+  status        TEXT,                     -- active|discontinued|prn; a discontinue
+                                          -- reason belongs in status_reason, not here
+  status_reason TEXT,                     -- verbatim discontinue reason; NULL = none stated
   dedup_key     TEXT NOT NULL,
   UNIQUE(dedup_key)
 );
@@ -1058,7 +1060,15 @@ pemr document set-text <id> --ocr-text-file <path> [--force]     # attach/replac
 pemr document reocr [<id>...] [--where-empty [--person <slug>]] [--dry-run] [--force]
                                                          # re-derive ocr_text from the stored blob using the ingest dispatch
 pemr query labs --person jane --test hba1c --since 2023-01-01 [--raw]
-pemr query meds --person jane --active [--raw]
+pemr query meds --person jane --active [--raw]           # --active = query.med_is_current per row:
+                                                         # a past ended_on or a terminal status ends
+                                                         # the course, EXCEPT when status_reason is a
+                                                         # renewal (query.RENEWAL_MED_REASONS, e.g.
+                                                         # a CCDA's "Discontinued (Reorder)") - a
+                                                         # renewed prescription's end date closes an
+                                                         # authorization period, not the therapy, so
+                                                         # it stays current and prints "(renewed)".
+                                                         # Every other reason still ends the course
 pemr query timeline --person jane --since 2024-01-01 [--raw] # merged event stream
                                                          # all three (issue #131): filtered at read
                                                          # time against the curation overlay, same

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -52,7 +52,8 @@ CREATE TABLE medication (
   started_on    TEXT,
   ended_on      TEXT,                    -- NULL = current
   prescriber    TEXT,
-  status        TEXT,                    -- active|discontinued|prn
+  status        TEXT,                    -- active|discontinued|prn; a discontinue
+                                         -- reason belongs in status_reason (014), not here
   dedup_key     TEXT NOT NULL,
   UNIQUE(dedup_key)
 );

--- a/migrations/014_medication_status_reason.sql
+++ b/migrations/014_medication_status_reason.sql
@@ -1,0 +1,47 @@
+-- 014_medication_status_reason: the CCDA discontinue reason gets its own column
+-- (issue #159).
+--
+-- A CCDA medication table does not just say a drug was discontinued - it says why, in
+-- the same narrative cell as the status word:
+--
+--   <td>Discontinued<content> (Reorder)</content></td>
+--   <td>Discontinued<content> (Therapy Completed)</content></td>
+--
+-- Since #138 that parenthetical reaches `document.ocr_text` intact, but `medication` had
+-- nowhere to put it, so every variant collapsed to `status = 'discontinued'` plus an
+-- `ended_on` at commit time. That erases an opposition that matters: `(Therapy
+-- Completed)` means the course finished and `ended_on` is a true end, while `(Reorder)`
+-- means the prescription was RENEWED - therapy continues and `ended_on` is only the end
+-- of an authorization period. After commit the two were byte-identical, and a human
+-- reviewer had to overturn a stored `ended_on` from clinical knowledge twice to recover
+-- a fact the source had stated outright.
+--
+-- The column holds the parenthetical VERBATIM, parentheses stripped (`Reorder`,
+-- `Therapy Completed`, `Patient Stopped Taking`, `Substitution/Alternate Therapy
+-- Placed`, ...). NULL = the source stated no reason, which behaves exactly as before.
+--
+-- Deliberately NOT constrained:
+--
+--   * No `CHECK` and no `dedup.ENUM_FIELDS` entry. A closed vocabulary would hard-reject
+--     the reasons other EHR exports print (`Never Started`, `Provider Discontinued`, ...)
+--     and turn an unseen literal into a failed commit, and a `CHECK` would reject rows
+--     already stored. ENUM_FIELDS' own bar is "fields the read layer branches on, where a
+--     typo makes the row silently vanish" - a typo'd reason here degrades to today's
+--     behaviour (terminal, reason still stored and displayed), so it never vanishes.
+--   * Not part of identity. `medication.dedup_key` stays
+--     `person | norm(name) | dose | started_on` (`dedup.KEY_FIELDS`), so no family is
+--     re-keyed and no curation verdict is orphaned. It IS in `dedup._COMPARE_FIELDS`: a
+--     re-ingest stating a DIFFERENT reason stages a conflict, as a differing `status`
+--     already does.
+--
+-- The reading of the reason lives in Python, not here: `query.RENEWAL_MED_REASONS` is the
+-- closed set of spellings that mean "renewed", and `query.med_is_current` treats those as
+-- non-terminal; every other reason keeps ending the course (the safe default).
+--
+-- Purely additive: one nullable ALTER, no rebuild, no backfill. A pre-014 database just
+-- needs `pemr migrate`; readers use `query._row_get`, which tolerates the missing column.
+-- Rows committed before this migration keep `status_reason IS NULL` - their reasons are
+-- still recoverable from `document.ocr_text` via a `pemr record edit` curation pass, which
+-- is a human-in-the-loop job over PHI and deliberately not a migration.
+
+ALTER TABLE medication ADD COLUMN status_reason TEXT;   -- verbatim discontinue reason; NULL = none stated

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -2749,14 +2749,19 @@ def _cmd_query_meds(args: argparse.Namespace) -> int:
         for r in shown:
             dose = f"  {r['dose']}" if r["dose"] else ""
             freq = f"  {r['frequency']}" if r["frequency"] else ""
+            current = query.med_is_current(r)
             if r["ended_on"]:
-                end = f" -> {r['ended_on']}"
-            elif query.med_is_current(r):
+                # A renewal's end date closes an authorization period, not the therapy
+                # (issue #159) - mark it, so a row that appears under --active does not
+                # read as flatly ended.
+                end = f" -> {r['ended_on']}" + (" (renewed)" if current else "")
+            elif current:
                 end = " -> (current)"
             else:  # terminal status but no explicit end date (issue #21)
                 end = " -> (ended)"
             span = _fmt(r["started_on"]) + end
-            status = f"  [{r['status']}]" if r["status"] else ""
+            bits = [str(b) for b in (r["status"], r.get("status_reason")) if b]
+            status = f"  [{': '.join(bits)}]" if bits else ""
             print(f"{r['name']:24}{dose}{freq}  {span}{status}"
                   f"{_verdict_suffix(r, raw=args.raw)}")
         if hidden:

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -63,6 +63,11 @@ FIELD_SPECS: dict[str, dict[str, tuple[object, bool]]] = {
         "ended_on": (str, False),
         "prescriber": (str, False),
         "status": (str, False),
+        # Verbatim discontinue reason, parentheses stripped (issue #159): a CCDA med
+        # table states WHY a drug stopped in the same cell as the status word, and
+        # `(Reorder)` (renewed) vs `(Therapy Completed)` (finished) are opposites. Free
+        # text, deliberately NOT an ENUM_FIELDS entry - see migrations/014.
+        "status_reason": (str, False),
     },
     "procedure": {
         "name": (str, True),
@@ -688,7 +693,8 @@ class CommitSummary:
 # value_num/value_text appear below.
 _COMPARE_FIELDS: dict[str, list[str]] = {
     "lab_result": ["value_num", "value_text", "unit", "ref_low", "ref_high", "flag", "loinc"],
-    "medication": ["route", "frequency", "ended_on", "prescriber", "status"],
+    "medication": ["route", "frequency", "ended_on", "prescriber", "status",
+                   "status_reason"],
     "procedure": ["provider", "outcome"],
     "appointment": ["specialty", "reason", "summary"],
     "observation": ["value_num", "value_text", "unit"],

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -38,6 +38,20 @@ _WORD = re.compile(r"\w+", re.UNICODE)
 # terminal values like completed/stopped as well), so matching is lowercased and trimmed.
 TERMINAL_MED_STATUSES = frozenset({"completed", "stopped", "discontinued"})
 
+# Medication ``status_reason`` values that mean the prescription was RENEWED rather than
+# stopped (issue #159). A CCDA med table states the reason beside the status word
+# (``Discontinued (Reorder)``), and a reorder's ``ended_on`` is the end of an
+# authorization period, not of therapy — so those rows stay current while every *other*
+# reason (``Therapy Completed``, ``Patient Stopped Taking``, ``Substitution/Alternate
+# Therapy Placed``, or anything unrecognized) keeps ending the course. Matched on
+# ``enum_token``, so stored casing/spacing is irrelevant.
+#
+# **Closed by design.** ``status_reason`` is free text precisely so an unfamiliar reason
+# from another EHR still commits; the safety of that rests on unrecognized reasons
+# degrading to today's terminal behavior. Widening this set is a decision on its own
+# issue, not a build-time convenience.
+RENEWAL_MED_REASONS = frozenset({"reorder", "re-order", "renewal", "renewed"})
+
 
 def _row_get(row: sqlite3.Row | dict, key: str) -> object:
     """Column access that tolerates a missing key on either a dict or ``sqlite3.Row``."""
@@ -86,10 +100,24 @@ def med_is_current(row: sqlite3.Row | dict, *, now: datetime | None = None) -> b
     ``ended_on`` was extracted — the contradiction behind issue #21, where a
     ``completed`` med with a null ``ended_on`` rendered as ``(current)``.
 
+    A **renewal** ``status_reason`` (:data:`RENEWAL_MED_REASONS`) keeps the course open
+    whatever the dates say (issue #159). A CCDA med table records why a drug stopped
+    beside the status word, and ``Discontinued (Reorder)`` does not mean stopped — the
+    prescription was renewed, so its ``ended_on`` is the end of an *authorization
+    period*, not of therapy. Reading that date as an end is the documented harm: a
+    reviewer had to overturn it by hand from clinical knowledge. Every other reason
+    (``Therapy Completed``, ``Patient Stopped Taking``, ``Substitution/Alternate Therapy
+    Placed``, or one this layer doesn't recognize) still ends the course. The trade is
+    deliberate: a renewed drug may over-report as current — the paired fresh row from the
+    same export is a separate row, so one drug can list twice — which beats silently
+    ending a live therapy.
+
     ``now`` is injectable for deterministic tests/renders, like the ``render`` layer's.
     """
     status = str(_row_get(row, "status") or "").strip().lower()
     ended_on = _row_get(row, "ended_on")
+    if enum_token(_row_get(row, "status_reason")) in RENEWAL_MED_REASONS:
+        return True
     if ended_on:
         end = _end_of_period(ended_on)
         if end is not None and end < (now or datetime.now()).date():
@@ -166,8 +194,11 @@ def query_meds(
     (Architecture.md §5, :func:`med_is_current`). A terminal status
     (completed/stopped/discontinued) ends the course even without an ``ended_on``
     (issue #21), and a *past* ``ended_on`` ends it even under ``status='active'``
-    (issue #57), so both are excluded from ``active``. ``now`` is injectable so the
-    render layer's deterministic clock reaches the currency test."""
+    (issue #57), so both are excluded from ``active``. The one exception is a renewal
+    ``status_reason`` (``Reorder``, :data:`RENEWAL_MED_REASONS`): a renewed prescription
+    is kept in ``active`` even with a past ``ended_on``, because that date ends an
+    authorization period rather than the therapy (issue #159). ``now`` is injectable so
+    the render layer's deterministic clock reaches the currency test."""
     person_id = resolve_person_id(conn, slug)
     sql = ("SELECT * FROM medication WHERE person_id = ? "
            "ORDER BY (started_on IS NULL), started_on, name")

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -954,6 +954,135 @@ def test_ocr_auto_makes_a_docx_findable(ready, capsys):
     assert "#1" in capsys.readouterr().out
 
 
+# The five status cells a CCDA med table prints, in the shape the reason arrives in:
+# inline `<content>` inside the same cell as the lifecycle word. The sixth row is the
+# paired fresh prescription a reorder produces in the same export.
+_CCDA_MED_ROWS = (
+    ("Amoxicillin 500 MG", "08/28/2025", "Discontinued"),
+    ("Lisinopril 10 MG", "11/11/2024", "Discontinued<content> (Therapy Completed)</content>"),
+    ("Levothyroxine 50 MCG", "06/11/2026", "Discontinued<content> (Reorder)</content>"),
+    ("Atorvastatin 20 MG", "03/02/2025",
+     "Discontinued<content> (Patient Stopped Taking)</content>"),
+    ("Omeprazole 20 MG", "05/09/2025",
+     "Discontinued<content> (Substitution/Alternate Therapy Placed)</content>"),
+    ("Levothyroxine 50 MCG", "06/12/2026", "Active"),
+)
+
+
+def _ccda_with_med_table(tmp_path, name="DOC0159.XML"):
+    rows = "".join(
+        f"<tr><td>{drug}</td><td>{date}</td><td>{cell}</td></tr>"
+        for drug, date, cell in _CCDA_MED_ROWS
+    )
+    doc = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<ClinicalDocument xmlns="urn:hl7-org:v3">'
+        "<recordTarget><patientRole><patient>"
+        "<name><given>Jane</given><family>Doe</family></name>"
+        '<birthTime value="19620314"/>'
+        "</patient></patientRole></recordTarget>"
+        "<component><structuredBody><component><section>"
+        "<title>Medications</title><text><table>"
+        "<thead><tr><th>Medication</th><th>Date</th><th>Status</th></tr></thead>"
+        f"<tbody>{rows}</tbody>"
+        "</table></text></section></component></structuredBody></component>"
+        "</ClinicalDocument>"
+    )
+    p = tmp_path / name
+    p.write_text(doc, encoding="utf-8")
+    return p
+
+
+def test_ccda_discontinue_reason_survives_ingest_to_query_end_to_end(ready, capsys):
+    """Issue #159 through the CLI, whole chain: a CCDA med table's discontinue reason
+    reaches `ocr_text` (#138), lands on `medication.status_reason` at commit time, and
+    changes what `query meds --active` says - a renewal stays current while a completed
+    course does not. Pre-#159 every variant collapsed to a bare `discontinued` and the
+    renewal read as stopped."""
+    tmp_path = ready
+    src = _ccda_with_med_table(tmp_path)
+
+    assert _run(tmp_path, "ingest", str(src), "--person", "jane-doe",
+                "--sources", str(tmp_path / "sources"), "--ocr", "auto") == 0
+    assert "ingested document #1" in capsys.readouterr().out
+
+    # 1. the reason reaches ocr_text attached to its own row's status word (#138)
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        text = conn.execute(
+            "SELECT ocr_text FROM document WHERE document_id = 1"
+        ).fetchone()["ocr_text"]
+    finally:
+        conn.close()
+    for drug, _date, cell in _CCDA_MED_ROWS:
+        expected = cell.replace("<content>", "").replace("</content>", "")
+        assert any(line.startswith(drug) and line.endswith(expected)
+                   for line in text.splitlines()), (drug, expected)
+
+    # 2. the lifecycle word and the parenthetical split across two fields (AGENTS.md 8)
+    meds = _write_json(tmp_path, "meds.json", {"medication": [
+        {"name": "Amoxicillin", "dose": "500 MG", "started_on": "2025-08-01",
+         "ended_on": "2025-08-28", "status": "discontinued"},
+        {"name": "Lisinopril", "dose": "10 MG", "started_on": "2024-10-01",
+         "ended_on": "2024-11-11", "status": "discontinued",
+         "status_reason": "Therapy Completed"},
+        {"name": "Levothyroxine", "dose": "50 MCG", "started_on": "2025-06-11",
+         "ended_on": "2026-06-11", "status": "discontinued",
+         "status_reason": "Reorder"},
+        {"name": "Atorvastatin", "dose": "20 MG", "started_on": "2025-01-02",
+         "ended_on": "2025-03-02", "status": "discontinued",
+         "status_reason": "Patient Stopped Taking"},
+        {"name": "Omeprazole", "dose": "20 MG", "started_on": "2025-02-09",
+         "ended_on": "2025-05-09", "status": "discontinued",
+         "status_reason": "Substitution/Alternate Therapy Placed"},
+        {"name": "Levothyroxine", "dose": "50 MCG", "started_on": "2026-06-12",
+         "status": "active"},
+    ]})
+    assert _run(tmp_path, "commit-extraction", "--document", "1",
+                "--json", str(meds)) == 0
+    assert "6 new" in capsys.readouterr().out
+
+    # 3. each reason is stored verbatim and readable off the row - no ocr_text parsing
+    assert _run(tmp_path, "query", "meds", "--person", "jane-doe", "--json") == 0
+    stored = {(m["name"], m["started_on"]): m
+              for m in json.loads(capsys.readouterr().out)}
+    assert [stored[k]["status_reason"] for k in (
+        ("Amoxicillin", "2025-08-01"), ("Lisinopril", "2024-10-01"),
+        ("Levothyroxine", "2025-06-11"), ("Atorvastatin", "2025-01-02"),
+        ("Omeprazole", "2025-02-09"), ("Levothyroxine", "2026-06-12"),
+    )] == [None, "Therapy Completed", "Reorder", "Patient Stopped Taking",
+           "Substitution/Alternate Therapy Placed", None]
+    # ...and `status` stays lifecycle-only: the reason is never smuggled back into it
+    assert {m["status"] for m in stored.values()} == {"discontinued", "active"}
+
+    # 4. the human-readable listing shows the reason and marks the renewal
+    assert _run(tmp_path, "query", "meds", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    assert out.isascii()                                        # issue #23
+    levo = next(x for x in out.splitlines() if "2026-06-11" in x)
+    assert "[discontinued: Reorder]" in levo
+    assert "-> 2026-06-11 (renewed)" in levo
+    amox = next(x for x in out.splitlines() if "Amoxicillin" in x)
+    assert "[discontinued]" in amox and "(renewed)" not in amox  # bare: unchanged
+    for reason in ("Therapy Completed", "Patient Stopped Taking",
+                   "Substitution/Alternate Therapy Placed"):
+        row = next(x for x in out.splitlines() if reason in x)
+        assert f"[discontinued: {reason}]" in row
+        assert "(renewed)" not in row                            # still terminal
+
+    # 5. the verdict that matters: the renewal survives --active, the completed course
+    #    does not. Both have a terminal status and a past end date.
+    assert _run(tmp_path, "query", "meds", "--person", "jane-doe", "--active",
+                "--json") == 0
+    active = {(m["name"], m["started_on"]) for m in json.loads(capsys.readouterr().out)}
+    assert ("Levothyroxine", "2025-06-11") in active     # renewed -> still current
+    assert ("Levothyroxine", "2026-06-12") in active     # the paired fresh row
+    assert ("Lisinopril", "2024-10-01") not in active    # therapy completed -> ended
+    assert ("Atorvastatin", "2025-01-02") not in active
+    assert ("Omeprazole", "2025-02-09") not in active
+    assert ("Amoxicillin", "2025-08-01") not in active   # bare discontinued -> ended
+
+
 def _ooxml_entity_bomb(root, levels=7, width=4, leaf=64):
     """A `<!DOCTYPE` whose internal subset amplifies ``&e{levels};`` ~1 MB."""
     chain = "".join(

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -115,6 +115,62 @@ def test_query_meds_terminal_status_renders_ended_not_current(ready, capsys):
     assert "(current)" in metformin
 
 
+def test_query_meds_shows_the_discontinue_reason_and_marks_a_renewal(ready, capsys):
+    """Issue #159: the reason prints beside the lifecycle word, and a renewed
+    prescription's end date is marked rather than reading as a flat stop."""
+    conn = db.connect(ready / "cli.db")
+    d = dedup.load_dictionary(DICT_ARG[1])
+    doc = conn.execute("SELECT document_id FROM document LIMIT 1").fetchone()["document_id"]
+    dedup.commit_extraction(conn, doc, {
+        "medication": [
+            {"name": "Levothyroxine", "dose": "50mcg", "started_on": "2025-06-11",
+             "ended_on": "2026-06-11", "status": "discontinued",
+             "status_reason": "Reorder"},
+            {"name": "Amoxicillin", "dose": "500mg", "started_on": "2024-11-01",
+             "ended_on": "2024-11-11", "status": "discontinued",
+             "status_reason": "Therapy Completed"},
+        ],
+    }, d)
+    conn.close()
+
+    assert _run(ready, "query", "meds", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    levo = next(line for line in out.splitlines() if "Levothyroxine" in line)
+    assert "[discontinued: Reorder]" in levo
+    assert "-> 2026-06-11 (renewed)" in levo
+    amox = next(line for line in out.splitlines() if "Amoxicillin" in line)
+    assert "[discontinued: Therapy Completed]" in amox
+    assert "(renewed)" not in amox
+    assert out.isascii()
+
+    # ...and only the renewal survives --active.
+    assert _run(ready, "query", "meds", "--person", "jane-doe", "--active",
+                "--json") == 0
+    names = [m["name"] for m in json.loads(capsys.readouterr().out)]
+    assert "Levothyroxine" in names and "Amoxicillin" not in names
+
+
+def test_query_meds_bare_discontinued_line_is_unchanged(ready, capsys):
+    """A row with no reason prints exactly as it always did - no empty bracket, no
+    stray separator (issue #159's no-regression bar)."""
+    conn = db.connect(ready / "cli.db")
+    d = dedup.load_dictionary(DICT_ARG[1])
+    doc = conn.execute("SELECT document_id FROM document LIMIT 1").fetchone()["document_id"]
+    dedup.commit_extraction(conn, doc, {
+        "medication": [{"name": "Atorvastatin", "dose": "20mg",
+                        "started_on": "2025-01-01", "ended_on": "2025-08-28",
+                        "status": "discontinued"}],
+    }, d)
+    conn.close()
+
+    assert _run(ready, "query", "meds", "--person", "jane-doe") == 0
+    line = next(x for x in capsys.readouterr().out.splitlines()
+                if "Atorvastatin" in x)
+    assert "[discontinued]" in line
+    assert "-> 2025-08-28" in line and "(renewed)" not in line
+    assert ": ]" not in line
+
+
 def test_query_meds_active_drops_expired_course_labelled_active(ready, capsys):
     """Issue #57 repro: a 2024 ten-day course carrying status='active' must not come
     back from `query meds --active`; a future end date under the same status must."""

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -50,6 +50,7 @@ ALL_MIGRATIONS = [
     "011_curation_distinct_status.sql",
     "012_record_edit.sql",
     "013_person_unit_pref.sql",
+    "014_medication_status_reason.sql",
 ]
 
 # Every record table carries the occurrence-family columns (migration 005; 006's two
@@ -80,6 +81,21 @@ def test_migrate_is_idempotent(conn):
 def test_migrate_records_versions(conn):
     db.migrate(conn)
     assert db.applied_versions(conn) == set(ALL_MIGRATIONS)
+
+
+def test_medication_has_status_reason_column(conn):
+    """Migration 014 (issue #159): the CCDA discontinue reason gets its own nullable
+    column, so a renewal is distinguishable from a completed course after commit."""
+    db.migrate(conn)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(medication)").fetchall()}
+    assert "status_reason" in cols
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane', 'Jane')")
+    conn.execute(
+        "INSERT INTO medication (person_id, name, dedup_key) VALUES (1, 'Metformin', 'k')"
+    )
+    assert conn.execute(
+        "SELECT status_reason FROM medication"
+    ).fetchone()["status_reason"] is None   # nullable, no backfill
 
 
 def test_person_has_deactivated_at_column(conn):
@@ -141,6 +157,7 @@ def test_migration_006_moves_condition_and_allergy_observations(conn, tmp_path):
         "008_curation.sql", "009_record_attestation.sql",
         "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
         "012_record_edit.sql", "013_person_unit_pref.sql",
+        "014_medication_status_reason.sql",
     ]
 
     a = conn.execute("SELECT * FROM allergy").fetchone()
@@ -275,6 +292,7 @@ def test_migration_008_applies_on_a_007_era_database(conn, tmp_path):
         "008_curation.sql", "009_record_attestation.sql",
         "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
         "012_record_edit.sql", "013_person_unit_pref.sql",
+        "014_medication_status_reason.sql",
     ]
 
     assert curation.has_table(conn) is True
@@ -327,7 +345,7 @@ def test_migration_009_applies_on_an_008_era_database(conn, tmp_path):
     assert db.migrate(conn) == [
         "009_record_attestation.sql", "010_curation_row_scope.sql",
         "011_curation_distinct_status.sql", "012_record_edit.sql",
-        "013_person_unit_pref.sql",
+        "013_person_unit_pref.sql", "014_medication_status_reason.sql",
     ]
 
     assert attestations.has_columns(conn) is True
@@ -379,6 +397,7 @@ def test_migration_010_rebuilds_curation_and_preserves_every_verdict(conn, tmp_p
     assert db.migrate(conn) == [
         "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
         "012_record_edit.sql", "013_person_unit_pref.sql",
+        "014_medication_status_reason.sql",
     ]
 
     after = [dict(r) for r in conn.execute(
@@ -463,7 +482,7 @@ def test_migration_011_widens_the_status_check_and_preserves_every_verdict(
 
     assert db.migrate(conn) == [
         "011_curation_distinct_status.sql", "012_record_edit.sql",
-        "013_person_unit_pref.sql",
+        "013_person_unit_pref.sql", "014_medication_status_reason.sql",
     ]
 
     after = [dict(r) for r in conn.execute(

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -918,6 +918,50 @@ def test_ccda_renders_real_vendor_export_shapes(conn, tmp_path, sources):
     assert "Ferrous sulfate 325 MG - 1 tablet daily" in text
 
 
+# The medication-table shape #159 rests on: the discontinue reason is inline `<content>`
+# inside the same status cell as the lifecycle word. This pins the #138 extraction that
+# `medication.status_reason` depends on, so a narrative regression is caught here rather
+# than in a live corpus.
+_CCDA_MEDS = (
+    "<section><title>Medications</title><text><table>"
+    "<thead><tr><th>Medication</th><th>Date</th><th>Status</th></tr></thead>"
+    "<tbody>"
+    "<tr><td>Amoxicillin 500 MG</td><td>08/28/2025</td><td>Discontinued</td></tr>"
+    "<tr><td>Lisinopril 10 MG</td><td>11/11/2024</td>"
+    "<td>Discontinued<content> (Therapy Completed)</content></td></tr>"
+    "<tr><td>Levothyroxine 50 MCG</td><td>06/11/2026</td>"
+    "<td>Discontinued<content> (Reorder)</content></td></tr>"
+    "<tr><td>Atorvastatin 20 MG</td><td>03/02/2025</td>"
+    "<td>Discontinued<content> (Patient Stopped Taking)</content></td></tr>"
+    "<tr><td>Omeprazole 20 MG</td><td>05/09/2025</td>"
+    "<td>Discontinued<content> (Substitution/Alternate Therapy Placed)</content></td>"
+    "</tr>"
+    "</tbody></table></text></section>",
+)
+
+
+@pytest.mark.parametrize("drug, cell", [
+    ("Amoxicillin 500 MG", "Discontinued"),
+    ("Lisinopril 10 MG", "Discontinued (Therapy Completed)"),
+    ("Levothyroxine 50 MCG", "Discontinued (Reorder)"),
+    ("Atorvastatin 20 MG", "Discontinued (Patient Stopped Taking)"),
+    ("Omeprazole 20 MG", "Discontinued (Substitution/Alternate Therapy Placed)"),
+])
+def test_ccda_med_table_keeps_the_discontinue_reason_in_its_cell(
+    conn, tmp_path, sources, drug, cell
+):
+    """Each status cell reaches ocr_text whole - reason attached to its own row's status
+    word, never split across cells or dropped (issue #159's extraction dependency)."""
+    src = _make_ccda(tmp_path, name="DOC0159.XML", sections=_CCDA_MEDS)
+    text = ingest.ingest_document(
+        conn, src, "jane-doe", sources, ocr=True
+    ).document.ocr_text
+    assert f"{drug}\t" in text
+    assert text.count(cell) >= 1
+    row = next(line for line in text.splitlines() if line.startswith(drug))
+    assert row.endswith(cell)
+
+
 def test_ccda_never_shells_out(conn, tmp_path, sources, monkeypatch):
     def boom(path):  # pragma: no cover - the assertion is that this never runs
         raise AssertionError(f"run_ocr must not be called for {path}")

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -151,9 +151,52 @@ NOW = datetime(2026, 8, 2, 9, 30)  # fixed "today" so the currency tests never a
     # a future one.
     ({"status": None, "ended_on": "2026-09-04"}, False),
     ({"status": "completed", "ended_on": "2026-09-04"}, False),
+    # issue #159: the CCDA discontinue reason. One row per status cell in the corpus
+    # distribution, each with a past end date and a terminal status - only a *renewal*
+    # keeps the course open, because its ended_on closes an authorization period.
+    ({"status": "discontinued", "ended_on": "2026-06-11",
+      "status_reason": "Reorder"}, True),
+    ({"status": "discontinued", "ended_on": "2024-11-11",
+      "status_reason": "Therapy Completed"}, False),
+    ({"status": "discontinued", "ended_on": "2024-11-11",
+      "status_reason": "Patient Stopped Taking"}, False),
+    ({"status": "discontinued", "ended_on": "2024-11-11",
+      "status_reason": "Substitution/Alternate Therapy Placed"}, False),
+    # A bare `Discontinued` (no parenthetical) is unchanged: terminal, as always.
+    ({"status": "discontinued", "ended_on": "2025-08-28",
+      "status_reason": None}, False),
+    ({"status": "discontinued", "ended_on": "2025-08-28",
+      "status_reason": ""}, False),
+    # Stored casing/spacing is irrelevant - the match runs through enum_token.
+    ({"status": "discontinued", "ended_on": "2026-06-11",
+      "status_reason": "REORDER"}, True),
+    ({"status": "discontinued", "ended_on": "2026-06-11",
+      "status_reason": " re-order "}, True),
+    ({"status": "discontinued", "ended_on": "2026-06-11",
+      "status_reason": "Renewed"}, True),
+    # A reason this layer does not recognize keeps today's terminal behaviour (the safe
+    # default that lets status_reason stay free text).
+    ({"status": "discontinued", "ended_on": "2026-06-11",
+      "status_reason": "Provider Discontinued"}, False),
+    # A renewal with no end date at all is current too, over a terminal status.
+    ({"status": "discontinued", "ended_on": None, "status_reason": "Reorder"}, True),
 ])
 def test_med_is_current(row, expected):
     assert query.med_is_current(row, now=NOW) is expected
+
+
+def test_renewal_med_reasons_are_enum_token_stable():
+    """Every member is already in ``enum_token`` form, or it could never match a stored
+    value; and none of them is a *status* word (the two axes stay separate, #151/#159)."""
+    assert all(dedup.enum_token(v) == v for v in query.RENEWAL_MED_REASONS)
+    assert not (query.RENEWAL_MED_REASONS & query.TERMINAL_MED_STATUSES)
+
+
+def test_med_is_current_tolerates_a_row_without_the_status_reason_column():
+    """A pre-014 database (or a caller's hand-built dict) has no ``status_reason`` key —
+    ``_row_get`` must read that as 'no reason', not raise."""
+    assert query.med_is_current({"status": "active", "ended_on": None}) is True
+    assert query.med_is_current({"status": "completed", "ended_on": None}) is False
 
 
 def test_med_is_current_defaults_to_the_real_clock():
@@ -196,6 +239,30 @@ def test_query_meds_active_excludes_expired_course_labelled_active(seeded):
     active = {m["name"] for m in query.query_meds(seeded, "jane-doe", active=True, now=NOW)}
     assert "Amoxicillin" not in active
     assert "Skyrizi" in active
+
+
+def test_query_meds_active_keeps_a_renewed_prescription(seeded):
+    """A renewed prescription stays current through the real read path, while a course
+    that ran to completion does not (issue #159) - same shape, opposite verdicts."""
+    doc = _doc(seeded, "jane-doe")
+    dedup.commit_extraction(seeded, doc, {
+        "medication": [
+            {"name": "Levothyroxine", "dose": "50mcg", "frequency": "daily",
+             "started_on": "2025-06-11", "ended_on": "2026-06-11",
+             "status": "discontinued", "status_reason": "Reorder"},
+            {"name": "Amoxicillin", "dose": "500mg", "frequency": "TID",
+             "started_on": "2024-11-01", "ended_on": "2024-11-11",
+             "status": "discontinued", "status_reason": "Therapy Completed"},
+        ],
+    }, dedup.load_dictionary(DICT_PATH))
+    rows = {m["name"]: m for m in query.query_meds(seeded, "jane-doe")}
+    assert {"Levothyroxine", "Amoxicillin"} <= set(rows)
+    # The reason is retrievable off the row itself - no ocr_text parsing - and verbatim.
+    assert rows["Levothyroxine"]["status_reason"] == "Reorder"
+    assert rows["Amoxicillin"]["status_reason"] == "Therapy Completed"
+    active = {m["name"] for m in query.query_meds(seeded, "jane-doe", active=True, now=NOW)}
+    assert "Levothyroxine" in active
+    assert "Amoxicillin" not in active
 
 
 # --- structured: timeline -----------------------------------------------------

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -622,6 +622,7 @@ FIELD_VALUES = {
         "ended_on": ("2026-01-01", "2026-02-01"),
         "prescriber": ("Dr Who", "Dr No"),
         "status": ("active", "discontinued"),
+        "status_reason": ("Reorder", "Therapy Completed"),
     },
     "procedure": {
         "name": ("Colonoscopy", "Endoscopy"),
@@ -731,6 +732,58 @@ def test_editable_fields_excludes_identity_and_never_names_provenance():
 def test_editable_fields_rejects_an_unknown_type():
     with pytest.raises(ValueError, match="lab_result"):
         dedup.editable_fields("family_history")
+
+
+# --- medication.status_reason (issue #159) -----------------------------------
+
+
+def _med(conn, name="Levothyroxine"):
+    return dict(conn.execute(
+        "SELECT * FROM medication WHERE name = ?", (name,)
+    ).fetchone())
+
+
+def test_commit_extraction_stores_the_discontinue_reason_verbatim(seeded):
+    """The reason survives commit with its source casing, on its own column - the whole
+    point of #159 is that it stops being reconstructible only from ocr_text."""
+    conn = seeded["conn"]
+    doc = _insert_document(conn, seeded["jane"].person_id, "bb22cc33dd44ee55")
+    dedup.commit_extraction(conn, doc, {"medication": [
+        {"name": "Levothyroxine", "dose": "50 mcg", "started_on": "2025-06-11",
+         "ended_on": "2026-06-11", "status": "discontinued",
+         "status_reason": "Substitution/Alternate Therapy Placed"},
+    ]})
+    assert _med(conn)["status_reason"] == "Substitution/Alternate Therapy Placed"
+
+
+def test_status_reason_is_editable_but_not_identity(seeded):
+    """`record edit` can set it (it is a non-key payload field), and doing so cannot
+    re-key the row - the property that keeps curation verdicts attached."""
+    conn = seeded["conn"]
+    assert "status_reason" in dedup.editable_fields("medication")
+    assert "status_reason" not in dedup.KEY_FIELDS["medication"]
+    row_id = _row_id(conn, "medication", "name", "Metformin")
+    before = _med(conn, "Metformin")["dedup_key"]
+    records.edit_record(conn, "medication", row_id, {"status_reason": "Reorder"},
+                        note="#159", apply=True)
+    after = _med(conn, "Metformin")
+    assert after["status_reason"] == "Reorder"
+    assert after["dedup_key"] == before
+
+
+def test_a_differing_status_reason_stages_a_conflict(seeded):
+    """Two documents disagreeing about *why* a med stopped is a real disagreement, so it
+    surfaces for review rather than deduping away (status_reason is in _COMPARE_FIELDS)."""
+    conn = seeded["conn"]
+    med = {"name": "Metformin", "dose": "500 mg", "started_on": "2025-06-01",
+           "status": "discontinued", "status_reason": "Reorder"}
+    first = _insert_document(conn, seeded["jane"].person_id, "cc33dd44ee55ff66")
+    dedup.commit_extraction(conn, first, {"medication": [med]})
+    second = _insert_document(conn, seeded["jane"].person_id, "dd44ee55ff66aa77")
+    summary = dedup.commit_extraction(conn, second, {
+        "medication": [{**med, "status_reason": "Therapy Completed"}],
+    })
+    assert summary.conflict, summary.counts
 
 
 # --- the module surface ------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `medication.status_reason` (migration 014, nullable `TEXT`) so a CCDA discontinue
  parenthetical (`Discontinued (Reorder)`, `(Therapy Completed)`, `(Patient Stopped Taking)`,
  `(Substitution/Alternate Therapy Placed)`) is stored verbatim instead of collapsing into the
  same `status = 'discontinued'` as every other reason.
- `pemr/dedup.py`: `status_reason` is an editable, comparable field (a differing reason on
  re-ingest stages a conflict) and is **not** a key field — identity/dedup untouched.
- `pemr/query.py`: `RENEWAL_MED_REASONS` (closed set: reorder/re-order/renewal/renewed) makes
  `med_is_current` treat a renewal as non-terminal — a renewed prescription's `ended_on` is the
  end of an authorization period, not the end of therapy, so it stays current under
  `query meds --active`. Any other reason, recognized or not, still ends the course (safe
  default for an unfamiliar EHR export).
- `pemr/cli.py`: `query meds` now prints `[discontinued: Reorder]` (bracket includes the reason
  when present) and `-> <ended_on> (renewed)` for a renewal row.
- Docs: `docs/Architecture.md` schema mirror + `query meds --active` contract, `AGENTS.md` §8
  (extraction rule for the two-field split, free-text rationale, conflict behavior, and the
  backfill gap below).

Closes #159

## Verify + audit reports
- Verify: https://github.com/meridun/pemr/issues/159#issuecomment-5308972032
- Audit: https://github.com/meridun/pemr/issues/159#issuecomment-5309017782

## Known gaps (non-blocking, carried from verify/audit — not fixed in this PR)
- **Backfill**: rows committed before migration 014 keep `status_reason IS NULL`. Not automated
  (matching an `ocr_text` line back to a committed row is a name/date heuristic over PHI); the
  recovery path (`pemr record edit medication <id> --set status_reason=...`) is documented in
  `AGENTS.md` §8 and was verified live (does not move `dedup_key`).
- **Two reader surfaces don't carry the new axis yet**: `render summary`'s Active Medications
  list shows a renewed drug as two indistinguishable lines with no `(renewed)` marker or end
  date, and `query timeline`'s `med-stop` event reads a renewal the same as a completed course.
  Neither is an AC failure (`render.py` was explicitly out of scope; `query timeline` is
  pre-existing, untouched code), but both are the natural next issue — flagging here per audit's
  request so it isn't lost once this closes.

## Test plan
- [x] Targeted: `pytest tests/test_query.py tests/test_db.py tests/test_records.py tests/test_ingest.py tests/test_cli_phase3.py tests/test_cli_phase2.py tests/test_render.py` — all pass (post-merge re-run)
- [x] Full suite (verify, pre-merge): `pytest` — 1332 passed
- [x] Real CCDA ingest -> commit -> `query meds`/`--active`/`--json`/`render summary` end-to-end (verify); pre-014 DB read + `pemr migrate` + `pemr restore` of a pre-014 snapshot (verify)
- [x] `npm run check:pii` clean (116 files), `npm run check:meta-drift` clean, `npm run sync:claude-config:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
