### PR TITLE
fix(reocr): refuse re-derived text shorter than what is stored

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -967,6 +967,20 @@ either way) stores and warns rather than refusing, since the recovered text cann
 wrong household member — refusing would only withhold the evidence that the document is
 misfiled at the row level.
 
+Both of `--force`'s meanings stop at the **shrinkage guard** (issue #174): re-derived text
+shorter than the `ocr_text` already stored is refused (`shorter-text`, a `refused` status,
+so rc=1), and `--allow-shrink` is the separate override. Separate deliberately — a
+populated corpus needs `--force` just to reach the write at all, so it cannot also mean
+"and discard most of it", and the only read-only owner audit there is (`reocr --force
+--dry-run`, since `check_owner`'s three call sites are all write paths) would otherwise be
+one missing flag away from losing text. The threshold is any shrinkage rather than a
+percentage: it is unreachable without `--force` — the has-text skip returns first — so
+`--where-empty` never trips it, and one predicate drives the refusal, the human line and
+the `--json` `shrunk` key alike. `shrunk` also rides the writes that *are* permitted, so a
+shorter replacement warns on its own line instead of reading as an ordinary success.
+Truncation against `OCR_MAX_PAGES` is one *cause* of a shorter replacement, not the
+condition — a document that is both reports both.
+
 ### Study directories (issue #69)
 
 A burned imaging disc is clinically *one* document but physically one folder holding
@@ -1079,8 +1093,9 @@ pemr document tombstone add (--file <path> | --sha256 <hex>) [--reason ...] [--n
                                                          # pre-emptive exclusion; ingests and copies nothing
 pemr document tombstone rm <sha256>                      # lift one (full hash only)
 pemr document set-text <id> --ocr-text-file <path> [--force]     # attach/replace ocr_text after ingest; FTS follows via trigger
-pemr document reocr [<id>...] [--where-empty [--person <slug>]] [--dry-run] [--force]
+pemr document reocr [<id>...] [--where-empty [--person <slug>]] [--dry-run] [--force] [--allow-shrink]
                                                          # re-derive ocr_text from the stored blob using the ingest dispatch
+                                                         # --allow-shrink: store text shorter than what is there (refused otherwise)
 pemr query labs --person jane --test hba1c --since 2023-01-01 [--raw]
 pemr query meds --person jane --active [--raw]           # --active = query.med_is_current per row:
                                                          # a past ended_on or a terminal status ends

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -631,6 +631,7 @@ def _reocr_json(result: "ingest.ReocrResult") -> dict:
         "route": result.route,
         "pages": result.pages,
         "truncated": result.truncated,
+        "shrunk": result.shrunk,
         "blob_path": result.blob_path,
         "owner_check": None if check is None else {
             "verdict": check.verdict,
@@ -641,8 +642,9 @@ def _reocr_json(result: "ingest.ReocrResult") -> dict:
 
 
 def _print_reocr_result(result: "ingest.ReocrResult") -> None:
-    """One human line per document, plus the two things a sweep must not miss:
-    truncation against `OCR_MAX_PAGES`, and any owner verdict that isn't reassuring."""
+    """One human line per document, plus the three things a sweep must not miss:
+    truncation against `OCR_MAX_PAGES`, text that shrank against what is stored
+    (issue #174), and any owner verdict that isn't reassuring."""
     was = (
         f"was {result.previous_chars} chars"
         if result.previous_chars
@@ -662,6 +664,10 @@ def _print_reocr_result(result: "ingest.ReocrResult") -> None:
         line = f"no text      nothing could be extracted from the blob{route}"
     elif result.status == "owner-mismatch":
         line = "refused      owner verification failed - nothing written"
+    elif result.status == "shorter-text":
+        line = (
+            f"refused      shorter than stored  {result.chars} chars ({was}){route}"
+        )
     elif result.status == "missing-blob":
         line = f"missing blob {result.blob_path}"
     else:  # study-blob
@@ -671,10 +677,22 @@ def _print_reocr_result(result: "ingest.ReocrResult") -> None:
         )
     print(f"#{result.document_id}  {line}")
 
+    if result.status == "shorter-text":
+        print(
+            "    store it anyway with --allow-shrink, or leave the stored text as it is"
+        )
     if result.truncated:
         print(
             f"    pages: {result.pages} (over the {ingest.OCR_MAX_PAGES}-page cap - "
             "text is truncated)"
+        )
+    # The issue's floor ask, for the shrinkage that was *permitted*: a written or
+    # would-write line reading `104 chars (was 3221 chars)` says nothing about the 97%
+    # that just went away. A refusal already says it on its own line above.
+    if result.shrunk and result.status != "shorter-text":
+        print(
+            f"    shrink: {result.chars} chars replaces {result.previous_chars} - "
+            "the difference is discarded"
         )
     check = result.owner_check
     if check is not None and check.verdict not in ("match", "unverified"):
@@ -730,6 +748,7 @@ def _cmd_document_reocr(args: argparse.Namespace) -> int:
             results = ingest.reocr_documents(
                 conn, document_ids, sources_dir,
                 force=args.force, dry_run=args.dry_run,
+                allow_shrink=args.allow_shrink,
             )
         except ingest.IngestError as exc:
             # Not in `_with_document_conn`'s catch list (it is an engine-side
@@ -3389,6 +3408,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--force", action="store_true",
         help="replace existing ocr_text, and store despite an owner mismatch "
              "(both refused without this, same as `ingest --force`)",
+    )
+    d_reocr.add_argument(
+        "--allow-shrink", dest="allow_shrink", action="store_true",
+        help="store re-derived text that is shorter than the text already stored "
+             "(refused without this; --force does not imply it)",
     )
     d_reocr.add_argument("--sources", help="sources blob dir (overrides config)")
     d_reocr.add_argument("--json", action="store_true", help="machine-readable output")

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -1617,6 +1617,9 @@ class ReocrResult:
     * ``no-text`` — extraction ran and recovered nothing. A warning, not an error.
     * ``owner-mismatch`` — the recovered text affirmatively names a *different* roster
       person (issue #61's check, re-run against text that did not exist at ingest).
+    * ``shorter-text`` — the re-derived text is shorter than the text already stored,
+      and ``allow_shrink`` was off (issue #174). Nothing written: a replacement that
+      drops characters is a loss unless the operator says otherwise.
     * ``missing-blob`` — ``source_path`` does not resolve under ``sources_dir``.
     * ``study-blob`` — a packed DICOM study, whose ``ocr_text`` is a derived header
       summary rather than extracted text (see :func:`ingest_study_dir`).
@@ -1637,6 +1640,21 @@ class ReocrResult:
         return self.status == "written"
 
     @property
+    def shrunk(self) -> bool:
+        """Whether the re-derived text is shorter than what is already stored (#174).
+
+        Gated on the statuses whose ``chars`` is a real would-be-stored length. The
+        skips (``has-text``, ``missing-blob``, ``study-blob``) and ``no-text`` carry
+        ``chars == 0`` beside a populated ``previous_chars``, so a bare comparison would
+        call every one of them shrunk — including the has-text skip, which by definition
+        never got as far as extracting anything to compare.
+        """
+        return (
+            self.status in ("written", "would-write", "shorter-text")
+            and self.chars < self.previous_chars
+        )
+
+    @property
     def refused(self) -> bool:
         """Whether the caller asked for work that was declined (drives the exit code).
 
@@ -1645,8 +1663,8 @@ class ReocrResult:
         expected outcomes trains `|| true` — the same reasoning as
         :attr:`IngestResult.is_tombstoned`.
         """
-        return self.status in ("has-text", "owner-mismatch", "missing-blob",
-                               "study-blob")
+        return self.status in ("has-text", "owner-mismatch", "shorter-text",
+                               "missing-blob", "study-blob")
 
 
 def reocr_documents(
@@ -1656,6 +1674,7 @@ def reocr_documents(
     *,
     force: bool = False,
     dry_run: bool = False,
+    allow_shrink: bool = False,
 ) -> list[ReocrResult]:
     """Re-derive ``ocr_text`` for each document from its stored blob (`document reocr`).
 
@@ -1668,6 +1687,11 @@ def reocr_documents(
     ``force`` means both "replace existing ``ocr_text``" and "store despite an owner
     mismatch", matching what ``--force`` already means on `ingest`. ``dry_run`` reports
     what would be stored and writes nothing.
+
+    ``allow_shrink`` is the separate override for storing text *shorter* than what is
+    already there (issue #174) — deliberately not ``force``, which a populated corpus
+    already needs just to reach the write, so reusing it would conflate "replace the
+    stored text" with "and discard most of it".
 
     Raises :class:`IngestError` for an unknown document id.
     """
@@ -1739,6 +1763,22 @@ def reocr_documents(
         # affirmative evidence of a cross-owner leak, so it still earns the refusal.
         if owner_check is not None and owner_check.verdict == "mismatch" and not force:
             results.append(ReocrResult(status="owner-mismatch", **common))
+            continue
+
+        # Issue #174: a replacement shorter than what is stored is a loss, and only the
+        # page-cap case (`truncated`) was ever loud about it. Any shrinkage refuses —
+        # no percentage floor, because this is only reachable under `force` at all (the
+        # has-text skip above returns first whenever `previous` is non-empty), so the
+        # `--where-empty` backlog sweep cannot trip it and one predicate can drive the
+        # refusal, the human line and the JSON key alike. Placed *after* the owner check
+        # so `owner_check` is still populated on the refusal — a `--force --dry-run`
+        # owner audit over a populated corpus is the only read-only owner verification
+        # there is — and *before* `dry_run`, so a dry run and a real run report the same
+        # refusal; nothing was going to be written either way.
+        if len(text) < len(previous) and not allow_shrink:
+            results.append(
+                ReocrResult(status="shorter-text", chars=len(text), **common)
+            )
             continue
 
         if dry_run:

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1368,7 +1368,7 @@ def test_cli_document_reocr_json_carries_a_stable_key_set(cli_ready, capsys):
     assert [row["document_id"] for row in payload] == [1, 2]
     assert set(payload[0]) == {
         "document_id", "status", "chars", "previous_chars", "route", "pages",
-        "truncated", "blob_path", "owner_check",
+        "truncated", "shrunk", "blob_path", "owner_check",
     }
     assert payload[0]["status"] == "has-text"
     assert payload[0]["owner_check"] is None            # refused before any check
@@ -1418,6 +1418,102 @@ def test_cli_document_reocr_owner_mismatch_refuses_and_names_the_remedy(
     assert _run(cli_ready, "document", "reocr", "2", "--force",
                 "--sources", _sources(cli_ready)) == 0
     assert _ocr_text_of(cli_ready, 2) == "Patient: ROE, ROBERT ALAN  summary"
+
+
+# --- the shrinkage guard at the operator's surface (issue #174) --------------
+
+
+def _set_long_text(tmp_path, document_id, text):
+    """`document set-text --force` a long transcription onto a document - the issue's
+    own verification setup, and the shape that makes the blob's text a shrinkage."""
+    path = tmp_path / f"long-{document_id}.txt"
+    path.write_text(text, encoding="utf-8")
+    assert _run(tmp_path, "document", "set-text", str(document_id),
+                "--ocr-text-file", str(path), "--force") == 0
+
+
+_LONG = "a long stored transcription that took somebody real effort to type out"
+
+
+def test_cli_document_reocr_refuses_a_shrinking_replacement(cli_ready, capsys):
+    """The issue's verification case verbatim: ingest, set-text a long text, then
+    `reocr --force --dry-run` against a blob that extracts to something shorter."""
+    _ingest_textless(cli_ready, "scan2.txt", b"three words only")
+    _set_long_text(cli_ready, 2, _LONG)
+    capsys.readouterr()
+
+    assert _run(cli_ready, "document", "reocr", "2", "--force", "--dry-run",
+                "--sources", _sources(cli_ready)) == 1
+    out = capsys.readouterr().out
+    assert "#2  refused" in out
+    assert "shorter than stored" in out
+    assert f"16 chars (was {len(_LONG)} chars)" in out
+    assert "--allow-shrink" in out
+    assert "would write" not in out
+    assert "1 document(s): 1 shorter-text" in out
+    assert out.isascii(), repr(out)
+    assert _ocr_text_of(cli_ready, 2) == _LONG
+
+
+def test_cli_document_reocr_allow_shrink_stores_and_warns(cli_ready, capsys):
+    _ingest_textless(cli_ready, "scan2.txt", b"three words only")
+    _set_long_text(cli_ready, 2, _LONG)
+    capsys.readouterr()
+
+    assert _run(cli_ready, "document", "reocr", "2", "--force", "--allow-shrink",
+                "--sources", _sources(cli_ready)) == 0
+    out = capsys.readouterr().out
+    assert "#2  written" in out
+    assert f"shrink: 16 chars replaces {len(_LONG)}" in out
+    assert "the difference is discarded" in out
+    assert out.isascii(), repr(out)
+    assert _ocr_text_of(cli_ready, 2) == "three words only"
+
+
+def test_cli_document_reocr_json_reports_shrinkage(cli_ready, capsys):
+    _ingest_textless(cli_ready, "scan2.txt", b"three words only")
+    _set_long_text(cli_ready, 2, _LONG)
+    capsys.readouterr()
+
+    assert _run(cli_ready, "document", "reocr", "2", "--force", "--json",
+                "--sources", _sources(cli_ready)) == 1
+    (row,) = json.loads(capsys.readouterr().out)
+    assert row["status"] == "shorter-text"
+    assert row["shrunk"] is True
+    assert row["chars"] == 16 and row["previous_chars"] == len(_LONG)
+    # The owner audit the guard sits behind still gets its verdict.
+    assert row["owner_check"]["verdict"] == "unverified"
+    assert _ocr_text_of(cli_ready, 2) == _LONG
+
+
+def test_cli_document_reocr_truncated_and_shrunk_prints_both_notices(
+    cli_ready, capsys, monkeypatch
+):
+    """Two independent conditions on one document, so neither notice may swallow the
+    other - the page cap is one cause of a shorter replacement, not the condition."""
+    _ingest_textless(cli_ready, "bundle.txt", b"three words only")
+    _set_long_text(cli_ready, 2, _LONG)
+    monkeypatch.setattr(ingest, "pdf_page_count", lambda src: 21)
+    capsys.readouterr()
+
+    assert _run(cli_ready, "document", "reocr", "2", "--force",
+                "--sources", _sources(cli_ready)) == 1
+    out = capsys.readouterr().out
+    assert "#2  refused" in out and "shorter than stored" in out
+    assert f"pages: 21 (over the {ingest.OCR_MAX_PAGES}-page cap" in out
+    assert out.isascii(), repr(out)
+
+
+def test_cli_document_reocr_allow_shrink_alone_does_not_replace_text(
+    cli_ready, capsys
+):
+    """It overrides one refusal, not the has-text guard - `--force` still means what it
+    meant, and neither flag implies the other."""
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "reocr", "1", "--allow-shrink",
+                "--sources", _sources(cli_ready)) == 1
+    assert "#1  skipped" in capsys.readouterr().out
+    assert _ocr_text_of(cli_ready, 1) == "hba1c 5.7 percent"
 
 
 def test_cli_document_reocr_unknown_id_is_a_friendly_error(cli_ready, capsys):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1516,6 +1516,28 @@ def test_cli_document_reocr_allow_shrink_alone_does_not_replace_text(
     assert _ocr_text_of(cli_ready, 1) == "hba1c 5.7 percent"
 
 
+def test_cli_document_reocr_mixed_sweep_summarises_both_outcomes(cli_ready, capsys):
+    """The shape a real sweep takes: one document re-derives to the same text and is
+    written, another shrinks and is refused. The summary must name both, and one
+    refusal must carry the whole run to rc=1 - a sweep that exits 0 because most of it
+    succeeded is how the silent loss this issue reports goes unnoticed."""
+    _ingest_textless(cli_ready, "scan2.txt", b"three words only")
+    _set_long_text(cli_ready, 2, _LONG)
+    capsys.readouterr()
+
+    assert _run(cli_ready, "document", "reocr", "1", "2", "--force",
+                "--sources", _sources(cli_ready)) == 1
+    out = capsys.readouterr().out
+    assert "#1  written" in out
+    assert "#2  refused" in out and "shorter than stored" in out
+    assert "2 document(s): 1 shorter-text, 1 written" in out
+    # The written one did not shrink, so it draws no shrink notice.
+    assert "shrink:" not in out
+    assert out.isascii(), repr(out)
+    assert _ocr_text_of(cli_ready, 1) == "hba1c 5.7 percent"
+    assert _ocr_text_of(cli_ready, 2) == _LONG
+
+
 def test_cli_document_reocr_unknown_id_is_a_friendly_error(cli_ready, capsys):
     capsys.readouterr()
     assert _run(cli_ready, "document", "reocr", "999",

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1869,15 +1869,22 @@ def test_reocr_refuses_a_populated_document_without_force(
 
 
 def test_reocr_force_replaces_existing_text(conn, tmp_path, sources):
+    # The blob is deliberately longer than the transcription: this test is about the
+    # has-text guard, and a shrinking replacement would be refused by the #174 guard
+    # before it ever got there (passing allow_shrink=True would stop it proving what it
+    # names).
     doc = _file_document(
-        conn, tmp_path, sources, content=b"machine text", ocr_text="old transcription"
+        conn, tmp_path, sources, content=b"machine text, and then some more of it",
+        ocr_text="old transcription",
     )
 
     (result,) = ingest.reocr_documents(conn, [doc.document_id], sources, force=True)
 
     assert result.status == "written"
     assert result.previous_chars == len("old transcription")
-    assert _stored_text(conn, doc.document_id) == "machine text"
+    assert _stored_text(conn, doc.document_id) == (
+        "machine text, and then some more of it"
+    )
 
 
 def test_reocr_dry_run_reports_chars_and_writes_nothing(conn, tmp_path, sources):
@@ -2019,6 +2026,159 @@ def test_reocr_native_route_does_not_trust_anchors(conn, tmp_path, sources):
     assert result.route == "native"
     assert result.status == "written"
     assert result.owner_check.verdict == "unverified"
+
+
+# --- the shrinkage guard (issue #174) -----------------------------------------
+#
+# `truncated` only ever caught one *cause* of a shorter replacement (the page cap).
+# These cover the condition itself: text shorter than what is stored refuses by default,
+# and `--force` is not the way past it - a populated corpus needs `--force` just to
+# reach the write, so it cannot also mean "and discard most of it".
+
+_LONG_STORED = "a long stored transcription that took somebody real effort"
+
+
+def test_reocr_refuses_text_shorter_than_what_is_stored(conn, tmp_path, sources):
+    doc = _file_document(
+        conn, tmp_path, sources, content=b"short", ocr_text=_LONG_STORED
+    )
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources, force=True)
+
+    assert result.status == "shorter-text"
+    assert result.refused is True
+    assert result.shrunk is True
+    assert result.chars == len("short")
+    assert result.previous_chars == len(_LONG_STORED)
+    assert _stored_text(conn, doc.document_id) == _LONG_STORED
+
+
+def test_reocr_allow_shrink_stores_the_shorter_text(conn, tmp_path, sources):
+    doc = _file_document(
+        conn, tmp_path, sources, content=b"short", ocr_text=_LONG_STORED
+    )
+
+    (result,) = ingest.reocr_documents(
+        conn, [doc.document_id], sources, force=True, allow_shrink=True
+    )
+
+    assert result.status == "written"
+    assert result.refused is False
+    assert result.shrunk is True          # permitted, still reported
+    assert _stored_text(conn, doc.document_id) == "short"
+
+
+def test_reocr_allow_shrink_does_not_bypass_the_other_guards(
+    conn, tmp_path, sources, monkeypatch
+):
+    """It is an override for one refusal, not a second `--force`."""
+    doc = _file_document(
+        conn, tmp_path, sources, content=b"short", ocr_text=_LONG_STORED
+    )
+    _forbid_extraction(monkeypatch)
+
+    (result,) = ingest.reocr_documents(
+        conn, [doc.document_id], sources, allow_shrink=True
+    )
+
+    assert result.status == "has-text"
+    assert _stored_text(conn, doc.document_id) == _LONG_STORED
+
+
+def test_reocr_dry_run_refuses_a_shrinking_document_too(conn, tmp_path, sources):
+    """The guard sits before the dry-run branch, so an audit sweep reports the refusal
+    it would hit for real rather than an unqualified `would write`."""
+    doc = _file_document(
+        conn, tmp_path, sources, content=b"short", ocr_text=_LONG_STORED
+    )
+
+    (result,) = ingest.reocr_documents(
+        conn, [doc.document_id], sources, force=True, dry_run=True
+    )
+
+    assert result.status == "shorter-text"
+    assert _stored_text(conn, doc.document_id) == _LONG_STORED
+
+
+def test_reocr_equal_length_replacement_is_not_shrinkage(conn, tmp_path, sources):
+    doc = _file_document(
+        conn, tmp_path, sources, content=b"machine text", ocr_text="human typing"
+    )
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources, force=True)
+
+    assert result.status == "written"
+    assert result.chars == result.previous_chars == 12
+    assert result.shrunk is False
+    assert _stored_text(conn, doc.document_id) == "machine text"
+
+
+def test_reocr_shrinkage_records_the_owner_check(conn, tmp_path, sources):
+    """The refusal keeps `owner_check` populated, so the `--force --dry-run` owner audit
+    this guard is wrapped around still verifies owners on the documents it refuses."""
+    _seed_roster(conn)
+    doc = _file_document(
+        conn, tmp_path, sources, name="labs.csv",
+        content=b"Patient ID,Test\n1,HbA1c\n", ocr_text=_LONG_STORED,
+    )
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources, force=True)
+
+    assert result.status == "shorter-text"
+    assert result.owner_check is not None
+    assert result.owner_check.verdict == "unverified"
+    assert result.route == "native"
+
+
+def test_reocr_force_waives_the_mismatch_but_not_the_shrinkage(conn, tmp_path, sources):
+    """The two refusals cannot both be live on one document, and the ordering is what
+    decides which one you see. `owner-mismatch` only fires without `force`; shrinkage is
+    only reachable *with* it (the has-text skip returns first otherwise). So a forced
+    re-derivation that both names another person and shrinks is exactly where `--force`
+    stops being enough - and the waived mismatch is still on the result to be audited.
+    """
+    _seed_roster(conn)
+    doc = _file_document(
+        conn, tmp_path, sources, content=b"Patient: ROE, ROBERT ALAN",
+        ocr_text=_LONG_STORED,
+    )
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources, force=True)
+
+    assert result.status == "shorter-text"
+    assert result.owner_check.verdict == "mismatch"
+    assert result.owner_check.matched_slug == "bob-roe"
+    assert _stored_text(conn, doc.document_id) == _LONG_STORED
+
+
+def test_reocr_shrunk_is_false_on_a_has_text_skip(conn, tmp_path, sources, monkeypatch):
+    """`chars` is 0 on a skip because nothing was extracted, not because the text
+    shrank - an ungated comparison would flag every skip on a populated corpus."""
+    doc = _file_document(
+        conn, tmp_path, sources, content=b"short", ocr_text=_LONG_STORED
+    )
+    _forbid_extraction(monkeypatch)
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources)
+
+    assert result.status == "has-text"
+    assert result.chars == 0 and result.previous_chars == len(_LONG_STORED)
+    assert result.shrunk is False
+
+
+def test_reocr_truncated_and_shrunk_reports_both(
+    conn, tmp_path, sources, monkeypatch
+):
+    doc = _file_document(
+        conn, tmp_path, sources, content=b"short", ocr_text=_LONG_STORED
+    )
+    monkeypatch.setattr(ingest, "pdf_page_count", lambda src: ingest.OCR_MAX_PAGES + 1)
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources, force=True)
+
+    assert result.status == "shorter-text"
+    assert result.truncated is True
+    assert result.shrunk is True
 
 
 def test_reocr_reports_a_missing_blob_without_writing(conn, tmp_path, sources):


### PR DESCRIPTION
## Summary

`document reocr` previously warned only on the `OCR_MAX_PAGES` truncation case when re-derived
text came back shorter than what was already stored — every other cause (a stale extractor, an
out-of-band `set-text`, a route that no longer matches) was reported as an ordinary `written`
success. Measured on a real corpus: 247 of 252 shrinking documents produced no warning at all
(41,014 characters silently lost).

This change adds a general shrinkage guard:

- `reocr_documents` now refuses (`status = "shorter-text"`, `refused = True`, rc=1) whenever
  re-derived text is shorter than the stored `ocr_text`, unless `--allow-shrink` is passed.
- `--force` alone does **not** permit a shrunk write — it stays scoped to "replace existing
  text," so it can't also mean "and discard most of it." `--allow-shrink` is the separate,
  explicit override.
- `owner-mismatch` still outranks shrinkage when both apply (existing precedence, unchanged).
- `_print_reocr_result` / `_reocr_json` (`pemr/cli.py`) surface the new `shorter-text` status
  and a `shrunk` key on both the human line and `--json` output, including when a write *is*
  permitted (`--allow-shrink`) — a shorter accepted replacement still warns instead of reading
  as a plain success.
- `docs/Architecture.md` documents the guard, why `--allow-shrink` is separate from `--force`,
  and why the threshold is any shrinkage (unreachable without `--force`, since the `has-text`
  skip returns first).

Noticed but out of scope: `docs/Architecture.md:953`'s claim that the owner-mismatch refusal
"stays 0" on exit code is stale prose — `ReocrResult.refused` includes `owner-mismatch`, so the
CLI already returns 1 there. Left unrelated to this change per the audit note.

Closes #174

Verify report: https://github.com/meridun/pemr/issues/174#issuecomment-5334922160
Audit report: https://github.com/meridun/pemr/issues/174#issuecomment-5334975045

🤖 Generated with [Claude Code](https://claude.com/claude-code)