### PR TITLE
fix(render): bound the abnormal-labs summary section to 12 months (#165)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1188,6 +1188,14 @@ default to the same exclusion unless a human explicitly decides otherwise.
   the dictionary declares as one analyte is never split, and the whole-key match is tried
   before the per-component one — decomposition can only ever move an order from
   "renders" toward "suppressed", never take away a suppression that already worked.
+  `Abnormal Labs` is bounded to the last 12 months of the render's `now` (issue #165) —
+  unbounded it renders the entire abnormal history, where a live marker reads exactly like
+  one abnormal a decade ago — with a **keep-latest-per-analyte guard** that always retains
+  an analyte's most recent abnormal result however old it is. The guard is not politeness:
+  a fixed window alone renders the section *empty* for a person on a slow draw cadence,
+  and an empty section reads as "nothing flagged", which is worse than the dump it
+  replaces. Like the #128 order constants the window is a named constant, and the heading
+  text is built from it, so the stated window and the actual filter cannot desync.
 - **appointment brief** — for a given upcoming appointment: relevant history for that
   specialty, recent labs/imaging, current meds, med-interaction flags, suggested
   questions. This is your "walk-in readiness" as a repeatable command.
@@ -1236,7 +1244,7 @@ same fact is the intended behaviour.
 **Display-time unit canonicalisation** (issue #136) is a second read-time overlay, and it
 rests on exactly the same purity argument. When a person has recorded a canonical display
 unit for a measurement key (`person_unit_pref`, §2), `render summary` converts that key's
-Latest Vitals and Recent Abnormal Labs into it — value *and* reference interval together,
+Latest Vitals and Abnormal Labs into it — value *and* reference interval together,
 since a value in `lb` beside a `(ref ...)` still in kg is a clinical misread — and `trends`
 converts every point of the series **before** computing min/max/latest/slope, so the stats
 and the printed unit cannot disagree. Every converted number is disclosed where it prints

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -51,7 +51,7 @@ unmarked, like any other sourced fact.
 **Display units** (issue #136). A person may record one canonical display unit per
 measurement key (``person_unit_pref``, migration 013). ``render_summary`` reads that
 overlay the way it reads ``curation`` -- once, at the top -- and converts Latest Vitals
-and Recent Abnormal Labs into it, value and reference bounds together, disclosing every
+and Abnormal Labs into it, value and reference bounds together, disclosing every
 conversion with :func:`_unit_suffix`. The stored row is never touched, abnormality is
 still decided on stored values, and a person with no preference renders byte-identically
 to what they did before the overlay existed. Like curation, this is still a pure function
@@ -69,6 +69,7 @@ prints it correctly instead of ``?`` (issue #46). Literal vs. data are orthogona
 
 from __future__ import annotations
 
+import calendar
 import sqlite3
 from datetime import date, datetime
 
@@ -109,6 +110,17 @@ CONDITION_FAMILY = "family-history"
 # Default window for "recent labs" in an appointment brief (last N most recent).
 _BRIEF_RECENT_LABS = 10
 
+#: Age bound for the summary's abnormal-labs section (issue #165). Unlike
+#: `_BRIEF_RECENT_LABS` above this bounds *age*, not count: the summary is the document
+#: read between visits, and unbounded it renders the whole abnormal history -- on a real
+#: record 250 of 475 lines across 16 years, in which a marker abnormal now reads exactly
+#: like one abnormal a decade ago. 6 months was measured against real data and rejected:
+#: for a person on a slower draw cadence (most recent abnormal draw ~7 months old) it
+#: renders the section *empty*, and an empty section reads as "nothing flagged" -- a worse
+#: miss than the dump it bounds. The window controls volume; the keep-latest guard in
+#: `_abnormal_labs` controls that false-empty, which recurs at *any* fixed window.
+_ABNORMAL_LABS_WINDOW_MONTHS = 12
+
 
 class AppointmentNotFoundError(ValueError):
     """Raised when an appointment id does not resolve (friendly rc=1 at the CLI)."""
@@ -143,6 +155,19 @@ def _as_date(value: object) -> date | None:
         return date.fromisoformat(text)
     except ValueError:
         return None
+
+
+def _months_before(day: date, months: int) -> date:
+    """``day`` shifted back ``months`` calendar months, day-of-month clamped *down* to the
+    target month's last day (2028-02-29 -> 2027-02-28).
+
+    Never raises: like :func:`_as_date` this sits on a render path, so it resolves every
+    input to a real date rather than letting a leap day crash a summary.
+    """
+    index = (day.year * 12 + day.month - 1) - months
+    year, month = divmod(index, 12)
+    month += 1
+    return date(year, month, min(day.day, calendar.monthrange(year, month)[1]))
 
 
 def _generated_at(now: datetime | None) -> str:
@@ -839,8 +864,29 @@ def _order_line(row: dict) -> str:
 
 
 def _abnormal_labs(
-    conn: sqlite3.Connection, person_id: int, cur: "_CurationPass | None" = None
+    conn: sqlite3.Connection,
+    person_id: int,
+    today: str,
+    cur: "_CurationPass | None" = None,
 ) -> list[dict]:
+    """Abnormal results, newest first, bounded to the last
+    ``_ABNORMAL_LABS_WINDOW_MONTHS`` months of ``today`` (issue #165).
+
+    Four selection rules, applied in the query's newest-first order to rows the curation
+    overlay and :func:`_is_abnormal` have already decided on -- the window never
+    resurrects a row a verdict removed, and never changes what counts as abnormal:
+
+    * a row collected **on or after** the cutoff renders (the boundary is inclusive);
+    * the most recent abnormal result for an analyte (``test_name``) always renders, even
+      when it falls outside the window -- the *keep-latest guard*, without which a person
+      on a slow draw cadence sees an empty section while their marker is live and
+      abnormal;
+    * a row whose ``collected_at`` will not parse renders anyway: an undated row cannot be
+      *proven* stale, and the fail-open posture of :func:`_as_date` / :func:`_is_resulted`
+      holds here too -- a bad date must never silently empty a medical section. An
+      unparseable ``today`` skips the bound entirely, for the same reason;
+    * a future-dated row is untouched; only the old side is bounded.
+    """
     rows = conn.execute(
         # lab_result_id DESC breaks same-timestamp ties (a `--keep both` sibling shares
         # its date): newest-first ordering treats the later row id as the later point.
@@ -849,7 +895,22 @@ def _abnormal_labs(
         (person_id,),
     ).fetchall()
     kept = _apply_curation([dict(r) for r in rows], "lab_result", cur)
-    return [r for r in kept if _is_abnormal(r)]
+    abnormal = [r for r in kept if _is_abnormal(r)]
+    anchor = _as_date(today)
+    if anchor is None:
+        return abnormal
+    start = _months_before(anchor, _ABNORMAL_LABS_WINDOW_MONTHS)
+    # Filtered in place, never re-sorted: the query's ordering is load-bearing both for
+    # the same-date sibling rule (#58) and for "first row seen for an analyte" being that
+    # analyte's most recent -- which is what makes the guard a single pass.
+    out: list[dict] = []
+    seen: set[str] = set()
+    for row in abnormal:
+        when = _as_date(row["collected_at"])
+        if when is None or when >= start or row["test_name"] not in seen:
+            out.append(row)
+        seen.add(row["test_name"])
+    return out
 
 
 def _open_appointments(
@@ -1019,7 +1080,7 @@ def render_summary(
         )
 
     lab_lines = []
-    for r in _abnormal_labs(conn, person_id, cur):
+    for r in _abnormal_labs(conn, person_id, today, cur):
         d = units.display(
             r["value_num"], r["unit"], _target_unit(prefs, r["test_name"], dictionary)
         )
@@ -1045,7 +1106,11 @@ def render_summary(
         _section("Allergies", allergy_lines),
         _section("Orders & Referrals", order_lines),
         _section("Latest Vitals", vital_lines),
-        _section("Recent Abnormal Labs", lab_lines, empty="_none flagged_"),
+        _section(
+            f"Abnormal Labs (last {_ABNORMAL_LABS_WINDOW_MONTHS} months)",
+            lab_lines,
+            empty="_none flagged_",
+        ),
         _section("Upcoming / Open Appointments", appt_lines),
         _section(
             "Open Conflicts", _open_conflict_lines(conn, person_id), empty="_none_"

--- a/tests/test_cli_phase4.py
+++ b/tests/test_cli_phase4.py
@@ -3,11 +3,12 @@ stdout (the §5 redirect contract), --out file convenience, unknown-slug/appoint
 rc=1, and unmigrated-DB friendliness."""
 
 import json
+from datetime import date, timedelta
 from pathlib import Path
 
 import pytest
 
-from pemr import cli, db, dedup, persons
+from pemr import cli, db, dedup, persons, render
 
 DICT_PATH = str(
     Path(__file__).resolve().parent.parent / "data" / "dictionary.example.toml"
@@ -291,6 +292,71 @@ def test_render_summary_keeps_panel_order_with_unreadable_component_end_to_end(
     ).fetchone()["n"] == 3
     conn.close()
     assert out.isascii()
+
+
+def test_render_summary_abnormal_labs_are_age_bounded_end_to_end(tmp_path, capsys):
+    """Issue #165 walked through the real command. The CLI injects no `now`, so this is
+    the one place the section is exercised against the wall clock the way a real record
+    ages -- rows are dated relative to today, not to a pinned datetime.
+
+    All four selection rules at once: an in-window draw renders, a stale draw of an
+    analyte that also has a recent one does not, and an analyte whose *only* abnormal
+    draw is years old still renders -- the keep-latest guard, without which a person on
+    a slow draw cadence reads as "nothing flagged" while the marker is live.
+
+    The boundary rows sit a day inside and two days outside the cutoff rather than on it:
+    the exact inclusive edge is pinned in `test_summary_abnormal_labs_window_edges_are_exact`,
+    which can pin `now`, and this test must stay green across a midnight crossing between
+    its own `date.today()` and the render's.
+    """
+    assert _run(tmp_path, "migrate", "--create") == 0
+    assert _run(tmp_path, "person", "add", "--slug", "jane-doe",
+                "--name", "Jane Doe", "--dob", "1980-01-01") == 0
+    today = date.today()
+    cutoff = render._months_before(today, render._ABNORMAL_LABS_WINDOW_MONTHS)
+    recent, edge = today - timedelta(days=10), cutoff + timedelta(days=1)
+    stale, ancient = cutoff - timedelta(days=2), cutoff - timedelta(days=300)
+    _commit_labs(tmp_path, "sha-window-labs", [
+        # LDL: a current draw plus the decade-old history the section used to dump
+        {"test_name": "LDL", "collected_at": recent.isoformat(),
+         "value_num": 161, "unit": "mg/dL", "flag": "H"},
+        {"test_name": "LDL", "collected_at": ancient.isoformat(),
+         "value_num": 158, "unit": "mg/dL", "flag": "H"},
+        # Glucose: a recent draw holds the guard open, so the two older rows test the
+        # window itself rather than being retained as the analyte's latest
+        {"test_name": "Glucose", "collected_at": edge.isoformat(),
+         "value_num": 210, "unit": "mg/dL", "flag": "H"},
+        {"test_name": "Glucose", "collected_at": stale.isoformat(),
+         "value_num": 205, "unit": "mg/dL", "flag": "H"},
+        # TSH: slow cadence, only abnormal draw is out of window -> keep-latest
+        {"test_name": "TSH", "collected_at": ancient.isoformat(),
+         "value_num": 9.4, "unit": "uIU/mL", "flag": "H"},
+        # normal and in window: never in this section at any window
+        {"test_name": "HbA1c", "collected_at": (today - timedelta(days=5)).isoformat(),
+         "value_num": 5.4, "unit": "%", "ref_low": 4.0, "ref_high": 5.7},
+    ])
+    capsys.readouterr()
+
+    assert _run(tmp_path, "render", "summary", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    # heading built from the same constant that drives the filter -- they cannot desync
+    heading = f"## Abnormal Labs (last {render._ABNORMAL_LABS_WINDOW_MONTHS} months)"
+    assert heading in out
+    assert "## Abnormal Labs (last 12 months)" in out
+    section = out.split(heading)[1].split("\n## ")[0]
+    bullets = [ln for ln in section.splitlines() if ln.startswith("- ")]
+    assert [ln.split()[1:3] for ln in bullets] == [
+        [recent.isoformat(), "LDL"],           # in window
+        [edge.isoformat(), "Glucose"],         # in window, a day inside the cutoff
+        [ancient.isoformat(), "TSH"],          # keep-latest: not a false-empty
+    ]
+    assert stale.isoformat() not in section    # aged out
+    assert "HbA1c" not in section              # normal, window is not what excludes it
+    assert out.isascii()                       # cp1252/cp437 console contract
+    # render-only: every aged-out row is still in the database
+    conn = db.connect(tmp_path / "cli.db")
+    assert conn.execute("SELECT COUNT(*) AS n FROM lab_result").fetchone()["n"] == 6
+    conn.close()
 
 
 def test_render_on_unmigrated_db_is_friendly(tmp_path, capsys, unmigrated_db):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -5,7 +5,7 @@ abnormal-lab selection, latest-vitals pick, brief scoping, journal ordering + pr
 footnotes, ASCII output (cp1252/cp437 console lesson), and the read-only guarantee
 (no row-count change after any render)."""
 
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 
 import pytest
@@ -628,6 +628,13 @@ def test_summary_orders_comma_bearing_name_suppresses_without_a_dictionary(seede
     assert "cervical collar" in section
 
 
+def _abnormal_section(md):
+    """The abnormal-labs section body. Split on the constant-built heading (#165) so a
+    change to the window can't leave these tests silently matching nothing."""
+    heading = f"## Abnormal Labs (last {render._ABNORMAL_LABS_WINDOW_MONTHS} months)"
+    return md.split(heading)[1].split("\n## ")[0]
+
+
 def test_summary_latest_vitals_pick(seeded):
     md = render.render_summary(seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH))
     assert "blood_pressure: 118.0 mmHg" in md   # most recent per key
@@ -636,8 +643,10 @@ def test_summary_latest_vitals_pick(seeded):
 
 
 def test_summary_abnormal_lab_selection(seeded):
-    md = render.render_summary(seeded, "jane-doe")
-    section = md.split("## Recent Abnormal Labs")[1].split("##")[0]
+    # `now` is pinned because the section is age-bounded (#165): unpinned, this test
+    # would start reading the wall clock and drift out of window in real 2027.
+    md = render.render_summary(seeded, "jane-doe", now=_NOW)
+    section = _abnormal_section(md)
     assert "LDL" in section          # flagged abnormal
     assert "Glucose" in section      # outside ref_high
     assert "HbA1c" not in section    # within ref range
@@ -659,9 +668,121 @@ def test_summary_same_date_lab_siblings_order_by_row_id(seeded):
     admitted = dedup.resolve_conflict(seeded, conflict_id, keep="both")
     assert admitted.occurrence == 1
 
-    md = render.render_summary(seeded, "jane-doe", dictionary=d)
-    section = md.split("## Recent Abnormal Labs")[1].split("##")[0]
+    # Pinned for #165: the two siblings are one analyte, so once 2026-01-01 ages out the
+    # keep-latest guard would retain only the newer and this ordering assertion would
+    # silently stop testing an ordering at all.
+    md = render.render_summary(seeded, "jane-doe", dictionary=d, now=_NOW)
+    section = _abnormal_section(md)
     assert section.index("320.0") < section.index("200.0")
+
+
+# --- abnormal labs: the 12-month window + keep-latest guard (issue #165) -------
+#
+# The section is bounded by *age*, so every test here pins `now`. jane's seeded abnormal
+# rows are LDL 2025-01-01 (flag H) and Glucose, fasting 2026-01-01 (over ref_high); HbA1c
+# 2024-01-01 and TSH 2023-01-01 are normal and never in the section at any window.
+
+def _abnormal_for(conn, slug="jane-doe", *, now):
+    return _abnormal_section(render.render_summary(conn, slug, now=now))
+
+
+def test_summary_abnormal_labs_window_edges_are_exact(seeded):
+    """The cutoff is a hard, inclusive `today - 12 months`, pinned on both edges so a
+    later widening is a deliberate edit rather than a drift. Each analyte also carries a
+    recent in-window abnormal, which is what stops the keep-latest guard from masking the
+    drop -- without it the older row would be retained as the analyte's latest and the
+    boundary would go untested."""
+    d = dedup.load_dictionary(DICT_PATH)
+    now = datetime(2026, 6, 1)                       # cutoff: 2025-06-01, inclusive
+    dedup.commit_extraction(seeded, _doc(seeded, "john-doe"), {"lab_result": [
+        {"test_name": "Ferritin", "collected_at": "2026-05-01", "value_num": 900,
+         "unit": "ng/mL", "flag": "H"},              # recent: holds the guard
+        {"test_name": "Ferritin", "collected_at": "2025-06-01", "value_num": 800,
+         "unit": "ng/mL", "flag": "H"},              # exactly on the cutoff: kept
+        {"test_name": "Ceruloplasmin", "collected_at": "2026-05-01", "value_num": 60,
+         "unit": "mg/dL", "flag": "H"},              # recent: holds the guard
+        {"test_name": "Ceruloplasmin", "collected_at": "2025-05-31", "value_num": 55,
+         "unit": "mg/dL", "flag": "H"},              # cutoff - 1 day: dropped
+    ]}, d)
+    section = _abnormal_for(seeded, "john-doe", now=now)
+    assert "900" in section and "800" in section     # on the boundary still renders
+    assert "60.0" in section
+    assert "55.0" not in section                     # one day past it does not
+
+
+def test_summary_abnormal_labs_keep_latest_prevents_false_empty(seeded):
+    """AC2 and the reason the window alone is not enough: with every abnormal draw older
+    than the window, the section must still name each abnormal analyte once. An empty
+    section reads as "nothing flagged" while the markers are live -- a worse miss than
+    the unbounded dump this bounds."""
+    section = _abnormal_for(seeded, now=datetime(2030, 1, 1))
+    assert "_none flagged_" not in section
+    assert "LDL" in section and "Glucose" in section
+    assert "HbA1c" not in section and "TSH" not in section   # normal stays normal
+    # One row per analyte: the guard retains the latest, not the history.
+    assert len([ln for ln in section.splitlines() if ln.startswith("- ")]) == 2
+
+
+def test_summary_abnormal_labs_mixes_in_window_rows_with_keep_latest(seeded):
+    """AC3: an analyte with in-window abnormals shows those (and drops its superseded
+    older rows), while an analyte whose only abnormals are out of window is still
+    represented by its most recent one."""
+    d = dedup.load_dictionary(DICT_PATH)
+    now = datetime(2026, 6, 1)                       # cutoff: 2025-06-01
+    dedup.commit_extraction(seeded, _doc(seeded, "john-doe"), {"lab_result": [
+        {"test_name": "Ferritin", "collected_at": "2026-05-01", "value_num": 900,
+         "unit": "ng/mL", "flag": "H"},              # in window
+        {"test_name": "Ferritin", "collected_at": "2019-01-01", "value_num": 700,
+         "unit": "ng/mL", "flag": "H"},              # superseded and stale: dropped
+        {"test_name": "Ceruloplasmin", "collected_at": "2018-01-01", "value_num": 55,
+         "unit": "mg/dL", "flag": "H"},              # only abnormal, stale: kept
+    ]}, d)
+    section = _abnormal_for(seeded, "john-doe", now=now)
+    assert "900" in section                          # in-window row
+    assert "55.0" in section                         # keep-latest for its analyte
+    assert "700" not in section                      # not resurrected by the guard
+
+
+def test_summary_abnormal_labs_heading_states_the_window(seeded):
+    """AC4: the window is self-documenting, and the heading is built from the same
+    constant that drives the filter so the two cannot desync."""
+    md = render.render_summary(seeded, "jane-doe", now=_NOW)
+    assert "## Abnormal Labs (last 12 months)" in md
+    assert (
+        f"## Abnormal Labs (last {render._ABNORMAL_LABS_WINDOW_MONTHS} months)" in md
+    )
+
+
+def test_summary_abnormal_labs_undated_row_is_never_aged_out(seeded):
+    """Fail-open, mirroring `_is_resulted`: a `collected_at` that will not parse cannot
+    be *proven* stale, so it renders rather than being silently dropped -- a bad date must
+    never empty a medical section."""
+    seeded.execute(
+        "UPDATE lab_result SET collected_at = 'not-a-date' WHERE test_name = 'LDL' "
+        "AND person_id = (SELECT person_id FROM person WHERE slug = 'jane-doe')"
+    )
+    seeded.commit()
+    assert "LDL" in _abnormal_for(seeded, now=datetime(2030, 1, 1))
+
+
+def test_summary_abnormal_labs_unparseable_now_skips_the_bound(seeded):
+    """Same posture one level up: if the render's own date will not parse there is no
+    cutoff to apply, so the section falls back to every abnormal row."""
+    pid = seeded.execute(
+        "SELECT person_id FROM person WHERE slug = 'jane-doe'"
+    ).fetchone()["person_id"]
+    unbounded = render._abnormal_labs(seeded, pid, "")
+    assert unbounded == render._abnormal_labs(seeded, pid, "not-a-date")
+    # 2025's LDL is a year and a half stale at any plausible clock, and still renders.
+    assert [r["test_name"] for r in unbounded] == ["Glucose, fasting", "LDL"]
+
+
+def test_months_before_clamps_a_short_target_month():
+    """The leap-day case: 12 months before 2028-02-29 is 2027-02-28, not a ValueError."""
+    assert render._months_before(date(2028, 2, 29), 12) == date(2027, 2, 28)
+    assert render._months_before(date(2026, 3, 31), 1) == date(2026, 2, 28)
+    assert render._months_before(date(2026, 1, 15), 12) == date(2025, 1, 15)
+    assert render._months_before(date(2026, 1, 15), 13) == date(2024, 12, 15)
 
 
 def test_summary_upcoming_and_open_appointments(seeded):
@@ -711,7 +832,7 @@ def test_summary_empty_sections_are_explicit(seeded):
     assert "## Orders & Referrals" in md
     order_section = md.split("## Orders & Referrals")[1].split("##")[0]
     assert "_none recorded_" in order_section  # no orders -> explicit empty state
-    assert "## Recent Abnormal Labs" in md  # john has an abnormal LDL, so it appears
+    assert "## Abnormal Labs (last 12 months)" in md  # john's abnormal LDL appears
     assert "999" in md
 
 


### PR DESCRIPTION
## Summary

`_abnormal_labs` (`pemr/render.py`) selected every abnormal `lab_result` row for a person with
no date bound, so the summary's **Abnormal Labs** section rendered the entire abnormal history
(on a real dataset: 250 of 475 lines, spanning 16 years). This bounds it to a 12-month window on
`collected_at`, with a keep-latest guard so an analyte whose only abnormal draw predates the
window is never silently dropped (false-empty).

- New constant `_ABNORMAL_LABS_WINDOW_MONTHS = 12` and helper `_months_before` (`pemr/render.py`).
- `_abnormal_labs` gains a `today` parameter (mirroring `_open_appointments`) and filters to:
  in-window (inclusive boundary) OR the analyte's most-recent abnormal result (keep-latest guard)
  OR an unparseable `collected_at` (fail-open — a bad date must not silently empty a medical
  section). `_is_abnormal`, the `[H]`/`[L]` flag, and ref-range comparison are unchanged.
- **User-visible change:** the section heading changes from `## Recent Abnormal Labs` to
  `## Abnormal Labs (last 12 months)`. Any downstream consumer splitting on the old heading
  string breaks.
- `docs/Architecture.md` updated: the window + keep-latest guard are documented in the §6
  master-summary bullet (why 12 and not 6 — a 6-month window renders a false-empty section for a
  slow-cadence patient), plus the name-only heading rename.
- Real-run validation (verify): against a synthetic person with a 16-year, 33-draw LDL history,
  a Glucose pair straddling the cutoff, and a slow-cadence TSH whose only abnormal draw is ~21
  months old, the summary dropped from 81 to 49 lines / the section from 40 to 8 lines, correctly
  retaining the boundary-exact row, dropping the cutoff-minus-one-day row, and keeping the
  out-of-window TSH via the guard.

`_BRIEF_RECENT_LABS` / the brief's count-based cap is explicitly out of scope.

Closes #165

## Test plan
- [x] `pytest` full suite green (1370 passed, verify stage)
- [x] `pytest tests/test_render.py tests/test_cli_phase4.py` green at audit HEAD (104 passed)
- [x] New unit coverage: window boundary edges (inclusive cutoff), keep-latest false-empty guard,
      mixed in/out-of-window rows, heading/constant consistency, undated-row fail-open,
      unparseable-`today` fail-open, `_months_before` leap-day clamp
- [x] New end-to-end CLI smoke: `test_render_summary_abnormal_labs_are_age_bounded_end_to_end`
- [x] Real-run diff against `dev` on the same DB (verify stage — see report below)
- [x] `node scripts/pii-scan.mjs` clean; `node scripts/check-meta-drift.mjs` passed
- [x] Invariants forced, not assumed: read-only render (DB hash unchanged), pure function of
      DB state + injected `now` (byte-identical consecutive renders), ASCII-only output,
      curation precedes window/guard (forced via `record annotate` + re-render)

Verify report: https://github.com/meridun/pemr/issues/165#issuecomment-5309796710
Audit report: https://github.com/meridun/pemr/issues/165#issuecomment-5309818475

🤖 Generated with [Claude Code](https://claude.com/claude-code)