### PR TITLE
feat(ingest): extract text from saved HTML pages (#173)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,9 @@ to `find` (FTS5); an ingest without it is silently unsearchable.
 - **Fallback:** `ocr=true` (CLI: `--ocr auto`) only when you cannot read the file type yourself.
   It extracts by whatever route the type allows — plaintext/`.csv`/`.json` read directly,
   `.docx`/`.xlsx` parsed from their OOXML, a CCDA `.xml` (a portal "download my record"
-  export) rendered from its section narrative, everything else (images, unknown suffixes)
+  export) rendered from its section narrative, a saved `.html`/`.htm` page parsed with the
+  stdlib HTML parser (tags stripped, scripts and styles dropped), everything else (images,
+  unknown suffixes)
   through tesseract. A `.pdf` is read page by page — embedded text layer where there is one, a
   300-dpi render OCR'd where there isn't (first 20 pages, joined by `\f`); that route needs the
   optional `pip install pemr[ocr]` extra, and without it a PDF stores no text and says so on
@@ -250,10 +252,12 @@ ingest-time owner check: it scans that text for the claimed person's name/DOB an
 *different* roster person), `suspect` (a patient-identity header naming nobody on the roster), or
 `unverified` (no text, no identity anchor in it, or a claimed person whose name is too short to
 carry a signal — their absence from the text is ignorance, not evidence). `mismatch`/`suspect`
-**refuse the ingest** before anything is written. `suspect` is scoped by **route**: it applies to
-the text you supply and to a tesseract pass, and never to anything `--ocr auto` extracts natively
-— the whole `.txt`/`.md`/`.csv`/`.tsv`/`.json`/`.log`/`.docx`/`.xlsx` set, CCDA `.xml`
-included — because in a
+**refuse the ingest** before anything is written. `suspect` is scoped by **route**, and the split
+is *structured vs prose*, not native vs OCR: it applies to the text you supply, to a tesseract
+pass, and to a natively-extracted `.html`/`.htm` page (route `native-prose` — a saved portal page
+is a printed page, so its `Patient:` header is a real claim). It never applies to the
+**structured** native routes — the whole `.txt`/`.md`/`.csv`/`.tsv`/`.json`/`.log`/`.docx`/`.xlsx`
+set, CCDA `.xml` included — because in a
 structured export `Patient`/`DOB`/`MRN` are column labels rather than an identity header. The
 route is the line, not how prose-like the format is: a transcript you save as `.txt` and ingest
 with `--ocr auto` gets no identity-header check either, so pass your transcription as `ocr_text` /

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -871,7 +871,9 @@ Optional `--ocr auto` flag pre-fills `document.ocr_text`, giving the agent text 
 from instead of re-reading the source every time. It extracts by whatever route the file
 type allows (issue #66), with only the image and PDF routes reaching outside the stdlib:
 `.txt/.md/.csv/.tsv/.json/.log` read directly, `.docx`/`.xlsx` unzipped and their OOXML
-parsed, **everything else** through `tesseract` (a soft dependency) — no image-suffix
+parsed, `.html`/`.htm` parsed with `html.parser` (issue #173 — tags stripped,
+`<script>`/`<style>` dropped, tables as tab-delimited rows), **everything else** through
+`tesseract` (a soft dependency) — no image-suffix
 allowlist, so `.jfif`, `.jpe` and extension-less scans OCR like any other image. Every
 OOXML member goes through one guarded parse helper that applies the same encoding-agnostic
 `<!DOCTYPE` refusal described for CCDA below before `ElementTree` sees the bytes (issue
@@ -929,12 +931,18 @@ capped at 32 MiB per file — `ocr_text` is mirrored into the FTS index, so an u
 both a database-size problem and a decompression-bomb surface (a small `.docx` can declare a
 gigabyte of `word/document.xml`).
 
-Extraction route feeds the owner check: the identity-anchor (`suspect`) verdict is applied
-only to an agent transcription or a tesseract pass, never to natively-extracted text —
-the whole `.txt/.md/.csv/.tsv/.json/.log/.docx/.xlsx` set, CCDA `.xml` included. In a
+Extraction route feeds the owner check, and the route vocabulary has **three** words for
+it: `native` (natively extracted, *structured*), `native-prose` (natively extracted,
+*prose* — HTML, issue #173) and `ocr` (a tesseract pass or an agent transcription, prose
+by definition). The identity-anchor (`suspect`) verdict is applied on the two prose
+routes and withheld on `native` — the whole `.txt/.md/.csv/.tsv/.json/.log/.docx/.xlsx`
+set, CCDA `.xml` included. In a
 structured export
 `Patient`/`DOB`/`MRN` are column labels and field keys, and counting them as an identity
-header refuses ordinary lab exports as belonging to a stranger. The line is the *route*
+header refuses ordinary lab exports as belonging to a stranger. A saved portal page is
+the other case: tags aside it is a printed page, so its `Patient:` header **is** a claim
+and the anchor stays armed — which is the whole reason the boolean `route != "native"`
+grew into `_trusts_anchors()`, one predicate both call sites share. The line is the *route*
 rather than how prose-like the format is, because the route is what the extractor actually
 knows; the cost is that a prose transcript saved as `.txt` and ingested with `--ocr auto`
 loses the anchor check too. That is no worse than before native extraction existed (such a

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -3689,7 +3689,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_ingest.add_argument(
         "--ocr",
         choices=["auto"],
-        help="pre-fill ocr_text: text/.docx/.xlsx/CCDA .xml read natively, "
+        help="pre-fill ocr_text: text/.docx/.xlsx/CCDA .xml/.html read natively, "
              "PDF page by page "
              "(text layer + rendered-page OCR), other files via tesseract "
              "(soft dependency)",

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -59,6 +59,7 @@ import zipfile
 import uuid
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Callable, Iterator, Sequence
 from urllib.parse import urlsplit
@@ -418,6 +419,20 @@ def run_ocr(path: str | Path) -> str | None:
 # --------------------------------------------------------------------------- #
 
 _PLAINTEXT_SUFFIXES = frozenset({".txt", ".md", ".csv", ".tsv", ".json", ".log"})
+
+# HTML (issue #173) — a saved portal page. Deliberately **not** in
+# `_PLAINTEXT_SUFFIXES`: reading the markup verbatim would store tags and inline
+# scripts as document text (and route it `"native"`, see `_trusts_anchors`).
+_HTML_SUFFIXES = frozenset({".html", ".htm"})
+# Element content that is code/markup, never document text.
+_HTML_SKIP_TAGS = frozenset({"script", "style", "noscript", "template"})
+# Tags that end a line — the ones that render as a block or a line break.
+_HTML_BLOCK_TAGS = frozenset({
+    "p", "div", "br", "tr", "li", "h1", "h2", "h3", "h4", "h5", "h6",
+    "table", "thead", "tbody", "section", "article", "header", "footer",
+    "blockquote", "hr", "pre", "dt", "dd", "ul", "ol", "title",
+})
+_HTML_CELL_TAGS = frozenset({"td", "th"})
 
 _WORD_NS = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
 _SHEET_NS = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
@@ -810,6 +825,169 @@ def _extract_ccda(path: Path) -> str | None:
     return "\n".join(lines)
 
 
+class _HtmlText(HTMLParser):
+    """Readable text out of an HTML page: tags stripped, `<script>`/`<style>` dropped.
+
+    Rendering mirrors :func:`_ccda_narrative` / :func:`_ccda_table_rows` (issue #138) so
+    both native routes produce the same *shaped* text — one line per block element,
+    one tab-delimited line per `<tr>` — which is what keeps a lab table's header cell
+    on the same line as its value.
+
+    Unlike the CCDA walk this is event-driven, so there is **no recursion here at all**
+    and no `RecursionError` surface, however deeply the page nests.
+    """
+
+    def __init__(self) -> None:
+        # `convert_charrefs` (the default) must stay on: with it off, every `&amp;` /
+        # `&#160;` would need `handle_entityref`/`handle_charref` or be silently lost.
+        super().__init__(convert_charrefs=True)
+        self.lines: list[str] = []
+        self._parts: list[str] = []          # the line being built
+        self._cells: list[str] | None = None  # non-None while a `<tr>` is open
+        # A *depth counter*, not a boolean. `<script>`/`<style>` are the easy half —
+        # the stdlib reads them in CDATA mode, so their bodies never re-enter the tag
+        # machinery — but `<noscript>`/`<template>` are parsed normally and do nest, and
+        # a boolean flips back on the innermost close, leaking their contents into
+        # `ocr_text` and thence the FTS index. The counter also has to floor at 0, or a
+        # stray `</script>` (ordinary in a saved page) would swallow the rest of it.
+        self._skip = 0
+
+    # -- line/cell plumbing --------------------------------------------------- #
+
+    def _take(self) -> str:
+        """The pending text, whitespace-collapsed as `_ccda_flat` does — `str.split()`
+        also folds the `\\xa0` that `&nbsp;` decodes to."""
+        chunk = " ".join("".join(self._parts).split())
+        self._parts.clear()
+        return chunk
+
+    def _break(self) -> None:
+        """A block boundary. Ends the current line — except **inside a `<tr>`**, where it
+        is only a word separator: a `<div>` wrapping a cell's value must not split the
+        cell, which is what keeps a lab row's header cell beside its value."""
+        if self._cells is not None:
+            self._parts.append(" ")
+            return
+        chunk = self._take()
+        if chunk:
+            self.lines.append(chunk)
+
+    def _close_cell(self) -> None:
+        """`</td>`/`</th>`: the pending text becomes one cell — empty ones included, so
+        columns stay aligned."""
+        chunk = self._take()
+        if self._cells is None:      # a stray `</td>` outside any row: keep its text
+            if chunk:
+                self.lines.append(chunk)
+        else:
+            self._cells.append(chunk)
+
+    def _end_row(self) -> None:
+        trailing = self._take()      # text after the last `</td>`, if any
+        cells, self._cells = self._cells or [], None
+        if trailing:
+            cells.append(trailing)
+        # `any(cells)` is `_ccda_table_rows`'s rule (line 609): an all-empty row
+        # contributes nothing.
+        if any(cells):
+            self.lines.append("\t".join(cells))
+
+    # -- HTMLParser hooks ----------------------------------------------------- #
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in _HTML_SKIP_TAGS:
+            self._skip += 1
+            return
+        if self._skip:
+            return
+        if tag == "tr":
+            self._break()
+            self._cells = []
+        elif tag in _HTML_CELL_TAGS:
+            self._parts.append(" ")   # separator only; the cell closes on `</td>`
+        elif tag in _HTML_BLOCK_TAGS:
+            self._break()
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in _HTML_SKIP_TAGS:
+            # Floored: an unmatched `</script>` must not push the depth negative, or
+            # every later close would keep us "inside" a skip and drop the real page.
+            self._skip = max(0, self._skip - 1)
+            return
+        if self._skip:
+            return
+        if tag == "tr":
+            self._end_row()
+        elif tag in _HTML_CELL_TAGS:
+            self._close_cell()
+        elif tag in _HTML_BLOCK_TAGS:
+            self._break()
+
+    def handle_data(self, data: str) -> None:
+        if self._skip:
+            return
+        self._parts.append(data)
+
+    def text(self) -> str:
+        """The page as lines. Flushes whatever an unclosed final tag left open."""
+        if self._cells is not None:
+            self._end_row()
+        else:
+            self._break()
+        return "\n".join(self.lines)
+
+
+def _extract_html(path: Path) -> str:
+    """Readable text from a saved HTML page (`.html`/`.htm`, issue #173).
+
+    Same shape and contract as :func:`_extract_ccda`, except it never returns ``None``:
+    dispatch is on the suffix, not on sniffed content, so there is no "not actually
+    HTML, fall through to OCR" case — a `.html` that is really something else extracts
+    to little or nothing and takes the usual stderr note. Tesseract could not read it
+    either.
+    """
+    size = path.stat().st_size
+    if size > _MAX_EXTRACT_BYTES:
+        raise ValueError(
+            f"{size} bytes, past the {_MAX_EXTRACT_BYTES}-byte extraction cap"
+        )
+    # Same trade as the plaintext branch: utf-8-sig eats a BOM, errors="replace" keeps a
+    # legacy-encoded page usable rather than losing it. No `<meta charset>` sniffing.
+    data = path.read_text(encoding="utf-8-sig", errors="replace")
+    parser = _HtmlText()
+    try:
+        parser.feed(data)
+        parser.close()
+    except AssertionError as exc:
+        # `_markupbase.ParserBase.parse_marked_section` ends in a plain
+        # `raise AssertionError(...)` (so `python -O` does not remove it), which input as
+        # ordinary as `<![foo[ x ]]>` reaches. `AssertionError` is not in
+        # `_EXTRACT_ERRORS` and would escape the "never raises" contract and cost the
+        # document — the defect class the #138 audit caught with `RecursionError`.
+        # Translated here rather than by widening `_EXTRACT_ERRORS`, which would swallow
+        # our own asserts, including the ones tests use as tripwires.
+        raise ValueError(f"malformed HTML markup: {exc}") from exc
+    return parser.text()
+
+
+def _trusts_anchors(route: str) -> bool:
+    """Whether :func:`check_owner` may read `Patient`/`DOB`/`MRN` as an identity claim.
+
+    The route vocabulary, and the reason it has three words rather than two:
+
+    - ``"native"`` — natively extracted **structured** data (plaintext-ish suffixes,
+      `.docx`/`.xlsx`, CCDA). A `Patient ID` there is a column label, not a claim, so
+      anchors are **not** trusted (issue #66 audit).
+    - ``"native-prose"`` — natively extracted **prose** (HTML, issue #173). Tags aside,
+      a saved portal page is a printed page: its `Patient:` header is a claim.
+    - ``"ocr"`` — tesseract output or an agent transcription; prose by definition.
+
+    One definition for both call sites (:func:`ingest_document`,
+    :func:`reocr_documents`), so a fourth route can never disagree with itself.
+    """
+    return route != "native"
+
+
 def extract_text_routed(path: str | Path) -> tuple[str | None, str]:
     """:func:`extract_text` plus the **route** that produced the text.
 
@@ -818,7 +996,10 @@ def extract_text_routed(path: str | Path) -> tuple[str | None, str]:
     `.xml` (issue #138) is rendered natively too — sections' narrative plus a
     `recordTarget` identity header — but on the parsed **root element**, not the
     suffix: a non-CCDA or malformed `.xml` falls through to the OCR route exactly as
-    it did before that branch existed.
+    it did before that branch existed. A saved `.html`/`.htm` portal page (issue #173)
+    is rendered natively as well, but on the third route ``"native-prose"``: it is
+    natively extracted *and* prose, which the two-word vocabulary could not express —
+    see :func:`_trusts_anchors`.
     **Everything else falls through to :func:`run_ocr`** (route ``"ocr"``) — the same
     thing `ocr=True` did before this dispatcher existed. Deliberately not a suffix
     allowlist: image extensions vary far too widely (`.jfif`, `.jpe`, extension-less
@@ -838,6 +1019,10 @@ def extract_text_routed(path: str | Path) -> tuple[str | None, str]:
     """
     src = Path(path)
     suffix = src.suffix.lower()
+    # Hoisted so the failure path reports the branch's own route: a `.html` that fails
+    # extraction reads `route native-prose` in `pemr document reocr` output, not a fixed
+    # word. Every existing format keeps `"native"`.
+    route = "native"
     try:
         if suffix in _PLAINTEXT_SUFFIXES:
             size = src.stat().st_size
@@ -852,6 +1037,9 @@ def extract_text_routed(path: str | Path) -> tuple[str | None, str]:
             text = _extract_docx(src)
         elif suffix == ".xlsx":
             text = _extract_xlsx(src)
+        elif suffix in _HTML_SUFFIXES:
+            route = "native-prose"     # set *before* the call, so `except` sees it
+            text = _extract_html(src)
         # `.xml` deliberately stays out of `_PLAINTEXT_SUFFIXES`: only a file whose
         # root element is `{urn:hl7-org:v3}ClinicalDocument` is read natively, and
         # every other `.xml` falls through to the `run_ocr` branch below unchanged.
@@ -874,11 +1062,11 @@ def extract_text_routed(path: str | Path) -> tuple[str | None, str]:
             "storing without ocr_text",
             file=sys.stderr,
         )
-        return None, "native"
+        return None, route
     # Same predicate as the supplied-text route below - one emptiness notion per
     # column, so `--ocr auto` cannot store what `--ocr-text-file` rejects (issue #87).
     text = normalize_document_text(text)
-    return (text or None), "native"
+    return (text or None), route
 
 
 def extract_text(path: str | Path) -> str | None:
@@ -1370,11 +1558,10 @@ def ingest_document(
         ocr_text, route = None, "ocr"  # no text at all; the route is moot
 
     roster = _roster(conn)
-    # Natively-extracted text (CSV/OOXML/JSON) is structured, so a `Patient ID` column
-    # header is not an identity claim — trusting anchors there refuses ordinary lab
-    # exports as belonging to a stranger. `mismatch` still blocks on every route.
+    # Structured vs prose per route — see `_trusts_anchors`. `mismatch` still blocks on
+    # every route.
     owner_check = check_owner(
-        ocr_text, person, roster, trust_anchors=(route != "native")
+        ocr_text, person, roster, trust_anchors=_trusts_anchors(route)
     )
     if owner_check.blocks and not force:
         raise OwnerMismatchError(
@@ -1728,8 +1915,8 @@ def reocr_documents(
         person = _person_for_id(conn, row.person_id)
         owner_check = None
         if person is not None:
-            owner_check = check_owner(
-                text, person, roster, trust_anchors=(route != "native")
+            owner_check = check_owner(     # structured vs prose — see `_trusts_anchors`
+                text, person, roster, trust_anchors=_trusts_anchors(route)
             )
         common["owner_check"] = owner_check
         # Only `mismatch` refuses here, unlike ingest where `suspect` blocks too: this

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -189,8 +189,8 @@ def ingest_document(
     ``ocr_text`` is the agent's own transcription — the ``AGENTS.md`` default path.
     The response's ``ocr_text_populated`` lets the agent self-check the FTS-visibility
     contract without a follow-up read. ``ocr=true`` is the fallback: it extracts by
-    whatever route the file type allows (plaintext/`.docx`/`.xlsx` and CCDA `.xml`
-    natively, everything
+    whatever route the file type allows (plaintext/`.docx`/`.xlsx`, CCDA `.xml` and a
+    saved `.html`/`.htm` page natively, everything
     else via tesseract), and stores nothing when nothing could be read — `.pdf`, `.rtf`,
     `.msg` and `.doc` have no route at all (tesseract does not accept PDF input), so
     transcribe those yourself.
@@ -208,8 +208,10 @@ def ingest_document(
     ``mismatch``/``suspect`` verdict refuses the ingest pre-write — per ``AGENTS.md``
     §3, surface the verdict and its evidence to the human and get an explicit
     go-ahead before retrying with ``force=true``. ``suspect`` (a patient-identity
-    header naming nobody on the roster) is scoped by route: it applies to the text you
-    supply and to a tesseract pass, never to anything ``ocr=true`` extracts natively
+    header naming nobody on the roster) is scoped by route, and the split is *structured
+    vs prose*: it applies to the text you supply, to a tesseract pass, and to a natively
+    extracted ``.html``/``.htm`` page (a saved portal page is a printed page). Never to
+    the structured native routes
     (``.txt``/``.md``/``.csv``/``.tsv``/``.json``/``.log``/``.docx``/``.xlsx``, CCDA
     ``.xml``), where
     those words are column labels — so pass your transcription as ``ocr_text`` rather

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -1217,6 +1217,118 @@ def test_lab_export_with_a_patient_column_is_not_refused(ready, capsys):
 
     assert _run(tmp_path, "find", "--person", "jane-doe", "glucose") == 0
     assert "#1" in capsys.readouterr().out
+
+
+# --- saved HTML portal pages at the CLI (issue #173) ---------------------------
+# `tests/test_ingest.py` covers the extractor and both `trust_anchors` call sites at
+# the library level; these two walk the same behaviour through `pemr ingest`/`find`/
+# `document reocr` — the verify-stage real run, kept as a repeatable spec.
+
+_PORTAL_PAGE = """<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<title>MyChart &mdash; Visit Summary</title>
+<style>.banner { color: #003366; font-family: "Helvetica Neue", sans-serif; }</style>
+<script>var portalSessionToken = "abc123"; analytics.send("visit-summary");</script>
+</head><body onload="trackPageView()">
+<div class="banner">Mercy Clinic &amp; Labs</div>
+<p>Patient: Jane Doe<br>DOB: 01/01/1980</p>
+<table><thead><tr><th>Test</th><th>Result</th></tr></thead><tbody>
+<tr><td><div>Ferritin</div></td><td>201&#160;ng/mL</td></tr>
+<tr><td></td><td></td></tr>
+</tbody></table>
+<noscript><p>Enable JavaScript for the interactive chart.</p></noscript>
+</body></html>
+"""
+
+# The same lab table twice, in the two formats whose owner-check verdicts now differ.
+_LAB_TABLE_CSV = "Patient ID,Test,Result\n00998877,Ferritin,201 ng/mL\n"
+_LAB_TABLE_HTML = (
+    "<html><body><table>"
+    "<tr><th>Patient ID</th><th>Test</th></tr>"
+    "<tr><td>00998877</td><td>Ferritin 201 ng/mL</td></tr>"
+    "</table></body></html>"
+)
+
+
+def test_ocr_auto_reads_a_saved_portal_page_end_to_end(ready, capsys):
+    """Issue #173 through the CLI: a saved portal page used to reach tesseract, which
+    cannot decode HTML, so it stored nothing and never entered `find`. Now it is read
+    natively on the `native-prose` route — tags stripped, `<script>`/`<style>` out of
+    the FTS index, the identity header live, and the route named in `reocr` output."""
+    from pemr import ingest as ingest_mod
+
+    tmp_path = ready
+    page = tmp_path / "portal.html"
+    page.write_text(_PORTAL_PAGE, encoding="utf-8")
+    sources = tmp_path / "sources"
+
+    assert _run(tmp_path, "ingest", str(page), "--person", "jane-doe",
+                "--sources", str(sources), "--ocr", "auto") == 0
+    out = capsys.readouterr()
+    assert "ingested document #1" in out.out
+    # the anchor is armed on this route, and the header names the owner
+    assert "owner verified: matched 'jane-doe' in document text" in out.out
+    assert "no ocr_text stored" not in out.err
+
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        text = conn.execute(
+            "SELECT ocr_text FROM document WHERE document_id = 1"
+        ).fetchone()["ocr_text"]
+    finally:
+        conn.close()
+    lines = text.splitlines()
+    assert "Patient: Jane Doe" in lines             # `<br>` ended the line...
+    assert "DOB: 01/01/1980" in lines               # ...so the DOB is its own
+    assert "Mercy Clinic & Labs" in lines           # `&amp;` decoded
+    assert "Ferritin\t201 ng/mL" in lines           # `<div>` did not split the cell
+    assert "\t\t" not in text and "\t" in text      # the all-empty row contributed none
+    assert "<" not in text                          # every tag stripped
+    assert text == ingest_mod.normalize_document_text(text)   # stored normalized
+
+    # `ocr_text` is mirrored into FTS, so the page's code must be unfindable...
+    assert _run(tmp_path, "find", "--person", "jane-doe", "ferritin") == 0
+    assert "#1" in capsys.readouterr().out
+    for junk in ("portalSessionToken", "Helvetica", "JavaScript"):
+        assert _run(tmp_path, "find", "--person", "jane-doe", junk) == 0
+        assert "no matches" in capsys.readouterr().out, junk
+
+    # ...and `document reocr` reports the third route value on its own line (#143)
+    assert _run(tmp_path, "document", "reocr", "1", "--sources", str(sources),
+                "--dry-run", "--force") == 0
+    assert "route native-prose" in capsys.readouterr().out
+
+
+def test_html_lab_table_is_refused_where_the_csv_equivalent_is_not(ready, capsys):
+    """The intended, bounded cost of arming the anchor on HTML: the *same* lab table
+    files as `.csv` (structured — `Patient ID` is a column label, issue #66) and is
+    refused as `suspect` when it arrives as a saved `.html` page. `--force` is the
+    one-flag recovery. Pin it, so the divergence stays a decision rather than drift."""
+    tmp_path = ready
+    sources = tmp_path / "sources"
+    csv = tmp_path / "labs.csv"
+    csv.write_text(_LAB_TABLE_CSV, encoding="utf-8")
+    page = tmp_path / "labs.html"
+    page.write_text(_LAB_TABLE_HTML, encoding="utf-8")
+
+    assert _run(tmp_path, "ingest", str(csv), "--person", "jane-doe",
+                "--sources", str(sources), "--ocr", "auto") == 0
+    assert "ingested document #1" in capsys.readouterr().out
+
+    assert _run(tmp_path, "ingest", str(page), "--person", "jane-doe",
+                "--sources", str(sources), "--ocr", "auto") == 1
+    err = capsys.readouterr().err
+    assert "owner verification failed" in err
+    assert "re-run with --force" in err
+    assert len(_document_id(tmp_path)) == 1          # pre-write refusal: nothing landed
+
+    assert _run(tmp_path, "ingest", str(page), "--person", "jane-doe",
+                "--sources", str(sources), "--ocr", "auto", "--force") == 0
+    out = capsys.readouterr()
+    assert "ingested document #2" in out.out
+    assert "verdict: suspect" in out.err
+
+
 def _stage_pre_006(tmp_path):
     """Copy every migration below 006 into a staging dir (leaving 006 pending)."""
     import shutil

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1414,6 +1414,198 @@ def test_extract_text_has_no_route_for_msg(conn, tmp_path, sources, capsys, monk
     assert "--ocr-text-file" in capsys.readouterr().err
 
 
+# --- HTML (issue #173) ---------------------------------------------------------
+# A saved portal page used to reach tesseract, which cannot decode HTML, so it stored
+# nothing. It is the first format that is natively extracted *and* prose, which is why
+# the route vocabulary grew a third word (`native-prose`) rather than reusing `native`:
+# `trust_anchors` reads "not native ⇒ prose", and a printed `Patient:` header on a
+# portal page **is** an identity claim, unlike a spreadsheet's `Patient ID` column.
+
+
+def _make_html(
+    tmp_path, name="portal.html", patient="Jane Doe", dob="03/14/1962", body=None,
+):
+    """A saved visit-summary page: `<style>`/`<script>` in the head, an identity header
+    split by a `<br>`, a results table, and both entity forms."""
+    if body is None:
+        body = (
+            '<div class="banner"><p>Mercy Clinic &amp; Labs</p></div>\n'
+            f"<p>Patient: {patient}<br>DOB: {dob}</p>\n"
+            "<table>"
+            "<thead><tr><th>Test</th><th>Value</th></tr></thead>"
+            "<tbody><tr><td><div>Ferritin</div></td><td>201&#160;ng/mL</td></tr></tbody>"
+            "</table>"
+        )
+    page = (
+        "<!DOCTYPE html>\n<html><head><title>Visit Summary</title>\n"
+        "<style>.banner { color: #003366; }</style>\n"
+        "<script>var portalPatientId = 1043;</script>\n"
+        f"</head><body>\n{body}\n</body></html>\n"
+    )
+    p = tmp_path / name
+    p.write_text(page, encoding="utf-8")
+    return p
+
+
+@pytest.mark.parametrize("name", ["portal.html", "portal.htm"])
+def test_extract_text_reads_saved_portal_html(tmp_path, name):
+    text, route = ingest.extract_text_routed(_make_html(tmp_path, name=name))
+    assert route == "native-prose"
+    lines = text.splitlines()
+    assert "Patient: Jane Doe" in lines          # `<br>` ended the line...
+    assert "DOB: 03/14/1962" in lines            # ...so the DOB is its own
+    assert "Mercy Clinic & Labs" in lines        # `&amp;` decoded
+    # the row's header cell stays beside its value, `&#160;` folded to a space
+    assert "Ferritin\t201 ng/mL" in lines
+    assert "Test\tValue" in lines
+    assert "<" not in text                       # every tag stripped
+
+
+def test_html_script_and_style_contents_are_dropped(tmp_path):
+    """`ocr_text` is mirrored into the FTS index, so JS and CSS must never reach it."""
+    text, _ = ingest.extract_text_routed(_make_html(tmp_path))
+    assert "portalPatientId" not in text
+    assert "#003366" not in text
+    assert ".banner" not in text
+
+
+def test_nested_skip_tags_do_not_leak_their_contents(tmp_path):
+    """The skip state is a depth counter, not a boolean, which a boolean would get wrong
+    in both directions. `<script>`/`<style>` are the easy case — the stdlib reads them in
+    CDATA mode, so their bodies arrive as one `handle_data` — but `<noscript>` and
+    `<template>` are parsed normally and *do* nest, and a boolean flips back on the
+    innermost close, leaking markup-ish text into `ocr_text` and thence the FTS index."""
+    text, route = ingest.extract_text_routed(
+        _make_html(
+            tmp_path, name="nested.html",
+            body="<template><template>inner</template>outer</template>"
+                 "<p>Ferritin 201</p>",
+        )
+    )
+    assert route == "native-prose"
+    assert text.splitlines() == ["Visit Summary", "Ferritin 201"]
+
+
+def test_stray_end_tag_does_not_drop_the_rest_of_the_page(tmp_path):
+    """The other direction: an unmatched `</script>` must floor the depth at 0 rather
+    than go negative, or every later `</...>` would keep it "inside" a skip and the real
+    content would vanish."""
+    text, _ = ingest.extract_text_routed(
+        _make_html(
+            tmp_path, name="stray.html",
+            body="</script></template><p>Ferritin 201</p>",
+        )
+    )
+    assert "Ferritin 201" in text.splitlines()
+
+
+def test_malformed_html_does_not_raise(tmp_path):
+    """Crossed and unclosed tags are what a saved page actually looks like."""
+    src = _make_file(
+        tmp_path, "broken.html", b"<p>alpha<div><span>beta</p></div></span><td>gamma",
+    )
+    text, route = ingest.extract_text_routed(src)
+    assert route == "native-prose"
+    assert "alpha" in text and "beta" in text and "gamma" in text
+
+
+def test_html_marked_section_does_not_raise(tmp_path, capsys):
+    """`_markupbase.parse_marked_section` ends in a plain `raise AssertionError`, which
+    input as ordinary as `<![foo[ x ]]>` reaches. `AssertionError` is not in
+    `_EXTRACT_ERRORS`, so without `_extract_html`'s guard it escapes the "never raises"
+    contract and costs the document — the #138 audit's `RecursionError` defect again."""
+    src = _make_file(
+        tmp_path, "marked.html", b"<p>Ferritin 201</p><![foo[ x ]]><p>tail</p>",
+    )
+    text, route = ingest.extract_text_routed(src)      # must not raise
+    assert route == "native-prose"                     # ...and reports its own route
+    assert text is None
+    assert "malformed HTML markup" in capsys.readouterr().err
+
+
+def test_html_is_not_read_as_plaintext(tmp_path):
+    """Adding the suffixes to `_PLAINTEXT_SUFFIXES` would be the tempting simplification:
+    it stores the markup verbatim *and* routes the page `"native"`, losing the anchor."""
+    assert ".html" not in ingest._PLAINTEXT_SUFFIXES
+    assert ".htm" not in ingest._PLAINTEXT_SUFFIXES
+    text, _ = ingest.extract_text_routed(_make_html(tmp_path))
+    assert "<p>" not in text and "<table" not in text
+
+
+def test_html_never_shells_out(conn, tmp_path, sources, monkeypatch):
+    def boom(path):  # pragma: no cover - the assertion is that this never runs
+        raise AssertionError(f"run_ocr must not be called for {path}")
+
+    monkeypatch.setattr(ingest, "run_ocr", boom)
+    src = _make_html(tmp_path)
+    assert ingest.ingest_document(
+        conn, src, "jane-doe", sources, ocr=True
+    ).ocr_text_populated
+
+
+@pytest.mark.parametrize(
+    "route, trusts",
+    [("ocr", True), ("native", False), ("native-prose", True)],
+)
+def test_trusts_anchors_route_table(route, trusts):
+    """The one place the route vocabulary is asserted: `native` is structured, the other
+    two are prose."""
+    assert ingest._trusts_anchors(route) is trusts
+
+
+def test_html_route_keeps_the_identity_anchor_check(conn, tmp_path, sources):
+    """AC bullet 3, and the whole point of the third route value: a page headed with a
+    stranger's name is `suspect`, where the `.csv` equivalent is `unverified`."""
+    _seed_roster(conn)
+    src = _make_html(
+        tmp_path, name="stranger.html", patient="SMITH, KAREN", dob="09/09/1971",
+    )
+    with pytest.raises(ingest.OwnerMismatchError) as excinfo:
+        ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert excinfo.value.check.verdict == "suspect"
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 0
+
+
+def test_html_mismatch_still_blocks(conn, tmp_path, sources):
+    """The protective half of #61 fires on the new route too."""
+    _seed_roster(conn)
+    src = _make_html(
+        tmp_path, name="other.html", patient="ROE, ROBERT ALAN", dob="11/02/1955",
+    )
+    with pytest.raises(ingest.OwnerMismatchError) as excinfo:
+        ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert excinfo.value.check.verdict == "mismatch"
+    assert excinfo.value.check.matched_slug == "bob-roe"
+    assert conn.execute("SELECT COUNT(*) AS n FROM document").fetchone()["n"] == 0
+
+
+def test_html_ingest_stores_normalized_text(conn, tmp_path, sources):
+    """AC bullet 2 — the branch falls through to the shared tail, so `--ocr auto` and
+    `--ocr-text-file` keep agreeing on what "empty" means (issue #87)."""
+    result = ingest.ingest_document(
+        conn, _make_html(tmp_path), "jane-doe", sources, ocr=True
+    )
+    assert result.ocr_text_populated
+    stored = result.document.ocr_text
+    assert stored == ingest.normalize_document_text(stored)
+
+
+def test_empty_html_degrades_like_any_other_textless_file(
+    conn, tmp_path, sources, capsys, monkeypatch
+):
+    """Nothing extractable is `None`, not an empty string — and it degrades natively
+    rather than falling through to tesseract."""
+    def never(path):  # pragma: no cover - the degrade is native, not a fallback
+        raise AssertionError(f"run_ocr must not be called for {path}")
+
+    monkeypatch.setattr(ingest, "run_ocr", never)
+    src = _make_file(tmp_path, "blank.html", b"<html><body><div> </div></body></html>")
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.status == "new"                # the document still lands
+    assert result.document.ocr_text is None
+    assert "--ocr-text-file" not in capsys.readouterr().err   # no OCR advice: it parsed
+
+
 # --- routing boundary (issue #66 verify bounce) --------------------------------
 # `ocr=True` used to hand *every* file to tesseract. An image-suffix allowlist silently
 # dropped `.jfif`/`.jpe`/extension-less scans out of `find`, so anything without a native
@@ -1717,7 +1909,11 @@ def test_plaintext_suffixes_are_route_scoped_too(conn, tmp_path, sources, name):
     identity header in a natively-read `.txt`/`.md`/`.tsv`/`.log` yields `unverified`,
     not `suspect`. Not a regression — before native extraction these went to tesseract,
     which declined, so there was no text and no check either — but it is the behavior
-    `AGENTS.md` §3 documents, so pin it rather than let it drift silently."""
+    `AGENTS.md` §3 documents, so pin it rather than let it drift silently.
+
+    HTML (issue #173) is deliberately the exception, not a precedent to extend here: it
+    rides `"native-prose"` and *does* keep the anchor. Re-classifying these four suffixes
+    would change owner-check behaviour for already-ingested formats — a separate issue."""
     _seed_roster(conn)
     src = _make_file(
         tmp_path, name, b"MERCY LABS\nPatient: SMITH, KAREN\nDOB: 09/09/1971\n"
@@ -1763,7 +1959,7 @@ def test_ocr_route_still_produces_suspect(conn, tmp_path, sources, monkeypatch):
 # `word/document.xml`). Over the cap degrades like any other extraction failure.
 
 
-@pytest.mark.parametrize("kind", ["docx", "xlsx", "txt", "ccda"])
+@pytest.mark.parametrize("kind", ["docx", "xlsx", "txt", "ccda", "html"])
 def test_oversized_extraction_degrades_instead_of_reading_it(
     conn, tmp_path, sources, capsys, monkeypatch, kind
 ):
@@ -1776,6 +1972,8 @@ def test_oversized_extraction_degrades_instead_of_reading_it(
         # over the cap degrades *native* with the cap note, rather than falling
         # through to a tesseract failure that says nothing useful
         src = _make_ccda(tmp_path)
+    elif kind == "html":
+        src = _make_html(tmp_path)
     else:
         src = _make_file(tmp_path, "big.txt", b"x" * 500)
     result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
@@ -2019,6 +2217,23 @@ def test_reocr_native_route_does_not_trust_anchors(conn, tmp_path, sources):
     assert result.route == "native"
     assert result.status == "written"
     assert result.owner_check.verdict == "unverified"
+
+
+def test_reocr_html_reports_the_prose_route(conn, tmp_path, sources):
+    """The second `trust_anchors` call site reaches the same route value ingest does —
+    which is also what `pemr document reocr` prints (issue #143 backfills `.html` for
+    free once this branch exists)."""
+    _seed_roster(conn)
+    page = _make_html(tmp_path, name="reocr-src.html").read_bytes()
+    doc = _file_document(conn, tmp_path, sources, name="portal.html", content=page)
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources)
+
+    assert result.route == "native-prose"
+    assert result.status == "written"
+    # anchors trusted on this route, and the header names the owner
+    assert result.owner_check.verdict == "match"
+    assert "Ferritin\t201 ng/mL" in _stored_text(conn, doc.document_id)
 
 
 def test_reocr_reports_a_missing_blob_without_writing(conn, tmp_path, sources):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1509,16 +1509,38 @@ def test_malformed_html_does_not_raise(tmp_path):
     assert "alpha" in text and "beta" in text and "gamma" in text
 
 
-def test_html_marked_section_does_not_raise(tmp_path, capsys):
-    """`_markupbase.parse_marked_section` ends in a plain `raise AssertionError`, which
-    input as ordinary as `<![foo[ x ]]>` reaches. `AssertionError` is not in
-    `_EXTRACT_ERRORS`, so without `_extract_html`'s guard it escapes the "never raises"
-    contract and costs the document — the #138 audit's `RecursionError` defect again."""
+def test_html_marked_section_does_not_raise(tmp_path):
+    """`<![foo[ x ]]>` crashed `html.parser` with a bare `AssertionError` from
+    `_markupbase.parse_marked_section` up to mid-3.12 (gh-81928); the HTML5-conformance
+    rework (gh-135661, ~3.12.12) now skips it as a bogus comment. The contract is the
+    same on both sides — extraction must not raise — but which side the interpreter is
+    on decides whether the document is refused (old: guard translates the crash) or
+    survives (new: parser copes, text extracted). Assert only the shared contract; the
+    guard's translation is pinned deterministically in the next test."""
     src = _make_file(
         tmp_path, "marked.html", b"<p>Ferritin 201</p><![foo[ x ]]><p>tail</p>",
     )
     text, route = ingest.extract_text_routed(src)      # must not raise
     assert route == "native-prose"                     # ...and reports its own route
+    assert text is None or "Ferritin 201" in text
+
+
+def test_html_parser_assertion_is_translated_to_a_refusal(
+    tmp_path, capsys, monkeypatch
+):
+    """The `_extract_html` guard itself, version-independent: interpreters up to
+    mid-3.12 still raise `AssertionError` on ordinary saved pages (previous test), and
+    `AssertionError` is deliberately not in `_EXTRACT_ERRORS` (widening it would
+    swallow our own asserts). Simulate the raise at the `feed` seam the guard wraps
+    and pin the translation: no escape, stderr note, document refused not crashed —
+    the #138 audit's `RecursionError` defect class."""
+    def _raise(self, data):
+        raise AssertionError("unknown status keyword 'foo' in marked section")
+
+    monkeypatch.setattr(ingest._HtmlText, "feed", _raise)
+    src = _make_file(tmp_path, "marked.html", b"<p>Ferritin 201</p>")
+    text, route = ingest.extract_text_routed(src)      # must not raise
+    assert route == "native-prose"
     assert text is None
     assert "malformed HTML markup" in capsys.readouterr().err
 


### PR DESCRIPTION
## Summary

- Adds a stdlib-only HTML/`.htm` text extractor to `extract_text_routed` (`pemr/ingest.py`),
  following the existing suffix-dispatch pattern used by `.docx`/`.xlsx`/CCDA `.xml`. A saved
  portal page no longer falls through to `run_ocr` (which can't decode HTML and stores nothing).
- Introduces a third route value, `native-prose`, alongside `native` (structured) and `ocr`
  (prose), via a shared `_trusts_anchors(route)` helper — so `check_owner`'s identity-anchor
  (`suspect`/`mismatch`) check correctly stays armed for HTML (a saved portal page's `Patient:`
  header is a real claim) while staying off for structured native formats (`.docx`/`.xlsx`, where
  `Patient`/`DOB`/`MRN` are column labels, not headers).
- Malformed/unparseable HTML degrades the same way the other native extractors do — never raises,
  falls through to the established `_EXTRACT_ERRORS` handling.
- Extracted text goes through `normalize_document_text` before storage, same as other native
  routes.
- Docs fan-out: `AGENTS.md` and `docs/Architecture.md` updated to describe the three-route
  vocabulary and HTML's place in it (already landed in build's commits); this PR additionally
  updates the `pemr ingest --ocr auto` CLI help text (`pemr/cli.py`), which still named only
  `text/.docx/.xlsx/CCDA .xml` as natively read — a gap the audit flagged. The fix preserves every
  substring `tests/test_cli_phase2.py::test_ocr_help_names_only_auto_and_no_pdf_tesseract_claim`
  asserts.
- Merged `origin/dev` (#177, #178) into the branch; no code conflicts, docs conflicts none either.
  Re-ran `pytest tests/test_cli_phase2.py tests/test_mcp_server.py tests/test_ingest.py` after the
  merge — 220 passed.

## Known follow-up (not fixed here, flagged by audit as advisory/non-blocking)

Self-closing `<script/>`/`<style/>` tags leak their (empty) element body handling incorrectly and
can let surrounding text leak into `ocr_text`/FTS in an edge case; fix direction noted by audit is
overriding `handle_startendtag` for `_HTML_SKIP_TAGS` in `pemr/ingest.py`. Left as a follow-up —
not a blocker for this change, no test currently exercises a self-closing `<script/>`/`<style/>`.

## Reports

- Verify: https://github.com/meridun/pemr/issues/173#issuecomment-5333795275
- Audit: https://github.com/meridun/pemr/issues/173#issuecomment-5333895673

Closes #173

🤖 Generated with the pemr agentic SDLC pipeline (ship worker)