### PR TITLE
fix(curation): refuse cross-person record annotate --merged-into targets

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -132,7 +132,8 @@ CREATE TABLE curation (
   record_id        INTEGER NOT NULL DEFAULT 0,  -- 0 = family scope; else <record_type>_id
   status           TEXT NOT NULL,   -- confirmed|superseded|erroneous-in-source|disputed|merged-into|distinct
   note             TEXT NOT NULL,   -- required: the why, and who said so
-  merged_into_base TEXT,            -- set iff status = 'merged-into'; always a FAMILY
+  merged_into_base TEXT,            -- set iff status = 'merged-into'; always a FAMILY, and of the
+                                    -- SAME person unless --allow-cross-person (issue #161)
   attributed_to    TEXT,
   created_at       TEXT NOT NULL,   -- ISO8601 UTC
   PRIMARY KEY (record_type, dedup_base, record_id)
@@ -172,6 +173,15 @@ CREATE TABLE record_edit (
 );
 CREATE INDEX record_edit_row ON record_edit (record_type, record_id);
 ```
+
+A `merged_into_base` names a family **of the same person**. A `dedup_base` folds
+`person_id` in (§3), so two people's same-named facts never collide — which is exactly why
+an accidental cross-person merge is silent: the target family genuinely exists, so `verify`
+reports no orphan, while the fact leaves the annotated person's chart and never appears on
+the target person's. `record annotate` therefore refuses a cross-person `--merged-into`,
+and `record reaffirm` refuses the same shape at plan time (issue #161).
+`--allow-cross-person` is the explicit escape hatch for the rare deliberate case: never the
+default, and disclosed in the report (`cross_person`) rather than recorded silently.
 
 A correction is **not** a re-attribution. Before `record edit`, a wrong display field
 could only be repaired by re-submitting the row through `commit-extraction` (or deleting
@@ -1024,11 +1034,14 @@ pemr record edit <table> <id> --set NAME=VALUE [--set ...] --note <text>
                                                          # every change ledgered; dry run by default
 pemr record edit --list [<table>] [--json]               # recorded corrections, newest first (field: old -> new)
 pemr record annotate <table> <base-or-id> --status <s> --note <text> [--attributed-to ...]
-                     [--merged-into <base-or-id>] [--row] [--apply]
+                     [--merged-into <base-or-id>] [--allow-cross-person] [--row] [--apply]
                                                          # record a human verdict over a record FAMILY (§2 curation):
                                                          # confirmed|superseded|erroneous-in-source|disputed|merged-into|distinct
                                                          # distinct: two rows that recompute to one dedup_key are TWO facts
                                                          #        (generic extracted labels); unblocks `rekey`, both stay live
+                                                         # --merged-into must name a family of the SAME person; a cross-person
+                                                         #        merge is refused (the fact would leave one chart without
+                                                         #        appearing on the other) unless --allow-cross-person says so
                                                          # --row: scope it to that ROW only (a keep-both family holds
                                                          #        two live rows; row scope beats family scope there)
                                                          # pure overlay - no record row is mutated; dry run by default

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -1309,6 +1309,13 @@ def _print_curation_report(report: "curation.CurationReport") -> None:
         print(f"  attributed to: {report.attributed_to}")
     if report.merged_into_base:
         print(f"  merged into: {report.merged_into_base[:12]}")
+    if report.cross_person:
+        # Never silent (issue #161): the escape hatch was taken, so say so where the
+        # verdict itself is read back.
+        print(
+            "  cross-person merge: allowed by --allow-cross-person "
+            "(the target family belongs to a different person)"
+        )
     if report.previous is not None and report.action != "clear":
         print(f"  replaces: {curation.describe(report.previous)}")
 
@@ -1388,6 +1395,7 @@ def _cmd_record_annotate(args: argparse.Namespace) -> int:
             note=args.note,
             attributed_to=args.attributed_to,
             merged_into_base=args.merged_into,
+            allow_cross_person=args.allow_cross_person,
             row=args.row,
             apply=args.apply,
         )
@@ -1674,6 +1682,31 @@ def _plan_one_reaffirm(
                 f"merge target {str(to_merge_base)[:12]}... is not live - the map is "
                 "stale; re-run `pemr rekey --apply --json`"
             )
+        if to_merge_base != to_base:
+            # The #161 guard, refused in the *plan* rather than at write time: the batch
+            # is fully planned before any write, and a mid-batch `ValueError` out of
+            # `annotate_record` would stop the run after N partial writes. No `--map-file`
+            # key plumbs the override through - `rekey` never rewrites `person_id`, so a
+            # cross-person successor can only come from a hand-edited map, which deserves
+            # a refusal rather than an option.
+            if orphan.record_id:
+                ruled_id, ruled_slug = curation.row_person(
+                    conn, orphan.record_type, orphan.record_id
+                )
+            else:
+                ruled_id, ruled_slug = curation.family_person(
+                    conn, orphan.record_type, to_base
+                )
+            target_id, target_slug = curation.family_person(
+                conn, orphan.record_type, to_merge_base
+            )
+            if ruled_id is not None and target_id is not None and ruled_id != target_id:
+                return skip(
+                    f"the merge target belongs to a different person ({ruled_slug} -> "
+                    f"{target_slug}) - the fact would leave one chart without appearing "
+                    "on the other; re-rule it with `pemr record annotate ... "
+                    "--allow-cross-person` if that is genuinely intended"
+                )
         if to_merge_base == to_base and not orphan.record_id:
             # This rekey fused the ruled family into its own merge target. A family merged
             # into itself renders nowhere at all (`annotate_record` refuses it at family
@@ -3510,6 +3543,12 @@ def build_parser() -> argparse.ArgumentParser:
     r_annotate.add_argument(
         "--merged-into", metavar="BASE-OR-ID",
         help="target family, required with --status merged-into",
+    )
+    r_annotate.add_argument(
+        "--allow-cross-person", action="store_true",
+        help="allow --merged-into to name a family belonging to a DIFFERENT person "
+             "(refused by default: the fact would leave one chart without appearing "
+             "on the other)",
     )
     r_annotate.add_argument(
         "--list", action="store_true", help="list current verdicts and exit"

--- a/pemr/curation.py
+++ b/pemr/curation.py
@@ -234,6 +234,7 @@ class CurationReport:
     applied: bool = False
     record_id: int = FAMILY_SCOPE      # 0 = family scope; else the annotated row
     scope: str = SCOPE_FAMILY          # SCOPE_FAMILY | SCOPE_ROW (derived from record_id)
+    cross_person: bool = False         # a merge into another person's family, allowed
 
     def as_dict(self) -> dict:
         return {
@@ -253,6 +254,9 @@ class CurationReport:
             # only widen it (Architecture.md's additive-only rule).
             "record_id": self.record_id,
             "scope": self.scope,
+            # Appended, never inserted (#161): True only when --allow-cross-person
+            # actually permitted a merge across two people's families.
+            "cross_person": self.cross_person,
         }
 
 
@@ -587,6 +591,65 @@ def row_label(
     )
 
 
+def _person_slug(conn: sqlite3.Connection, person_id: int | None) -> str:
+    """``person.slug`` for one id, or ``""`` when it names nothing.
+
+    A plain SQL read rather than a :mod:`records`/:mod:`query` import: this module is
+    pinned to :mod:`db` + :mod:`dedup` (module docstring), and reaching for a helper
+    elsewhere would put a cycle in the import graph for one column.
+    """
+    if not person_id:
+        return ""
+    row = conn.execute(
+        "SELECT slug FROM person WHERE person_id = ?", (int(person_id),)
+    ).fetchone()
+    return str(row["slug"]) if row is not None else ""
+
+
+def family_person(
+    conn: sqlite3.Connection, record_type: str, base: str
+) -> tuple[int | None, str]:
+    """``(person_id, slug)`` for one family — read off occurrence 0.
+
+    A family is **single-person by construction**: :func:`dedup._key_parts` folds
+    ``person_id`` into every record type's identity tuple, so two people's same-named
+    facts never share a ``dedup_base``. That is exactly why an accidental cross-person
+    ``--merged-into`` is silent — nothing collides — and why the person has to be looked
+    up explicitly to catch one (issue #161).
+
+    An empty family reports ``(None, "")`` rather than raising, the :func:`family_label`
+    convention: an unknown person is not evidence of a cross-person merge.
+    """
+    _require_type(record_type)
+    family = dedup.load_family(conn, record_type, base)
+    if not family:
+        return None, ""
+    person_id = family[0]["person_id"]
+    if person_id is None:
+        return None, ""
+    return int(person_id), _person_slug(conn, int(person_id))
+
+
+def row_person(
+    conn: sqlite3.Connection, record_type: str, record_id: int
+) -> tuple[int | None, str]:
+    """:func:`family_person`'s row twin — the person off the annotated row itself.
+
+    Row scope rules on one occurrence, so its person comes from that row rather than
+    from occurrence 0 (the :func:`row_label` distinction). A removed row reports
+    ``(None, "")``.
+    """
+    _require_type(record_type)
+    pk = f"{record_type}_id"
+    row = conn.execute(
+        f"SELECT person_id FROM {record_type} WHERE {pk} = ?", (int(record_id),)
+    ).fetchone()
+    if row is None or row["person_id"] is None:
+        return None, ""
+    person_id = int(row["person_id"])
+    return person_id, _person_slug(conn, person_id)
+
+
 def resolve_base(conn: sqlite3.Connection, record_type: str, token: str) -> str:
     """Resolve a ``<base-or-id>`` token to a ``dedup_base`` in ``record_type``.
 
@@ -673,6 +736,7 @@ def annotate_record(
     note: str,
     attributed_to: str | None = None,
     merged_into_base: str | None = None,
+    allow_cross_person: bool = False,
     row: bool = False,
     now: str | None = None,
     apply: bool = False,
@@ -703,9 +767,24 @@ def annotate_record(
     here would make `pemr verify`'s "re-affirm it" notice impossible to follow for the
     one status that most often carries it.
 
-    Raises ``ValueError`` for an unknown ``record_type``/``status``/empty note or a bad
-    merge target, :class:`FamilyNotFoundError` when a family target does not resolve, and
-    :class:`RowNotFoundError` when a ``--row`` target does not.
+    The merge target must also belong to the **same person** as the annotated family or
+    row (issue #161), unless ``allow_cross_person=True``. A ``dedup_base`` is
+    person-scoped (:func:`dedup._key_parts` folds ``person_id`` in), so two people can
+    each hold a family with the same clinical label under different, unrelated bases:
+    nothing collides at dedup time, and a merge across them moves the fact out of one
+    person's chart without it ever appearing on the other's — silently, with `pemr verify`
+    seeing a live target and reporting no orphan. The check is skipped when the target
+    *is* the annotated family (the row-scope narrowing shape above — same person by
+    construction) and when either side's person is unknown (a removed row, an empty
+    family): an unknown person is not evidence of a mismatch, and refusing there would
+    break the orphan-repair paths this module exists to keep runnable.
+    ``allow_cross_person`` is a silent no-op on a same-person merge, and is refused —
+    like ``merged_into_base`` itself — on any other status.
+
+    Raises ``ValueError`` for an unknown ``record_type``/``status``/empty note, a bad
+    merge target or an unpermitted cross-person merge, :class:`FamilyNotFoundError` when
+    a family target does not resolve, and :class:`RowNotFoundError` when a ``--row``
+    target does not.
     """
     db.require_migrated(conn)
     _require_type(record_type)
@@ -726,6 +805,7 @@ def annotate_record(
         record_id, base = FAMILY_SCOPE, resolve_base(conn, record_type, token)
 
     merge_target = (merged_into_base or "").strip() or None
+    cross_person = False
     if status == "merged-into":
         if merge_target is None:
             raise ValueError(
@@ -739,9 +819,37 @@ def annotate_record(
                 "family renders only under its target, so this would hide it "
                 "entirely; nothing was written"
             )
+        # Whose fact is being merged, and whose family absorbs it (issue #161). Skipped
+        # for `merge_target == base` (a row absorbed into its own family, #116) - same
+        # person by construction, and no lookup should be able to disagree.
+        if merge_target != base:
+            if record_id:
+                ruled_id, ruled_slug = row_person(conn, record_type, record_id)
+            else:
+                ruled_id, ruled_slug = family_person(conn, record_type, base)
+            target_id, target_slug = family_person(conn, record_type, merge_target)
+            # Only a *known* mismatch refuses: an unknown person on either side (a
+            # removed row, an empty family) is not evidence of a cross-person merge, and
+            # refusing there would break the orphan-repair paths.
+            if ruled_id is not None and target_id is not None and ruled_id != target_id:
+                if not allow_cross_person:
+                    raise ValueError(
+                        f"cannot merge {record_type} {base[:12]}... ({ruled_slug}) into "
+                        f"{merge_target[:12]}... ({target_slug}) - the target family "
+                        f"belongs to a different person, so the fact would leave "
+                        f"{ruled_slug}'s chart without ever appearing on "
+                        f"{target_slug}'s; pass --allow-cross-person if that is "
+                        "genuinely intended; nothing was written"
+                    )
+                cross_person = True
     elif merge_target is not None:
         raise ValueError(
             f"--merged-into is only meaningful with status 'merged-into', not "
+            f"'{status}'; nothing was written"
+        )
+    elif allow_cross_person:
+        raise ValueError(
+            f"--allow-cross-person is only meaningful with status 'merged-into', not "
             f"'{status}'; nothing was written"
         )
 
@@ -756,6 +864,7 @@ def annotate_record(
         dedup_base=base,
         record_id=record_id,
         scope=SCOPE_ROW if record_id else SCOPE_FAMILY,
+        cross_person=cross_person,
         status=status,
         note=cleaned_note,
         attributed_to=(attributed_to or "").strip() or None,

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -2663,3 +2663,96 @@ def test_cli_reaffirm_mixed_batch_lands_what_it_can_and_names_the_rest(
     capsys.readouterr()
     assert _run(cli_ready, "verify") == 0
     assert "warnings       2" in capsys.readouterr().out
+
+
+# --- smoke: the cross-person merge accident, end to end through the CLI ------
+
+
+def _summary_section(tmp_path, slug, heading, capsys):
+    """The named `## <heading>` block of one person's rendered master summary."""
+    capsys.readouterr()
+    assert _run(tmp_path, "render", "summary", "--person", slug) == 0
+    body = capsys.readouterr().out.split(f"## {heading}\n", 1)[1]
+    return body.split("\n## ", 1)[0]
+
+
+def test_cli_smoke_walks_the_cross_person_merge_accident(cli_two_people, capsys):
+    """The reporter's story, driven entirely through the CLI (issue #161).
+
+    The unit tests prove the guard fires; this one earns the guard the way the
+    reporter found the bug — two people who each carry "Type 2 Diabetes", an
+    `annotate` that points one at the other, and a `render` showing what the
+    accident costs. The last two steps are the load-bearing ones: with
+    `--allow-cross-person` the fact really does leave jane's chart without ever
+    appearing on john's, and `pemr verify` really is clean while it happens, so the
+    refusal is the only thing standing between an operator and a silent loss.
+    """
+    jane = _cli_person_base(cli_two_people, "condition", "name", "Type 2 Diabetes",
+                            "jane-doe")
+    john = _cli_person_base(cli_two_people, "condition", "name", "Type 2 Diabetes",
+                            "john-doe")
+    jane_row = _cli_person_row_id(cli_two_people, "condition", "name",
+                                  "Type 2 Diabetes", "jane-doe")
+    john_row = _cli_person_row_id(cli_two_people, "condition", "name",
+                                  "Type 2 Diabetes", "john-doe")
+    # The premise: the same clinical label, two unrelated person-scoped bases, so
+    # nothing collides at dedup time and nothing warns.
+    assert jane != john
+
+    # 1. The accident, at family scope - refused in dry run *and* under --apply,
+    #    since the check is front-loaded ahead of every write.
+    for extra in ([], ["--apply"]):
+        capsys.readouterr()
+        assert _run(cli_two_people, "record", "annotate", "condition", jane,
+                    "--status", "merged-into", "--merged-into", john,
+                    "--note", "looks like the same dx", *extra) == 1
+        err = capsys.readouterr().err
+        assert err.startswith("error: ") and err.isascii()
+        assert "jane-doe" in err and "john-doe" in err
+        assert "--allow-cross-person" in err
+        assert "nothing was written" in err
+
+    # 2. The same accident at row scope, where the ruled person comes off the row.
+    capsys.readouterr()
+    assert _run(cli_two_people, "record", "annotate", "condition", str(jane_row),
+                "--row", "--status", "merged-into", "--merged-into", str(john_row),
+                "--note", "looks like the same dx", "--apply") == 1
+    assert "belongs to a different person" in capsys.readouterr().err
+    assert _cli_curation_count(cli_two_people) == 0
+
+    # 3. No collateral damage: jane's own same-person merge still lands, and her
+    #    chart still shows the condition the accident was aimed at.
+    prediabetes = _cli_person_base(cli_two_people, "condition", "name",
+                                   "Prediabetes", "jane-doe")
+    assert _run(cli_two_people, "record", "annotate", "condition", prediabetes,
+                "--status", "merged-into", "--merged-into", jane,
+                "--note", "progressed to the same dx", "--apply") == 0
+    assert "Type 2 Diabetes" in _summary_section(
+        cli_two_people, "jane-doe", "Active Problems", capsys)
+
+    # 4. What the guard is standing in front of: forced through with the escape
+    #    hatch, the fact leaves jane's chart and never arrives on john's...
+    capsys.readouterr()
+    assert _run(cli_two_people, "record", "annotate", "condition", jane,
+                "--status", "merged-into", "--merged-into", john,
+                "--note", "deliberate, for the smoke", "--allow-cross-person",
+                "--apply") == 0
+    assert "cross-person merge: allowed by --allow-cross-person" in (
+        capsys.readouterr().out)
+    jane_problems = _summary_section(cli_two_people, "jane-doe",
+                                     "Active Problems", capsys)
+    john_problems = _summary_section(cli_two_people, "john-doe",
+                                     "Active Problems", capsys)
+    assert "Type 2 Diabetes" not in jane_problems
+    assert john_problems.count("Type 2 Diabetes") == 1   # john's own row, not jane's
+
+    # ...and `verify` stays clean throughout, because the target family genuinely
+    # exists. Nothing in the database is broken; a fact simply stopped rendering.
+    capsys.readouterr()
+    assert _run(cli_two_people, "verify") == 0
+
+    # 5. And it is reversible: lifting the verdict restores jane's chart.
+    assert _run(cli_two_people, "record", "annotate", "condition", jane,
+                "--clear", "--apply") == 0
+    assert "Type 2 Diabetes" in _summary_section(
+        cli_two_people, "jane-doe", "Active Problems", capsys)

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -63,6 +63,38 @@ def seeded(conn):
     return {"conn": conn, "jane": jane, "doc": doc_id}
 
 
+@pytest.fixture()
+def two_people(conn):
+    """Jane and John each own a document holding the *same* facts (issue #161).
+
+    A ``dedup_base`` folds ``person_id`` in, so "Type 2 Diabetes" lands under two
+    different, unrelated bases here — nothing collides, which is precisely why a merge
+    across them is silent without an explicit person check.
+    """
+    jane = persons.add_person(conn, "jane-doe", "Jane Doe")
+    john = persons.add_person(conn, "john-doe", "John Doe")
+    jane_doc = _insert_document(conn, jane.person_id, "aa11bb22cc33dd44")
+    john_doc = _insert_document(conn, john.person_id, "bb22cc33dd44ee55")
+    dedup.commit_extraction(conn, jane_doc, RECORDS)
+    dedup.commit_extraction(conn, john_doc, RECORDS)
+    return {"conn": conn, "jane": jane, "john": john}
+
+
+def _person_row_id(conn, record_type, column, value, person_id):
+    return int(conn.execute(
+        f"SELECT {record_type}_id FROM {record_type} "
+        f"WHERE {column} = ? AND person_id = ?",
+        (value, person_id),
+    ).fetchone()[f"{record_type}_id"])
+
+
+def _person_base(conn, record_type, column, value, person_id):
+    return conn.execute(
+        f"SELECT dedup_base FROM {record_type} WHERE {column} = ? AND person_id = ?",
+        (value, person_id),
+    ).fetchone()["dedup_base"]
+
+
 def _row_id(conn, record_type, column, value):
     return int(conn.execute(
         f"SELECT {record_type}_id FROM {record_type} WHERE {column} = ?", (value,)
@@ -235,6 +267,175 @@ def test_merge_target_must_be_a_live_other_family(seeded):
             merged_into_base=base,
         )
     assert _curation_count(conn) == 0
+
+
+# --- the merge target's person (issue #161) -----------------------------------
+#
+# A dedup_base is person-scoped, so two people's same-named families never collide and a
+# merge across them is silent: the fact leaves one chart and appears on neither, while
+# `verify` sees a live target and reports no orphan.
+
+
+def _cross_person_bases(two_people):
+    """``(conn, jane's condition base, john's condition base)`` for the same label."""
+    conn = two_people["conn"]
+    return (
+        conn,
+        _person_base(conn, "condition", "name", "Type 2 Diabetes",
+                     two_people["jane"].person_id),
+        _person_base(conn, "condition", "name", "Type 2 Diabetes",
+                     two_people["john"].person_id),
+    )
+
+
+def test_the_same_fact_gets_a_different_base_per_person(two_people):
+    """The premise of the guard — without it nothing would need checking."""
+    _conn, jane_base, john_base = _cross_person_bases(two_people)
+    assert jane_base != john_base
+
+
+def test_annotate_merged_into_refuses_a_cross_person_target(two_people):
+    conn, jane_base, john_base = _cross_person_bases(two_people)
+    with pytest.raises(ValueError, match="belongs to a different person"):
+        curation.annotate_record(
+            conn, "condition", jane_base, status="merged-into",
+            note="same condition, two charts", merged_into_base=john_base, apply=True,
+        )
+    assert _curation_count(conn) == 0
+
+
+def test_annotate_cross_person_refusal_fires_in_dry_run(two_people):
+    """Validation is front-loaded, so the refusal is identical with and without
+    ``--apply`` — a dry run must not report a write that would be refused."""
+    conn, jane_base, john_base = _cross_person_bases(two_people)
+    with pytest.raises(ValueError, match="belongs to a different person"):
+        curation.annotate_record(
+            conn, "condition", jane_base, status="merged-into", note="x",
+            merged_into_base=john_base,
+        )
+    assert _curation_count(conn) == 0
+
+
+def test_annotate_cross_person_refusal_names_both_people(two_people):
+    conn, jane_base, john_base = _cross_person_bases(two_people)
+    with pytest.raises(ValueError) as exc:
+        curation.annotate_record(
+            conn, "condition", jane_base, status="merged-into", note="x",
+            merged_into_base=john_base,
+        )
+    message = str(exc.value)
+    assert "jane-doe" in message and "john-doe" in message
+    assert "--allow-cross-person" in message
+    assert "nothing was written" in message
+    assert message.isascii()
+
+
+def test_annotate_merged_into_refuses_cross_person_at_row_scope(two_people):
+    """Row scope resolves the ruled person off the *row*, not off occurrence 0."""
+    conn = two_people["conn"]
+    jane_row = _person_row_id(conn, "condition", "name", "Type 2 Diabetes",
+                              two_people["jane"].person_id)
+    john_row = _person_row_id(conn, "condition", "name", "Type 2 Diabetes",
+                              two_people["john"].person_id)
+    with pytest.raises(ValueError, match="belongs to a different person"):
+        curation.annotate_record(
+            conn, "condition", str(jane_row), row=True, status="merged-into",
+            note="x", merged_into_base=str(john_row), apply=True,
+        )
+    assert _curation_count(conn) == 0
+
+
+def test_annotate_allows_cross_person_merge_with_the_override(two_people):
+    """The check must not make a legitimate cross-person merge impossible — only
+    explicit."""
+    conn, jane_base, john_base = _cross_person_bases(two_people)
+    report = curation.annotate_record(
+        conn, "condition", jane_base, status="merged-into",
+        note="one person, two records in this database",
+        merged_into_base=john_base, allow_cross_person=True, apply=True,
+    )
+    assert report.cross_person is True
+    assert report.as_dict()["cross_person"] is True
+    stored = curation.get_verdict(conn, "condition", jane_base)
+    assert stored["merged_into_base"] == john_base
+    assert _curation_count(conn) == 1
+
+
+def test_annotate_same_person_merge_is_unchanged(two_people):
+    """No regression to the common case, nor to the report's key set (contract)."""
+    conn = two_people["conn"]
+    jane_id = two_people["jane"].person_id
+    base = _person_base(conn, "condition", "name", "Prediabetes", jane_id)
+    target = _person_base(conn, "condition", "name", "Type 2 Diabetes", jane_id)
+    report = curation.annotate_record(
+        conn, "condition", base, status="merged-into", note="evolved into the same dx",
+        merged_into_base=target, apply=True,
+    )
+    assert report.cross_person is False
+    assert set(report.as_dict()) == {
+        "record_type", "dedup_base", "status", "note", "attributed_to", "created_at",
+        "merged_into_base", "label", "family_size", "previous", "action", "applied",
+        "record_id", "scope", "cross_person",
+    }
+    assert curation.get_verdict(conn, "condition", base)["merged_into_base"] == target
+
+
+def test_annotate_allow_cross_person_is_a_no_op_on_a_same_person_merge(two_people):
+    """A redundant override never fails: scripted same-person annotates stay robust."""
+    conn = two_people["conn"]
+    jane_id = two_people["jane"].person_id
+    base = _person_base(conn, "condition", "name", "Prediabetes", jane_id)
+    target = _person_base(conn, "condition", "name", "Type 2 Diabetes", jane_id)
+    report = curation.annotate_record(
+        conn, "condition", base, status="merged-into", note="evolved",
+        merged_into_base=target, allow_cross_person=True, apply=True,
+    )
+    assert report.cross_person is False
+
+
+def test_annotate_row_merged_into_its_own_family_still_allowed(seeded):
+    """The #116 narrowing shape survives the new guard — the person check is skipped
+    when the target *is* the annotated family."""
+    conn = seeded["conn"]
+    row_id = _row_id(conn, "condition", "name", "Prediabetes")
+    base = _base(conn, "condition", "name", "Prediabetes")
+    report = curation.annotate_record(
+        conn, "condition", str(row_id), row=True, status="merged-into",
+        note="absorbed into its own family", merged_into_base=base, apply=True,
+    )
+    assert report.applied is True and report.cross_person is False
+    assert curation.get_verdict(
+        conn, "condition", base, record_id=row_id
+    )["merged_into_base"] == base
+
+
+def test_annotate_allow_cross_person_is_rejected_on_other_statuses(seeded):
+    """Mirrors the `--merged-into` flag rule sitting next to it."""
+    conn = seeded["conn"]
+    base = _base(conn, "condition", "name", "Prediabetes")
+    with pytest.raises(
+        ValueError, match="only meaningful with status 'merged-into'"
+    ):
+        curation.annotate_record(
+            conn, "condition", base, status="confirmed", note="x",
+            allow_cross_person=True, apply=True,
+        )
+    assert _curation_count(conn) == 0
+
+
+def test_person_lookups_report_an_unknown_person_rather_than_raising(two_people):
+    """The `family_label`/`row_label` convention: a gone family or row is described,
+    never raised on. That is what keeps the guard from refusing on absence — an unknown
+    person is not evidence of a mismatch, and refusing there would break the
+    orphan-repair paths this module exists to keep runnable."""
+    conn, jane_base, _john_base = _cross_person_bases(two_people)
+    jane_id = two_people["jane"].person_id
+    jane_row = _person_row_id(conn, "condition", "name", "Type 2 Diabetes", jane_id)
+    assert curation.family_person(conn, "condition", jane_base) == (
+        jane_id, "jane-doe")
+    assert curation.row_person(conn, "condition", jane_row) == (jane_id, "jane-doe")
+    assert curation.family_person(conn, "condition", "deadbeef" * 8) == (None, "")
+    assert curation.row_person(conn, "condition", 9999) == (None, "")
 
 
 def test_a_bad_verdict_never_overwrites_a_good_one(seeded):
@@ -1568,7 +1769,7 @@ def test_cli_annotate_json_shape_is_stable(cli_ready, capsys):
     expected = {
         "record_type", "dedup_base", "status", "note", "attributed_to",
         "created_at", "merged_into_base", "label", "family_size", "previous",
-        "action", "applied", "record_id", "scope",
+        "action", "applied", "record_id", "scope", "cross_person",
     }
     capsys.readouterr()
     assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
@@ -1625,6 +1826,86 @@ def test_cli_annotate_clear(cli_ready, capsys):
                 "--clear", "--apply") == 0
     assert "cleared curation verdict for lab_result" in capsys.readouterr().out
     assert _cli_curation_count(cli_ready) == 0
+
+
+@pytest.fixture()
+def cli_two_people(cli_ready):
+    """`cli_ready` plus John, holding the same facts under his own bases (issue #161)."""
+    assert _run(cli_ready, "person", "add", "--slug", "john-doe",
+                "--name", "John") == 0
+    scan = cli_ready / "scan2.txt"
+    scan.write_bytes(b"visit note for john: hba1c 5.7 percent, glucose 95")
+    assert _run(cli_ready, "ingest", str(scan), "--person", "john-doe",
+                "--sources", str(cli_ready / "sources"), "--ocr-text-file",
+                str(scan)) == 0
+    payload = cli_ready / "extract2.json"
+    payload.write_text(json.dumps(RECORDS), encoding="utf-8")
+    assert _run(cli_ready, "commit-extraction", "--document", "2",
+                "--json", str(payload)) == 0
+    return cli_ready
+
+
+def _cli_person_base(tmp_path, record_type, column, value, slug):
+    conn = _cli_conn(tmp_path)
+    try:
+        person_id = int(conn.execute(
+            "SELECT person_id FROM person WHERE slug = ?", (slug,)
+        ).fetchone()["person_id"])
+        return _person_base(conn, record_type, column, value, person_id)
+    finally:
+        conn.close()
+
+
+def _cli_person_row_id(tmp_path, record_type, column, value, slug):
+    conn = _cli_conn(tmp_path)
+    try:
+        person_id = int(conn.execute(
+            "SELECT person_id FROM person WHERE slug = ?", (slug,)
+        ).fetchone()["person_id"])
+        return _person_row_id(conn, record_type, column, value, person_id)
+    finally:
+        conn.close()
+
+
+def test_cli_annotate_cross_person_exits_1_and_writes_nothing(cli_two_people, capsys):
+    """The refusal reaches the operator as this codebase's usual friendly rc=1, naming
+    both people and the escape hatch."""
+    jane = _cli_person_base(cli_two_people, "condition", "name", "Type 2 Diabetes",
+                            "jane-doe")
+    john = _cli_person_base(cli_two_people, "condition", "name", "Type 2 Diabetes",
+                            "john-doe")
+    capsys.readouterr()
+
+    assert _run(cli_two_people, "record", "annotate", "condition", jane,
+                "--status", "merged-into", "--merged-into", john,
+                "--note", "same condition", "--apply") == 1
+    err = capsys.readouterr().err
+    assert err.startswith("error: ")
+    assert "jane-doe" in err and "john-doe" in err
+    assert "--allow-cross-person" in err and err.isascii()
+    assert _cli_curation_count(cli_two_people) == 0
+
+
+def test_cli_annotate_allow_cross_person_writes_and_discloses(cli_two_people, capsys):
+    jane = _cli_person_base(cli_two_people, "condition", "name", "Type 2 Diabetes",
+                            "jane-doe")
+    john = _cli_person_base(cli_two_people, "condition", "name", "Type 2 Diabetes",
+                            "john-doe")
+    capsys.readouterr()
+
+    assert _run(cli_two_people, "record", "annotate", "condition", jane,
+                "--status", "merged-into", "--merged-into", john,
+                "--note", "one person, filed twice", "--allow-cross-person",
+                "--json", "--apply") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["cross_person"] is True and payload["applied"] is True
+
+    assert _run(cli_two_people, "record", "annotate", "condition", jane,
+                "--status", "merged-into", "--merged-into", john,
+                "--note", "one person, filed twice", "--allow-cross-person") == 0
+    out = capsys.readouterr().out
+    assert "cross-person merge: allowed by --allow-cross-person" in out
+    assert _cli_curation_count(cli_two_people) == 1
 
 
 def test_cli_annotate_requires_table_and_target_unless_list(cli_ready):
@@ -2078,6 +2359,45 @@ def test_cli_reaffirm_skips_a_merge_target_with_no_successor(cli_ready, capsys):
                 "--apply") == 1
     assert "no successor for the merge target" in capsys.readouterr().out
     assert _cli_curation_rows(cli_ready) == before
+
+
+def test_cli_reaffirm_skips_a_cross_person_merge_target(cli_two_people, capsys):
+    """The #161 guard, refused in the *plan*: `annotate_record` would raise on this
+    successor, and a mid-batch raise would stop the run after N partial writes. No
+    `--map-file` key plumbs the override through — `rekey` never rewrites `person_id`,
+    so this state is only reachable from a hand-edited map."""
+    prediabetes = _cli_person_base(cli_two_people, "condition", "name", "Prediabetes",
+                                   "jane-doe")
+    diabetes = _cli_person_base(cli_two_people, "condition", "name",
+                                "Type 2 Diabetes", "jane-doe")
+    johns = _cli_person_base(cli_two_people, "condition", "name", "Type 2 Diabetes",
+                             "john-doe")
+    assert _run(cli_two_people, "record", "annotate", "condition", prediabetes,
+                "--status", "merged-into", "--merged-into", diabetes,
+                "--note", "evolved into the same dx", "--apply") == 0
+    # Remove the merge target's only row: the verdict is now a dangling-merge orphan.
+    assert _run(cli_two_people, "record", "rm", "condition",
+                str(_cli_person_row_id(cli_two_people, "condition", "name",
+                                       "Type 2 Diabetes", "jane-doe")),
+                "--apply") == 0
+
+    capsys.readouterr()
+    assert _run(cli_two_people, "record", "reaffirm", "--json") == 0
+    listed = json.loads(capsys.readouterr().out)
+    assert [e["kinds"] for e in listed] == [[curation.ORPHAN_DANGLING_MERGE]]
+    # Hand-edited: the successor named is the *other person's* family.
+    listed[0]["successor_merge_base"] = johns
+    mapped = cli_two_people / "hand-edited.json"
+    mapped.write_text(json.dumps(listed), encoding="utf-8")
+    before = _cli_curation_rows(cli_two_people)
+
+    assert _run(cli_two_people, "record", "reaffirm", "--map-file", str(mapped),
+                "--apply") == 1
+    out = capsys.readouterr().out
+    assert "belongs to a different person" in out
+    assert "jane-doe" in out and "john-doe" in out
+    assert "--allow-cross-person" in out
+    assert _cli_curation_rows(cli_two_people) == before
 
 
 def test_cli_reaffirm_skips_a_row_verdict_whose_row_is_gone(cli_ready, capsys):


### PR DESCRIPTION
## What shipped

`record annotate <type> <id> --status merged-into --merged-into <target>` resolved the
target purely by `dedup_base`, with no check that the target family's person matches the
annotated family's/row's person. Since `dedup_base` is a person-scoped hash, two people
carrying a condition with the same name got unrelated bases that never collided at
dedup time — so `annotate` would silently point one person's family at the other
person's. The fact disappeared from the annotated person's render with no error, and
`verify` reported clean (the target family genuinely existed, just under the wrong
person).

This closes that write path:

- `curation.annotate_record` gains `allow_cross_person: bool = False`. A `merged-into`
  verdict whose resolved target family belongs to a different (known) person is refused
  with a `ValueError` naming both people, placed before `get_verdict`/`CurationReport`
  construction so the refusal fires identically in dry run and under `--apply` — nothing
  is written either way. The `merge_target == base` row-into-own-family shape (#116)
  still short-circuits past the check.
- New `family_person` / `row_person` helpers (raw SQL against `person`, mirroring the
  existing `family_label`/`row_label` pair) keep `curation.py`'s `db` + `dedup`-only
  import graph intact.
- `CurationReport.cross_person: bool = False`, appended last to the dataclass and to
  `as_dict()` per the additive-only key-set rule — set `True` only when
  `--allow-cross-person` actually permitted a mismatch, so a deliberate cross-person
  merge leaves a trace instead of being as silent as the bug it replaces.
- `--allow-cross-person` on the `record annotate` CLI subparser, disclosed in the human
  report output. Refused (mirroring `--merged-into`'s own rule) when combined with a
  status other than `merged-into`; a silent no-op on an already-same-person merge.
- `record reaffirm`'s bulk write path (`_plan_one_reaffirm`) refuses the same shape at
  **plan** time (`action: "skip"`), so a batch can't abort mid-write; no new key in the
  `--map-file` contract, since `rekey` cannot itself produce a cross-person successor.
- `docs/Architecture.md` §2 (curation DDL comment + prose) and §5 (CLI usage line)
  document the rule and the escape hatch.
- 11 new tests in `tests/test_curation.py` (fixtures `two_people`/`cli_two_people`,
  synthetic `jane-doe`/`john-doe`) covering both scopes, dry-run refusal, message
  content, the override, the `--allow-cross-person` + wrong-status refusal, the
  same-person and #116 no-regression paths, the CLI surface, and the reaffirm skip.

**Out of scope** (unchanged from the reviewed plan): no sweep/repair of cross-person
`merged_into_base` values already stored before this fix — filed separately as #169.
No MCP surface change (`record annotate` stays CLI-only). No `--allow-cross-person` key
in the `record reaffirm --map-file` format.

## Reports

- Verify: https://github.com/meridun/pemr/issues/161#issuecomment-5309274250
- Audit: https://github.com/meridun/pemr/issues/161#issuecomment-5309307533 (clean, 3
  non-blocking advisories; advisory 3 filed as #169)

Full pipeline history (intake → design → build → verify → audit) is on issue #161.

Closes #161

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
