### PR TITLE
feat(render): add a filtered Procedures section to the master summary (#166)

### DIFF
--- a/data/dictionary.example.toml
+++ b/data/dictionary.example.toml
@@ -302,3 +302,40 @@
 "oxygen saturation" = "spo2"
 "respiratory rate" = "respiratory_rate"
 "resp rate" = "respiratory_rate"
+
+# =============================================================================
+# Routine procedures — the master summary's ## Procedures filter (issue #166).
+#
+# THIS TABLE MUST STAY AT THE END OF THE FILE. `[synonyms]` above runs to EOF, so a
+# table header inserted anywhere above it would silently swallow every synonym key
+# that follows into this table and empty the synonym map.
+#
+# `procedure` rows arrive largely from billing documents, so the table mixes genuine
+# procedural history with routine service lines. `pemr render summary` hides a
+# procedure whose name matches one of these patterns; `pemr render journal` and
+# `pemr render brief` are unaffected and stay the complete record. Nothing is
+# deleted — the filter is render-only, and the summary discloses how many rows it hid.
+#
+# Rules:
+#   * DEFAULT-SHOW. A procedure matching no pattern always renders. Significance is
+#     never established by absence from this list, so a procedure type nobody
+#     anticipated cannot be dropped silently. The list can only SUPPRESS.
+#   * Patterns are name fragments matched on TOKEN BOUNDARIES after the same
+#     lowercase/trim/collapse normalization the keys above use, so "cast" suppresses
+#     "Cast application, short arm" but never "Castration". Boundaries are exact:
+#     "radiograph" does not match "radiographs", so add a plural spelling of its own
+#     when your documents use one.
+#   * RENDER-ONLY. Unlike [synonyms], nothing here touches dedup identity — adding or
+#     removing a pattern changes no stored row and does NOT require `pemr rekey`.
+#   * An absent table or an empty list suppresses nothing.
+[procedures]
+routine = [
+  "office visit",
+  "established patient",
+  "venipuncture",
+  "blood draw",
+  "radiograph",
+  "x-ray",
+  "cast application",
+  "cast removal",
+]

--- a/data/dictionary.example.toml
+++ b/data/dictionary.example.toml
@@ -325,6 +325,11 @@
 #     "Cast application, short arm" but never "Castration". Boundaries are exact:
 #     "radiograph" does not match "radiographs", so add a plural spelling of its own
 #     when your documents use one.
+#   * Normalization ALSO STRIPS PARENTHETICALS on both the stored name and the pattern
+#     (same qualifier-stripping norm() applies everywhere else). "cast application"
+#     therefore also suppresses "Cast application (open reduction internal fixation)",
+#     and a pattern written entirely inside parentheses (e.g. "(routine)") normalizes
+#     to an empty string and matches nothing.
 #   * RENDER-ONLY. Unlike [synonyms], nothing here touches dedup identity — adding or
 #     removing a pattern changes no stored row and does NOT require `pemr rekey`.
 #   * An absent table or an empty list suppresses nothing.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1196,6 +1196,19 @@ default to the same exclusion unless a human explicitly decides otherwise.
   and an empty section reads as "nothing flagged", which is worse than the dump it
   replaces. Like the #128 order constants the window is a named constant, and the heading
   text is built from it, so the stated window and the actual filter cannot desync.
+  `Procedures` (issue #166) lists `procedure` rows reverse-chronologically, undated last,
+  narrowed by a routine-pattern list authored in `dictionary.toml` (`[procedures].routine`)
+  — those rows arrive largely from billing documents, so the table mixes genuine
+  procedural history with routine service lines (office visits, serial radiographs,
+  venipuncture) and rendering all of them recreates the unreadable-section problem #165
+  bounds. The list is **default-show** (a name matching no pattern always renders, so
+  significance is never established by absence from a list), **suppress-only and
+  summary-only** (the brief and the journal stay the complete record and no stored row
+  changes), and **disclosed** — the section states how many rows it hid, on #93's
+  precedent. Matching is token-boundary on normalized text, both sides, so `cast` cannot
+  suppress `Castration`: over-suppression is the failure that matters here, and
+  under-suppression only costs a line. Unlike `[synonyms]` the list never reaches a dedup
+  key, so editing it needs no `pemr rekey`.
 - **appointment brief** — for a given upcoming appointment: relevant history for that
   specialty, recent labs/imaging, current meds, med-interaction flags, suggested
   questions. This is your "walk-in readiness" as a repeatable command.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1207,8 +1207,11 @@ default to the same exclusion unless a human explicitly decides otherwise.
   changes), and **disclosed** — the section states how many rows it hid, on #93's
   precedent. Matching is token-boundary on normalized text, both sides, so `cast` cannot
   suppress `Castration`: over-suppression is the failure that matters here, and
-  under-suppression only costs a line. Unlike `[synonyms]` the list never reaches a dedup
-  key, so editing it needs no `pemr rekey`.
+  under-suppression only costs a line. Normalization also strips parenthetical qualifiers
+  on both sides, so `cast application` also suppresses `Cast application (open reduction
+  internal fixation)`, and a pattern written entirely inside parentheses matches nothing.
+  Unlike `[synonyms]` the list never reaches a dedup key, so editing it needs no
+  `pemr rekey`.
 - **appointment brief** — for a given upcoming appointment: relevant history for that
   specialty, recent labs/imaging, current meds, med-interaction flags, suggested
   questions. This is your "walk-in readiness" as a repeatable command.

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -2963,8 +2963,16 @@ def _render_with_conn(args: argparse.Namespace, work) -> int:
 
 def _cmd_render_summary(args: argparse.Namespace) -> int:
     def work(conn):
-        dictionary = dedup.load_dictionary(_resolve_dictionary_path(args))
-        markdown = render.render_summary(conn, args.person, dictionary=dictionary)
+        # One resolved path, two overlays read from it: the synonym map and the
+        # render-only routine-procedure list (issue #166). No new flag -- `--dictionary` /
+        # `PEMR_DICTIONARY` / `[paths].dictionary_file` already select the file.
+        path = _resolve_dictionary_path(args)
+        markdown = render.render_summary(
+            conn,
+            args.person,
+            dictionary=dedup.load_dictionary(path),
+            routine_procedures=dedup.load_routine_procedures(path),
+        )
         return _emit_markdown(markdown, args.out)
 
     return _render_with_conn(args, work)
@@ -3794,7 +3802,11 @@ def build_parser() -> argparse.ArgumentParser:
         "summary", help="master summary for a person -> Markdown on stdout"
     )
     r_summary.add_argument("--person", required=True, help="owner slug")
-    r_summary.add_argument("--dictionary", help="synonym dictionary TOML (overrides default)")
+    r_summary.add_argument(
+        "--dictionary",
+        help="synonym dictionary TOML (overrides default); also supplies the "
+             "[procedures].routine list the Procedures section narrows against",
+    )
     r_summary.add_argument("--out", help="write to file instead of stdout")
     r_summary.set_defaults(func=_cmd_render_summary)
 

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -257,6 +257,45 @@ def load_dictionary(path: str | Path | None) -> dict[str, str]:
     return {_collapse(str(k)): str(v).strip() for k, v in raw.items()}
 
 
+def load_routine_procedures(path: str | Path | None) -> tuple[str, ...]:
+    """Load the routine-procedure pattern list (``[procedures].routine``) from the same
+    TOML file :func:`load_dictionary` reads (issue #166).
+
+    Returns the patterns :func:`norm`-normalized (no dictionary -- see below), blanks
+    dropped, duplicates dropped, authoring order preserved. ``None``, a missing file, an
+    absent ``[procedures]`` table and an absent/empty ``routine`` key all give ``()`` --
+    the empty list suppresses nothing, which is the whole point of the default-show rule
+    the render side implements.
+
+    **Render-only.** These patterns narrow the master summary's ``## Procedures`` section
+    and nothing else: they never reach :func:`dedup_key`/:func:`key_token`, no stored row
+    depends on them, and `pemr rekey` must ignore this table entirely. It lives in
+    ``dictionary.toml`` because that is the project's one human-curated naming file, not
+    because it participates in identity.
+
+    Normalization runs **without** the synonym dictionary on purpose: ``[synonyms]`` is
+    lab-analyte vocabulary and must never rewrite a procedure name on either side of the
+    match.
+    """
+    if path is None:
+        return ()
+    p = Path(path)
+    if not p.is_file():
+        return ()
+    with p.open("rb") as fh:
+        data = tomllib.load(fh)
+    table = data.get("procedures", {})
+    entries = table.get("routine", []) if isinstance(table, dict) else []
+    out: list[str] = []
+    seen: set[str] = set()
+    for entry in entries:
+        token = norm(entry)
+        if token and token not in seen:
+            seen.add(token)
+            out.append(token)
+    return tuple(out)
+
+
 def _collapse(value: str) -> str:
     """Case/whitespace-normalized spelling of a free-text name.
 

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -69,6 +69,12 @@ def _dictionary() -> dict[str, str]:
     return _dedup.load_dictionary(cli._resolve_dictionary_path(_ARGS))
 
 
+def _routine_procedures() -> tuple[str, ...]:
+    """The summary's render-only routine-procedure list (issue #166), from the same file
+    :func:`_dictionary` reads -- so both front doors narrow identically."""
+    return _dedup.load_routine_procedures(cli._resolve_dictionary_path(_ARGS))
+
+
 def _connect() -> sqlite3.Connection:
     """Same missing-database gate the CLI applies, raised as a tool error (issue #55).
 
@@ -472,7 +478,12 @@ def trends(conn: sqlite3.Connection, *, person: str, test: str) -> dict[str, Any
 def render_summary(conn: sqlite3.Connection, *, person: str) -> dict[str, str]:
     """[read] Master summary for a person -> Markdown. Mirrors ``pemr render summary``."""
     try:
-        markdown = _render.render_summary(conn, person, dictionary=_dictionary())
+        markdown = _render.render_summary(
+            conn,
+            person,
+            dictionary=_dictionary(),
+            routine_procedures=_routine_procedures(),
+        )
     except (db.NotMigratedError, _query.PersonNotFoundError) as exc:
         raise _friendly(exc) from exc
     return {"markdown": markdown}

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -28,6 +28,27 @@ canonical *vital* vocabulary in ``data/dictionary.example.toml``):
     collapse disclosed on the line (issue #93) -- the stored rows keep their dates
     and stay distinct, because an order is an event, not a standing fact.
 
+**Procedures on the summary** (issue #166). ``procedure`` rows arrive largely from billing
+documents, so the table mixes genuine procedural history with routine service lines
+(office visits, serial radiographs, venipuncture). ``render_summary`` therefore narrows
+its ``## Procedures`` section against a **routine-pattern list** authored in
+``dictionary.toml`` (``[procedures].routine``, loaded by
+:func:`dedup.load_routine_procedures`), under three rules that are all one stance --
+significance is never established by *absence* from a list:
+
+  * **default-show** -- a name matching no configured pattern always renders, so a
+    procedure type nobody anticipated cannot be silently dropped;
+  * **suppress-only, summary-only** -- the list can remove a row from this one section and
+    nothing else. ``render_brief`` and ``render_journal`` stay the complete record, and
+    the stored rows are untouched;
+  * **disclosed on the page** -- when anything was filtered the section says how many, the
+    way order grouping discloses its collapse (issue #93). A summary that silently drops
+    rows is the thing default-show is defending against.
+
+Matching is token-boundary on :func:`dedup.norm`-normalized text, both sides, so ``cast``
+cannot suppress ``Castration``: over-suppression is the failure mode here, and
+under-suppression merely leaves a line on the page.
+
 **Curation overlay** (issues #109, #114). Every section is filtered at read time against
 the ``curation`` table, a pure overlay of recorded human verdicts scoped to a whole dedup
 family or to a **single row** (:meth:`curation.VerdictMap.for_row` resolves per row, row
@@ -70,7 +91,9 @@ prints it correctly instead of ``?`` (issue #46). Literal vs. data are orthogona
 from __future__ import annotations
 
 import calendar
+import re
 import sqlite3
+from collections.abc import Sequence
 from datetime import date, datetime
 
 from . import curation, db, query, units
@@ -913,6 +936,75 @@ def _abnormal_labs(
     return out
 
 
+def _routine_matcher(patterns: Sequence[str] | None) -> re.Pattern[str] | None:
+    """One compiled, token-boundary alternation over already-normalized routine-procedure
+    patterns -- or ``None`` when there is nothing to suppress (issue #166).
+
+    ``None`` is both the fast path and the default: no list, no compile, no filtering, so
+    a caller that passes nothing renders every procedure exactly as it would have before
+    the section learned to narrow.
+
+    The boundary is the point. A bare substring test would let ``cast`` suppress
+    ``Castration``, and over-suppression is precisely what the default-show rule exists to
+    prevent -- a procedure nobody anticipated must never vanish silently, while a routine
+    one that slips through merely costs a line. After :func:`norm` the alphabet is
+    ``[a-z0-9]`` plus punctuation, so a lookaround pair on the alphanumerics is a word
+    boundary that still lets a pattern begin or end on punctuation (``x-ray``).
+    """
+    cleaned = [p for p in (patterns or ()) if p]
+    if not cleaned:
+        return None
+    alternation = "|".join(re.escape(p) for p in cleaned)
+    return re.compile(rf"(?<![a-z0-9])(?:{alternation})(?![a-z0-9])")
+
+
+def _is_routine(name: object, matcher: re.Pattern[str] | None) -> bool:
+    """True when a procedure ``name`` matches a configured routine pattern.
+
+    Normalized with **no dictionary** (as the patterns were, on load): ``[synonyms]`` is
+    lab-analyte vocabulary and must never rewrite a procedure name on either side of the
+    match.
+    """
+    return matcher is not None and bool(matcher.search(norm(name)))
+
+
+def _procedures(
+    conn: sqlite3.Connection, person_id: int, cur: "_CurationPass | None" = None
+) -> list[dict]:
+    """Procedure rows, newest first, undated last -- the summary's ``## Procedures``
+    source (issue #166).
+
+    ``performed_on`` is nullable *and* unvalidated free text, so the SQL ordering is not
+    trusted to place undated rows on its own: SQLite's ``DESC`` puts ``NULL`` last but
+    sorts ``''`` in among the dated rows. One extra **stable** pass on
+    :func:`_date_part`'s truthiness moves every undated row -- ``NULL`` and ``''`` alike --
+    behind the dated ones without disturbing their relative order.
+
+    Curation runs first, as everywhere else: an appendix-bound verdict must route the row
+    before the routine filter (applied by the caller) ever sees it, or a superseded row
+    would be reported twice.
+    """
+    rows = conn.execute(
+        "SELECT * FROM procedure WHERE person_id = ? "
+        "ORDER BY performed_on DESC, procedure_id",
+        (person_id,),
+    ).fetchall()
+    kept = _apply_curation([dict(r) for r in rows], "procedure", cur)
+    kept.sort(key=lambda p: not _date_part(p["performed_on"]))
+    return kept
+
+
+def _procedure_line(row: dict) -> str:
+    """One ``## Procedures`` bullet. No ``procedure:`` prefix -- the brief needs one
+    because its section is shared with observations, a dedicated section does not."""
+    outcome = f" - {row['outcome']}" if row["outcome"] else ""
+    who = f"  ({row['provider']})" if row["provider"] else ""
+    return (
+        f"- {_date_part(row['performed_on']) or '(undated)'}  {row['name']}"
+        f"{outcome}{who}{_dispute_suffix(row)}{_attest_suffix(row)}"
+    )
+
+
 def _open_appointments(
     conn: sqlite3.Connection,
     person_id: int,
@@ -996,17 +1088,24 @@ def render_summary(
     slug: str,
     *,
     dictionary: dict[str, str] | None = None,
+    routine_procedures: Sequence[str] | None = None,
     now: datetime | None = None,
 ) -> str:
     """Markdown master summary for a person: active meds, active problems, past medical
     history, family history, allergies, orders, latest vitals, recent abnormal labs,
-    upcoming/open appointments, and any open conflicts --
+    procedures, upcoming/open appointments, and any open conflicts --
     with a self-identifying header (name, DOB, generated-at, source row counts).
     Read-only.
 
     The summary is the document read *between* appointments, so an open conflict has to
     surface here too: without it a staged correction is invisible and the summary prints
     the stale value with no hint that a corrected one is pending (issue #59).
+
+    ``routine_procedures`` is the ``[procedures].routine`` pattern list (issue #166,
+    module docstring). It is **suppress-only** and defaults to ``None``, which suppresses
+    nothing -- so every caller that does not pass one gets default-show behavior for free.
+    A section that filtered anything says so; a section that filtered *everything* says
+    that too, rather than the false ``_none recorded_``.
 
     Raises :class:`query.PersonNotFoundError` for an unknown slug (friendly rc=1)."""
     person_id = query.resolve_person_id(conn, slug)
@@ -1092,6 +1191,22 @@ def render_summary(
             f"{_dispute_suffix(r)}{_attest_suffix(r)}{_unit_suffix(d)}"
         )
 
+    # Curation first, routine filter second (issue #166): an appendix-bound row has to be
+    # routed by its verdict before the pattern list sees it, or the disclosure count below
+    # would report a superseded row as a hidden routine one.
+    proc_rows = _procedures(conn, person_id, cur)
+    matcher = _routine_matcher(routine_procedures)
+    proc_kept = [p for p in proc_rows if not _is_routine(p["name"], matcher)]
+    proc_lines = [_procedure_line(p) for p in proc_kept]
+    hidden = len(proc_rows) - len(proc_kept)
+    if hidden:
+        note = (
+            f"_{hidden} routine procedure{'' if hidden == 1 else 's'} not shown "
+            "(name matches the dictionary's routine list); "
+            "`pemr render journal` lists them._"
+        )
+        proc_lines.append(f"\n{note}" if proc_lines else note)
+
     appt_lines = [
         f"- {_appt_line(a)}{_dispute_suffix(a)}{_attest_suffix(a)}"
         for a in _open_appointments(conn, person_id, today, cur)
@@ -1111,6 +1226,7 @@ def render_summary(
             lab_lines,
             empty="_none flagged_",
         ),
+        _section("Procedures", proc_lines),
         _section("Upcoming / Open Appointments", appt_lines),
         _section(
             "Open Conflicts", _open_conflict_lines(conn, person_id), empty="_none_"

--- a/tests/test_cli_phase4.py
+++ b/tests/test_cli_phase4.py
@@ -131,6 +131,93 @@ def _commit_labs(tmp_path, sha, rows):
                 "--json", str(payload)) == 0
 
 
+def _commit_procedures(tmp_path, sha, rows):
+    """`_commit_orders`'s sibling for `procedure` rows, committed the same way."""
+    conn = db.connect(tmp_path / "cli.db")
+    pid = conn.execute(
+        "SELECT person_id FROM person WHERE slug='jane-doe'"
+    ).fetchone()["person_id"]
+    cur = conn.execute(
+        "INSERT INTO document (sha256, person_id, source_path, ingested_at) "
+        "VALUES (?, ?, 'aa/x.pdf', '2026-01-01T00:00:00')", (sha, pid)
+    )
+    conn.commit()
+    doc = cur.lastrowid
+    conn.close()
+    payload = tmp_path / f"extract-{sha}.json"
+    payload.write_text(json.dumps({"procedure": rows}), encoding="utf-8")
+    assert _run(tmp_path, "commit-extraction", "--document", str(doc),
+                "--json", str(payload)) == 0
+
+
+def test_render_summary_routine_procedures_come_from_the_dictionary(ready, capsys):
+    """Issue #166 at the command boundary: `--dictionary` selects one file and the
+    summary reads *both* tables from it -- the synonym map and the render-only
+    `[procedures].routine` list. This pins the wiring, not the filter logic (that lives
+    in `tests/test_render.py`); without it the arg could go unpassed and every summary
+    would silently render unfiltered."""
+    tmp_path, _ = ready
+    _commit_procedures(tmp_path, "sha-proc", [
+        {"name": "Office Visit, Established Patient", "performed_on": "2026-02-01"},
+        {"name": "Total knee arthroplasty", "performed_on": "2026-01-15"},
+    ])
+    d = tmp_path / "dict.toml"
+    d.write_text(
+        '[synonyms]\n"a1c" = "hba1c"\n\n'
+        '[procedures]\nroutine = ["office visit"]\n',
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    assert _run(tmp_path, "render", "summary", "--person", "jane-doe",
+                "--dictionary", str(d)) == 0
+    out = capsys.readouterr().out
+    section = out.split("## Procedures")[1].split("\n## ")[0]
+    assert "- 2026-01-15  Total knee arthroplasty" in section
+    assert "Office Visit" not in section
+    assert "_1 routine procedure not shown" in section
+    # render-only: the hidden row is untouched in the DB
+    conn = db.connect(tmp_path / "cli.db")
+    assert conn.execute("SELECT COUNT(*) AS n FROM procedure").fetchone()["n"] == 2
+    conn.close()
+    assert out.isascii()          # cp1252/cp437 console contract
+
+
+def test_render_summary_default_dictionary_applies_the_starter_list(ready, capsys):
+    """With no `--dictionary` the CLI falls back to the shipped
+    `data/dictionary.example.toml`, exactly as it already does for `[synonyms]` -- so the
+    starter routine list is live out of the box, and the run that suppresses discloses it
+    while an unlisted procedure still renders (default-show)."""
+    tmp_path, _ = ready
+    _commit_procedures(tmp_path, "sha-proc2", [
+        {"name": "Office Visit, Established Patient", "performed_on": "2026-02-01"},
+        {"name": "Total knee arthroplasty", "performed_on": "2026-01-15"},
+    ])
+    capsys.readouterr()
+    assert _run(tmp_path, "render", "summary", "--person", "jane-doe") == 0
+    section = capsys.readouterr().out.split("## Procedures")[1].split("\n## ")[0]
+    assert "Office Visit" not in section
+    assert "- 2026-01-15  Total knee arthroplasty" in section
+    assert "_1 routine procedure not shown" in section
+
+
+def test_render_summary_empty_routine_list_hides_nothing(ready, capsys):
+    """The default-show rule survives the front door: a dictionary with an empty list
+    suppresses nothing and discloses nothing."""
+    tmp_path, _ = ready
+    _commit_procedures(tmp_path, "sha-proc3", [
+        {"name": "Office Visit, Established Patient", "performed_on": "2026-02-01"},
+    ])
+    d = tmp_path / "empty.toml"
+    d.write_text("[procedures]\nroutine = []\n", encoding="utf-8")
+    capsys.readouterr()
+    assert _run(tmp_path, "render", "summary", "--person", "jane-doe",
+                "--dictionary", str(d)) == 0
+    section = capsys.readouterr().out.split("## Procedures")[1].split("\n## ")[0]
+    assert "Office Visit, Established Patient" in section
+    assert "not shown" not in section
+
+
 def test_render_summary_groups_repeated_orders_end_to_end(ready, capsys):
     """Issue #93, walked through the real CLI: an order restated by three documents is
     one bullet carrying the latest detail plus the `+N earlier` disclosure; distinct and

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -53,6 +53,49 @@ def test_load_missing_dictionary_is_empty(tmp_path):
     assert dedup.load_dictionary(None) == {}
 
 
+# --- issue #166: the render-only routine-procedure list ------------------------
+
+def test_load_routine_procedures_missing_or_none(tmp_path):
+    """No file, no list: the summary suppresses nothing, which is the default-show rule
+    holding even when the dictionary itself is absent."""
+    assert dedup.load_routine_procedures(None) == ()
+    assert dedup.load_routine_procedures(tmp_path / "nope.toml") == ()
+
+
+def test_load_routine_procedures_absent_table(tmp_path):
+    """A dictionary that predates this feature (only `[synonyms]`) is not an error and
+    not a partial filter -- it suppresses nothing."""
+    p = tmp_path / "d.toml"
+    p.write_text('[synonyms]\n"a1c" = "hba1c"\n', encoding="utf-8")
+    assert dedup.load_routine_procedures(p) == ()
+
+    empty = tmp_path / "e.toml"
+    empty.write_text("[procedures]\nroutine = []\n", encoding="utf-8")
+    assert dedup.load_routine_procedures(empty) == ()
+
+
+def test_load_routine_procedures_normalizes_and_dedupes(tmp_path):
+    """Authoring is lenient the way `[synonyms]` keys are: case, padding and underscores
+    collapse, blanks drop, duplicates drop, and the authored order survives."""
+    p = tmp_path / "d.toml"
+    p.write_text(
+        "[procedures]\n"
+        'routine = ["  Office   Visit ", "office_visit", "", "Venipuncture"]\n',
+        encoding="utf-8",
+    )
+    assert dedup.load_routine_procedures(p) == ("office visit", "venipuncture")
+
+
+def test_example_dictionary_keeps_both_tables():
+    """The shipped example must yield BOTH overlays. `[synonyms]` runs to EOF, so a
+    `[procedures]` header placed above it would silently swallow every following synonym
+    key -- this is the guard on that placement."""
+    assert dedup.load_dictionary(DICT_PATH)          # synonyms survived the new table
+    assert dedup.norm("A1c", dedup.load_dictionary(DICT_PATH)) == "hba1c"
+    routine = dedup.load_routine_procedures(DICT_PATH)
+    assert routine and "office visit" in routine
+
+
 def test_esr_synonyms_map_to_canonical():
     # Issue #41: an ESR result labeled "SED RATE BY MODIFIED WESTERGREN" on a Quest
     # report must share the `esr` identity with every other ESR spelling.

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -159,6 +159,33 @@ def test_renderers_return_markdown(seeded):
     assert mcp_server.render_journal(seeded, person="jane-doe")["markdown"].startswith("#")
 
 
+def test_render_summary_narrows_procedures_like_the_cli(seeded):
+    """Issue #166, verify pass: the MCP front door must *apply* the routine list, not
+    merely accept the kwarg. `test_renderers_return_markdown` asserts only that the
+    section exists, which a `_routine_procedures()` stuck at `()` would also satisfy --
+    so the two front doors could silently disagree. `_ARGS.dictionary` is unset here,
+    exactly as a real server starts, so this resolves the shipped
+    `data/dictionary.example.toml` and its starter patterns: the same file and the same
+    fallback `pemr render summary` uses."""
+    doc = _doc(seeded, "jane-doe")
+    dedup.commit_extraction(seeded, doc, {
+        "procedure": [
+            {"name": "Office Visit, Established Patient", "performed_on": "2026-02-01"},
+            {"name": "Total knee arthroplasty", "performed_on": "2026-01-15"},
+        ],
+    }, {})
+    section = mcp_server.render_summary(
+        seeded, person="jane-doe"
+    )["markdown"].split("## Procedures")[1].split("\n## ")[0]
+
+    assert "- 2026-01-15  Total knee arthroplasty" in section   # default-show
+    assert "Office Visit" not in section                        # suppressed
+    assert "_1 routine procedure not shown" in section          # and disclosed
+    # Render-only: the suppressed row is still in the journal both front doors serve.
+    journal = mcp_server.render_journal(seeded, person="jane-doe")["markdown"]
+    assert "Office Visit, Established Patient" in journal
+
+
 def test_read_tools_leave_db_byte_stable(seeded, db_path):
     seeded.commit()
     before = _sha(db_path)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -149,7 +149,11 @@ def test_find_household_wide_omits_person(seeded):
 
 
 def test_renderers_return_markdown(seeded):
-    assert mcp_server.render_summary(seeded, person="jane-doe")["markdown"].startswith("#")
+    summary = mcp_server.render_summary(seeded, person="jane-doe")["markdown"]
+    assert summary.startswith("#")
+    # Issue #166: the wrapper passes the routine-procedure list, so the section exists
+    # and the extra kwarg cannot silently drift into a TypeError.
+    assert "## Procedures" in summary
     brief = mcp_server.render_brief(seeded, appointment=_appt_id(seeded))["markdown"]
     assert "Medication Interaction Review" in brief  # the placeholder AGENTS.md fills
     assert mcp_server.render_journal(seeded, person="jane-doe")["markdown"].startswith("#")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -785,6 +785,180 @@ def test_months_before_clamps_a_short_target_month():
     assert render._months_before(date(2026, 1, 15), 13) == date(2024, 12, 15)
 
 
+# --- issue #166: the summary's Procedures section -----------------------------
+#
+# `procedure` rows arrive largely from billing documents, so the table mixes genuine
+# procedural history with routine service lines. The section narrows against a
+# suppress-only pattern list, under one stance throughout: significance is never
+# established by absence from a list, so every ambiguity resolves to *render*.
+
+def _seed_procedures(conn, rows):
+    """Extra `procedure` rows on jane, committed as their own document."""
+    dedup.commit_extraction(conn, _doc(conn, "jane-doe"), {
+        "procedure": list(rows),
+    }, dedup.load_dictionary(DICT_PATH))
+
+
+def _procedures_section(conn, routine=None, slug="jane-doe"):
+    md = render.render_summary(conn, slug, routine_procedures=routine)
+    return md.split("## Procedures")[1].split("\n## ")[0]
+
+
+def _procedure_bullets(section):
+    return [ln for ln in section.splitlines() if ln.startswith("- ")]
+
+
+def test_summary_has_a_procedures_section(seeded):
+    """AC1: procedure rows were stored, deduped and journalled but never reached the
+    master summary. The section sits between results and the forward-looking sections --
+    everything above it is standing state, everything below is what happens next."""
+    md = render.render_summary(seeded, "jane-doe")
+    assert "- 2025-03-15  Colonoscopy - normal" in _procedures_section(seeded)
+    assert (md.index("## Abnormal Labs")
+            < md.index("## Procedures")
+            < md.index("## Upcoming / Open Appointments"))
+
+
+def test_summary_procedures_no_patterns_suppress_nothing(seeded):
+    """The default is default-show *and* the fast path: no list, no filtering, no
+    disclosure line -- so every caller that never learns about this arg is unaffected."""
+    _seed_procedures(seeded, [
+        {"name": "Office Visit, Established Patient", "performed_on": "2026-02-01"},
+    ])
+    for routine in (None, [], ()):
+        section = _procedures_section(seeded, routine)
+        assert "Office Visit" in section and "Colonoscopy" in section
+        assert "not shown" not in section
+
+
+def test_summary_procedures_routine_pattern_is_suppressed(seeded):
+    """AC3: a configured routine line leaves the summary, and the narrowing is disclosed
+    on the page (issue #93's precedent) -- a summary that silently drops rows is exactly
+    what the default-show rule is defending against."""
+    _seed_procedures(seeded, [
+        {"name": "Office Visit, Established Patient", "performed_on": "2026-02-01"},
+    ])
+    section = _procedures_section(seeded, ["office visit"])
+    assert "Office Visit" not in section
+    assert "Colonoscopy" in section                      # control: unmatched row stays
+    assert "_1 routine procedure not shown" in section
+
+
+def test_summary_procedures_default_show_unlisted_name(seeded):
+    """AC2: a procedure nobody anticipated renders in the same pass that hides a listed
+    one. Absence from the list can never establish that a row is insignificant."""
+    _seed_procedures(seeded, [
+        {"name": "Venipuncture", "performed_on": "2026-02-01"},
+        {"name": "Cryoablation of renal tumor", "performed_on": "2026-02-02"},
+    ])
+    section = _procedures_section(seeded, ["venipuncture"])
+    assert "Cryoablation of renal tumor" in section
+    assert "Venipuncture" not in section
+
+
+def test_summary_procedures_match_is_token_bounded(seeded):
+    """Over-suppression is the failure that matters here, so the match lands on a token
+    boundary: `cast` reaches a cast application and never `Castration`."""
+    _seed_procedures(seeded, [
+        {"name": "Cast application, short arm", "performed_on": "2026-02-01"},
+        {"name": "Castration", "performed_on": "2026-02-02"},
+    ])
+    section = _procedures_section(seeded, ["cast"])
+    assert "Castration" in section
+    assert "Cast application" not in section
+    assert "_1 routine procedure not shown" in section
+
+
+def test_summary_procedures_reverse_chronological_undated_last(seeded):
+    """AC4: newest first, and every undated row sorts after every dated one --
+    `performed_on` is nullable *and* unvalidated, so `''` must land with `NULL` rather
+    than in among the dates where SQLite's own DESC ordering would leave it."""
+    _seed_procedures(seeded, [
+        {"name": "Appendectomy", "performed_on": "2015-03-08"},
+        {"name": "Knee arthroscopy", "performed_on": "2026-02-01"},
+        {"name": "Tonsillectomy"},                                    # NULL
+        {"name": "Mole removal", "performed_on": "2019-01-01"},
+    ])
+    seeded.execute("UPDATE procedure SET performed_on = '' WHERE name = 'Mole removal'")
+    seeded.commit()
+    bullets = _procedure_bullets(_procedures_section(seeded))
+    assert [b.split("  ", 1)[1] for b in bullets] == [
+        "Knee arthroscopy", "Colonoscopy - normal", "Appendectomy",
+        "Mole removal", "Tonsillectomy",
+    ]
+    assert bullets[-2:] == ["- (undated)  Mole removal", "- (undated)  Tonsillectomy"]
+
+
+def test_summary_procedures_empty_state(seeded):
+    """AC7: john has no procedures, and an absent section must never read as an
+    overlooked one -- the project's existing explicit empty state applies here too."""
+    md = render.render_summary(seeded, "john-doe")
+    assert "## Procedures" in md
+    assert "_none recorded_" in md.split("## Procedures")[1].split("\n## ")[0]
+
+
+def test_summary_procedures_all_routine_discloses_the_filter(seeded):
+    """The all-filtered case must not render `_none recorded_`: the person *has*
+    procedures, and claiming otherwise would be the one outright false statement this
+    section could make."""
+    section = _procedures_section(seeded, ["colonoscopy"])
+    assert "_none recorded_" not in section
+    assert "_1 routine procedure not shown" in section
+
+
+def test_summary_procedures_plural_disclosure(seeded):
+    _seed_procedures(seeded, [
+        {"name": "Venipuncture", "performed_on": "2026-02-01"},
+        {"name": "Office visit", "performed_on": "2026-02-02"},
+    ])
+    section = _procedures_section(seeded, ["venipuncture", "office visit"])
+    assert "_2 routine procedures not shown" in section
+
+
+def test_summary_procedures_filter_is_render_only(seeded):
+    """AC3: nothing is deleted or mutated, and the journal stays the complete chronology
+    -- the summary is the only view that narrows."""
+    _seed_procedures(seeded, [{"name": "Venipuncture", "performed_on": "2026-02-01"}])
+    before = _row_counts(seeded)
+    assert "Venipuncture" not in _procedures_section(seeded, ["venipuncture"])
+    assert _row_counts(seeded) == before
+    assert "Venipuncture" in render.render_journal(seeded, "jane-doe")
+
+
+def test_brief_procedures_are_unfiltered(seeded):
+    """The brief takes no pattern list at all, so a routine row a clinician might still
+    ask about cannot be hidden from the document handed to them."""
+    _seed_procedures(seeded, [{"name": "Venipuncture", "performed_on": "2026-02-01"}])
+    md = render.render_brief(seeded, _upcoming_appt_id(seeded))
+    assert "Venipuncture" in md.split("## Procedures & Observations")[1]
+
+
+def test_summary_procedures_dispute_and_attest_suffixes(seeded):
+    """AC6: the section is a first-class one -- it carries the same dispute marker and
+    attestation provenance suffix every other summary section does."""
+    _annotate(seeded, "procedure", "name", "Colonoscopy", status="disputed",
+              note="two reports disagree on the date")
+    _attest_all(seeded)
+    section = _procedures_section(seeded)
+    assert "[DISPUTED: two reports disagree on the date]" in section
+    assert any("Wisdom tooth extraction" in ln and _ATTEST_MARKER in ln
+               for ln in section.splitlines())
+
+
+def test_summary_procedures_superseded_row_leaves_for_the_appendix(seeded):
+    """Filter order: curation first, routine list second. An appendix-bound row must be
+    routed by its verdict before the pattern list counts anything, or a superseded row
+    would be reported twice -- once in the appendix, once as a hidden routine one."""
+    _seed_procedures(seeded, [{"name": "Venipuncture", "performed_on": "2026-02-01"}])
+    _annotate(seeded, "procedure", "name", "Colonoscopy", status="superseded",
+              note="duplicated by the later report")
+    md = render.render_summary(seeded, "jane-doe", routine_procedures=["venipuncture"])
+    section = md.split("## Procedures")[1].split("\n## ")[0]
+    assert "Colonoscopy" not in section
+    assert "## Superseded / corrected" in md and "procedure: Colonoscopy" in md
+    assert "_1 routine procedure not shown" in section   # the superseded row is not counted
+
+
 def test_summary_upcoming_and_open_appointments(seeded):
     md = render.render_summary(seeded, "jane-doe")
     section = md.split("## Upcoming / Open Appointments")[1].split("\n## ")[0]
@@ -1339,10 +1513,11 @@ def test_summary_marks_an_attested_row_in_every_section(seeded):
         line.split("  ")[0].lstrip("- ")
         for line in md.splitlines() if _ATTEST_MARKER in line
     }
-    # Meds, active problems, allergies, orders, vitals, abnormal labs, appointments:
-    # every section that can show an attested row does, so none can render it bare.
+    # Meds, active problems, allergies, orders, vitals, abnormal labs, procedures,
+    # appointments: every section that can show an attested row does, so none can render
+    # it bare.
     for token in ("Amlodipine", "Migraine", "Shellfish", "sleep study", "pulse",
-                  "Potassium", "Dr. Attested"):
+                  "Potassium", "Wisdom tooth extraction", "Dr. Attested"):
         assert any(
             token in line and _ATTEST_MARKER in line for line in md.splitlines()
         ), token


### PR DESCRIPTION
## Summary

- Adds a `## Procedures` section to `render_summary`, sourced from the `procedure` table,
  reverse-chronological on `performed_on` (undated rows last), with the existing
  dispute/attestation suffixes and curation overlay applied same as every other section.
- Narrowed by a new **render-only, suppress-only, default-show** routine-procedure pattern
  list read from `dictionary.toml`'s new `[procedures]` table (`dedup.load_routine_procedures`).
  Matching is token-boundary on normalized text, both sides — a name matching no pattern
  always renders, so significance is never established by absence. Filtered rows stay
  unchanged in `render_journal`; the section discloses how many rows it hid when any are
  filtered.
- `data/dictionary.example.toml` gains a starter `[procedures]` table (appended at EOF, with
  an explicit warning against reordering, since `[synonyms]` runs to EOF and a table inserted
  above it would silently swallow the synonym map).
- Wired through both front doors (`cli._cmd_render_summary`, `mcp_server.render_summary`).
- Docs fan-out (this PR, per ship's docs sink for #166): both the `[procedures]` comment
  block in `data/dictionary.example.toml` and the `docs/Architecture.md` §6 Procedures bullet
  now state that matching normalizes by stripping parenthetical qualifiers from both the
  stored name and the pattern — e.g. `cast application` also suppresses `Cast application
  (open reduction internal fixation)`, and a pattern written entirely inside parentheses
  normalizes to empty and matches nothing. This closes an advisory gap audit flagged (matching
  behavior existed but was undocumented) — no code change, no behavior change.

## Test plan
- [x] `pytest tests/test_render.py tests/test_dedup.py tests/test_cli_phase4.py tests/test_mcp_server.py` — 341 passed (audit's targeted rerun at the audited HEAD)
- [x] Re-ran `tests/test_render.py` + `tests/test_dedup.py` locally after the docs-only ship commit — all green
- [x] `data/dictionary.example.toml` still parses with both `[synonyms]` (169 entries) and `[procedures].routine` (8 entries) non-empty after the doc-note edit

Verify report: https://github.com/meridun/pemr/issues/166#issuecomment-5310578107
Audit report: https://github.com/meridun/pemr/issues/166#issuecomment-5310604489

Closes #166

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>