### PR TITLE
render: move the curation appendix out of the summary into its own target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,9 @@ Read-only tools (never mutate the DB; safe to call freely):
 - `render_summary` — master summary Markdown for a person.
 - `render_brief` — walk-in brief Markdown for one appointment.
 - `render_journal` — narrative chronology Markdown for a person.
+- `render_curation` — curation audit trail Markdown for a person: every recorded verdict that
+  removed a row from the three documents above, grouped by ruling. Empty Markdown means the
+  person has no verdicts, not a failure.
 
 Write tools (mutate the DB; the only tools that do):
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -55,7 +55,8 @@ pemr/
     <sha256[:2]>/<sha256>.pdf  # dedup-friendly, immutable blob store
     .tmp/                      # staging for study archives (§4); exclude from cloud sync
   inbox/                       # drop zone for new un-ingested scans
-  exports/                     # generated docs (disposable): summaries, briefs, journal
+  exports/                     # generated docs (disposable): summaries, briefs, journal,
+                               #   curation records
   backups/                     # local VACUUM INTO snapshots before they sync
   config.toml                  # paths, cloud backup dir, people roster
   AGENTS.md                    # conventions + tool contract for any agent
@@ -478,9 +479,9 @@ recommends `record annotate` when annotating that row could actually change the 
 a row already released is never named. Once every colliding row is released the attestation
 proceeds as an ordinary new occurrence of the identity (the next free `dedup_occurrence`),
 not a replacement of what is stored. One consequence worth knowing: a **family**-scoped
-release covers that new occurrence too, so the freshly attested row itself renders in the
-`## Superseded / corrected` appendix (§6) until the verdict is re-scoped to the rows it
-meant or lifted — the CLI prints a note when this happens so it is not a silent surprise.
+release covers that new occurrence too, so the freshly attested row itself leaves the
+clinical documents for the curation record (§6) until the verdict is re-scoped to the rows
+it meant or lifted — the CLI prints a note when this happens so it is not a silent surprise.
 
 `norm()` = lowercase, trim, collapse whitespace, drop parenthetical qualifiers, map
 synonyms via an **analyte/name dictionary** (`data/dictionary.toml`) — e.g. `A1c`,
@@ -1101,6 +1102,7 @@ pemr due --person jane                                   # screening/vaccine gap
 pemr render summary --person jane        > exports/jane-summary.md
 pemr render brief --appointment <id>     > exports/brief.md
 pemr render journal --person jane        > exports/jane-journal.md
+pemr render curation --person jane       > exports/jane-curation.md  # curation audit trail (empty = no verdicts)
 pemr backup                                              # VACUUM INTO snapshot
 pemr restore latest [--force]                            # install a snapshot back over pemr.db (§8)
 pemr verify                                              # integrity + row counts + source-blob resolution
@@ -1124,7 +1126,8 @@ under a PEP 660 editable install); see issue #22.
 ### MCP tools (thin wrappers, same verbs) — implemented phase 5
 
 Read-only: `person_list`, `person_show`, `query` (`kind` = `labs`/`meds`/`timeline`), `find`,
-`trends`, `render_summary`, `render_brief`, `render_journal`. Write: `person_add`, `person_edit`,
+`trends`, `render_summary`, `render_brief`, `render_journal`, `render_curation`. Write:
+`person_add`, `person_edit`,
 `ingest` (`study="dicom"` + `allow_large` make `file` a study directory, §4), `commit_extraction`,
 `document_set_text` (fills an empty `ocr_text` only — the `--force`
 replace is CLI-only), `review_conflicts` (resolution gated on human sign-off). Each returns the
@@ -1165,10 +1168,13 @@ default to the same exclusion unless a human explicitly decides otherwise.
 `render.py` produces your current deliverables as pure functions of DB state:
 
 - **master summary** — active meds, conditions, allergies, latest vitals, recent
-  abnormal labs, open follow-ups, open conflicts. One query bundle → Markdown. The
-  conflicts section is not decoration: an open conflict means a stored value is disputed
-  and its correction is still staged, so the summary would otherwise print the stale
-  value silently (the brief carries the same section, but it is per-appointment). An
+  abnormal labs, open follow-ups. One query bundle → Markdown. Open conflicts are not
+  decoration: an open conflict means a stored value is disputed and its correction is
+  still staged, so the summary would otherwise print the stale value silently. Since
+  issue #168 the summary says so in a single `> [!WARNING]` line under the header,
+  emitted only when the count is non-zero — the safety property of issue #59 without an
+  always-present `## Open Conflicts` / `_none_` header on the common case. The brief keeps
+  the per-conflict section, since it is per-appointment. An
   order in `Orders & Referrals` leaves the section once a matching `lab_result` lands
   (issue #128) — matching is deliberately narrow (exact `key_token` plus a tight,
   edge-tested date window) and biased toward under-suppression, since age alone is never
@@ -1217,13 +1223,20 @@ default to the same exclusion unless a human explicitly decides otherwise.
   questions. This is your "walk-in readiness" as a repeatable command.
 - **journal** — chronological event stream (documents + appointments + procedures)
   rendered as a narrative timeline.
+- **curation record** (issue #168) — the audit trail: every recorded verdict that removed a
+  row from the three documents above, grouped **by ruling** rather than by row, so one merge
+  session's note against forty families is one block with a count. Read from the stored
+  `curation` table (not from a render pass), so it is person-scoped and complete rather than
+  "whatever sections happened to select" — a deliberate superset of the
+  `## Superseded / corrected` appendix it replaced. Empty output when the person has no
+  verdicts, which is what keeps the additive-only guarantee below true.
 
 Every section is filtered at read time against the `curation` overlay (§2, issues #109 and
-#114): `superseded` / `erroneous-in-source` / `merged-into` leave their section for a
-`## Superseded / corrected` appendix, `disputed` renders in place with a
+#114): `superseded` / `erroneous-in-source` / `merged-into` leave their section entirely
+(their trail is the curation record), `disputed` renders in place with a
 `[DISPUTED: <note>]` marker and reaches the brief's `## Questions for the Clinician`, and
 `confirmed` — and `distinct` (§3, issue #122), whose whole point is that both rows stay
-live — render unchanged. Both new sections are omitted entirely when empty, so a record
+live — render unchanged. The questions section is omitted entirely when empty, so a record
 with no verdicts renders byte-identically to before the overlay existed. This does not weaken
 the purity rule: the filter is a read, and output changes after a verdict because the
 *database* changed. Resolution is **per row**: a row-scoped verdict affects only its own

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -2924,11 +2924,17 @@ def _cmd_trends(args: argparse.Namespace) -> int:
 
 
 # --------------------------------------------------------------------------- #
-# Phase 4: render (summary / brief / journal)
+# Phase 4: render (summary / brief / journal / curation)
 # --------------------------------------------------------------------------- #
 
 def _emit_markdown(markdown: str, out: str | None) -> int:
-    """Write rendered Markdown to ``--out`` or stdout (the §5 shell-redirect default)."""
+    """Write rendered Markdown to ``--out`` or stdout (the §5 shell-redirect default).
+
+    An **empty** document (``render curation`` for a subject with no verdicts, issue #168)
+    writes a genuinely zero-byte file and prints nothing at all -- the additive-only
+    guarantee reaches the bytes on disk, and a lone newline on stdout would be a document
+    where there is none. Every non-empty target is unaffected.
+    """
     if out:
         try:
             with open(out, "w", encoding="utf-8", newline="\n") as fh:
@@ -2937,6 +2943,8 @@ def _emit_markdown(markdown: str, out: str | None) -> int:
             print(f"error: cannot write {out}: {exc}", file=sys.stderr)
             return 1
         print(f"wrote {out}")
+        return 0
+    if not markdown:
         return 0
     # Default stdout keeps the documented `> exports/...` redirect contract. Output is
     # ASCII-only by construction (render layer), so a cp1252/cp437 console is safe.
@@ -2990,6 +2998,14 @@ def _cmd_render_brief(args: argparse.Namespace) -> int:
 def _cmd_render_journal(args: argparse.Namespace) -> int:
     def work(conn):
         markdown = render.render_journal(conn, args.person, since=args.since)
+        return _emit_markdown(markdown, args.out)
+
+    return _render_with_conn(args, work)
+
+
+def _cmd_render_curation(args: argparse.Namespace) -> int:
+    def work(conn):
+        markdown = render.render_curation(conn, args.person)
         return _emit_markdown(markdown, args.out)
 
     return _render_with_conn(args, work)
@@ -3792,7 +3808,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_trends.add_argument("--json", action="store_true", help="machine-readable output")
     p_trends.set_defaults(func=_cmd_trends)
 
-    # --- phase 4: render (summary / brief / journal) ----------------------
+    # --- phase 4: render (summary / brief / journal / curation) -----------
     p_render = sub.add_parser(
         "render", help="generate Markdown documents from DB state (read-only)"
     )
@@ -3827,6 +3843,13 @@ def build_parser() -> argparse.ArgumentParser:
     r_journal.add_argument("--since", help="ISO date; keep events on/after this date")
     r_journal.add_argument("--out", help="write to file instead of stdout")
     r_journal.set_defaults(func=_cmd_render_journal)
+
+    r_curation = render_sub.add_parser(
+        "curation", help="curation audit trail for a person -> Markdown on stdout"
+    )
+    r_curation.add_argument("--person", required=True, help="owner slug")
+    r_curation.add_argument("--out", help="write to file instead of stdout")
+    r_curation.set_defaults(func=_cmd_render_curation)
 
     # --- phase 6: backup (VACUUM INTO snapshot + rotation) ----------------
     p_backup = sub.add_parser(

--- a/pemr/curation.py
+++ b/pemr/curation.py
@@ -113,8 +113,8 @@ STATUSES: tuple[str, ...] = (
     "distinct",
 )
 
-#: The statuses that move a family **out** of its normal rendered section and into the
-#: "Superseded / corrected" appendix. ``confirmed`` renders exactly as today (it records
+#: The statuses that move a family **out** of its normal rendered section, leaving their
+#: audit trail to `pemr render curation` (issue #168). ``confirmed`` renders as today (it records
 #: agreement, it does not change the document); ``disputed`` renders in place, marked —
 #: a disputed fact that vanished from the summary would be worse than an unmarked one.
 APPENDIX_STATUSES: tuple[str, ...] = (
@@ -404,8 +404,9 @@ def load_verdicts(conn: sqlite3.Connection) -> VerdictMap:
 # The *stamping* rule (which verdict applies to which carrier) lives here, beside
 # :meth:`VerdictMap.for_row` and :data:`APPENDIX_STATUSES`; the *policy* rule (what to do
 # with a carrier bound for the appendix) stays with each front door, because they
-# legitimately differ: `render` collects the carrier into its "Superseded / corrected"
-# section, `pemr query` hides it behind a count, and the MCP payload hides nothing at all.
+# legitimately differ: `render` drops the carrier from its clinical documents (the audit
+# trail is `pemr render curation`, issue #168), `pemr query` hides it behind a count, and
+# the MCP payload hides nothing at all.
 #
 # Before #131 the stamping half lived only inside `render`, and `pemr query` had no
 # overlay at all — the two verbs disagreed about which medications a person is on.

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -514,11 +514,25 @@ def render_journal(
     return {"markdown": markdown}
 
 
+def render_curation(conn: sqlite3.Connection, *, person: str) -> dict[str, str]:
+    """[read] Curation audit trail for a person -> Markdown. Mirrors ``pemr render curation``.
+
+    The verdict record that issue #168 moved out of the three clinical documents. Without
+    it here the content would vanish from every MCP-visible surface with no replacement;
+    an empty ``markdown`` means the person has no curation verdicts, not an error.
+    """
+    try:
+        markdown = _render.render_curation(conn, person)
+    except (db.NotMigratedError, _query.PersonNotFoundError) as exc:
+        raise _friendly(exc) from exc
+    return {"markdown": markdown}
+
+
 # The exposed tool surface, in one place. AGENTS.md's contract-lint asserts it
 # references every name here; build_server registers exactly these.
 READ_ONLY_TOOLS = (
     "person_list", "person_show", "query", "find", "trends",
-    "render_summary", "render_brief", "render_journal",
+    "render_summary", "render_brief", "render_journal", "render_curation",
 )
 WRITE_TOOLS = (
     "person_add", "person_edit", "ingest", "commit_extraction", "document_set_text",
@@ -603,6 +617,10 @@ def build_server():  # pragma: no cover - exercised only with the mcp SDK instal
     @server.tool(name="render_journal", annotations=ro)
     def render_journal_tool(person: str, since: str | None = None) -> dict:
         return _run(render_journal, person=person, since=since)
+
+    @server.tool(name="render_curation", annotations=ro)
+    def render_curation_tool(person: str) -> dict:
+        return _run(render_curation, person=person)
 
     # -- write --
     @server.tool(name="person_add", annotations=rw)

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -1,8 +1,9 @@
 """Phase 4 render layer: generated Markdown documents as pure functions of DB state.
 
 Architecture.md §6/§9. ``render.py`` produces the project's current deliverables --
-master summary, appointment brief, journal -- as pure, **read-only** functions of DB
-state, so they never drift from truth (old exports are disposable). Every function is
+master summary, appointment brief, journal, curation record -- as pure, **read-only**
+functions of DB state, so they never drift from truth (old exports are disposable). Every
+function is
 callable as plain Python with structured args (a person slug or appointment id, plus an
 optional synonym ``dictionary`` and a ``now`` for a deterministic generated-at stamp) so
 phase 5's MCP wrapper stays thin. The CLI owns argument parsing and the §5
@@ -53,15 +54,34 @@ under-suppression merely leaves a line on the page.
 the ``curation`` table, a pure overlay of recorded human verdicts scoped to a whole dedup
 family or to a **single row** (:meth:`curation.VerdictMap.for_row` resolves per row, row
 scope winning over family scope): ``superseded`` / ``erroneous-in-source`` /
-``merged-into`` leave their section for a ``## Superseded / corrected``
-appendix, ``disputed`` renders in place with a ``[DISPUTED: ...]`` marker (and
-reach the brief's ``## Questions for the Clinician``), and ``confirmed`` — like
-``distinct``, the collision ruling that says both rows are real facts (issue #122) —
-renders exactly
-as before. Both new sections are **omitted entirely** when empty, so a record with no
+``merged-into`` leave their section entirely, ``disputed`` renders in place with a
+``[DISPUTED: ...]`` marker (and reaches the brief's ``## Questions for the Clinician``),
+and ``confirmed`` — like ``distinct``, the collision ruling that says both rows are real
+facts (issue #122) — renders exactly
+as before. The questions section is **omitted entirely** when empty, so a record with no
 verdicts renders byte-identically to what it did before the overlay existed. This is
 still a pure function of DB state -- the filter is a read, and output changes after a
 verdict because the database changed.
+
+**The audit trail is its own target** (issue #168). Where the three clinical documents
+once each carried a ``## Superseded / corrected`` appendix at their foot, the verdicts
+now render as :func:`render_curation` -- ``pemr render curation``, redirected to a
+``curation.md`` of the operator's choosing. That block was merge bookkeeping addressed to
+a future curation session, not chart content, and on a curated dataset it dominated the
+summary. Two consequences are deliberate:
+
+  * the curation record is a **superset** of the block it replaced -- it enumerates
+    :func:`curation.list_curation` scoped to the person, rather than the verdicts whichever
+    sections happened to select, because a standalone audit trail must not depend on which
+    render pass produced it;
+  * it groups **by ruling**, not by row: one merge session's note recorded against forty
+    families renders once with a count.
+
+Nothing replaces the appendix inline. An ``APPENDIX_STATUSES`` verdict *removes* its row,
+so no reader is shown a stale value -- the hazard :func:`_open_conflicts_warning` answers
+(issue #59: the summary printing a value a staged correction disputes) has no analogue
+here. The empty-state rule the appendix documented survives the move: a subject with no
+verdicts gets ``""``, never a header implying a review happened.
 
 **Attested rows** (issue #110). A row whose provenance is a named human rather than a
 document (`pemr record assert`) is tagged wherever it renders, by :func:`_attest_suffix` at
@@ -96,7 +116,7 @@ import sqlite3
 from collections.abc import Sequence
 from datetime import date, datetime
 
-from . import curation, db, query, units
+from . import curation, db, dedup, query, units
 from .dedup import enum_token, is_attested, key_token, norm
 
 # Observation obs_type conventions this layer reads (see module docstring).
@@ -237,18 +257,24 @@ def _ref_range(row: sqlite3.Row | dict) -> str:
 # --------------------------------------------------------------------------- #
 
 class _CurationPass:
-    """One render's view of the `curation` overlay: the verdict map plus the two
-    out-of-band collections a render builds while filtering its sections.
+    """One render's view of the `curation` overlay: the verdict map plus the
+    out-of-band collection a render builds while filtering its sections.
 
-    One object rather than threading ``verdicts``/``appendix``/``disputed`` through
-    every read helper: a render touches ten sections and the three always travel
-    together. It is created once per render and is read-only with respect to the DB --
-    ``render`` never writes, and the overlay does not change that.
+    One object rather than threading ``verdicts``/``disputed`` through every read
+    helper: a render touches ten sections and the two always travel together. It is
+    created once per render and is read-only with respect to the DB -- ``render`` never
+    writes, and the overlay does not change that.
 
     ``verdicts`` empty (the overwhelmingly common case, and every pre-008 snapshot) is
     the fast path: :func:`_apply_curation` returns its rows untouched, no row is given a
-    ``_curation`` key, and both new sections are omitted -- which is what keeps output
+    ``_curation`` key, and the questions section is omitted -- which is what keeps output
     byte-identical for unannotated data.
+
+    There is no ``appendix`` bucket since issue #168: the audit trail moved to
+    :func:`render_curation`, which reads the stored verdict table directly, and keeping a
+    write-only bucket here would cost a ``row_label``/``family_label`` query per verdict
+    on every curated render for nothing. The :data:`curation.APPENDIX_STATUSES` *filter*
+    is unaffected -- it keys off :func:`curation.is_appendix`, not off this bucket.
     """
 
     def __init__(self, conn: sqlite3.Connection):
@@ -258,7 +284,6 @@ class _CurationPass:
         # listed once however many of its rows a section selected -- while two rows of
         # one family carrying *different* row-scoped verdicts (issue #114) are two
         # entries rather than one swallowing the other. Insertion-ordered.
-        self.appendix: dict[tuple[str, str, int], dict] = {}
         self.disputed: dict[tuple[str, str, int], dict] = {}
 
     def _entry(self, verdict: dict) -> dict:
@@ -274,25 +299,24 @@ class _CurationPass:
         return dict(verdict, label=label, family_size=family_size)
 
     def record(self, verdict: dict) -> None:
-        """File a verdict under the section its status sends it to, once.
+        """File a ``disputed`` verdict for the questions section, once.
 
         Identity comes off the verdict itself rather than off the row that matched it:
         the key must be the verdict's *scope* (family or this one row), and passing the
         matching row's id alongside a family-scoped verdict would split one family into
-        an appendix line per occurrence.
+        a question line per occurrence.
 
-        ``confirmed`` is filed nowhere on purpose: it records agreement, so it neither
-        leaves its section nor raises a question.
+        Every other status is filed nowhere. ``confirmed`` records agreement, so it
+        neither leaves its section nor raises a question; the
+        :data:`curation.APPENDIX_STATUSES` verdicts do leave their section, but their
+        audit trail is :func:`render_curation`'s job (issue #168), read from the stored
+        table rather than accumulated here.
         """
-        if verdict["status"] in curation.APPENDIX_STATUSES:
-            bucket = self.appendix
-        elif verdict["status"] == "disputed":
-            bucket = self.disputed
-        else:
+        if verdict["status"] != "disputed":
             return
         key = (verdict["record_type"], verdict["dedup_base"], verdict["record_id"])
-        if key not in bucket:
-            bucket[key] = self._entry(verdict)
+        if key not in self.disputed:
+            self.disputed[key] = self._entry(verdict)
 
 
 def _apply_curation(
@@ -302,8 +326,8 @@ def _apply_curation(
 
     Returns the rows that still render, stamping each annotated survivor with its
     verdict under ``_curation``; rows whose verdict is in
-    :data:`curation.APPENDIX_STATUSES` are dropped from the section and collected for the
-    appendix instead.
+    :data:`curation.APPENDIX_STATUSES` are dropped from the section, their audit trail
+    left to :func:`render_curation` (issue #168).
 
     Resolution is **per row**, not per family (issue #114): a row-scoped verdict applies
     to its own occurrence and a family-scoped one to every row that has no verdict of its
@@ -316,10 +340,9 @@ def _apply_curation(
 
     The stamping itself is :func:`curation.annotate_rows` (issue #131) — shared with
     `pemr query`, so the two verbs cannot drift apart about which rows carry which
-    verdict. What stays here is the *policy*: collect into the appendix, then drop. An
-    appendix-bound row is now stamped a moment before it is dropped, which is invisible
-    (the row is discarded) but is why this is a filter over stamped rows rather than a
-    stamp-only-survivors loop.
+    verdict. What stays here is the *policy*: drop the appendix-bound rows. Such a row is
+    stamped a moment before it is dropped, which is invisible (the row is discarded) but
+    is why this is a filter over stamped rows rather than a stamp-only-survivors loop.
     """
     if cur is None or not cur.verdicts:
         return rows
@@ -344,7 +367,7 @@ def _apply_curation_events(
     journal never asks for the extra keys in the first place.
 
     Stamping is :func:`curation.annotate_events`, shared with `pemr query timeline`
-    (issue #131); the appendix policy stays here, as in :func:`_apply_curation`.
+    (issue #131); the drop policy stays here, as in :func:`_apply_curation`.
     """
     if cur is None or not cur.verdicts:
         return events
@@ -438,24 +461,6 @@ def _converted_lab(row: dict, d: units.Displayed) -> dict:
         moved = None if raw is None else units.convert(raw, d.source_unit, d.unit)
         bounds[name] = raw if moved is None else units.round_display(moved)
     return dict(row, value_num=d.value, unit=d.unit, **bounds)
-
-
-def _appendix_section(entries: dict[tuple[str, str, int], dict]) -> str | None:
-    """The ``## Superseded / corrected`` section, or ``None`` when there is nothing
-    to say.
-
-    Deliberately **not** built with :func:`_section`: that helper's always-present
-    header is right for a clinical section whose emptiness is itself information, and
-    exactly wrong here -- an empty appendix on every unannotated record would break the
-    additive-only guarantee for output that has no verdicts at all.
-    """
-    if not entries:
-        return None
-    lines = []
-    for (record_type, _base, _record_id), entry in entries.items():
-        label = entry["label"] or "(no live rows)"
-        lines.append(f"- {record_type}: {label}  [{curation.describe(entry)}]")
-    return _section("Superseded / corrected", lines)
 
 
 def _questions_section(entries: dict[tuple[str, str, int], dict]) -> str | None:
@@ -585,11 +590,10 @@ def _result_index(
     Scoped to ``person_id``: one person's results can never close another's order.
 
     Verdicts are read **directly** rather than through :func:`_apply_curation`, on
-    purpose. A result in :data:`curation.APPENDIX_STATUSES` must not close an order, but
-    this helper runs *before* ``_abnormal_labs``, and filing appendix entries from here
-    would re-order ``## Superseded / corrected`` for existing records. Reading without
-    recording keeps the overlay additive. ``disputed``/``confirmed``/``distinct``
-    results still count: they are live rows.
+    purpose: a result in :data:`curation.APPENDIX_STATUSES` must not close an order, and
+    this helper only needs to *ask*, not to file anything. Reading without recording keeps
+    the overlay additive. ``disputed``/``confirmed``/``distinct`` results still count:
+    they are live rows.
     """
     index: dict[str, list[date]] = {}
     rows = conn.execute(
@@ -1056,6 +1060,31 @@ def _open_conflict_lines(conn: sqlite3.Connection, person_id: int) -> list[str]:
     ]
 
 
+def _open_conflicts_warning(conn: sqlite3.Connection, person_id: int) -> str | None:
+    """The summary's one-line open-conflicts warning, or ``None`` at zero (issue #168).
+
+    #59's safety property, at a section's worth less page: an open conflict means the
+    summary is *currently displaying* a value a staged correction disputes, so the
+    document has to say so -- but it does not need a per-conflict list to say it, and an
+    always-present ``## Open Conflicts`` / ``_none_`` header on the common case was
+    exactly the noise this issue is about. The per-conflict lines survive in the brief
+    (:func:`_open_conflict_lines`, unchanged) and in `pemr review-conflicts`.
+
+    Not built with :func:`_section` for :func:`_questions_section`'s reason: emptiness
+    here is not information, it is the normal case.
+    """
+    count = len(_open_conflict_lines(conn, person_id))
+    if not count:
+        return None
+    plural = "" if count == 1 else "s"
+    return (
+        "> [!WARNING]\n"
+        f"> {count} open conflict{plural} - some values below may be superseded. See "
+        "curation.md, or run\n"
+        "> `pemr review-conflicts`.\n"
+    )
+
+
 def _appt_who(row: sqlite3.Row | dict) -> str:
     return " ".join(p for p in (row["provider"], row["specialty"]) if p)
 
@@ -1093,13 +1122,16 @@ def render_summary(
 ) -> str:
     """Markdown master summary for a person: active meds, active problems, past medical
     history, family history, allergies, orders, latest vitals, recent abnormal labs,
-    procedures, upcoming/open appointments, and any open conflicts --
+    procedures and upcoming/open appointments --
     with a self-identifying header (name, DOB, generated-at, source row counts).
     Read-only.
 
     The summary is the document read *between* appointments, so an open conflict has to
     surface here too: without it a staged correction is invisible and the summary prints
-    the stale value with no hint that a corrected one is pending (issue #59).
+    the stale value with no hint that a corrected one is pending (issue #59). Since issue
+    #168 it says so in one :func:`_open_conflicts_warning` line under the header, emitted
+    only when the count is non-zero, rather than an always-present section. The curation
+    audit trail is no longer inlined here either -- it is :func:`render_curation`.
 
     ``routine_procedures`` is the ``[procedures].routine`` pattern list (issue #166,
     module docstring). It is **suppress-only** and defaults to ``None``, which suppresses
@@ -1212,8 +1244,11 @@ def render_summary(
         for a in _open_appointments(conn, person_id, today, cur)
     ]
 
+    # Immediately after the header, not at the foot: the wording says "some values
+    # *below* may be superseded", and a warning at the end of the document warns nobody.
     parts = [
         header,
+        *(w for w in (_open_conflicts_warning(conn, person_id),) if w is not None),
         _section("Active Medications", med_lines),
         _section("Active Problems", active_lines),
         _section("Past Medical History", past_lines),
@@ -1228,12 +1263,7 @@ def render_summary(
         ),
         _section("Procedures", proc_lines),
         _section("Upcoming / Open Appointments", appt_lines),
-        _section(
-            "Open Conflicts", _open_conflict_lines(conn, person_id), empty="_none_"
-        ),
     ]
-    # Omitted entirely when there are no verdicts -- see _appendix_section.
-    parts += [p for p in (_appendix_section(cur.appendix),) if p is not None]
     return "\n".join(parts).rstrip() + "\n"
 
 
@@ -1397,13 +1427,12 @@ def render_brief(
         _section("Procedures & Observations", ctx_lines),
         _section("Open Conflicts", conflict_lines, empty="_none_"),
     ]
-    # Both omitted entirely when empty, so an unannotated brief is byte-identical to
-    # what it was before the overlay existed. The clinician questions sit immediately
-    # before the interaction block: the last thing read is what to ask about.
-    parts += [
-        p for p in (_appendix_section(cur.appendix), _questions_section(cur.disputed))
-        if p is not None
-    ]
+    # Omitted entirely when empty, so an unannotated brief is byte-identical to what it
+    # was before the overlay existed. The clinician questions sit immediately before the
+    # interaction block: the last thing read is what to ask about. The superseded/
+    # corrected appendix used to sit here too; issue #168 dropped it -- what belongs in
+    # front of a clinician is the questions, and the audit trail is `render curation`.
+    parts += [p for p in (_questions_section(cur.disputed),) if p is not None]
     parts.append(interaction)
     return "\n".join(parts).rstrip() + "\n"
 
@@ -1421,6 +1450,9 @@ def render_journal(
 ) -> str:
     """The phase-3 timeline event stream rendered as a narrative Markdown chronology,
     grouped by date, with document-provenance footnotes. Read-only.
+
+    Curated-away events simply do not appear; their audit trail is
+    :func:`render_curation` (issue #168), not a tail section here.
 
     Raises :class:`query.PersonNotFoundError` for an unknown slug (friendly rc=1)."""
     person_id = query.resolve_person_id(conn, slug)
@@ -1440,11 +1472,7 @@ def render_journal(
         f"- Generated: {_generated_at(now)} (read-only view of DB state)\n"
     )
     if not events:
-        # An appendix can outlive the events: a journal whose every dated event was
-        # superseded still has to say where they went.
-        tail = _appendix_section(cur.appendix)
-        empty = header + "\n_No dated events on record._\n"
-        return empty if tail is None else empty + "\n" + tail
+        return header + "\n_No dated events on record._\n"
 
     # Provenance footnotes: assign a stable [^n] marker per referenced document, in
     # first-appearance order, and resolve each to a one-line source description.
@@ -1471,12 +1499,6 @@ def render_journal(
             f"{_dispute_suffix(e)}{_attest_suffix(e)}"
         )
 
-    # Before the footnote block: footnotes are reference apparatus for the events
-    # above them and stay last.
-    appendix = _appendix_section(cur.appendix)
-    if appendix is not None:
-        lines.append("\n" + appendix.rstrip())
-
     if footnote_order:
         lines.append("\n---\n")
         for doc_id in footnote_order:
@@ -1501,3 +1523,161 @@ def _document_citation(doc: sqlite3.Row | None, doc_id: int) -> str:
     if doc["source_path"]:
         bits.append(f"sources/{doc['source_path']}")
     return ", ".join(bits)
+
+
+# --------------------------------------------------------------------------- #
+# Curation record -- the audit trail as its own target (Architecture.md §6)
+# --------------------------------------------------------------------------- #
+
+def _verdict_heading(verdict: dict) -> str:
+    """One ruling's ``##`` heading: :func:`curation.describe` **minus the note**.
+
+    Deliberately not ``describe()`` itself. An operator note is free-form text that may
+    run to several lines -- the merge-bookkeeping notes issue #168 was raised over do
+    exactly that -- and a multi-line ``##`` heading is broken Markdown, so the note goes
+    in a blockquote under the heading instead.
+
+    ``merged_into_base`` keeps ``describe()``'s 12-character truncation and carries **no**
+    resolved label: a merge target may be another person's family (issue #161), which must
+    never leak into this person's document.
+    """
+    status = verdict.get("status") or ""
+    if status == "merged-into" and verdict.get("merged_into_base"):
+        status = f"merged into {str(verdict['merged_into_base'])[:12]}..."
+    who = verdict.get("attributed_to")
+    return f"{status} ({who})" if who else status
+
+
+def _curation_target_line(verdict: dict) -> str:
+    """One ``- <record_type>: <label>  (<scope>)`` bullet under a ruling.
+
+    The scope note carries the row count a family-scoped verdict covers, which is what
+    makes the group counts auditable rather than assertions: ``(family, 4 rows)`` against
+    ``(row)``.
+    """
+    label = verdict["label"] or "(no live rows)"
+    if verdict["record_id"]:
+        scope = "row"
+    else:
+        size = verdict["family_size"]
+        scope = f"family, {size} row{'' if size == 1 else 's'}"
+    return f"- {verdict['record_type']}: {label}  ({scope})"
+
+
+def _curation_groups(conn: sqlite3.Connection, person_id: int) -> list[dict]:
+    """This person's :data:`curation.APPENDIX_STATUSES` verdicts, grouped by ruling.
+
+    Read from :func:`curation.list_curation` -- the stored table -- rather than from a
+    render pass's collected verdicts, and that is the point of the target: the block this
+    replaced listed only whatever verdicts some section's ``SELECT`` happened to hit, so
+    "the appendix" was a different set per document (the summary's missed a superseded
+    *inactive* med and a superseded lab older than the abnormal-labs window). A standalone
+    audit trail must not depend on which sections ran, so the curation record is a
+    deliberate **superset** of the block it replaces.
+
+    The group key is the ruling itself -- ``(status, merged_into_base, note,
+    attributed_to)`` -- so one merge session's note recorded against forty families is one
+    block with a count instead of forty near-identical bullets.
+
+    Orphan verdicts (the target is gone, so there is no person to scope them to) are
+    excluded exactly as they were before, and keep their own surfaces: `pemr verify`,
+    `pemr record reaffirm`, `pemr record --list`.
+
+    Order is :func:`curation.list_curation`'s (``created_at DESC, record_type,
+    dedup_base, record_id``), both across groups and inside one; it is already
+    deterministic, so nothing re-sorts.
+    """
+    groups: dict[tuple, dict] = {}
+    for verdict in curation.list_curation(conn):
+        if verdict["status"] not in curation.APPENDIX_STATUSES:
+            continue
+        record_type = verdict["record_type"]
+        if record_type not in dedup.FIELD_SPECS:
+            # A hand-edited row can name anything, and `row_person`/`family_person`
+            # interpolate the type into a table name. Guard before, never after.
+            continue
+        if verdict["record_id"]:
+            owner, _slug = curation.row_person(conn, record_type, verdict["record_id"])
+        else:
+            owner, _slug = curation.family_person(
+                conn, record_type, verdict["dedup_base"]
+            )
+        if owner is None or owner != person_id:
+            continue
+        key = (
+            verdict["status"],
+            verdict["merged_into_base"],
+            verdict["note"],
+            verdict["attributed_to"],
+        )
+        group = groups.get(key)
+        if group is None:
+            group = groups[key] = {
+                "heading": _verdict_heading(verdict),
+                "note": verdict["note"] or "",
+                "verdicts": 0,
+                "rows": 0,
+                "targets": [],
+            }
+        group["verdicts"] += 1
+        group["rows"] += 1 if verdict["record_id"] else verdict["family_size"]
+        group["targets"].append(_curation_target_line(verdict))
+    return list(groups.values())
+
+
+def _curation_group_block(group: dict) -> str:
+    """One ruling rendered to Markdown: heading, counts, the note as a blockquote, then
+    the targets it covers.
+
+    Not :func:`_section`, for :func:`_questions_section`'s reason -- and because the body
+    is not a bullet list but three stanzas. An empty note emits no blockquote rather than
+    a bare ``>``.
+    """
+    lines = [f"## {group['heading']}", ""]
+    verdicts, rows = group["verdicts"], group["rows"]
+    lines.append(
+        f"_{verdicts} verdict{'' if verdicts == 1 else 's'}, "
+        f"{rows} row{'' if rows == 1 else 's'}_"
+    )
+    if group["note"]:
+        lines.append("")
+        lines.extend(f"> {line}" for line in group["note"].splitlines())
+    lines.append("")
+    lines.extend(group["targets"])
+    return "\n".join(lines) + "\n"
+
+
+def render_curation(
+    conn: sqlite3.Connection,
+    slug: str,
+    *,
+    now: datetime | None = None,
+) -> str:
+    """Markdown curation record for a person -- the audit trail of every recorded verdict
+    that removed a row from the clinical documents, grouped by ruling. Read-only.
+
+    ``""`` when there is nothing to say: no qualifying verdicts, or a pre-008 snapshot
+    with no ``curation`` table at all (:func:`curation.list_curation` returns ``[]``
+    there, the `has_table` degradation convention `render`/`verify` already use). That
+    empty state is a **rule, not an optimisation** -- it is the additive-only guarantee
+    the old ``_appendix_section`` documented, carried across the move: a subject nobody
+    has curated must never be handed a document whose header implies a review happened.
+
+    Raises :class:`query.PersonNotFoundError` for an unknown slug (friendly rc=1)."""
+    person_id = query.resolve_person_id(conn, slug)
+    groups = _curation_groups(conn, person_id)
+    if not groups:
+        return ""
+    person = conn.execute(
+        "SELECT * FROM person WHERE person_id = ?", (person_id,)
+    ).fetchone()
+    verdicts = sum(g["verdicts"] for g in groups)
+    rows = sum(g["rows"] for g in groups)
+    header = (
+        f"# Curation Record: {person['full_name']}\n\n"
+        f"- Person: {person['slug']}\n"
+        f"- Generated: {_generated_at(now)} (read-only view of DB state)\n"
+        f"- Verdicts: {verdicts} covering {rows} row{'' if rows == 1 else 's'}\n"
+    )
+    parts = [header] + [_curation_group_block(g) for g in groups]
+    return "\n".join(parts).rstrip() + "\n"

--- a/tests/test_cli_ascii.py
+++ b/tests/test_cli_ascii.py
@@ -201,7 +201,13 @@ def test_record_annotate_output_is_console_safe(ready, capsys):
     capsys.readouterr()
     assert _run(ready, "render", "summary", "--person", "jane-doe") == 0
     out = capsys.readouterr().out
-    assert "## Superseded / corrected" in out
+    assert "Glucose" not in out              # curated out of the summary (#168)
+    _assert_console_safe(out)
+
+    # The audit trail is its own target now, and it is console-safe too (#168).
+    assert _run(ready, "render", "curation", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    assert "## superseded" in out and "lab_result: Glucose" in out
     _assert_console_safe(out)
 
     assert _run(ready, "record", "rm", "lab_result", "1", "--apply") == 0

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -733,14 +733,14 @@ def test_a_distinct_resolved_pair_still_renders_as_two_live_problems(
 ):
     """AC2 + AC3 as one chain at the CLI, on the real-world trigger (AC6): declare the
     pair distinct, `rekey --apply` writes the table, and the rendered summary still shows
-    *both* conditions with no `## Superseded / corrected` appendix at all.
+    *both* conditions with an empty curation record.
 
     The `superseded` leg is the control that keeps the assertion honest. Both statuses
     resolve the collision and both produce the identical two-occurrence family, so the
     only thing separating them is `distinct`'s absence from
     `curation.APPENDIX_STATUSES` - and on that leg the ruled row *does* leave Active
-    Problems for the appendix. Without the contrast, "no appendix" could equally mean the
-    appendix never fires for conditions."""
+    Problems, for the curation record (issue #168). Without the contrast, "empty record"
+    could equally mean the record never fires for conditions."""
     old = _dict_file(tmp_path, "old.toml", '"unrelated" = "unrelated"\n')
     new = _dict_file(tmp_path, "fuse.toml", '"diagnosis 2" = "diagnosis"\n')
     _seed_generic_condition_pair(ready, capsys, tmp_path, old)
@@ -771,13 +771,16 @@ def test_a_distinct_resolved_pair_still_renders_as_two_live_problems(
         assert (rows[first_id]["dedup_occurrence"],
                 rows[second_id]["dedup_occurrence"]) == (0, 1)
         summary = render.render_summary(conn, "jane-doe")
+        record = render.render_curation(conn, "jane-doe")
     finally:
         conn.close()
 
     problems = summary.split("## Active Problems")[1].split("##")[0]
     assert "asthma, per pulmonology" in problems           # never the ruled row
     assert ("hypertension, per cardiology" in problems) is both_live
-    assert ("## Superseded / corrected" not in summary) is both_live
+    assert (record == "") is both_live
+    if not both_live:
+        assert "two diagnoses, numbered labels" in record   # the ruling, with its note
 
 
 def test_rekey_json_still_reports_a_blocking_collision(ready, capsys, tmp_path):
@@ -1341,10 +1344,12 @@ def test_migration_006_allergy_collision_clears_when_a_verdict_covers_it(
     conn = db.connect(tmp_path / "cli.db")
     try:
         before = render.render_summary(conn, "jane-doe")
+        before_record = render.render_curation(conn, "jane-doe")
     finally:
         conn.close()
     assert "- Penicillin - anaphylaxis" in before
-    assert "allergy: PCN" in before.split("## Superseded / corrected")[1]
+    assert "PCN" not in before                        # curated out of the summary (#168)
+    assert "allergy: PCN" in before_record
 
     new = _dict_file(tmp_path, "fuse006.toml",
                      '"pcn" = "penicillin"\n"t2dm" = "type 2 diabetes"\n')
@@ -1369,7 +1374,8 @@ def test_migration_006_allergy_collision_clears_when_a_verdict_covers_it(
         # The verdict still covers PCN and only PCN: Penicillin stays where it was.
         after = render.render_summary(conn, "jane-doe")
         assert "- Penicillin - anaphylaxis" in after
-        assert "allergy: PCN" in after.split("## Superseded / corrected")[1]
+        assert "PCN" not in after
+        assert "allergy: PCN" in render.render_curation(conn, "jane-doe")
         # Nothing orphaned; the narrowing surfaces as a re-affirm notice instead.
         warnings = verify.verify_report(conn).warnings
         assert not any("no live family" in w for w in warnings)
@@ -1419,10 +1425,11 @@ def test_the_re_affirm_notice_from_a_narrowing_is_runnable(tmp_path, capsys):
         warnings = verify.verify_report(conn).warnings
         assert not any("a rekey moved it" in w or "no live family" in w
                        for w in warnings)
-        # Extension unchanged: PCN in the appendix, Penicillin still live.
+        # Extension unchanged: PCN in the curation record, Penicillin still live.
         after = render.render_summary(conn, "jane-doe")
         assert "- Penicillin - anaphylaxis" in after
-        assert "allergy: PCN" in after.split("## Superseded / corrected")[1]
+        assert "PCN" not in after
+        assert "allergy: PCN" in render.render_curation(conn, "jane-doe")
     finally:
         conn.close()
 

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -514,6 +514,7 @@ def test_query_meds_active_agrees_with_render_summary(curated, capsys):
         md = render.render_summary(
             conn, "jane-doe", dictionary=dedup.load_dictionary(DICT_ARG[1])
         )
+        record = render.render_curation(conn, "jane-doe")
     finally:
         conn.close()
     section = md.split("## Active Medications", 1)[1].split("\n## ", 1)[0]
@@ -526,8 +527,8 @@ def test_query_meds_active_agrees_with_render_summary(curated, capsys):
     # ... and the one the summary *would* have listed is accounted for, not lost.
     # (Prednisone is absent from both sides: an ended 2016 course never reaches the
     # Active Medications query in the first place, so nothing about it is suppressed.)
-    appendix = md.split("## Superseded / corrected", 1)[1]
-    assert "Breo Ellipta" in appendix
+    assert "Breo Ellipta" not in md            # nowhere in the summary at all (#168)
+    assert "Breo Ellipta" in record            # accounted for in the curation record
 
 
 # --- trends: display-unit conversion + its disclosure (issue #136) ------------

--- a/tests/test_cli_phase4.py
+++ b/tests/test_cli_phase4.py
@@ -1,6 +1,6 @@
-"""End-to-end CLI wiring for phase 4: render summary|brief|journal -- Markdown to
-stdout (the §5 redirect contract), --out file convenience, unknown-slug/appointment
-rc=1, and unmigrated-DB friendliness."""
+"""End-to-end CLI wiring for phase 4: render summary|brief|journal|curation -- Markdown
+to stdout (the §5 redirect contract), --out file convenience, unknown-slug/appointment
+rc=1, the empty-document contract, and unmigrated-DB friendliness."""
 
 import json
 from datetime import date, timedelta
@@ -452,3 +452,96 @@ def test_render_on_unmigrated_db_is_friendly(tmp_path, capsys, unmigrated_db):
     rc = _run(tmp_path, "render", "summary", "--person", "jane-doe")
     assert rc == 1
     assert "migrate" in capsys.readouterr().err
+
+
+# --- `render curation`: the audit-trail target (issue #168) -------------------
+
+
+def _annotate_ldl(tmp_path, note="repeat draw supersedes it"):
+    """Rule the fixture's one lab superseded, through the real CLI verb."""
+    lab = None
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        lab = conn.execute(
+            "SELECT lab_result_id FROM lab_result WHERE test_name='LDL'"
+        ).fetchone()["lab_result_id"]
+    finally:
+        conn.close()
+    assert _run(tmp_path, "record", "annotate", "lab_result", str(lab),
+                "--status", "superseded", "--note", note, "--apply") == 0
+
+
+def test_render_curation_to_stdout(ready, capsys):
+    tmp_path, _ = ready
+    _annotate_ldl(tmp_path)
+    capsys.readouterr()
+    assert _run(tmp_path, "render", "curation", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    assert "# Curation Record: Jane Doe" in out
+    assert "## superseded" in out
+    assert "lab_result: LDL" in out
+    assert out.isascii()                       # cp1252/cp437 console contract
+
+
+def test_render_curation_to_out_file(ready, capsys):
+    tmp_path, _ = ready
+    _annotate_ldl(tmp_path)
+    capsys.readouterr()
+    dest = tmp_path / "curation.md"
+    assert _run(tmp_path, "render", "curation", "--person", "jane-doe",
+                "--out", str(dest)) == 0
+    assert f"wrote {dest}" in capsys.readouterr().out
+    assert "# Curation Record: Jane Doe" in dest.read_text(encoding="utf-8")
+
+
+def test_render_curation_with_no_verdicts_writes_nothing(ready, capsys):
+    """The additive-only rule, all the way to the bytes on disk (issue #168): an
+    uncurated subject gets an empty document, not a header implying a review happened --
+    rc=0 on stdout with *no* stray newline, and a genuinely zero-byte `--out` file."""
+    tmp_path, _ = ready
+    capsys.readouterr()
+    assert _run(tmp_path, "render", "curation", "--person", "jane-doe") == 0
+    assert capsys.readouterr().out == ""
+
+    dest = tmp_path / "curation.md"
+    assert _run(tmp_path, "render", "curation", "--person", "jane-doe",
+                "--out", str(dest)) == 0
+    assert f"wrote {dest}" in capsys.readouterr().out
+    assert dest.stat().st_size == 0
+
+
+def test_render_curation_unknown_person_is_friendly_rc1(ready, capsys):
+    tmp_path, _ = ready
+    assert _run(tmp_path, "render", "curation", "--person", "ghost") == 1
+    assert "ghost" in capsys.readouterr().err
+
+
+def test_render_summary_open_conflicts_warning_end_to_end(ready, capsys):
+    """Issue #168 at the command boundary: no conflicts means no section and no `_none_`
+    line at all; a staged one means one warning block under the header. The section this
+    replaced was always present, so only the command boundary proves it is really gone."""
+    tmp_path, _ = ready
+    capsys.readouterr()
+    assert _run(tmp_path, "render", "summary", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    assert "## Open Conflicts" not in out and "_none_" not in out
+
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        conn.execute(
+            "INSERT INTO conflict (record_type, dedup_key, person_id, existing_json, "
+            "incoming_json, status, detected_at) VALUES ('lab_result', 'k', "
+            "(SELECT person_id FROM person WHERE slug='jane-doe'), '{}', '{}', 'open', "
+            "'2026-01-01')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert _run(tmp_path, "render", "summary", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    assert "## Open Conflicts" not in out
+    assert "> [!WARNING]" in out
+    assert "> 1 open conflict - some values below may be superseded." in out
+    assert "`pemr review-conflicts`" in out
+    assert out.isascii()

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -2110,7 +2110,6 @@ def test_cli_a_reused_row_id_is_not_filed_under_the_superseded_appendix(
     assert _run(cli_ready, "render", "summary", "--person", "jane-doe") == 0
     summary = capsys.readouterr().out
     assert "Anaphylaxis - epinephrine plan" in summary
-    assert "## Superseded / corrected" not in summary
     assert "loser of a keep-both" not in summary
 
     capsys.readouterr()
@@ -2124,8 +2123,9 @@ def test_cli_a_reused_row_id_is_not_filed_under_the_superseded_appendix(
 
 
 def test_cli_annotate_render_remove_verify_drill(cli_ready, capsys):
-    """annotate --apply -> render summary shows the appendix -> record rm the whole
-    family -> verify warns about the orphan and still exits ok."""
+    """annotate --apply -> the row leaves the summary and lands in `render curation`
+    (issue #168) -> record rm the whole family -> verify warns about the orphan and
+    still exits ok."""
     target = _cli_row_id(cli_ready, "lab_result", "test_name", "Glucose")
     assert _run(cli_ready, "record", "annotate", "lab_result", str(target),
                 "--status", "superseded", "--note", "repeat draw supersedes it",
@@ -2134,11 +2134,22 @@ def test_cli_annotate_render_remove_verify_drill(cli_ready, capsys):
     capsys.readouterr()
     assert _run(cli_ready, "render", "summary", "--person", "jane-doe") == 0
     summary = capsys.readouterr().out
-    assert "## Superseded / corrected" in summary
-    assert "lab_result: Glucose" in summary
-    assert "repeat draw supersedes it" in summary
+    assert "Glucose" not in summary
+    assert "repeat draw supersedes it" not in summary
+
+    assert _run(cli_ready, "render", "curation", "--person", "jane-doe") == 0
+    record = capsys.readouterr().out
+    assert "## superseded" in record
+    assert "lab_result: Glucose" in record
+    assert "repeat draw supersedes it" in record
 
     assert _run(cli_ready, "record", "rm", "lab_result", str(target), "--apply") == 0
+
+    # An orphan verdict has no person to scope it to, so it leaves the record too --
+    # `verify` / `record reaffirm` are its surfaces, exactly as before the move.
+    capsys.readouterr()
+    assert _run(cli_ready, "render", "curation", "--person", "jane-doe") == 0
+    assert capsys.readouterr().out == ""
 
     capsys.readouterr()
     assert _run(cli_ready, "verify") == 0
@@ -2255,10 +2266,10 @@ def test_cli_reaffirm_drill_moves_the_verdict_and_quiets_verify(cli_ready, capsy
 
     # And the ruling is doing its job again on the new identity.
     capsys.readouterr()
-    assert _run(cli_ready, "render", "summary", "--person", "jane-doe") == 0
-    summary = capsys.readouterr().out
-    assert "## Superseded / corrected" in summary
-    assert "one assay, two labels" in summary
+    assert _run(cli_ready, "render", "curation", "--person", "jane-doe") == 0
+    record = capsys.readouterr().out
+    assert "## superseded (Dr Who)" in record
+    assert "one assay, two labels" in record
 
 
 def test_cli_reaffirm_rerunning_the_same_map_file_is_a_clean_no_op(cli_ready, capsys):
@@ -2596,11 +2607,10 @@ def test_cli_reaffirm_carries_a_whole_batch_onto_the_new_identities(
     assert "but the row now sits in" in out
 
     capsys.readouterr()
-    assert _run(cli_ready, "render", "summary", "--person", "jane-doe") == 0
-    summary = capsys.readouterr().out
-    assert "## Superseded / corrected" in summary
+    assert _run(cli_ready, "render", "curation", "--person", "jane-doe") == 0
+    record = capsys.readouterr().out
     for note in ("same draw as the a1c", "progressed, one condition"):
-        assert note in summary
+        assert note in record
 
 
 def test_cli_reaffirm_mixed_batch_lands_what_it_can_and_names_the_rest(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -159,6 +159,30 @@ def test_renderers_return_markdown(seeded):
     assert mcp_server.render_journal(seeded, person="jane-doe")["markdown"].startswith("#")
 
 
+def test_render_curation_mirrors_the_cli_target(seeded):
+    """Issue #168: the appendix left the three clinical documents, so without this tool
+    its content would vanish from every MCP-visible surface. Empty Markdown for an
+    uncurated person is the documented state, not a failure."""
+    assert mcp_server.render_curation(seeded, person="jane-doe")["markdown"] == ""
+
+    base = seeded.execute(
+        "SELECT dedup_base FROM medication WHERE name = 'Metformin'"
+    ).fetchone()["dedup_base"]
+    curation.annotate_record(seeded, "medication", base, status="superseded",
+                             note="duplicate portal import", apply=True)
+
+    md = mcp_server.render_curation(seeded, person="jane-doe")["markdown"]
+    assert md.startswith("# Curation Record: Jane Doe")
+    assert "medication: Metformin" in md and "duplicate portal import" in md
+    # ... and it really is the content the summary no longer carries.
+    assert "Metformin" not in mcp_server.render_summary(seeded, person="jane-doe")["markdown"]
+
+
+def test_render_curation_unknown_person_is_a_friendly_tool_error(seeded):
+    with pytest.raises(mcp_server.ToolError):
+        mcp_server.render_curation(seeded, person="ghost")
+
+
 def test_render_summary_narrows_procedures_like_the_cli(seeded):
     """Issue #166, verify pass: the MCP front door must *apply* the routine list, not
     merely accept the kwarg. `test_renderers_return_markdown` asserts only that the
@@ -195,6 +219,7 @@ def test_read_tools_leave_db_byte_stable(seeded, db_path):
     mcp_server.trends(seeded, person="jane-doe", test="a1c")
     mcp_server.render_summary(seeded, person="jane-doe")
     mcp_server.render_journal(seeded, person="jane-doe")
+    mcp_server.render_curation(seeded, person="jane-doe")
     assert _sha(db_path) == before
 
 
@@ -618,10 +643,19 @@ def test_curation_verbs_are_not_on_the_mcp_surface():
     """Trust boundary (issue #109, the `document rm` / `record rm` precedent): a
     human's clinical verdict is CLI-only. AGENTS.md's blessed write set is
     commit_extraction/person_add/person_edit/ingest/document_set_text, and
-    `record annotate` is deliberately not in it - read or write."""
+    `record annotate` is deliberately not in it - read or write.
+
+    `render_curation` (issue #168) is the one tool that may say "curation" at all, and it
+    is a *renderer*: it reads the verdict table the same way `render_summary` reads the
+    clinical tables. Writing a verdict is still unreachable from here, which is the
+    property this test exists for - so the write surface may never say it."""
     surface = " ".join(mcp_server.TOOL_NAMES).lower()
-    for spelling in ("annotate", "curation", "record_rm", "record_annotate"):
+    for spelling in ("annotate", "record_rm", "record_annotate"):
         assert spelling not in surface, spelling
+    writes = " ".join(mcp_server.WRITE_TOOLS).lower()
+    for spelling in ("annotate", "curation", "record_rm", "record_annotate"):
+        assert spelling not in writes, spelling
+    assert [t for t in mcp_server.TOOL_NAMES if "curation" in t] == ["render_curation"]
 
 
 def test_record_assert_is_not_on_the_mcp_surface():

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -945,17 +945,18 @@ def test_summary_procedures_dispute_and_attest_suffixes(seeded):
                for ln in section.splitlines())
 
 
-def test_summary_procedures_superseded_row_leaves_for_the_appendix(seeded):
-    """Filter order: curation first, routine list second. An appendix-bound row must be
+def test_summary_procedures_superseded_row_leaves_for_the_curation_record(seeded):
+    """Filter order: curation first, routine list second. A curated-away row must be
     routed by its verdict before the pattern list counts anything, or a superseded row
-    would be reported twice -- once in the appendix, once as a hidden routine one."""
+    would be reported twice -- once as curated, once as a hidden routine one."""
     _seed_procedures(seeded, [{"name": "Venipuncture", "performed_on": "2026-02-01"}])
     _annotate(seeded, "procedure", "name", "Colonoscopy", status="superseded",
               note="duplicated by the later report")
     md = render.render_summary(seeded, "jane-doe", routine_procedures=["venipuncture"])
     section = md.split("## Procedures")[1].split("\n## ")[0]
     assert "Colonoscopy" not in section
-    assert "## Superseded / corrected" in md and "procedure: Colonoscopy" in md
+    assert "Colonoscopy" not in md                        # not anywhere in the summary
+    assert "procedure: Colonoscopy" in render.render_curation(seeded, "jane-doe")
     assert "_1 routine procedure not shown" in section   # the superseded row is not counted
 
 
@@ -967,31 +968,43 @@ def test_summary_upcoming_and_open_appointments(seeded):
     assert "Dr. Past" not in section  # past + documented -> closed
 
 
-def test_summary_open_conflicts_section(seeded):
+def test_summary_open_conflicts_warning_line(seeded):
     """The summary is the doc read between appointments, so a staged correction must be
     visible there and not only in `review-conflicts` / a per-appointment brief: without
-    it the summary prints the stale value with no hint a correction is pending (#59)."""
-    cid = _stage_conflict(seeded, "jane-doe")
+    it the summary prints the stale value with no hint a correction is pending (#59).
+
+    Issue #168 kept that guarantee and dropped the section: one `> [!WARNING]` block,
+    directly under the header, because the wording says "some values *below*"."""
+    _stage_conflict(seeded, "jane-doe")
     md = render.render_summary(seeded, "jane-doe")
-    section = md.split("## Open Conflicts")[1].split("\n## ")[0]
-    assert f"conflict #{cid} (lab_result)" in section
-    assert "`pemr review-conflicts`" in section       # tells the reader how to clear it
+    assert "## Open Conflicts" not in md              # the section is gone, not moved
+    warning = md.split("\n## ")[0]                    # everything above the first section
+    assert "> [!WARNING]" in warning
+    assert "> 1 open conflict - some values below may be superseded." in warning
+    assert "curation.md" in warning
+    assert "`pemr review-conflicts`" in warning       # tells the reader how to clear it
+
+
+def test_summary_open_conflicts_warning_pluralizes(seeded):
+    _stage_conflict(seeded, "jane-doe")
+    _stage_conflict(seeded, "jane-doe")
+    md = render.render_summary(seeded, "jane-doe")
+    assert "> 2 open conflicts - some values below may be superseded." in md
 
 
 def test_summary_open_conflicts_empty_state_and_scoping(seeded):
-    """Empty state is explicit (`_none_`, matching the brief), resolved conflicts drop
-    out of the section, and another person's conflict never leaks in."""
+    """Zero open conflicts means *nothing* -- no header, no `_none_` line (the noise
+    issue #168 was raised over). Resolved conflicts and another person's never count."""
     md = render.render_summary(seeded, "jane-doe")
-    assert "_none_" in md.split("## Open Conflicts")[1].split("\n## ")[0]
+    assert "## Open Conflicts" not in md
+    assert "_none_" not in md
+    assert "[!WARNING]" not in md
 
-    resolved = _stage_conflict(seeded, "jane-doe", status="resolved")
-    johns = _stage_conflict(seeded, "john-doe")
-    section = render.render_summary(
-        seeded, "jane-doe"
-    ).split("## Open Conflicts")[1].split("\n## ")[0]
-    assert f"conflict #{resolved}" not in section     # resolved -> not open
-    assert f"conflict #{johns}" not in section        # other person's conflict
-    assert "_none_" in section
+    _stage_conflict(seeded, "jane-doe", status="resolved")
+    _stage_conflict(seeded, "john-doe")
+    md = render.render_summary(seeded, "jane-doe")
+    assert "[!WARNING]" not in md                    # resolved / other person -> not open
+    assert "## Open Conflicts" not in md
 
 
 def test_summary_empty_sections_are_explicit(seeded):
@@ -1215,8 +1228,9 @@ def _renders(conn):
 
 
 def test_no_verdicts_renders_byte_identically(seeded):
-    """The load-bearing guarantee: the appendix and questions sections are *omitted*,
-    not rendered empty, so unannotated output is unchanged to the byte."""
+    """The load-bearing guarantee: the questions section is *omitted*, not rendered
+    empty, so unannotated output is unchanged to the byte. Since issue #168 the same rule
+    binds the curation record itself: no verdicts means no document at all."""
     before = _renders(seeded)
     # An empty `curation` table is the state every existing database is in.
     assert seeded.execute("SELECT COUNT(*) AS n FROM curation").fetchone()["n"] == 0
@@ -1226,22 +1240,24 @@ def test_no_verdicts_renders_byte_identically(seeded):
         assert "Superseded / corrected" not in md
         assert "Questions for the Clinician" not in md
         assert "DISPUTED" not in md
+    assert render.render_curation(seeded, "jane-doe") == ""
 
 
 @pytest.mark.parametrize("status", ["superseded", "erroneous-in-source"])
-def test_superseded_family_leaves_its_section_for_the_appendix(seeded, status):
+def test_superseded_family_leaves_its_section_for_the_curation_record(seeded, status):
     _annotate(seeded, "condition", "name", "Appendicitis", status=status,
               note="never actually confirmed")
     out = _renders(seeded)
     for name, md in out.items():
-        if name == "brief":
-            continue  # the brief has no past-medical-history section
-        assert "## Superseded / corrected" in md, name
-        assert "condition: Appendicitis" in md, name
-        assert "never actually confirmed" in md, name
-    # Gone from Past Medical History, but the row itself is untouched.
-    body = out["summary"].split("## Superseded / corrected")[0]
-    assert "Appendicitis" not in body
+        # Gone from every clinical document, appendix and all (issue #168).
+        assert "Superseded / corrected" not in md, name
+        assert "Appendicitis" not in md, name
+    # ... and the trail is the curation record, which is where it now lives alone.
+    record = render.render_curation(seeded, "jane-doe")
+    assert "condition: Appendicitis" in record
+    assert "never actually confirmed" in record
+    assert f"## {status}" in record          # grouped under its ruling
+    # The row itself is untouched: a verdict is an overlay, never a delete.
     assert seeded.execute(
         "SELECT COUNT(*) AS n FROM condition WHERE name = 'Appendicitis'"
     ).fetchone()["n"] == 1
@@ -1275,13 +1291,16 @@ def test_merged_into_renders_only_the_target(seeded):
     _annotate(seeded, "lab_result", "test_name", "Glucose, fasting",
               status="merged-into", merged_into_base=target,
               note="same analyte, two spellings")
-    md = render.render_summary(seeded, "jane-doe",
-                               dictionary=dedup.load_dictionary(DICT_PATH))
-    body, appendix = md.split("## Superseded / corrected")
+    body = render.render_summary(seeded, "jane-doe",
+                                 dictionary=dedup.load_dictionary(DICT_PATH))
     assert "Glucose, fasting" not in body
     assert "LDL" in body                                     # the target still renders
-    assert "lab_result: Glucose, fasting" in appendix
-    assert f"merged into {target[:12]}..." in appendix
+    record = render.render_curation(seeded, "jane-doe")
+    assert "lab_result: Glucose, fasting" in record
+    assert f"## merged into {target[:12]}..." in record
+    # The target base is truncated and never resolved to a label: it may name another
+    # person's family (issue #161), which must not leak into this person's document.
+    assert target not in record
 
 
 def test_confirmed_changes_nothing_but_the_row_still_renders(seeded):
@@ -1368,14 +1387,15 @@ def test_a_row_scoped_verdict_hides_one_occurrence_and_spares_its_sibling(seeded
     curation.annotate_record(seeded, "lab_result", str(occ1), status="superseded",
                              note="loser of an earlier keep-both", row=True, apply=True)
 
-    md = render.render_summary(seeded, "jane-doe",
-                               dictionary=dedup.load_dictionary(DICT_PATH))
-    body, appendix = md.split("## Superseded / corrected")
+    body = render.render_summary(seeded, "jane-doe",
+                                 dictionary=dedup.load_dictionary(DICT_PATH))
     assert "200.0" in body                  # the sibling renders normally
     assert "205.0" not in body              # the annotated occurrence does not
+    record = render.render_curation(seeded, "jane-doe")
     # Listed once, not once per row of the family.
-    assert appendix.count("lab_result: Glucose, fasting") == 1
-    assert "loser of an earlier keep-both" in appendix
+    assert record.count("lab_result: Glucose, fasting") == 1
+    assert "loser of an earlier keep-both" in record
+    assert "(row)" in record                # row scope, so it covers exactly one row
 
     # The contrast: the same verdict at family scope takes both rows with it.
     curation.clear_curation(seeded, "lab_result", str(occ1), row=True, apply=True)
@@ -1383,13 +1403,14 @@ def test_a_row_scoped_verdict_hides_one_occurrence_and_spares_its_sibling(seeded
                              note="the whole family", apply=True)
     body = render.render_summary(
         seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH)
-    ).split("## Superseded / corrected")[0]
+    )
     assert "200.0" not in body and "205.0" not in body
+    assert "(family, 2 rows)" in render.render_curation(seeded, "jane-doe")
 
 
 def test_a_row_verdict_overrides_its_family_verdict_at_render_time(seeded):
     """Precedence, end to end: the family is disputed, one occurrence is superseded.
-    The superseded row leaves for the appendix; its sibling renders in place, marked."""
+    The superseded row leaves the summary; its sibling renders in place, marked."""
     base, _occ0, occ1 = _keep_both_sibling(seeded)
     curation.annotate_record(seeded, "lab_result", base, status="disputed",
                              note="two sources disagree", apply=True)
@@ -1397,15 +1418,17 @@ def test_a_row_verdict_overrides_its_family_verdict_at_render_time(seeded):
                              note="this one is the transcription error", row=True,
                              apply=True)
 
-    md = render.render_summary(seeded, "jane-doe",
-                               dictionary=dedup.load_dictionary(DICT_PATH))
-    body, appendix = md.split("## Superseded / corrected")
+    body = render.render_summary(seeded, "jane-doe",
+                                 dictionary=dedup.load_dictionary(DICT_PATH))
     assert "200.0" in body
     assert "[DISPUTED: two sources disagree]" in body
     assert "205.0" not in body
-    assert "this one is the transcription error" in appendix
-    # One appendix line: the row verdict's, not one per row of the family.
-    assert appendix.count("lab_result: Glucose, fasting") == 1
+    record = render.render_curation(seeded, "jane-doe")
+    assert "this one is the transcription error" in record
+    # One line: the row verdict's, not one per row of the family. And the `disputed`
+    # family verdict is not in the curation record at all -- it never left its section.
+    assert record.count("lab_result: Glucose, fasting") == 1
+    assert "two sources disagree" not in record
 
 
 def test_a_distinct_verdict_keeps_both_siblings_live(seeded):
@@ -1758,3 +1781,218 @@ def test_brief_and_journal_are_deliberately_not_converted(seeded):
     journal = render.render_journal(seeded, "jane-doe", now=_NOW)
     assert "80.0 kg" in brief and "converted from" not in brief
     assert "80.0 kg" in journal and "converted from" not in journal
+
+
+# --- the curation record: the audit trail as its own target (issue #168) -------
+
+
+def _record(conn, slug="jane-doe"):
+    return render.render_curation(conn, slug, now=datetime(2026, 6, 1))
+
+
+def test_curation_record_header_is_self_identifying_and_counts_its_scope(seeded):
+    _annotate(seeded, "condition", "name", "Appendicitis", status="superseded",
+              note="never actually confirmed", attributed_to="mkd")
+    md = _record(seeded)
+    assert md.startswith("# Curation Record: Jane Doe\n")
+    assert "- Person: jane-doe" in md
+    assert "- Generated: 2026-06-01T00:00:00 (read-only view of DB state)" in md
+    assert "- Verdicts: 1 covering 1 row" in md
+    assert "## superseded (mkd)" in md
+    assert "_1 verdict, 1 row_" in md
+    assert "> never actually confirmed" in md
+    assert "- condition: Appendicitis  (family, 1 row)" in md
+
+
+def test_curation_record_groups_verdicts_that_share_a_ruling(seeded):
+    """The observed complaint: one merge session's note recorded against many families
+    rendered as one near-identical bullet per family. Same ruling -> one block."""
+    for rtype, column, value in (("condition", "name", "Appendicitis"),
+                                 ("condition", "name", "Chickenpox"),
+                                 ("allergy", "substance", "Sulfa")):
+        _annotate(seeded, rtype, column, value, status="superseded",
+                  note="duplicate portal import", attributed_to="mkd")
+    md = _record(seeded)
+    assert md.count("## superseded (mkd)") == 1
+    assert md.count("> duplicate portal import") == 1
+    assert "_3 verdicts, 3 rows_" in md
+    assert "- Verdicts: 3 covering 3 rows" in md
+    for target in ("condition: Appendicitis", "condition: Chickenpox", "allergy: Sulfa"):
+        assert target in md
+
+
+@pytest.mark.parametrize("differing", ["status", "note", "attributed_to"])
+def test_curation_record_splits_rulings_that_differ_in_any_key(seeded, differing):
+    """The group key is the ruling itself. Differ anywhere in it and they are two
+    rulings, however similar they read."""
+    base = dict(status="superseded", note="duplicate portal import",
+                attributed_to="mkd")
+    other = dict(base, **{differing: {"status": "erroneous-in-source",
+                                      "note": "wrong patient",
+                                      "attributed_to": "dr-who"}[differing]})
+    _annotate(seeded, "condition", "name", "Appendicitis", **base)
+    _annotate(seeded, "condition", "name", "Chickenpox", **other)
+    md = _record(seeded)
+    assert md.count("\n## ") == 2
+    assert "- Verdicts: 2 covering 2 rows" in md
+
+
+def test_curation_record_row_arithmetic_counts_the_family(seeded):
+    """A family-scoped verdict covers every occurrence; a row-scoped one covers one.
+    The counts are what make the grouping auditable rather than an assertion."""
+    base, _occ0, occ1 = _keep_both_sibling(seeded)
+    curation.annotate_record(seeded, "lab_result", base, status="superseded",
+                             note="the whole family", apply=True)
+    md = _record(seeded)
+    assert "_1 verdict, 2 rows_" in md
+    assert "- lab_result: Glucose, fasting  (family, 2 rows)" in md
+    assert "- Verdicts: 1 covering 2 rows" in md
+
+    curation.clear_curation(seeded, "lab_result", base, apply=True)
+    curation.annotate_record(seeded, "lab_result", str(occ1), status="superseded",
+                             note="just this occurrence", row=True, apply=True)
+    md = _record(seeded)
+    assert "_1 verdict, 1 row_" in md
+    assert "- lab_result: Glucose, fasting  (row)" in md
+
+
+def test_curation_record_puts_a_multi_line_note_in_a_blockquote(seeded):
+    """The heading must stay one line whatever the operator typed -- a multi-line `##`
+    is broken Markdown, and multi-line merge notes are exactly what prompted the move."""
+    _annotate(seeded, "condition", "name", "Appendicitis", status="superseded",
+              note="first line\nsecond line", attributed_to="mkd")
+    md = _record(seeded)
+    assert "## superseded (mkd)\n" in md
+    assert "> first line\n> second line\n" in md
+
+
+def test_curation_group_block_omits_the_blockquote_for_an_empty_note():
+    """A block-level unit test on purpose: `record annotate` demands a note and the
+    `curation` table CHECKs it non-blank + NOT NULL, so no fixture can reach this state
+    through the DB. The guard still has to exist -- a bare `>` is broken Markdown -- so
+    it is exercised where it lives."""
+    block = render._curation_group_block(
+        {"heading": "superseded", "note": "", "verdicts": 1, "rows": 1,
+         "targets": ["- condition: Appendicitis  (family, 1 row)"]}
+    )
+    assert ">" not in block
+    assert block == (
+        "## superseded\n\n_1 verdict, 1 row_\n\n"
+        "- condition: Appendicitis  (family, 1 row)\n"
+    )
+
+
+def test_curation_record_carries_only_appendix_status_verdicts(seeded):
+    """`disputed`/`confirmed`/`distinct` never left their section, so they have no audit
+    trail to carry -- they are still on the page where the reader can see them."""
+    _annotate(seeded, "allergy", "substance", "Sulfa", status="disputed",
+              note="two notes disagree")
+    _annotate(seeded, "allergy", "substance", "Penicillin", status="confirmed",
+              note="clinician agreed")
+    assert _record(seeded) == ""
+
+    target = seeded.execute(
+        "SELECT dedup_base FROM condition WHERE name = 'Chickenpox'"
+    ).fetchone()["dedup_base"]
+    _annotate(seeded, "condition", "name", "Appendicitis", status="merged-into",
+              merged_into_base=target, note="one episode, two notes")
+    md = _record(seeded)
+    assert "condition: Appendicitis" in md
+    assert "two notes disagree" not in md and "clinician agreed" not in md
+
+
+def test_curation_record_is_scoped_to_one_person(seeded):
+    """John's verdict is John's business. A family is single-person by construction
+    (`dedup._key_parts` folds `person_id` in), so scoping is a lookup, not a guess."""
+    _annotate(seeded, "condition", "name", "Appendicitis", status="superseded",
+              note="jane's ruling")
+    johns = seeded.execute(
+        "SELECT dedup_base FROM lab_result WHERE person_id = "
+        "(SELECT person_id FROM person WHERE slug='john-doe')"
+    ).fetchone()["dedup_base"]
+    curation.annotate_record(seeded, "lab_result", johns, status="superseded",
+                             note="john's ruling", apply=True)
+
+    jane = _record(seeded)
+    assert "jane's ruling" in jane and "john's ruling" not in jane
+    john = _record(seeded, "john-doe")
+    assert "john's ruling" in john and "jane's ruling" not in john
+
+
+def test_curation_record_excludes_an_orphan_verdict(seeded):
+    """A verdict whose target is gone has no person to scope it to, so it cannot appear
+    here -- unchanged from the block this replaced. `pemr verify` / `record reaffirm`
+    are its surfaces."""
+    base = _annotate(seeded, "condition", "name", "Appendicitis", status="superseded",
+                     note="never actually confirmed")
+    assert "Appendicitis" in _record(seeded)
+    seeded.execute("DELETE FROM condition WHERE dedup_base = ?", (base,))
+    seeded.commit()
+    assert curation.get_verdict(seeded, "condition", base) is not None
+    assert _record(seeded) == ""
+
+
+def test_curation_record_skips_an_unknown_record_type_without_raising(seeded):
+    """A hand-edited `curation` row can name anything, and `row_person`/`family_person`
+    interpolate the type into a table name. The membership guard runs first."""
+    _annotate(seeded, "condition", "name", "Appendicitis", status="superseded",
+              note="the good one")
+    seeded.execute(
+        "INSERT INTO curation (record_type, dedup_base, record_id, status, note, "
+        "created_at) VALUES ('not_a_table', 'deadbeef', 0, 'superseded', 'hand-edited', "
+        "'2026-01-01T00:00:00')"
+    )
+    seeded.commit()
+    md = _record(seeded)
+    assert "the good one" in md
+    assert "hand-edited" not in md and "not_a_table" not in md
+
+
+def test_curation_record_is_empty_for_a_person_with_no_verdicts(seeded):
+    assert _record(seeded, "john-doe") == ""
+
+
+def test_curation_record_unknown_slug_raises(seeded):
+    with pytest.raises(query.PersonNotFoundError):
+        render.render_curation(seeded, "nobody")
+
+
+def test_curation_record_degrades_on_a_pre_008_snapshot(tmp_path):
+    """A snapshot without the `curation` table renders the empty document rather than
+    raising `no such table` (the `has_table` degradation convention)."""
+    conn = db.connect(tmp_path / "old.db")
+    db.migrate(conn)
+    persons.add_person(conn, "jane-doe", "Jane Doe")
+    conn.execute("DROP TABLE curation")
+    conn.commit()
+    try:
+        assert render.render_curation(conn, "jane-doe") == ""
+    finally:
+        conn.close()
+
+
+def test_curation_record_stays_ascii_and_read_only(seeded):
+    before = _row_counts(seeded)
+    _annotate(seeded, "condition", "name", "Appendicitis", status="superseded",
+              note="duplicate portal import", attributed_to="mkd")
+    md = _record(seeded)
+    assert md.isascii(), f"non-ASCII would crash a cp437 console: {md!r}"
+    md.encode("cp437")
+    assert _row_counts(seeded) == before      # still a pure read
+
+
+def test_curation_record_never_resolves_a_cross_person_merge_target(seeded):
+    """Issue #161: the merge target may name another person's family. The heading prints
+    the truncated base and never a resolved label, so nothing of John's leaks into
+    Jane's document."""
+    johns = seeded.execute(
+        "SELECT dedup_base FROM lab_result WHERE person_id = "
+        "(SELECT person_id FROM person WHERE slug='john-doe')"
+    ).fetchone()["dedup_base"]
+    _annotate(seeded, "lab_result", "test_name", "Glucose, fasting",
+              status="merged-into", merged_into_base=johns,
+              note="same draw, filed twice", allow_cross_person=True)
+    md = _record(seeded)
+    assert f"## merged into {johns[:12]}..." in md
+    assert johns not in md                      # truncated, never printed in full
+    assert "LDL" not in md                      # the target's label never resolved


### PR DESCRIPTION
## Summary

- New render target `pemr render curation --person <p>` extracts the "Superseded / corrected"
  appendix (`_appendix_section`) out of the master summary into its own audit-trail document,
  grouped **by ruling** (status, merge target, note, attribution) rather than by row — one
  merge session's note against forty families now renders as one block with a count instead of
  forty near-identical bullets.
- `render_summary`'s always-present `## Open Conflicts` header collapses to a single
  `> [!WARNING]` line placed right after the header block, emitted only when the open-conflict
  count is non-zero — no more `_none_` header on the common case, and the warning now sits
  where it's actually seen (above the content it warns about, not the foot of the document).
- `render_brief` drops the appendix entirely (`## Questions for the Clinician` is unchanged);
  `render_journal` drops it too with no replacement pointer, since curated rows leave those
  documents entirely rather than being shown stale.
- `render_curation` is built from the stored `curation` table directly (not from a render
  pass), so it is a complete person-scoped audit trail rather than whatever a summary/brief/
  journal query happened to select — a deliberate superset of the block it replaces.
- MCP front door gains a read-only `render_curation` tool; `AGENTS.md` documents it.
- Additive-only guarantee preserved: a person with zero curation verdicts gets `""` (no file,
  no header implying a review happened).

## Docs

- `AGENTS.md` — `render_curation` added to the read-only tool list.
- `docs/Architecture.md` — curation-record CLI example, MCP tool list, exports/ comment, and
  the §6 "generated docs" + "curation overlay" prose updated to describe the new shape (no more
  references to a `## Superseded / corrected` summary appendix).

## Reports

- Verify: https://github.com/meridun/pemr/issues/168#issuecomment-5332740462
- Audit: https://github.com/meridun/pemr/issues/168#issuecomment-5332810619

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)