### PR TITLE
feat(observation): add self-reported symptom and activity lanes (#167)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -332,8 +332,11 @@ CREATE TABLE observation (
   document_id    INTEGER REFERENCES document(document_id),
   obs_type       TEXT NOT NULL,           -- 'vital' (key = canonical vital token, e.g.
                                            -- 'blood_pressure'/'weight'), 'order',
-                                           -- 'screening', 'immunization', 'functional'
-                                           -- ('functional' alone requires observed_at;
+                                           -- 'screening', 'immunization', 'functional',
+                                           -- 'symptom'/'activity' (self-reported, #167)
+                                           -- ('functional' requires observed_at;
+                                           -- symptom/activity require a `key` and an
+                                           -- observed_at carrying a time of day;
                                            -- condition/allergy graduated in 006)
   observed_at    TEXT,
   key            TEXT,
@@ -741,7 +744,10 @@ two rows preserved; a correction or OCR re-read of the *same* reading carries th
 timestamp → collides → surfaces as a conflict (below). When only a date is available,
 same-day differing values collide → conflict; that safety bias is intentional (a spurious
 conflict on a genuine repeat is human-recoverable, a silent duplicate of a correction
-poisons `trends`/brief/`query` irrecoverably).
+poisons `trends`/brief/`query` irrecoverably). The self-reported lanes
+(`obs_type='symptom'`/`'activity'`, issue #167) therefore *mandate* the time component in
+`validate_row`, so a same-day repeat is a second row rather than a conflict — a
+fluctuating complaint is reported several times a day by design.
 
 `lab_result.collected_at` is **truncated to the date** for key purposes (issue #117); the
 column itself still stores the most precise prefix the source gave, and the read layer

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -2997,7 +2997,12 @@ def _cmd_render_brief(args: argparse.Namespace) -> int:
 
 def _cmd_render_journal(args: argparse.Namespace) -> int:
     def work(conn):
-        markdown = render.render_journal(conn, args.person, since=args.since)
+        markdown = render.render_journal(
+            conn,
+            args.person,
+            since=args.since,
+            include_self_reported=args.include_self_reported,
+        )
         return _emit_markdown(markdown, args.out)
 
     return _render_with_conn(args, work)
@@ -3841,6 +3846,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     r_journal.add_argument("--person", required=True, help="owner slug")
     r_journal.add_argument("--since", help="ISO date; keep events on/after this date")
+    r_journal.add_argument(
+        "--include-self-reported", dest="include_self_reported", action="store_true",
+        help="include self-reported symptom and activity events (excluded by default)",
+    )
     r_journal.add_argument("--out", help="write to file instead of stdout")
     r_journal.set_defaults(func=_cmd_render_journal)
 

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -152,15 +152,47 @@ ENUM_FIELDS: dict[str, dict[str, frozenset[str]]] = {
     },
 }
 
+# The self-attested lanes (issue #167): what the *patient* reports about themselves on a
+# given day, as opposed to what a clinician or a document asserted. Deliberately two
+# obs_types, not one — `activity` is the higher-volume, lower-signal of the pair, and
+# sharing a lane would bury the symptom signal underneath it. Both stay inside the
+# `observation` catch-all and never reach `condition`/`Active Problems`, which is what
+# keeps unfiltered self-attested rows out of the verdict-curated problem list.
+#
+# They live here rather than beside render's `OBS_VITAL`/`OBS_ORDER` because `query` needs
+# them too and it already imports from this module while `render` imports `query` —
+# defining them in `render` would invert that edge.
+OBS_SYMPTOM = "symptom"
+OBS_ACTIVITY = "activity"
+SELF_REPORTED_OBS_TYPES: frozenset[str] = frozenset({OBS_SYMPTOM, OBS_ACTIVITY})
+
 # Per-`obs_type` required fields, enforced by validate_row after the per-field loop.
 # `observation`'s FIELD_SPECS entry marks `observed_at` optional because vitals and orders
 # legitimately arrive undated, but a `functional` row's whole value is being dated (issue
 # #132: "the running-balance column stops in July") — an undated one is exactly the
-# unqueryable prose that record type exists to eliminate. Scoped to `functional` alone:
-# widening it to the other families would reject already-valid extractions.
+# unqueryable prose that record type exists to eliminate. Scoped to `functional` and the
+# two self-attested lanes: widening it to the other families would reject already-valid
+# extractions. The self-attested pair needs a date because a fluctuating complaint with no
+# date answers no frequency question, and a `key` because a keyless symptom is exactly the
+# untyped blob the lane exists to prevent (issue #167).
 OBS_TYPE_REQUIRED: dict[str, frozenset[str]] = {
     "functional": frozenset({"observed_at"}),
+    OBS_SYMPTOM: frozenset({"observed_at", "key"}),
+    OBS_ACTIVITY: frozenset({"observed_at", "key"}),
 }
+
+# Obs_types whose `observed_at` must additionally carry a **time of day**, enforced right
+# after the OBS_TYPE_REQUIRED loop (issue #167). Kept a separate name from
+# :data:`OBS_TYPE_REQUIRED` so the presence rule and the precision rule stay separately
+# readable and separately testable.
+#
+# Why a precision rule rather than a new dedup discriminator: `_norm_ts` already keeps
+# `observation.observed_at` at full precision, so two same-day reports at *different times*
+# already get distinct keys (Architecture.md §3). The collision a same-day repeat hits is
+# therefore not a key defect — it is what a date-only `observed_at` means. Mandating the
+# time on these two lanes fixes it without forking observation identity, and it preserves
+# the property that a correction at the *same* timestamp still collides as a CONFLICT.
+OBS_TYPE_REQUIRES_TIME: frozenset[str] = SELF_REPORTED_OBS_TYPES
 
 _WS = re.compile(r"\s+")
 # Capturing group so the same pattern both removes a parenthetical (`sub`, giving the
@@ -233,6 +265,18 @@ def _is_iso_date(value: str) -> bool:
             return False
         return True
     return False
+
+
+def _has_time_component(value: str) -> bool:
+    """True when an ISO date value also carries a time of day (issue #167).
+
+    Correct **only** on a value :func:`_is_iso_date` has already accepted: at that point a
+    string longer than ``YYYY-MM-DD`` can only be a full date followed by the ``T``/space
+    separator and a valid time (month- and year-precision forms permit no time component
+    at all). The caller in :func:`validate_row` guarantees that ordering; the
+    ``len(value) > 10`` guard keeps a shorter value from ever indexing out of range.
+    """
+    return len(value) > 10 and value[10] in ("T", " ")
 
 
 # --------------------------------------------------------------------------- #
@@ -638,6 +682,18 @@ def validate_row(record_type: str, row: object) -> None:
                     f"observation: missing required field '{field}' "
                     f"for obs_type={row['obs_type']!r}"
                 )
+        # Ordering is load-bearing (issue #167): the per-field loop above has already
+        # proven `observed_at` is an ISO value, and the OBS_TYPE_REQUIRED loop has just
+        # proven it is present, so `_has_time_component` may index into it. Moving either
+        # block after this one would turn a ValidationError into an IndexError.
+        if row["obs_type"] in OBS_TYPE_REQUIRES_TIME and not _has_time_component(
+            row["observed_at"]
+        ):
+            raise ValidationError(
+                f"observation.observed_at: obs_type={row['obs_type']!r} requires a time "
+                f"of day (YYYY-MM-DDTHH:MM), got {row['observed_at']!r} - two reports of "
+                "one key on the same day would otherwise dedup into a single row"
+            )
 
 
 def _type_names(types: object) -> str:

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -504,11 +504,22 @@ def render_brief(conn: sqlite3.Connection, *, appointment: int) -> dict[str, str
 
 
 def render_journal(
-    conn: sqlite3.Connection, *, person: str, since: str | None = None
+    conn: sqlite3.Connection,
+    *,
+    person: str,
+    since: str | None = None,
+    include_self_reported: bool = False,
 ) -> dict[str, str]:
-    """[read] Narrative chronology for a person -> Markdown. Mirrors ``pemr render journal``."""
+    """[read] Narrative chronology for a person -> Markdown. Mirrors ``pemr render journal``.
+
+    ``include_self_reported`` mirrors the CLI's ``--include-self-reported`` (issue #167),
+    a pass-through with no logic of its own: the two verbs must not drift about what the
+    journal contains.
+    """
     try:
-        markdown = _render.render_journal(conn, person, since=since)
+        markdown = _render.render_journal(
+            conn, person, since=since, include_self_reported=include_self_reported
+        )
     except (db.NotMigratedError, _query.PersonNotFoundError) as exc:
         raise _friendly(exc) from exc
     return {"markdown": markdown}
@@ -615,8 +626,15 @@ def build_server():  # pragma: no cover - exercised only with the mcp SDK instal
         return _run(render_brief, appointment=appointment)
 
     @server.tool(name="render_journal", annotations=ro)
-    def render_journal_tool(person: str, since: str | None = None) -> dict:
-        return _run(render_journal, person=person, since=since)
+    def render_journal_tool(
+        person: str, since: str | None = None, include_self_reported: bool = False
+    ) -> dict:
+        return _run(
+            render_journal,
+            person=person,
+            since=since,
+            include_self_reported=include_self_reported,
+        )
 
     @server.tool(name="render_curation", annotations=ro)
     def render_curation_tool(person: str) -> dict:

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -214,6 +214,7 @@ def query_timeline(
     since: str | None = None,
     *,
     with_identity: bool = False,
+    exclude_obs_types: frozenset[str] | None = None,
 ) -> list[dict]:
     """Merged chronological event stream across the typed tables + observations.
 
@@ -239,6 +240,16 @@ def query_timeline(
     into both contracts. Since issue #131 the `pemr query timeline` CLI handler and the
     MCP ``query`` tool turn it on too — the same overlay `render_journal` applies — and
     both strip the three keys again before emitting anything.
+
+    ``exclude_obs_types`` drops ``observation`` rows whose ``obs_type`` is in the set,
+    before the event is built (issue #167). Keyword-only and **default-off**: ``None``
+    filters nothing, so every existing caller's output is byte-identical. It filters on
+    the *row* rather than on the built event deliberately — an event carries no
+    ``obs_type`` key (it is folded into ``summary``), string-prefix matching a rendered
+    sentence is exactly the fragile thing to avoid, and widening the event dict is the
+    same public-contract problem ``with_identity`` exists to sidestep. `render_journal`
+    is the one caller that passes a set, to keep a few hundred self-reported attestations
+    a year out of a decades-long chronology.
     """
     person_id = resolve_person_id(conn, slug)
     events: list[dict] = []
@@ -308,6 +319,8 @@ def query_timeline(
     for r in conn.execute(
         "SELECT * FROM observation WHERE person_id = ?", (person_id,)
     ).fetchall():
+        if exclude_obs_types and r["obs_type"] in exclude_obs_types:
+            continue
         value = r["value_num"] if r["value_num"] is not None else r["value_text"]
         unit = f" {r['unit']}" if r["unit"] else ""
         parts = [r["obs_type"]]

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -28,6 +28,18 @@ canonical *vital* vocabulary in ``data/dictionary.example.toml``):
     **grouped at render time** by normalized ``key``, newest first, with the
     collapse disclosed on the line (issue #93) -- the stored rows keep their dates
     and stay distinct, because an order is an event, not a standing fact.
+  * **self-reported** -> ``obs_type='symptom'`` (``key`` = the complaint, ``value_num`` =
+    a 0-10 severity where **0 means reported resolved**, ``value_text`` = the verbatim
+    wording) and ``obs_type='activity'`` (exercise and general activity), both entered
+    through `pemr record assert` (issue #167). Two lanes on purpose: activity is the
+    higher-volume, lower-signal of the pair and would bury the symptom signal. Symptoms
+    render as one **collapsed** ``## Self-Reported Symptoms`` line per ``key``
+    (:func:`_self_reported_symptoms`) -- a chronological dump of "achy on the 16th / fine
+    on the 18th" is worse than nothing. Activity renders in **no** summary section at
+    all; it stays reachable through `query`, `trends` and the journal's opt-in flag.
+    Neither lane may ever reach `condition` or the problem-list sections: those are
+    clinician-sourced and heavily verdict-suppressed, and routing unfiltered
+    self-attestations into them would undo that curation.
 
 **Procedures on the summary** (issue #166). ``procedure`` rows arrive largely from billing
 documents, so the table mixes genuine procedural history with routine service lines
@@ -114,10 +126,17 @@ import calendar
 import re
 import sqlite3
 from collections.abc import Sequence
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from . import curation, db, dedup, query, units
-from .dedup import enum_token, is_attested, key_token, norm
+from .dedup import (
+    OBS_SYMPTOM,
+    SELF_REPORTED_OBS_TYPES,
+    enum_token,
+    is_attested,
+    key_token,
+    norm,
+)
 
 # Observation obs_type conventions this layer reads (see module docstring).
 OBS_VITAL = "vital"
@@ -163,6 +182,14 @@ _BRIEF_RECENT_LABS = 10
 #: miss than the dump it bounds. The window controls volume; the keep-latest guard in
 #: `_abnormal_labs` controls that false-empty, which recurs at *any* fixed window.
 _ABNORMAL_LABS_WINDOW_MONTHS = 12
+
+#: Trailing window for the summary's self-reported symptom section (issue #167). Days,
+#: not months like `_ABNORMAL_LABS_WINDOW_MONTHS` above: a fluctuating complaint's
+#: decision-relevant span is weeks, and a report count is only meaningful against a span
+#: short enough to read as "lately". 30 is the window the issue's worked example states.
+#: There is deliberately no keep-latest guard here (unlike `_abnormal_labs`): a lab marker
+#: abnormal 14 months ago is still live, a complaint last mentioned 14 months ago is not.
+_SYMPTOM_WINDOW_DAYS = 30
 
 
 class AppointmentNotFoundError(ValueError):
@@ -566,6 +593,130 @@ def _latest_vitals(
     for r in kept:
         latest[key_token(r["key"], dictionary)] = r  # ascending -> last wins
     return [latest[k] for k in sorted(latest)]
+
+
+def _self_reported_symptoms(
+    conn: sqlite3.Connection,
+    person_id: int,
+    today: str,
+    dictionary: dict[str, str] | None,
+    cur: "_CurationPass | None" = None,
+) -> list[dict]:
+    """One collapsed entry per self-reported symptom ``key`` (issue #167).
+
+    A recurring, fluctuating complaint is reported over and over; rendering the reports
+    chronologically ("achy on the 16th / fine on the 18th") is worse than not rendering
+    them at all. So each ``key`` folds to **one** entry carrying how often it was
+    reported in the trailing ``_SYMPTOM_WINDOW_DAYS``, the latest present report, and the
+    latest report that it had *resolved*.
+
+    Selection rules, in the :func:`_abnormal_labs` spirit:
+
+    * curation runs **before** the fold, as in :func:`_latest_vitals`, so a superseded
+      report can neither win "latest" nor inflate the count;
+    * grouped on :func:`key_token`, matching the dedup key, so ``right foot ache
+      (morning)`` keeps its own entry rather than overwriting the plain one;
+    * a row whose ``observed_at`` will not parse counts as in-window, and an unparseable
+      ``today`` skips the bound entirely -- a bad date must never silently empty a medical
+      section;
+    * future-dated rows are untouched; only the old side is bounded.
+
+    ``value_num`` is the 0-10 severity, and **0 means reported resolved** -- the scale
+    already has a natural bottom, so absence needs no sentinel and no second obs_type. A
+    ``NULL`` ``value_num`` is a present report of unknown severity.
+    """
+    rows = conn.execute(
+        "SELECT * FROM observation WHERE person_id = ? AND obs_type = ? "
+        "ORDER BY observed_at, observation_id",
+        (person_id, OBS_SYMPTOM),
+    ).fetchall()
+    kept = _apply_curation([dict(r) for r in rows], "observation", cur)
+
+    anchor = _as_date(today)
+    start = None if anchor is None else anchor - timedelta(days=_SYMPTOM_WINDOW_DAYS)
+
+    entries: dict[str, dict] = {}
+    for r in kept:  # ascending -> the last row seen for a key is its newest
+        when = _as_date(r["observed_at"])
+        if start is not None and when is not None and when < start:
+            continue
+        entry = entries.setdefault(
+            key_token(r["key"], dictionary),
+            {"label": "", "count": 0, "latest": None, "resolved": None, "sort": ""},
+        )
+        entry["label"] = r["key"]
+        entry["count"] += 1
+        entry["sort"] = r["observed_at"] or ""
+        if r["value_num"] == 0:
+            entry["resolved"] = r
+        else:
+            entry["latest"] = r
+    # Newest activity first -- the live complaint belongs at the top -- with the label as
+    # a deterministic A-Z tiebreaker. Two stable passes rather than one composite key,
+    # because the two fields sort in opposite directions and `sorted` has no per-field
+    # reverse; an undated row (empty `sort`) lands last, not first.
+    out = sorted(entries.values(), key=lambda e: str(e["label"] or ""))
+    out.sort(key=lambda e: (bool(e["sort"]), e["sort"]), reverse=True)
+    return out
+
+
+def _severity(value: object) -> str:
+    """A 0-10 severity for display: ``3.0`` prints as ``3`` (issue #167's worked example).
+
+    Scoped to this one line builder rather than folded into :func:`_fmt`: every other
+    numeric section prints the stored REAL verbatim (``weight: 80.0 kg``) and changing
+    that would rewrite output this issue has no business touching.
+    """
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return _fmt(value)
+
+
+def _symptom_line(entry: dict) -> str:
+    """One ``## Self-Reported Symptoms`` bullet: the collapsed state of one complaint.
+
+    The provenance suffixes annotate the ``anchor`` row -- the one that supplied the
+    line's headline datum -- because :func:`_attest_suffix`'s contract is per row and a
+    suffix stays truthful only about the row it annotates. The rows folded into ``count``
+    contribute no suffix: a count is not a provenance claim, and the section title is
+    itself the standing statement that everything under it is self-reported.
+    """
+    count = entry["count"]
+    plural = "" if count == 1 else "s"
+    head = f"- {entry['label']} - {count} report{plural} in {_SYMPTOM_WINDOW_DAYS}d"
+
+    latest = entry["latest"]
+    resolved = entry["resolved"]
+    if latest is not None:
+        head += f", latest {_date_part(latest['observed_at'])}"
+        if latest["value_num"] is not None:
+            head += f" (severity {_severity(latest['value_num'])}/10)"
+    # A resolution older than the newest present report is not news; only a resolution
+    # that is the last word on the complaint earns the clause.
+    if resolved is not None and (
+        latest is None or str(resolved["observed_at"]) > str(latest["observed_at"])
+    ):
+        head += f"; last reported resolved {_date_part(resolved['observed_at'])}"
+
+    anchor = latest if latest is not None else resolved
+    if anchor is None:
+        return head
+    return f"{head}{_dispute_suffix(anchor)}{_attest_suffix(anchor)}"
+
+
+def _symptom_section(entries: list[dict]) -> str | None:
+    """The ``## Self-Reported Symptoms`` section, or ``None`` when there is nothing.
+
+    Built like :func:`_questions_section`, not like a plain :func:`_section` call.
+    ``_section``'s always-present ``_none recorded_`` header is right where emptiness is
+    *information* -- a clinician reviewed and found none -- but here it would read as "the
+    patient reports no symptoms", an assertion the record cannot make. Omitting the
+    section also keeps summary output byte-identical for every person who never uses the
+    lane, which is the additive-only rule issue #168 recorded for the appendix.
+    """
+    if not entries:
+        return None
+    return _section("Self-Reported Symptoms", [_symptom_line(e) for e in entries])
 
 
 def _order_display(row: dict) -> str:
@@ -1121,7 +1272,8 @@ def render_summary(
     now: datetime | None = None,
 ) -> str:
     """Markdown master summary for a person: active meds, active problems, past medical
-    history, family history, allergies, orders, latest vitals, recent abnormal labs,
+    history, family history, allergies, orders, latest vitals, self-reported symptoms
+    (omitted when there are none), recent abnormal labs,
     procedures and upcoming/open appointments --
     with a self-identifying header (name, DOB, generated-at, source row counts).
     Read-only.
@@ -1210,6 +1362,10 @@ def render_summary(
             f"{_dispute_suffix(v)}{_attest_suffix(v)}{_unit_suffix(d)}"
         )
 
+    symptom_section = _symptom_section(
+        _self_reported_symptoms(conn, person_id, today, dictionary, cur)
+    )
+
     lab_lines = []
     for r in _abnormal_labs(conn, person_id, today, cur):
         d = units.display(
@@ -1256,6 +1412,12 @@ def render_summary(
         _section("Allergies", allergy_lines),
         _section("Orders & Referrals", order_lines),
         _section("Latest Vitals", vital_lines),
+        # Between the vitals and the labs: both are "current state of the body", and it
+        # keeps the self-attested block well away from the clinician-sourced problem
+        # list at the top. Spliced the `_open_conflicts_warning` way because the section
+        # is omitted entirely when empty (issue #167) -- a header here would assert the
+        # patient reports nothing, which is not a thing the record knows.
+        *(s for s in (symptom_section,) if s is not None),
         _section(
             f"Abnormal Labs (last {_ABNORMAL_LABS_WINDOW_MONTHS} months)",
             lab_lines,
@@ -1447,12 +1609,19 @@ def render_journal(
     *,
     since: str | None = None,
     now: datetime | None = None,
+    include_self_reported: bool = False,
 ) -> str:
     """The phase-3 timeline event stream rendered as a narrative Markdown chronology,
     grouped by date, with document-provenance footnotes. Read-only.
 
     Curated-away events simply do not appear; their audit trail is
     :func:`render_curation` (issue #168), not a tail section here.
+
+    ``include_self_reported`` opts the ``symptom``/``activity`` lanes back in (issue
+    #167). **Off by default**: the journal is a chronology that already spans decades, and
+    a few hundred self-attestations a year swamps it -- while the summary's collapsed
+    ``## Self-Reported Symptoms`` section is the reading of them that is actually useful.
+    The rows stay reachable in full through `pemr query timeline`, which is unfiltered.
 
     Raises :class:`query.PersonNotFoundError` for an unknown slug (friendly rc=1)."""
     person_id = query.resolve_person_id(conn, slug)
@@ -1463,7 +1632,11 @@ def render_journal(
     # `with_identity` is what makes the overlay reachable from here: a timeline event
     # is a rendered sentence, not a row, so it carries no family identity by default.
     events = query.query_timeline(
-        conn, slug, since=since, with_identity=bool(cur.verdicts)
+        conn,
+        slug,
+        since=since,
+        with_identity=bool(cur.verdicts),
+        exclude_obs_types=None if include_self_reported else SELF_REPORTED_OBS_TYPES,
     )
     events = _apply_curation_events(events, cur)
 

--- a/tests/test_attestations.py
+++ b/tests/test_attestations.py
@@ -736,3 +736,79 @@ def test_cli_assert_a_functional_observation_without_a_document(cli_ready, capsy
         "--field", "obs_type=functional", "--field", "key=meal_regularity", "--apply",
     ) == 1
     assert "missing required field 'observed_at'" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# self-reported symptom / activity lanes (issue #167)
+# --------------------------------------------------------------------------- #
+
+SYMPTOM = {"obs_type": "symptom", "key": "right foot ache",
+           "observed_at": "2026-08-16T09:00", "value_num": 3,
+           "value_text": "achy after the walk"}
+
+
+def _assert_obs(conn, payload, **kwargs):
+    return attestations.assert_record(
+        conn, "observation", "jane-doe", dict(payload),
+        attributed_to=kwargs.pop("attributed_to", "Jane Doe"),
+        attested_on=kwargs.pop("attested_on", "2026-08-18"),
+        **kwargs,
+    )
+
+
+def test_a_symptom_asserts_through_the_existing_path(conn, jane):
+    """T4: no new CLI verb and no migration -- `record assert` already carries exactly
+    the right shape (a fact attributed to a person, dated, with no source document)."""
+    report = _assert_obs(conn, SYMPTOM, apply=True)
+    assert report.applied is True
+    row = conn.execute("SELECT * FROM observation").fetchone()
+    assert row["obs_type"] == "symptom"
+    assert row["key"] == "right foot ache"
+    assert row["value_num"] == 3
+    assert row["value_text"] == "achy after the walk"
+    assert row["document_id"] is None
+    assert dedup.attestation_state(row) == "attested"
+
+
+def test_an_activity_asserts_through_the_existing_path(conn, jane):
+    _assert_obs(conn, {"obs_type": "activity", "key": "morning walk",
+                       "observed_at": "2026-08-16T07:30", "value_num": 40,
+                       "unit": "min"}, apply=True)
+    row = conn.execute("SELECT * FROM observation").fetchone()
+    assert row["obs_type"] == "activity" and row["key"] == "morning walk"
+
+
+def test_asserting_a_self_report_never_touches_the_problem_list(conn, jane):
+    """The load-bearing invariant: these lanes live entirely inside the `observation`
+    catch-all and bypass the curation-verdict pipeline that governs `condition`."""
+    _assert_obs(conn, SYMPTOM, apply=True)
+    _assert_obs(conn, {"obs_type": "activity", "key": "morning walk",
+                       "observed_at": "2026-08-16T07:30"}, apply=True)
+    assert conn.execute("SELECT COUNT(*) AS n FROM condition").fetchone()["n"] == 0
+    assert conn.execute("SELECT COUNT(*) AS n FROM allergy").fetchone()["n"] == 0
+
+
+def test_a_keyless_symptom_assert_is_refused(conn, jane):
+    with pytest.raises(dedup.ValidationError, match="missing required field 'key'"):
+        _assert_obs(conn, {"obs_type": "symptom", "observed_at": "2026-08-16T09:00"},
+                    apply=True)
+    assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 0
+
+
+def test_a_date_only_symptom_assert_is_refused(conn, jane):
+    """The precision rule reaches the real write path, not just `validate_row`: without
+    it two reports of one complaint on one day would collapse into a single row."""
+    with pytest.raises(dedup.ValidationError, match="requires a time of day"):
+        _assert_obs(conn, dict(SYMPTOM, observed_at="2026-08-16"), apply=True)
+    assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 0
+
+
+def test_two_same_day_symptom_asserts_land_as_two_rows(conn, jane):
+    """The AC the whole D1 decision exists for."""
+    morning = _assert_obs(conn, SYMPTOM, apply=True)
+    evening = _assert_obs(
+        conn, dict(SYMPTOM, observed_at="2026-08-16T21:00", value_num=6), apply=True
+    )
+    assert evening.outcome == "new"
+    assert morning.dedup_key != evening.dedup_key
+    assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 2

--- a/tests/test_cli_ascii.py
+++ b/tests/test_cli_ascii.py
@@ -304,3 +304,14 @@ def test_record_assert_output_is_console_safe(ready, capsys):
     err = capsys.readouterr().err
     assert "already holds this identity" in err
     _assert_console_safe(err)
+
+
+def test_render_journal_help_is_console_safe(ready, capsys):
+    """Issue #167's one new flag: its help text joins the corpus the cp437 sweep
+    covers, since `render journal --help` was not previously exercised here."""
+    with pytest.raises(SystemExit):
+        _run(ready, "render", "journal", "--help")
+    out = capsys.readouterr().out
+    assert "--include-self-reported" in out
+    assert "excluded by default" in out
+    _assert_console_safe(out)

--- a/tests/test_cli_phase4.py
+++ b/tests/test_cli_phase4.py
@@ -545,3 +545,90 @@ def test_render_summary_open_conflicts_warning_end_to_end(ready, capsys):
     assert "> 1 open conflict - some values below may be superseded." in out
     assert "`pemr review-conflicts`" in out
     assert out.isascii()
+
+
+# --- self-reported symptom / activity lanes (issue #167) ----------------------
+#
+# End-to-end through the real argv surface: `record assert` in, `render summary` and
+# `render journal` out. The summary's window is relative to the real clock (the CLI
+# passes no `now`), so the dates here are computed from today rather than pinned.
+
+def _assert_symptom(tmp_path, observed_at, key="right foot ache", severity="3",
+                    obs_type="symptom"):
+    return _run(
+        tmp_path, "record", "assert", "observation", "--person", "jane-doe",
+        "--attributed-to", "Jane Doe", "--date", "2026-08-18",
+        "--field", f"obs_type={obs_type}", "--field", f"key={key}",
+        "--field", f"observed_at={observed_at}",
+        "--field", f"value_num={severity}", "--apply",
+    )
+
+
+def test_two_same_day_symptom_asserts_collapse_into_one_summary_line(ready, capsys):
+    """T10: the whole lane, through argv. Two reports on one calendar day survive as two
+    rows (the time-of-day rule) and render as one collapsed line (the section's point)."""
+    tmp_path, _ = ready
+    day = date.today() - timedelta(days=2)
+    assert _assert_symptom(tmp_path, f"{day}T09:00", severity="5") == 0
+    assert _assert_symptom(tmp_path, f"{day}T21:00", severity="3") == 0
+    capsys.readouterr()
+
+    assert _run(tmp_path, "render", "summary", "--person", "jane-doe") == 0
+    out = capsys.readouterr().out
+    assert "## Self-Reported Symptoms" in out
+    line = next(ln for ln in out.splitlines() if "right foot ache" in ln)
+    assert line.startswith(
+        f"- right foot ache - 2 reports in 30d, latest {day} (severity 3/10)"
+    )
+    assert "(attested by Jane Doe 2026-08-18; no source document)" in line
+
+
+def test_a_date_only_symptom_assert_exits_non_zero(ready, capsys):
+    """The precision rule is a refusal with a message that names the fix, not a crash."""
+    tmp_path, _ = ready
+    assert _assert_symptom(tmp_path, str(date.today())) == 1
+    err = capsys.readouterr().err
+    assert "requires a time of day (YYYY-MM-DDTHH:MM)" in err
+    assert err.isascii()
+
+
+def test_journal_hides_self_reports_until_asked(ready, capsys):
+    """The flag, end to end: a chronology spanning decades must not be swamped by a few
+    hundred attestations a year, but the events stay one flag away."""
+    tmp_path, _ = ready
+    day = date.today() - timedelta(days=1)
+    assert _assert_symptom(tmp_path, f"{day}T09:00") == 0
+    assert _assert_symptom(tmp_path, f"{day}T07:30", key="morning walk",
+                           obs_type="activity", severity="40") == 0
+    capsys.readouterr()
+
+    assert _run(tmp_path, "render", "journal", "--person", "jane-doe") == 0
+    default = capsys.readouterr().out
+    assert "right foot ache" not in default and "morning walk" not in default
+    assert "Metformin" in default            # control: the chronology is otherwise whole
+
+    assert _run(tmp_path, "render", "journal", "--person", "jane-doe",
+                "--include-self-reported") == 0
+    opted_in = capsys.readouterr().out
+    assert "symptom right foot ache" in opted_in
+    assert "activity morning walk" in opted_in
+
+
+def test_query_timeline_still_shows_every_self_report(ready, capsys):
+    """`activity` stays reachable: only the journal filters, and `query timeline` is the
+    complete record it filters *from*."""
+    tmp_path, _ = ready
+    day = date.today() - timedelta(days=1)
+    assert _assert_symptom(tmp_path, f"{day}T07:30", key="morning walk",
+                           obs_type="activity", severity="40") == 0
+    capsys.readouterr()
+    assert _run(tmp_path, "query", "timeline", "--person", "jane-doe", "--json") == 0
+    events = json.loads(capsys.readouterr().out)
+    assert any("morning walk" in e["summary"] for e in events)
+
+
+def test_a_person_with_no_self_reports_gets_no_symptom_section(ready, capsys):
+    """The additive-only rule at the CLI: no header implying the patient reports nothing."""
+    tmp_path, _ = ready
+    assert _run(tmp_path, "render", "summary", "--person", "jane-doe") == 0
+    assert "Self-Reported Symptoms" not in capsys.readouterr().out

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -869,6 +869,139 @@ def test_functional_commit_without_observed_at_is_rejected(conn):
     assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 0
 
 
+# --- self-reported symptom / activity lanes (issue #167) ----------------------
+
+def _symptom(observed_at="2026-08-16T09:00", key="right foot ache",
+             value_num=3, value_text="achy after the walk"):
+    return {"obs_type": "symptom", "key": key, "observed_at": observed_at,
+            "value_num": value_num, "value_text": value_text}
+
+
+def test_validate_accepts_a_self_reported_symptom_row():
+    # T1: the shape the lane is built for -- key = the complaint, value_num = a 0-10
+    # severity, value_text = the patient's verbatim wording.
+    dedup.validate_row("observation", _symptom())
+
+
+def test_validate_accepts_a_self_reported_activity_row():
+    dedup.validate_row(
+        "observation",
+        {"obs_type": "activity", "key": "walk", "observed_at": "2026-08-16T07:30",
+         "value_num": 40, "unit": "min"},
+    )
+
+
+@pytest.mark.parametrize("obs_type", ["symptom", "activity"])
+def test_validate_rejects_a_self_reported_row_without_a_key(obs_type):
+    # T2a: a keyless self-report is exactly the untyped blob the lane exists to prevent.
+    with pytest.raises(dedup.ValidationError,
+                       match=rf"missing required field 'key'.*{obs_type}"):
+        dedup.validate_row(
+            "observation",
+            {"obs_type": obs_type, "observed_at": "2026-08-16T09:00",
+             "value_text": "sore"},
+        )
+
+
+@pytest.mark.parametrize("obs_type", ["symptom", "activity"])
+def test_validate_rejects_a_self_reported_row_without_an_observed_at(obs_type):
+    # T2c: undated, a fluctuating complaint answers no frequency question at all.
+    with pytest.raises(dedup.ValidationError,
+                       match=rf"missing required field 'observed_at'.*{obs_type}"):
+        dedup.validate_row(
+            "observation", {"obs_type": obs_type, "key": "right foot ache"}
+        )
+
+
+@pytest.mark.parametrize("observed_at", ["2026-08-16", "2026-08", "2026"])
+def test_validate_rejects_a_self_report_dated_without_a_time(observed_at):
+    # T2b/T2b2: the precision rule, and the validation-order hazard with it. A
+    # year-precision value is 4 characters long, so a helper that indexed blindly would
+    # raise IndexError instead of a ValidationError -- the guard is what keeps the
+    # message honest at every precision.
+    with pytest.raises(dedup.ValidationError) as exc:
+        dedup.validate_row("observation", _symptom(observed_at=observed_at))
+    message = str(exc.value)
+    assert "requires a time of day (YYYY-MM-DDTHH:MM)" in message   # names the fix
+    assert observed_at in message                                   # names what it saw
+    assert message.isascii()                                        # cp1252 (issue #23)
+
+
+def test_self_report_precision_rule_does_not_shadow_the_iso_check():
+    # A present-but-junk observed_at still reports as an ISO-date error: the DATE_FIELDS
+    # loop is what proves the value parseable before the precision branch indexes it.
+    with pytest.raises(dedup.ValidationError, match=r"observed_at.*ISO date"):
+        dedup.validate_row("observation", _symptom(observed_at="yesterday morning"))
+
+
+@pytest.mark.parametrize("obs_type", ["vital", "order", "screening", "immunization",
+                                      "functional"])
+def test_the_time_of_day_rule_is_scoped_to_the_self_reported_lanes(obs_type):
+    # Scoping regression: mandating a time on the older families would reject every
+    # already-valid extraction, which state dates and not clock times.
+    dedup.validate_row(
+        "observation",
+        {"obs_type": obs_type, "key": "anything", "observed_at": "2026-07-14"},
+    )
+
+
+def test_same_day_symptom_reports_at_different_times_are_distinct_rows(conn):
+    # T3, the point of the whole precision rule: two reports of one complaint on one
+    # calendar day must survive as two rows.
+    doc = _make_document(conn)
+    summary = dedup.commit_extraction(conn, doc, {"observation": [
+        _symptom(observed_at="2026-08-16T09:00", value_num=3),
+        _symptom(observed_at="2026-08-16T21:00", value_num=6),
+    ]})
+    assert summary.counts["new"] == 2
+    keys = {r["dedup_key"] for r in conn.execute(
+        "SELECT dedup_key FROM observation WHERE obs_type='symptom'"
+    ).fetchall()}
+    assert len(keys) == 2
+
+
+def test_a_symptom_restated_at_the_same_timestamp_still_collides(conn):
+    # The other half of T3: the correction-collides property is preserved, not traded
+    # away. A re-read of the *same* report carries the same timestamp, so it dedups --
+    # a differing value stages a conflict rather than becoming a phantom second report.
+    doc1, doc2 = _make_document(conn), _make_document(conn)
+    dedup.commit_extraction(conn, doc1, {"observation": [_symptom()]})
+    same = dedup.commit_extraction(conn, doc2, {"observation": [_symptom()]})
+    assert same.counts["duplicate"] == 1
+    differing = dedup.commit_extraction(
+        conn, doc2, {"observation": [_symptom(value_num=8)]}
+    )
+    assert differing.counts["conflict"] == 1
+    assert conn.execute(
+        "SELECT COUNT(*) AS n FROM observation WHERE obs_type='symptom'"
+    ).fetchone()["n"] == 1
+
+
+def test_a_self_reported_row_never_creates_a_condition(conn):
+    # The load-bearing invariant (issue #167): these lanes stay inside the `observation`
+    # catch-all. The problem list is clinician-sourced and heavily verdict-suppressed;
+    # routing unfiltered self-attestations into it would undo that curation.
+    doc = _make_document(conn)
+    dedup.commit_extraction(conn, doc, {"observation": [
+        _symptom(),
+        {"obs_type": "activity", "key": "walk", "observed_at": "2026-08-16T07:30"},
+    ]})
+    assert conn.execute("SELECT COUNT(*) AS n FROM condition").fetchone()["n"] == 0
+    assert conn.execute("SELECT COUNT(*) AS n FROM allergy").fetchone()["n"] == 0
+
+
+def test_observation_identity_is_not_forked_by_obs_type():
+    # `_key_parts`/`KEY_FIELDS` are untouched: the fix is a validation-time precision
+    # rule, not a second key shape. So no stored row's dedup_key moves (no `pemr rekey`
+    # implied), and a symptom row keys on exactly the four parts every observation does.
+    assert dedup.KEY_FIELDS["observation"] == frozenset({"obs_type", "observed_at", "key"})
+    parts = dedup._key_parts("observation", _symptom(), 1)
+    assert parts == [1, "symptom", "2026-08-16 09:00", "right foot ache"]
+    # The severity is payload, never identity -- an edited value must keep colliding as a
+    # correction instead of silently becoming a second report.
+    assert dedup._key_parts("observation", _symptom(value_num=9), 1) == parts
+
+
 # --- intra-payload collisions (issue #58) -------------------------------------
 
 def test_intra_payload_collision_with_differing_values_is_rejected(conn):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -679,3 +679,58 @@ def test_record_edit_is_not_on_the_mcp_surface():
     for spelling in ("record_edit", "edit_record", "record_edits"):
         assert spelling not in surface, spelling
     assert "record_edit" not in mcp_server.WRITE_TOOLS
+
+
+# --------------------------------------------------------------------------- #
+# self-reported lanes: CLI/MCP verb parity (issue #167)
+# --------------------------------------------------------------------------- #
+
+def _attest_self_reports(conn, slug="jane-doe"):
+    from pemr import attestations
+
+    for row in (
+        {"obs_type": "symptom", "key": "right foot ache",
+         "observed_at": "2026-08-16T09:00", "value_num": 3},
+        {"obs_type": "activity", "key": "morning walk",
+         "observed_at": "2026-08-16T07:30", "value_num": 40, "unit": "min"},
+    ):
+        attestations.assert_record(
+            conn, "observation", slug, row, attributed_to="Jane Doe",
+            attested_on="2026-08-18", apply=True,
+        )
+
+
+def test_render_journal_tool_mirrors_the_cli_default(seeded):
+    """The MCP front door applies the same default-off filter the CLI does -- the two
+    verbs must not disagree about what the journal contains."""
+    _attest_self_reports(seeded)
+    md = mcp_server.render_journal(seeded, person="jane-doe")["markdown"]
+    assert "right foot ache" not in md and "morning walk" not in md
+
+
+def test_render_journal_tool_forwards_the_opt_in(seeded):
+    _attest_self_reports(seeded)
+    md = mcp_server.render_journal(
+        seeded, person="jane-doe", include_self_reported=True
+    )["markdown"]
+    assert "symptom right foot ache" in md
+    assert "activity morning walk" in md
+
+
+def test_the_self_reported_lanes_add_no_tool(seeded):
+    """`record assert` is CLI-only and stays that way: the lanes are entered through an
+    existing verb, and the MCP surface gains a parameter, never a name."""
+    assert "record_assert" not in mcp_server.TOOL_NAMES
+    assert set(mcp_server.TOOL_NAMES) == set(
+        mcp_server.READ_ONLY_TOOLS + mcp_server.WRITE_TOOLS
+    )
+    assert "render_journal" in mcp_server.READ_ONLY_TOOLS
+
+
+def test_the_query_tool_still_returns_self_reports(seeded):
+    """Only the journal filters. `query timeline` -- CLI and MCP alike -- is the
+    complete record it filters from."""
+    _attest_self_reports(seeded)
+    events = mcp_server.query(seeded, kind="timeline", person="jane-doe")
+    assert any("morning walk" in e["summary"] for e in events)
+    assert any("right foot ache" in e["summary"] for e in events)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -751,3 +751,66 @@ def test_trends_preference_is_person_scoped(mixed_weights):
     units.set_pref(mixed_weights, "jane-doe", "hba1c", "%", dictionary=d)
     john = query.trends(mixed_weights, "john-doe", "hba1c", dictionary=d)
     assert john["canonical_unit"] is None and john["latest"] == 9.0
+
+
+def _seed_self_reports(conn, slug="jane-doe"):
+    """Two self-reported rows (issue #167), entered the way `record assert` does."""
+    from pemr import attestations
+
+    for row in (
+        {"obs_type": "symptom", "key": "right foot ache",
+         "observed_at": "2026-08-16T09:00", "value_num": 3},
+        {"obs_type": "activity", "key": "morning walk",
+         "observed_at": "2026-08-16T07:30", "value_num": 40, "unit": "min"},
+    ):
+        attestations.assert_record(
+            conn, "observation", slug, row, attributed_to="Jane Doe",
+            attested_on="2026-08-18", apply=True,
+        )
+
+
+def test_timeline_returns_self_reports_by_default(seeded):
+    """Issue #167: `pemr query timeline` and the MCP `query` tool stay the complete
+    record. Only `render_journal` filters, and it does so by asking."""
+    _seed_self_reports(seeded)
+    summaries = [e["summary"] for e in query.query_timeline(seeded, "jane-doe")]
+    assert "symptom right foot ache = 3.0" in summaries
+    assert "activity morning walk = 40.0 min" in summaries
+
+
+def test_timeline_can_exclude_obs_types(seeded):
+    _seed_self_reports(seeded)
+    events = query.query_timeline(
+        seeded, "jane-doe", exclude_obs_types=dedup.SELF_REPORTED_OBS_TYPES
+    )
+    assert not any("right foot ache" in e["summary"] for e in events)
+    assert not any("morning walk" in e["summary"] for e in events)
+    # Control: another obs_type on the same table is untouched by the filter.
+    assert any("blood_pressure systolic" in e["summary"] for e in events)
+
+
+def test_excluding_obs_types_leaves_the_event_shape_alone(seeded):
+    """The filter drops rows before the event is built, so it can neither add nor remove
+    a key: an excluded-set call is the unfiltered call minus whole events."""
+    _seed_self_reports(seeded)
+    full = query.query_timeline(seeded, "jane-doe")
+    filtered = query.query_timeline(
+        seeded, "jane-doe", exclude_obs_types=dedup.SELF_REPORTED_OBS_TYPES
+    )
+    assert len(filtered) == len(full) - 2
+    assert all(set(e) == {"date", "type", "summary", "document_id"} for e in filtered)
+    assert filtered == [
+        e for e in full
+        if "right foot ache" not in e["summary"] and "morning walk" not in e["summary"]
+    ]
+
+
+def test_an_empty_exclusion_set_filters_nothing(seeded):
+    """Default-off, and `frozenset()` is treated as no filter too -- so no caller can
+    accidentally hand it an empty set and get a different-shaped result."""
+    _seed_self_reports(seeded)
+    full = query.query_timeline(seeded, "jane-doe")
+    assert query.query_timeline(seeded, "jane-doe", exclude_obs_types=None) == full
+    assert query.query_timeline(
+        seeded, "jane-doe", exclude_obs_types=frozenset()
+    ) == full

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1996,3 +1996,252 @@ def test_curation_record_never_resolves_a_cross_person_merge_target(seeded):
     assert f"## merged into {johns[:12]}..." in md
     assert johns not in md                      # truncated, never printed in full
     assert "LDL" not in md                      # the target's label never resolved
+
+
+# --- self-reported symptoms (issue #167) --------------------------------------
+#
+# The lane's whole point is the *collapse*: a recurring complaint is reported over and
+# over, and a chronological dump ("achy on the 16th / fine on the 18th") is worse than
+# nothing. So the assertions here are about one line per key carrying the state of the
+# complaint, and about everything the section is deliberately NOT.
+
+_SYMPTOM_NOW = datetime(2026, 8, 18, 9, 0)
+_SYMPTOM_HEADER = "## Self-Reported Symptoms"
+
+
+def _seed_symptoms(conn, rows, slug="jane-doe"):
+    """Attest a batch of self-reported rows the way `pemr record assert` does."""
+    from pemr import attestations
+
+    d = dedup.load_dictionary(DICT_PATH)
+    for row in rows:
+        attestations.assert_record(
+            conn, "observation", slug, dict(row), attributed_to="Jane Doe",
+            attested_on="2026-08-18", dictionary=d, apply=True,
+        )
+
+
+def _symptom_row(observed_at, key="right foot ache", value_num=3,
+                 value_text="achy after the walk", obs_type="symptom"):
+    return {"obs_type": obs_type, "key": key, "observed_at": observed_at,
+            "value_num": value_num, "value_text": value_text}
+
+
+def _symptom_summary(conn, slug="jane-doe", now=_SYMPTOM_NOW):
+    return render.render_summary(
+        conn, slug, dictionary=dedup.load_dictionary(DICT_PATH), now=now
+    )
+
+
+def test_summary_collapses_repeat_symptom_reports_into_one_line(seeded):
+    """T5: four in-window reports fold to one line carrying the count, the latest date
+    and the latest severity -- and an older report outside the window is not counted."""
+    _seed_symptoms(seeded, [
+        _symptom_row("2026-06-01T09:00", value_num=7),   # outside the 30d window
+        _symptom_row("2026-07-25T09:00", value_num=5),
+        _symptom_row("2026-08-02T09:00", value_num=4),
+        _symptom_row("2026-08-10T09:00", value_num=4),
+        _symptom_row("2026-08-16T09:00", value_num=3),
+    ])
+    line = _line(_symptom_summary(seeded), "right foot ache")
+    assert line.startswith(
+        "- right foot ache - 4 reports in 30d, latest 2026-08-16 (severity 3/10)"
+    )
+
+
+def test_summary_symptom_line_pluralizes_and_drops_a_missing_severity(seeded):
+    """A lone report says 'report', and a value_num-less row is a present report of
+    unknown severity -- not a resolution, and not a fabricated 0."""
+    _seed_symptoms(seeded, [_symptom_row("2026-08-17T08:00", key="jaw click",
+                                         value_num=None)])
+    line = _line(_symptom_summary(seeded), "jaw click")
+    assert line.startswith("- jaw click - 1 report in 30d, latest 2026-08-17")
+    assert "severity" not in line
+
+
+def test_summary_keeps_a_qualified_symptom_on_its_own_line(seeded):
+    """Grouped on `key_token`, matching the dedup key: a meaningful qualifier is its own
+    complaint, not an overwrite of the plain one (the `_latest_vitals` rule)."""
+    _seed_symptoms(seeded, [
+        _symptom_row("2026-08-16T09:00", key="right foot ache", value_num=3),
+        _symptom_row("2026-08-17T09:00", key="right foot ache (morning)", value_num=6),
+    ])
+    md = _symptom_summary(seeded)
+    assert "- right foot ache - 1 report in 30d" in md
+    assert "- right foot ache (morning) - 1 report in 30d" in md
+
+
+def test_summary_reports_a_resolution_as_the_last_word(seeded):
+    """T6: value_num == 0 is 'reported resolved' -- the 0-10 scale's natural bottom, no
+    sentinel and no second obs_type."""
+    _seed_symptoms(seeded, [
+        _symptom_row("2026-08-16T09:00", value_num=3),
+        _symptom_row("2026-08-18T08:00", value_num=0, value_text="fine today"),
+    ])
+    line = _line(_symptom_summary(seeded), "right foot ache")
+    assert line.startswith(
+        "- right foot ache - 2 reports in 30d, latest 2026-08-16 (severity 3/10)"
+        "; last reported resolved 2026-08-18"
+    )
+
+
+def test_summary_drops_a_resolution_older_than_the_latest_report(seeded):
+    """A resolution the complaint has since outlived is not news."""
+    _seed_symptoms(seeded, [
+        _symptom_row("2026-08-10T09:00", value_num=0),
+        _symptom_row("2026-08-16T09:00", value_num=3),
+    ])
+    line = _line(_symptom_summary(seeded), "right foot ache")
+    assert "latest 2026-08-16 (severity 3/10)" in line
+    assert "resolved" not in line
+
+
+def test_summary_renders_a_key_whose_only_reports_are_resolutions(seeded):
+    """Head + resolved clause, no `latest` clause: nothing is asserted to be present."""
+    _seed_symptoms(seeded, [_symptom_row("2026-08-18T08:00", value_num=0)])
+    line = _line(_symptom_summary(seeded), "right foot ache")
+    assert line.startswith(
+        "- right foot ache - 1 report in 30d; last reported resolved 2026-08-18"
+    )
+    assert "severity" not in line and "latest 2026" not in line
+
+
+def test_summary_sorts_symptoms_by_most_recent_report(seeded):
+    _seed_symptoms(seeded, [
+        _symptom_row("2026-08-02T09:00", key="jaw click"),
+        _symptom_row("2026-08-17T09:00", key="right foot ache"),
+    ])
+    md = _symptom_summary(seeded)
+    assert md.index("right foot ache") < md.index("jaw click")
+
+
+def test_summary_omits_the_symptom_section_entirely_when_empty(seeded):
+    """T7, the additive-only guarantee. `_none recorded_` would read as "the patient
+    reports no symptoms" -- an assertion the record cannot make -- and it would change
+    the rendered output of every person who never uses the lane."""
+    assert _SYMPTOM_HEADER not in _symptom_summary(seeded)
+
+
+def test_summary_omits_the_symptom_section_when_every_report_is_stale(seeded):
+    _seed_symptoms(seeded, [_symptom_row("2026-01-05T09:00")])
+    assert _SYMPTOM_HEADER not in _symptom_summary(seeded)
+
+
+def test_a_record_without_self_reports_renders_byte_identically(seeded):
+    """The strongest form of the additive-only rule: seeding *jane's* symptoms cannot
+    move a byte of *john's* summary or journal."""
+    d = dedup.load_dictionary(DICT_PATH)
+    before = (
+        render.render_summary(seeded, "john-doe", dictionary=d, now=_SYMPTOM_NOW),
+        render.render_journal(seeded, "john-doe", now=_SYMPTOM_NOW),
+    )
+    _seed_symptoms(seeded, [_symptom_row("2026-08-16T09:00")])
+    after = (
+        render.render_summary(seeded, "john-doe", dictionary=d, now=_SYMPTOM_NOW),
+        render.render_journal(seeded, "john-doe", now=_SYMPTOM_NOW),
+    )
+    assert before == after
+
+
+def test_activity_renders_in_no_summary_section(seeded):
+    """Activity is the higher-volume, lower-signal lane: it stays reachable through
+    `query`, `trends` and the journal's opt-in flag, and renders on no summary page."""
+    _seed_symptoms(seeded, [
+        _symptom_row("2026-08-16T07:30", key="morning walk", obs_type="activity",
+                     value_num=40, value_text="two miles, easy"),
+    ])
+    md = _symptom_summary(seeded)
+    assert "morning walk" not in md
+    assert _SYMPTOM_HEADER not in md            # activity alone opens no section
+
+
+def test_self_reports_never_reach_the_problem_list(seeded):
+    """The load-bearing invariant: neither lane may reach `condition` or Active
+    Problems, in either clinical document."""
+    _seed_symptoms(seeded, [
+        _symptom_row("2026-08-16T09:00"),
+        _symptom_row("2026-08-16T07:30", key="morning walk", obs_type="activity"),
+    ])
+    md = _symptom_summary(seeded)
+    active = md.split("## Active Problems")[1].split("\n## ")[0]
+    assert "right foot ache" not in active and "morning walk" not in active
+    assert seeded.execute(
+        "SELECT COUNT(*) AS n FROM condition WHERE name LIKE '%foot%'"
+    ).fetchone()["n"] == 0
+    brief = render.render_brief(
+        seeded, _upcoming_appt_id(seeded), dictionary=dedup.load_dictionary(DICT_PATH),
+        now=_SYMPTOM_NOW,
+    )
+    brief_active = brief.split("## Active Problems")[1].split("\n## ")[0]
+    assert "right foot ache" not in brief_active and "morning walk" not in brief_active
+    # The brief is otherwise deliberately untouched: its generic recent-observations list
+    # still shows the raw rows, tagged as attested. Only the *problem list* is off-limits
+    # to these lanes, and only the summary gains a collapsed section.
+    assert _SYMPTOM_HEADER not in brief
+
+
+def test_a_symptom_line_says_it_is_attested(seeded):
+    """T8: `record assert` is the only entry path, so the line must never read as a
+    document-sourced fact."""
+    _seed_symptoms(seeded, [_symptom_row("2026-08-16T09:00")])
+    line = _line(_symptom_summary(seeded), "right foot ache")
+    assert line.endswith("(attested by Jane Doe 2026-08-18; no source document)")
+
+
+def test_a_superseded_report_is_neither_counted_nor_latest(seeded):
+    """Curation runs before the fold, as in `_latest_vitals`: a superseded report can
+    neither win 'latest' nor inflate the count."""
+    _seed_symptoms(seeded, [
+        _symptom_row("2026-08-10T09:00", value_num=4),
+        _symptom_row("2026-08-16T09:00", value_num=9, value_text="mis-typed severity"),
+    ])
+    base = seeded.execute(
+        "SELECT dedup_base FROM observation WHERE observed_at = '2026-08-16T09:00'"
+    ).fetchone()["dedup_base"]
+    curation.annotate_record(seeded, "observation", base, status="superseded",
+                             note="severity mis-typed", apply=True)
+    line = _line(_symptom_summary(seeded), "right foot ache")
+    assert line.startswith(
+        "- right foot ache - 1 report in 30d, latest 2026-08-10 (severity 4/10)"
+    )
+
+
+def test_symptom_section_is_console_safe(seeded):
+    _seed_symptoms(seeded, [_symptom_row("2026-08-16T09:00")])
+    md = _symptom_summary(seeded)
+    assert md.isascii(), f"non-ASCII would crash a cp437 console: {md!r}"
+    md.encode("cp437")
+
+
+def test_rendering_symptoms_changes_no_rows(seeded):
+    _seed_symptoms(seeded, [_symptom_row("2026-08-16T09:00")])
+    before = _row_counts(seeded)
+    _symptom_summary(seeded)
+    render.render_journal(seeded, "jane-doe", include_self_reported=True)
+    assert _row_counts(seeded) == before
+
+
+# --- journal filtering (issue #167) -------------------------------------------
+
+def test_journal_excludes_self_reports_by_default(seeded):
+    """T9: a few hundred attestations a year would swamp a chronology spanning decades,
+    so the journal is the one reader that filters them out."""
+    _seed_symptoms(seeded, [
+        _symptom_row("2026-08-16T09:00"),
+        _symptom_row("2026-08-16T07:30", key="morning walk", obs_type="activity"),
+    ])
+    md = render.render_journal(seeded, "jane-doe", now=_SYMPTOM_NOW)
+    assert "right foot ache" not in md and "morning walk" not in md
+    assert "blood_pressure" in md          # control: other observations still there
+
+
+def test_journal_includes_self_reports_on_request(seeded):
+    _seed_symptoms(seeded, [
+        _symptom_row("2026-08-16T09:00"),
+        _symptom_row("2026-08-16T07:30", key="morning walk", obs_type="activity"),
+    ])
+    md = render.render_journal(
+        seeded, "jane-doe", now=_SYMPTOM_NOW, include_self_reported=True
+    )
+    assert "symptom right foot ache" in md
+    assert "activity morning walk" in md


### PR DESCRIPTION
## What shipped

Two new self-attested `observation.obs_type` lanes — `symptom` and `activity` — entered
through the existing `record assert` path (#110). No migration; the catch-all `observation`
table already had the shape.

- `symptom`: `key` = complaint, `value_num` = 0-10 severity, `value_text` = verbatim wording.
  `value_num == 0` means "reported absent" and drives the summary's
  `last reported resolved <date>` clause.
- `activity`: exercise/general activity, same generic columns, **no summary section** — stays
  reachable via `query`/`find`/the journal only.
- Both lanes require a **time of day** in `observed_at` (not just a date) — this is how
  same-day repeat reports get distinct dedup keys without touching the dedup key shape itself;
  a same-timestamp restatement still collides as a CONFLICT.
- New `render_summary` section `## Self-Reported Symptoms`, additive-only (omitted entirely
  when empty): collapses repeated reports of one `key` into a count/latest/severity line,
  fully isolated from `condition` / `Active Problems` in both `render_summary` and
  `render_brief`.
- `render_journal` excludes `symptom`/`activity` by default; new `--include-self-reported`
  opt-in on the CLI and the MCP tool.
- `docs/Architecture.md` §2/§3 updated to record the obs_type shapes and the mandatory-time
  decision.

~40 new tests across 7 files (`test_dedup.py`, `test_attestations.py`, `test_render.py`,
`test_query.py`, `test_cli_phase4.py`, `test_mcp_server.py`, `test_cli_ascii.py`). Full suite
1481/1481 green at verify; `npm test` 168/168; PII/meta-drift checks clean.

## Flagging for the merge gate

Audit confirmed a non-blocking but clinician-facing concern that's as-specified against this
issue's AC/plan (both scope `render_brief` out and bar these lanes only from
`Active Problems`), but is worth your eyes before merge:

**`render_brief`'s `## Procedures & Observations` section now carries raw self-reports,
chronologically and uncapped.** It's `ORDER BY observed_at DESC` with no cap
(`pemr/render.py:1538-1547`), so a few hundred `symptom`/`activity` attestations a year land
at the **top** of that clinician-facing document and push clinician-sourced observations
down. Nothing is evicted and every self-report line is correctly attest-tagged, so it's not
destructive today — but it's the same drowning failure mode issue #167's own constraint #4
called out for the journal, just left unaddressed here because the AC/plan scoped
`render_brief` out. Filed as follow-up #180, alongside three smaller audit advisories (a
`T`/space `observed_at` ordering hazard, no range check on `symptom.value_num`, and an
empty-string `key` passing the presence-only required-field check) — none blocking, all
as-designed against the current spec.

## Reports

- Build: issue #167 comment, 2026-08-18T21:39:34Z
- Verify: issue #167 comment, 2026-08-18T21:53:46Z
- Audit: issue #167 comment, 2026-08-18T22:02:30Z

Closes #167

🤖 Generated with the pemr agentic SDLC pipeline (ship worker)
