### PR TITLE
fix(verify): detect pre-existing cross-person merged_into_base verdicts (#169)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -181,7 +181,12 @@ reports no orphan, while the fact leaves the annotated person's chart and never 
 the target person's. `record annotate` therefore refuses a cross-person `--merged-into`,
 and `record reaffirm` refuses the same shape at plan time (issue #161).
 `--allow-cross-person` is the explicit escape hatch for the rare deliberate case: never the
-default, and disclosed in the report (`cross_person`) rather than recorded silently.
+default, and disclosed in the report (`cross_person`) rather than recorded silently. That
+guard is forward-only, so `pemr verify` also **flags** a stored `merged_into_base` that
+resolves to another person's live family (issue #169) — the shape a verdict written before
+#161 can still carry. `cross_person` is not persisted on the row, so a deliberate
+`--allow-cross-person` merge shows up in that warning too; the message says as much, and
+warning on both beats staying silent on the accidental one.
 
 A correction is **not** a re-attribution. Before `record edit`, a wrong display field
 could only be repaired by re-submitting the row through `commit-extraction` (or deleting
@@ -637,7 +642,10 @@ the warning it answers would re-annotate the wrong rows. It owns exactly two cla
 `dangling-merge-target` (either scope, `merged_into_base` names no live family). The
 row-scoped **stale breadcrumb** is deliberately not one of them — that verdict still
 resolves by row id, so nothing may re-point it — nor is the removed-row case, whose remedy
-is `--clear --row` and which the removal write paths already retire.
+is `--clear --row` and which the removal write paths already retire. Nor is the
+cross-person merge target (#169): its family is *live*, just the wrong person's, and
+neither `record reaffirm` nor `rekey --apply` has a remedy for that — making it a kind
+would have them offer to re-point a verdict only a human re-ruling can fix.
 
 The two halves compose **by file**, and have to: a `dedup_base` is a content hash
 overwritten in place, so once the run is over nothing in the database records that `F_old`

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -179,6 +179,19 @@ def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
     remedy at batch scale, beside the per-row `record annotate --clear`. The row-scoped
     stale-breadcrumb notice below is deliberately *not* one of those classes: that verdict
     still resolves by row id, so nothing re-points it.
+
+    A third class is checked here and is likewise **not** an orphan kind (issue #169): a
+    `merged-into` verdict whose `merged_into_base` resolves to a family belonging to a
+    *different person*. #161's write-time guard closed that door in
+    :func:`curation.annotate_record`, but forward-only - a verdict written before it can
+    still point across people, and no orphan check notices, because the target family
+    genuinely exists. It stays out of :func:`curation.orphan_kinds` because neither
+    `record reaffirm` nor `rekey --apply` has a remedy for a live-but-wrong-person target:
+    they would offer to re-point a verdict they cannot fix. Detection only - the repair is
+    a human re-ruling. Note that the schema does not persist `cross_person`, so a merge
+    recorded deliberately with `--allow-cross-person` is indistinguishable from an
+    accidental pre-#161 one and warns too; the message says so, and warning on both is the
+    safer failure mode than staying silent.
     """
     if not curation.has_table(conn):
         return
@@ -226,17 +239,37 @@ def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
                 "(removed?) - lift it with `pemr record annotate --clear`"
             )
         target = verdict.get("merged_into_base")
+        # The merge target is always a family, in either scope (`--merged-into`
+        # names a `dedup_base`), so both branches below are scope-independent.
+        ident = (
+            f"{record_type} row #{record_id}" if record_id
+            else f"{record_type}/{short}..."
+        )
         if curation.ORPHAN_DANGLING_MERGE in kinds:
-            # The merge target is always a family, in either scope (`--merged-into`
-            # names a `dedup_base`), so this check is scope-independent.
-            ident = (
-                f"{record_type} row #{record_id}" if record_id
-                else f"{record_type}/{short}..."
-            )
             report.warnings.append(
                 f"curation verdict {ident} merges into "
                 f"{str(target)[:12]}..., which has no live family"
             )
+        elif target:
+            # `elif`, not a second `if`: reaching here means the target family *is*
+            # live, which is what keeps this from double-reporting a dangling target.
+            # Turning it into a standalone `if` reintroduces that bug.
+            if record_id:
+                ruled_id, ruled_slug = curation.row_person(conn, record_type, record_id)
+            else:
+                ruled_id, ruled_slug = curation.family_person(conn, record_type, base)
+            target_id, target_slug = curation.family_person(conn, record_type, target)
+            # Only a *known* mismatch warns - an unknown person on either side is not
+            # evidence of a cross-person merge, the same convention
+            # `curation.annotate_record`'s write-time guard follows (issue #161).
+            if ruled_id is not None and target_id is not None and ruled_id != target_id:
+                report.warnings.append(
+                    f"curation verdict {ident} merges into "
+                    f"{str(target)[:12]}... ({target_slug}), which belongs to a "
+                    f"different person than {ruled_slug} - re-rule with `pemr record "
+                    "annotate` or lift it with `--clear`; if the merge was deliberate "
+                    "(`--allow-cross-person`) this warning is expected"
+                )
 
 
 def verify_report(

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -1377,6 +1377,152 @@ def test_verify_warns_about_an_orphaned_row_scoped_verdict(seeded):
     assert _curation_count(conn) == 0
 
 
+# --- verify catches the pre-#161 cross-person merge target (issue #169) -------
+#
+# #161's guard is forward-only: a `merged_into_base` written before it can still point at
+# another person's family, and neither orphan check notices, because that family genuinely
+# exists. `allow_cross_person=True` is how these tests reach that stored shape - the row
+# it writes is byte-identical to a pre-#161 one, since `cross_person` lives on the report
+# and is never persisted.
+
+CROSS_PERSON = "belongs to a different person"
+
+
+def _merged_cross_person(two_people, *, row=False):
+    """Rule one of jane's Type 2 Diabetes facts merged into john's family."""
+    conn, jane_base, john_base = _cross_person_bases(two_people)
+    token = jane_base
+    if row:
+        token = str(_person_row_id(conn, "condition", "name", "Type 2 Diabetes",
+                                   two_people["jane"].person_id))
+    curation.annotate_record(
+        conn, "condition", token, status="merged-into",
+        note="same condition, two charts", merged_into_base=john_base,
+        allow_cross_person=True, row=row, apply=True,
+    )
+    return conn, jane_base, john_base
+
+
+def test_verify_warns_about_a_live_cross_person_merge_target(two_people):
+    """AC 1: the target family resolves and is live, so no orphan check sees anything -
+    only the person comparison does."""
+    conn, jane_base, john_base = _merged_cross_person(two_people)
+
+    report = verify.verify_report(conn)
+
+    assert report.ok is True and report.problems == []
+    flagged = [w for w in report.warnings if CROSS_PERSON in w]
+    assert len(flagged) == 1
+    assert jane_base[:12] in flagged[0] and john_base[:12] in flagged[0]
+    assert "john-doe" in flagged[0] and "jane-doe" in flagged[0]
+    # Both families are live, so neither orphan warning may fire alongside it.
+    assert not any("has no live family" in w for w in report.warnings)
+
+
+def test_verify_warns_about_a_row_scoped_cross_person_merge_target(two_people):
+    """AC 5: the merge target is a family in either scope, so the check is too - but the
+    ruling side's person comes off the row, not occurrence 0."""
+    conn = two_people["conn"]
+    row_id = _person_row_id(conn, "condition", "name", "Type 2 Diabetes",
+                            two_people["jane"].person_id)
+    _merged_cross_person(two_people, row=True)
+
+    report = verify.verify_report(conn)
+
+    flagged = [w for w in report.warnings if CROSS_PERSON in w]
+    assert len(flagged) == 1 and f"row #{row_id}" in flagged[0]
+
+
+def test_verify_is_silent_on_a_same_person_merge(seeded):
+    """AC 2: the ordinary merge - two of jane's own families - stays quiet."""
+    conn = seeded["conn"]
+    base = _base(conn, "condition", "name", "Prediabetes")
+    target = _base(conn, "condition", "name", "Type 2 Diabetes")
+    curation.annotate_record(
+        conn, "condition", base, status="merged-into",
+        note="one condition, two labels", merged_into_base=target, apply=True,
+    )
+
+    assert verify.verify_report(conn).warnings == []
+
+
+def test_verify_does_not_flag_a_merge_whose_ruling_family_has_no_person(two_people):
+    """AC 3, family scope: an unknown person is not evidence of a cross-person merge -
+    `annotate_record`'s own convention. Emptying the ruling family is the reachable way
+    there, since `person_id` is NOT NULL on every record table."""
+    conn, jane_base, _john_base = _merged_cross_person(two_people)
+    records.remove_record(
+        conn, "condition",
+        _person_row_id(conn, "condition", "name", "Type 2 Diabetes",
+                       two_people["jane"].person_id),
+        apply=True,
+    )
+    assert not dedup.load_family(conn, "condition", jane_base)
+
+    report = verify.verify_report(conn)
+
+    assert not any(CROSS_PERSON in w for w in report.warnings)
+    # The family orphan warning still fires - it is the one this state is about.
+    assert any("has no live family" in w for w in report.warnings)
+
+
+def test_verify_does_not_flag_a_merge_whose_ruling_row_is_gone(two_people):
+    """AC 3, row scope: `row_person` reports ``(None, "")`` for a removed row, and an
+    unknown ruling person must not warn either."""
+    conn = two_people["conn"]
+    row_id = _person_row_id(conn, "condition", "name", "Type 2 Diabetes",
+                            two_people["jane"].person_id)
+    _merged_cross_person(two_people, row=True)
+    # Straight to the table: the write paths retire a row verdict with its row.
+    conn.execute("DELETE FROM condition WHERE condition_id = ?", (row_id,))
+    conn.commit()
+
+    report = verify.verify_report(conn)
+
+    assert not any(CROSS_PERSON in w for w in report.warnings)
+    assert any("names no live row" in w for w in report.warnings)
+
+
+def test_verify_does_not_flag_a_merge_whose_target_family_has_no_person(
+    two_people, monkeypatch
+):
+    """AC 3, target side. Unreachable through the write paths - `person_id` is NOT NULL,
+    so a live target family always has one, and an *empty* target is the dangling-merge
+    orphan below rather than this branch. The guard is defensive parity with
+    `annotate_record`, so it is pinned defensively."""
+    conn, _jane_base, john_base = _merged_cross_person(two_people)
+    real_family_person = curation.family_person
+
+    def unknown_target(conn_, record_type, base):
+        if base == john_base:
+            return None, ""
+        return real_family_person(conn_, record_type, base)
+
+    monkeypatch.setattr(curation, "family_person", unknown_target)
+
+    assert not any(CROSS_PERSON in w for w in verify.verify_report(conn).warnings)
+
+
+def test_verify_does_not_double_report_a_dangling_cross_person_target(two_people):
+    """AC 4: a dead target is the existing orphan warning's case, and only its case - the
+    `elif` placement is what guarantees that, not a second lookup."""
+    conn, _jane_base, john_base = _merged_cross_person(two_people)
+    records.remove_record(
+        conn, "condition",
+        _person_row_id(conn, "condition", "name", "Type 2 Diabetes",
+                       two_people["john"].person_id),
+        apply=True,
+    )
+    assert not dedup.load_family(conn, "condition", john_base)
+
+    report = verify.verify_report(conn)
+
+    merge_warnings = [w for w in report.warnings if "merges into" in w]
+    assert len(merge_warnings) == 1
+    assert "has no live family" in merge_warnings[0]
+    assert CROSS_PERSON not in merge_warnings[0]
+
+
 # --- row ids are reusable, so removing the row retires its verdict (issue #114) ---
 
 

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -2830,8 +2830,9 @@ def test_cli_smoke_walks_the_cross_person_merge_accident(cli_two_people, capsys)
     `annotate` that points one at the other, and a `render` showing what the
     accident costs. The last two steps are the load-bearing ones: with
     `--allow-cross-person` the fact really does leave jane's chart without ever
-    appearing on john's, and `pemr verify` really is clean while it happens, so the
-    refusal is the only thing standing between an operator and a silent loss.
+    appearing on john's, and `pemr verify` only *warns* about it after the fact
+    (issue #169) - nothing is corrupt, so the exit code never moves - which is why
+    the write-time refusal is what stands between an operator and a silent loss.
     """
     jane = _cli_person_base(cli_two_people, "condition", "name", "Type 2 Diabetes",
                             "jane-doe")
@@ -2892,13 +2893,93 @@ def test_cli_smoke_walks_the_cross_person_merge_accident(cli_two_people, capsys)
     assert "Type 2 Diabetes" not in jane_problems
     assert john_problems.count("Type 2 Diabetes") == 1   # john's own row, not jane's
 
-    # ...and `verify` stays clean throughout, because the target family genuinely
-    # exists. Nothing in the database is broken; a fact simply stopped rendering.
+    # ...and `verify` does not *fail* over it - the target family genuinely exists, so
+    # nothing in the database is broken; a fact simply stopped rendering. Since #169 it
+    # is at least reported, as a warning that leaves the exit code alone.
     capsys.readouterr()
     assert _run(cli_two_people, "verify") == 0
+    assert "belongs to a different person" in capsys.readouterr().out
 
     # 5. And it is reversible: lifting the verdict restores jane's chart.
     assert _run(cli_two_people, "record", "annotate", "condition", jane,
                 "--clear", "--apply") == 0
     assert "Type 2 Diabetes" in _summary_section(
         cli_two_people, "jane-doe", "Active Problems", capsys)
+
+
+def test_cli_smoke_verify_reports_the_live_cross_person_merge(cli_two_people, capsys):
+    """The read-time half of the same story, through the CLI (issue #169).
+
+    The unit tests above drive `verify_report` directly; this walks the operator's
+    view - real `record annotate` writes, then the real console block and the real
+    `--json` payload. The rows it leaves behind are byte-identical to pre-#161 ones,
+    since `cross_person` is disclosed in the annotate report and never persisted, so
+    what `verify` reads here is exactly the shape the guard cannot retroactively fix.
+    """
+    jane = _cli_person_base(cli_two_people, "condition", "name", "Type 2 Diabetes",
+                            "jane-doe")
+    john = _cli_person_base(cli_two_people, "condition", "name", "Type 2 Diabetes",
+                            "john-doe")
+    jane_pre = _cli_person_base(cli_two_people, "condition", "name", "Prediabetes",
+                                "jane-doe")
+    john_row = _cli_person_row_id(cli_two_people, "condition", "name",
+                                  "Type 2 Diabetes", "john-doe")
+
+    # The control: jane's own two families merge without a murmur - an ordinary
+    # same-person `merged-into` must stay as quiet as it was before this check.
+    assert _run(cli_two_people, "record", "annotate", "condition", jane_pre,
+                "--status", "merged-into", "--merged-into", jane,
+                "--note", "progressed to the same dx", "--apply") == 0
+    capsys.readouterr()
+    assert _run(cli_two_people, "verify") == 0
+    assert "warnings" not in capsys.readouterr().out
+
+    # The pre-#161 accident, family scope. Both families are live, so no orphan check
+    # sees anything; only the person comparison does, and it is a warning, not a
+    # problem - `pemr verify` still exits 0.
+    assert _run(cli_two_people, "record", "annotate", "condition", jane,
+                "--status", "merged-into", "--merged-into", john,
+                "--note", "deliberate, for the smoke", "--allow-cross-person",
+                "--apply") == 0
+    capsys.readouterr()
+    assert _run(cli_two_people, "verify") == 0
+    out = capsys.readouterr().out
+    assert out.isascii()                       # ASCII-only console output (issue #23)
+    flagged = [ln for ln in out.splitlines() if "belongs to a different person" in ln]
+    assert len(flagged) == 1
+    assert jane[:12] in flagged[0] and john[:12] in flagged[0]
+    assert "jane-doe" in flagged[0] and "john-doe" in flagged[0]
+    # The escape hatch is named, so a deliberate merge reads as expected, not corrupt.
+    assert "--allow-cross-person" in flagged[0]
+
+    # The same string reaches an agent through `--json`, and `ok` stays true.
+    capsys.readouterr()
+    assert _run(cli_two_people, "verify", "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True and payload["problems"] == []
+    assert len(payload["warnings"]) == 1
+    assert payload["warnings"][0] in flagged[0]
+
+    # Row scope, where the ruled person comes off the row rather than the family.
+    assert _run(cli_two_people, "record", "annotate", "condition", str(john_row),
+                "--row", "--status", "merged-into", "--merged-into", jane_pre,
+                "--note", "the same accident, row-scoped", "--allow-cross-person",
+                "--apply") == 0
+    capsys.readouterr()
+    assert _run(cli_two_people, "verify") == 0
+    out = capsys.readouterr().out
+    assert out.count("belongs to a different person") == 2
+    assert f"row #{john_row}" in out
+
+    # And no double-reporting: removing john's row kills the family the first verdict
+    # points at (and retires the row-scoped one with the row), leaving exactly one
+    # merge warning - the existing dangling-target orphan, not this check as well.
+    assert _run(cli_two_people, "record", "rm", "condition", str(john_row),
+                "--apply") == 0
+    capsys.readouterr()
+    assert _run(cli_two_people, "verify") == 0
+    out = capsys.readouterr().out
+    merge_lines = [ln for ln in out.splitlines() if "merges into" in ln]
+    assert len(merge_lines) == 1
+    assert "has no live family" in merge_lines[0]
+    assert "belongs to a different person" not in out


### PR DESCRIPTION
## What shipped

`pemr verify` now detects pre-existing cross-person `merged_into_base` verdicts — a
follow-up to #161's write-time guard (`curation.annotate_record`), which only refuses
*new* cross-person merge targets going forward and cannot retroactively catch verdicts
written before that fix landed.

- New read-only check in `verify._check_curation` (`pemr/verify.py`): for every
  `merged-into` verdict whose target family resolves and is live, compares the ruling
  side's person against the target family's person and warns when they differ and both
  are known. Sits as the `elif` sibling of the existing `ORPHAN_DANGLING_MERGE` branch,
  so a dead target is still reported exactly once (structural double-report guarantee).
- Covers both family-scoped and row-scoped `merged-into` verdicts.
- "Unknown is not evidence": no warning when either side's person is `None`, mirroring
  `annotate_record`'s own convention.
- Detection only — no repair/backfill tooling, no new CLI flag, no schema change.
- Deliberate false positive, recorded as a decision: `cross_person` is not persisted on
  the stored verdict, so an intentional `--allow-cross-person` merge warns identically to
  a pre-#161 accident. The warning text carries its own escape-hatch clause as the
  user-facing mitigation.
- `docs/Architecture.md` updated in both the curation section and the orphan-detector
  paragraph to document the new check alongside #161's write-time guard.
- New unit + CLI-smoke tests in `tests/test_curation.py` covering: same-person merge (no
  warning), cross-person merge (warning), unknown-person on either side (no warning), and
  the existing dangling-target case (only the existing warning fires, not both).

Closes #169

## Reports

- Verify: https://github.com/meridun/pemr/issues/169#issuecomment-5333120710
- Audit: https://github.com/meridun/pemr/issues/169#issuecomment-5333194356

🤖 Generated with [Claude Code](https://claude.com/claude-code)
