### PR TITLE
feat(document): record ocr_text provenance in text_source

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -98,6 +98,7 @@ CREATE TABLE document (
   provider      TEXT,
   source_path   TEXT NOT NULL,            -- sources/<hash>.<ext>
   ocr_text      TEXT,                     -- extracted full text (agent or tesseract)
+  text_source   TEXT,                     -- 'engine'|'attached'; NULL = none/pre-015 (#175)
   ingested_at   TEXT NOT NULL
 );
 
@@ -945,6 +946,17 @@ For those you get a stderr note telling you to transcribe it yourself and pass
 capped at 32 MiB per file — `ocr_text` is mirrored into the FTS index, so an unbounded read is
 both a database-size problem and a decompression-bomb surface (a small `.docx` can declare a
 gigabyte of `word/document.xml`).
+
+Whichever route produced it, the *provenance* of the stored text is recorded alongside it in
+`document.text_source` (issue #175, migration 015): text pemr extracted itself — any of the
+routes above, a `document reocr` re-derivation, or a study's DICOM-header summary — is
+`engine`; text the caller handed over verbatim (`--ocr-text-file`, `pemr document set-text`,
+the `document_set_text` MCP tool) is `attached`. It follows the text's *origin*, not the verb
+that wrote it, because engine text carries OCR-typical noise that a downstream consumer may
+want to weigh differently, and the distinction is unrecoverable afterwards — a transcription
+can be byte-identical to what OCR would have produced. `NULL` means no text, or text written
+before 015; pre-015 rows are deliberately **not** backfilled, since hand-attached rows already
+exist and a blanket `engine` would misclassify exactly the rows the column exists to find.
 
 Extraction route feeds the owner check, and the route vocabulary has **three** words for
 it: `native` (natively extracted, *structured*), `native-prose` (natively extracted,

--- a/migrations/015_document_text_source.sql
+++ b/migrations/015_document_text_source.sql
@@ -1,0 +1,54 @@
+-- 015_document_text_source: record which write path produced the current `ocr_text`
+-- (issue #175).
+--
+-- `document.ocr_text` has two writers that the schema could not tell apart after the
+-- fact:
+--
+--   * pemr's own extraction - `extract_text_routed` / `run_ocr` at ingest, the DICOM
+--     header summary a study gets, and `document reocr` re-deriving either;
+--   * the caller, verbatim - `pemr document set-text`, the `document_set_text` MCP tool,
+--     and `pemr ingest --ocr-text-file` (an agent's own transcription, which `AGENTS.md`
+--     makes the default path precisely because it beats tesseract on messy scans).
+--
+-- Both landed in the same column with no marker, and the distinction is NOT recoverable
+-- afterwards: a hand-attached transcription can be byte-identical to what OCR would have
+-- produced. Engine text carries OCR-typical noise (misreads, layout artifacts) that a
+-- downstream consumer - search ranking, a curation review queue, any future
+-- confidence-weighting - may reasonably want to treat differently, so the fact has to be
+-- stored at write time or it is lost.
+--
+--   'engine'   - pemr extracted the text itself
+--   'attached' - the caller supplied it verbatim
+--   NULL       - no provenance recorded
+--
+-- Provenance follows the text's ORIGIN, not the verb that wrote it: `ingest
+-- --ocr-text-file` records `attached` even though `ingest` is the engine's own command,
+-- because the bytes are the caller's.
+--
+-- Deliberately NOT constrained, and deliberately NOT backfilled:
+--
+--   * TEXT, not a `hand_attached` BOOLEAN. A boolean cannot express "no text at all" or
+--     "written before 015, provenance unknown" without overloading NULL against a third
+--     meaning, and a two-value TEXT column leaves room for a future third writer (a
+--     curation-time correction, say) without another migration.
+--   * No `CHECK`. Following 013's precedent, the closed vocabulary is validated in Python
+--     (`documents.TEXT_SOURCES`, the single definition both `documents` and `ingest`
+--     import) rather than in DDL - which also sidesteps SQLite's `ADD COLUMN` constraint
+--     restrictions entirely.
+--   * No backfill. Hand-attached rows already exist (`document set-text` has shipped),
+--     so blanket-setting every pre-015 row to 'engine' would silently misclassify the
+--     exact rows this issue exists to identify - worse than admitting ignorance. NULL's
+--     two readings are derivable from `ocr_text` itself: empty `ocr_text` means "no text,
+--     so no provenance", populated `ocr_text` means "written before 015, provenance
+--     unknown". No third literal is needed.
+--   * Not part of identity. `document` identity is layer-1 `sha256` only; `text_source`
+--     is in no dedup key, so no family is re-keyed and no curation verdict is orphaned.
+--
+-- Purely additive: one nullable ALTER, no rebuild, no backfill, safe under
+-- foreign_keys=ON. An `ALTER` fires no trigger, so migration 003's
+-- `record_fts_document_au` does not run here and there is no FTS churn at migrate time. A
+-- pre-015 database just needs `pemr migrate`; readers use `documents._text_source`, which
+-- tolerates the missing column (a restored pre-015 snapshot still passes
+-- `db.is_migrated`).
+
+ALTER TABLE document ADD COLUMN text_source TEXT;   -- 'engine' | 'attached'; NULL = none/pre-015

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -546,6 +546,9 @@ def _print_document_show(doc: dict) -> None:
         ("source_path", _fmt(doc["source_path"])),
         ("ingested_at", _fmt(doc["ingested_at"])),
         ("has_ocr_text", f"yes ({chars} chars)" if doc["has_ocr_text"] else "no"),
+        # Not `_fmt`: it renders None as an empty string, which would make "provenance
+        # unknown" (a pre-015 row, or no text at all) look like a rendering bug (#175).
+        ("text_source", doc["text_source"] or "unknown"),
         ("records", records),
         ("conflicts", conflicts),
     ]

--- a/pemr/documents.py
+++ b/pemr/documents.py
@@ -69,6 +69,18 @@ class OcrTextPresentError(ValueError):
     """`set-text` refused: the document already has ``ocr_text`` and ``force`` was off."""
 
 
+# `document.text_source` — which write path produced the current ``ocr_text``
+# (issue #175, migration 015). The closed vocabulary lives here rather than in a DDL
+# `CHECK`, following migration 013's precedent; :mod:`pemr.ingest` imports these names,
+# so there is exactly one definition. Provenance follows the text's *origin*, not the
+# verb that wrote it: `ingest --ocr-text-file` is ``attached``, because the bytes are
+# the caller's own transcription.
+TEXT_SOURCE_ENGINE = "engine"       # pemr extracted it (extract_text_routed / run_ocr /
+                                    # the DICOM header summary)
+TEXT_SOURCE_ATTACHED = "attached"   # the caller supplied it verbatim (CLI or MCP)
+TEXT_SOURCES = frozenset({TEXT_SOURCE_ENGINE, TEXT_SOURCE_ATTACHED})
+
+
 # Editable via `document edit`. None of these feed a dedup_key (keys are built from
 # record fields only), so correcting them is a pure metadata UPDATE. sha256 and
 # source_path are excluded by construction: the blob is content-addressed.
@@ -228,6 +240,21 @@ def _conflicts_anchored_to(conn: sqlite3.Connection, document_id: int) -> list[i
     return sorted(ids)
 
 
+def _text_source(row: sqlite3.Row) -> str | None:
+    """``document.text_source``, or ``None`` when the column isn't there (issue #175).
+
+    Required, not defensive: :func:`db.is_migrated` only looks for migration 001's
+    sentinel table, so a database restored from a pre-015 snapshot passes
+    :func:`db.require_migrated` and :func:`list_documents`' ``SELECT *`` would otherwise
+    raise on the missing key. Same tolerant-read shape as :func:`query._row_get`, and the
+    same reason :func:`curation.has_table` exists.
+    """
+    try:
+        return row["text_source"]
+    except (KeyError, IndexError):
+        return None
+
+
 def _document_view(conn: sqlite3.Connection, row: sqlite3.Row) -> dict:
     """One document as a JSON-safe dict. ``ocr_text`` is deliberately replaced by
     ``has_ocr_text`` — a full document transcription has no business in list output."""
@@ -243,6 +270,9 @@ def _document_view(conn: sqlite3.Connection, row: sqlite3.Row) -> dict:
         "source_path": row["source_path"],
         "ingested_at": row["ingested_at"],
         "has_ocr_text": bool(row["ocr_text"]),
+        # Which write path produced that text (issue #175). ``None`` = no text, or text
+        # written before migration 015 — the two are told apart by ``has_ocr_text``.
+        "text_source": _text_source(row),
         "records": counts,
         "record_count": sum(counts.values()),
     }
@@ -355,6 +385,7 @@ def set_document_text(
     text: str,
     *,
     force: bool = False,
+    source: str = TEXT_SOURCE_ATTACHED,
 ) -> dict:
     """Attach or replace a document's ``ocr_text`` after ingest (`pemr document set-text`).
 
@@ -368,17 +399,35 @@ def set_document_text(
     The stored value is :func:`normalize_document_text` of the input, matching
     :func:`ingest.ingest_document`.
 
+    ``source`` records the provenance of that text in ``document.text_source`` (issue
+    #175) and must be one of :data:`TEXT_SOURCES`. It defaults to
+    :data:`TEXT_SOURCE_ATTACHED` because this function's own contract is a hand-attach —
+    `pemr document set-text` and the ``document_set_text`` MCP tool, whose text is the
+    caller's verbatim. The one engine caller, :func:`ingest.reocr_documents`, overrides it
+    explicitly. It is written in the *same* UPDATE as ``ocr_text``, so migration 003's
+    ``record_fts_document_au`` trigger still fires exactly once per write; splitting it
+    into a second statement would double-fire it for no benefit.
+
     Raises :class:`DocumentNotFoundError` (unknown id), :class:`OcrTextPresentError` (the
     column already holds *visible* text and ``force`` is off — replacing a transcription is
     not cheaply undoable, so the surprising case is refused rather than silently applied;
     a row holding only invisible characters counts as unpopulated, so it can be repaired
     over MCP, where there is no ``force`` — issue #87), and
     ``ValueError`` for text with no visible content — whitespace, but also zero-width and
-    other invisible characters, which `str.strip()` misses (issue #87). There is
+    other invisible characters, which `str.strip()` misses (issue #87) — or for a
+    ``source`` outside :data:`TEXT_SOURCES`. There is
     deliberately no path to *clear* ``ocr_text``: that only removes FTS visibility, while
     an empty input is far more likely a wrong or truncated file.
     """
     db.require_migrated(conn)
+    # Before any write and before the document lookup's side-effect-free cousins below:
+    # a bad `source` must leave both columns exactly as they were.
+    if source not in TEXT_SOURCES:
+        raise ValueError(
+            f"unknown text source {source!r}; expected one of "
+            + ", ".join(repr(s) for s in sorted(TEXT_SOURCES))
+            + "; nothing was written"
+        )
     row = _require_document(conn, document_id)
     stored = normalize_document_text(text)
     if not stored:
@@ -396,8 +445,8 @@ def set_document_text(
         )
     with conn:
         conn.execute(
-            "UPDATE document SET ocr_text = ? WHERE document_id = ?",
-            (stored, document_id),
+            "UPDATE document SET ocr_text = ?, text_source = ? WHERE document_id = ?",
+            (stored, source, document_id),
         )
     return _show_view(conn, _require_document(conn, document_id))
 

--- a/pemr/ingest.py
+++ b/pemr/ingest.py
@@ -65,7 +65,12 @@ from typing import Callable, Iterator, Sequence
 from urllib.parse import urlsplit
 
 from . import db, study as _study, tombstones as _tombstones
-from .documents import normalize_document_text, set_document_text
+from .documents import (
+    TEXT_SOURCE_ATTACHED,
+    TEXT_SOURCE_ENGINE,
+    normalize_document_text,
+    set_document_text,
+)
 from .models import Document, Person
 
 
@@ -1426,8 +1431,13 @@ def _insert_document(
     category: str | None,
     provider: str | None,
     ocr_text: str | None,
+    text_source: str | None,
 ) -> Document:
     """Insert the `document` row and read it back. Shared by both ingest paths.
+
+    ``text_source`` is the provenance of ``ocr_text`` (issue #175) — ``None`` when there
+    is no text at all. This helper deliberately does not *infer* it: only the caller knows
+    whether the text came off the page through pemr or arrived from the caller verbatim.
 
     Blob cleanup on failure stays with the caller: the file path copies its blob in
     and the study path renames one in, so only they know what to undo.
@@ -1437,8 +1447,8 @@ def _insert_document(
             """
             INSERT INTO document
               (sha256, person_id, doc_date, category, provider, source_path,
-               ocr_text, ingested_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+               ocr_text, text_source, ingested_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 sha,
@@ -1448,6 +1458,7 @@ def _insert_document(
                 provider,
                 _relative_source_path(sha, ext),
                 ocr_text,
+                text_source,
                 datetime.now(timezone.utc).isoformat(timespec="seconds"),
             ),
         )
@@ -1557,6 +1568,15 @@ def ingest_document(
     else:
         ocr_text, route = None, "ocr"  # no text at all; the route is moot
 
+    # Provenance follows the text's origin, not the verb (issue #175): `--ocr-text-file`
+    # supplies the *caller's* transcription (the `AGENTS.md` default path), so recording
+    # it as engine output would misclassify exactly the rows this column exists to tell
+    # apart. No text at all leaves both columns NULL.
+    text_source = (
+        None if not ocr_text
+        else (TEXT_SOURCE_ATTACHED if supplied else TEXT_SOURCE_ENGINE)
+    )
+
     roster = _roster(conn)
     # Structured vs prose per route — see `_trusts_anchors`. `mismatch` still blocks on
     # every route.
@@ -1588,6 +1608,7 @@ def ingest_document(
             category=category,
             provider=provider,
             ocr_text=ocr_text,
+            text_source=text_source,
         )
     except Exception:
         if blob_created:
@@ -1709,6 +1730,9 @@ def ingest_study_dir(
     # study summary wins rather than an invisible character (issue #87).
     supplied = normalize_document_text(ocr_text) or None
     text = supplied or _study.summary_text(scan, metadata)
+    # The derived modality/date/series summary is engine output; caller-supplied text (a
+    # transcribed radiology report) is not (issue #175).
+    text_source = TEXT_SOURCE_ATTACHED if supplied else TEXT_SOURCE_ENGINE
 
     roster = _roster(conn)
     owner_check = _strongest_check([
@@ -1758,6 +1782,7 @@ def ingest_study_dir(
                 category=category or _STUDY_CATEGORY,
                 provider=provider,
                 ocr_text=text,
+                text_source=text_source,
             )
         except Exception:
             if blob_created:
@@ -1977,6 +2002,11 @@ def reocr_documents(
         # `force=True` unconditionally: this call is only reached once the `has-text`
         # guard above has already applied the caller's own force policy, and re-testing
         # it here would refuse the invisible-only rows that guard deliberately admits.
-        set_document_text(conn, row.document_id, text, force=True)
+        # `source` is the one thing that distinguishes this engine caller from the
+        # hand-attach `set_document_text` otherwise assumes (issue #175): re-OCR text is
+        # `extract_text_routed` output, so it stamps `engine` over whatever was there.
+        set_document_text(
+            conn, row.document_id, text, force=True, source=TEXT_SOURCE_ENGINE
+        )
         results.append(ReocrResult(status="written", chars=len(text), **common))
     return results

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -51,6 +51,7 @@ ALL_MIGRATIONS = [
     "012_record_edit.sql",
     "013_person_unit_pref.sql",
     "014_medication_status_reason.sql",
+    "015_document_text_source.sql",
 ]
 
 # Every record table carries the occurrence-family columns (migration 005; 006's two
@@ -96,6 +97,56 @@ def test_medication_has_status_reason_column(conn):
     assert conn.execute(
         "SELECT status_reason FROM medication"
     ).fetchone()["status_reason"] is None   # nullable, no backfill
+
+
+def _migrate_through_014(conn, tmp_path):
+    """Apply every migration up to 014, leaving 015 pending (a 014-era database)."""
+    import shutil
+
+    staged = tmp_path / "pre015"
+    staged.mkdir()
+    for path in sorted(db.DEFAULT_MIGRATIONS_DIR.glob("*.sql")):
+        if path.name < "015":
+            shutil.copy(path, staged / path.name)
+    db.migrate(conn, staged)
+    return staged
+
+
+def test_document_has_text_source_column(conn):
+    """Migration 015 (issue #175): which write path produced the current `ocr_text`."""
+    db.migrate(conn)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(document)").fetchall()}
+    assert "text_source" in cols
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane', 'Jane')")
+    conn.execute(
+        "INSERT INTO document (sha256, person_id, source_path, ocr_text, ingested_at) "
+        "VALUES ('aa11', 1, 'aa/aa11.pdf', 'scan text', '2026-03-16T00:00:00')"
+    )
+    assert conn.execute(
+        "SELECT text_source FROM document"
+    ).fetchone()["text_source"] is None   # nullable, no backfill
+
+
+def test_migration_015_applies_on_a_014_era_database_without_backfilling(
+    conn, tmp_path
+):
+    """The upgrade path: one additive nullable column, so an existing document keeps its
+    text and gains `text_source IS NULL` — deliberately *not* backfilled to 'engine',
+    which would misclassify the hand-attached rows `document set-text` has been writing
+    since #62."""
+    _migrate_through_014(conn, tmp_path)
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane', 'Jane')")
+    conn.execute(
+        "INSERT INTO document (sha256, person_id, source_path, ocr_text, ingested_at) "
+        "VALUES ('aa11', 1, 'aa/aa11.pdf', 'hand typed', '2026-03-16T00:00:00')"
+    )
+    conn.commit()
+
+    assert db.migrate(conn) == ["015_document_text_source.sql"]
+
+    row = conn.execute("SELECT * FROM document").fetchone()
+    assert row["ocr_text"] == "hand typed"
+    assert row["text_source"] is None
 
 
 def test_person_has_deactivated_at_column(conn):
@@ -157,7 +208,7 @@ def test_migration_006_moves_condition_and_allergy_observations(conn, tmp_path):
         "008_curation.sql", "009_record_attestation.sql",
         "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
         "012_record_edit.sql", "013_person_unit_pref.sql",
-        "014_medication_status_reason.sql",
+        "014_medication_status_reason.sql", "015_document_text_source.sql",
     ]
 
     a = conn.execute("SELECT * FROM allergy").fetchone()
@@ -292,7 +343,7 @@ def test_migration_008_applies_on_a_007_era_database(conn, tmp_path):
         "008_curation.sql", "009_record_attestation.sql",
         "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
         "012_record_edit.sql", "013_person_unit_pref.sql",
-        "014_medication_status_reason.sql",
+        "014_medication_status_reason.sql", "015_document_text_source.sql",
     ]
 
     assert curation.has_table(conn) is True
@@ -346,6 +397,7 @@ def test_migration_009_applies_on_an_008_era_database(conn, tmp_path):
         "009_record_attestation.sql", "010_curation_row_scope.sql",
         "011_curation_distinct_status.sql", "012_record_edit.sql",
         "013_person_unit_pref.sql", "014_medication_status_reason.sql",
+        "015_document_text_source.sql",
     ]
 
     assert attestations.has_columns(conn) is True
@@ -397,7 +449,7 @@ def test_migration_010_rebuilds_curation_and_preserves_every_verdict(conn, tmp_p
     assert db.migrate(conn) == [
         "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
         "012_record_edit.sql", "013_person_unit_pref.sql",
-        "014_medication_status_reason.sql",
+        "014_medication_status_reason.sql", "015_document_text_source.sql",
     ]
 
     after = [dict(r) for r in conn.execute(
@@ -483,6 +535,7 @@ def test_migration_011_widens_the_status_check_and_preserves_every_verdict(
     assert db.migrate(conn) == [
         "011_curation_distinct_status.sql", "012_record_edit.sql",
         "013_person_unit_pref.sql", "014_medication_status_reason.sql",
+        "015_document_text_source.sql",
     ]
 
     after = [dict(r) for r in conn.execute(

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -328,6 +328,112 @@ def test_set_text_leaves_records_and_keys_untouched(seeded):
     assert documents.get_document_view(conn, seeded["doc"])["record_count"] == _SEEDED_ROWS
 
 
+# --- text_source provenance (issue #175) ------------------------------------
+
+
+def _text_source(conn, document_id):
+    return conn.execute(
+        "SELECT text_source FROM document WHERE document_id = ?", (document_id,)
+    ).fetchone()["text_source"]
+
+
+def test_set_text_defaults_to_attached_provenance(conn):
+    """The function's own contract is a hand-attach - `pemr document set-text` and the
+    `document_set_text` MCP tool - so `attached` is what an unqualified call records."""
+    person = persons.add_person(conn, "jane-doe", "Jane Doe")
+    doc = _insert_document(conn, person.person_id, "ff00", ocr_text=None)
+    view = documents.set_document_text(conn, doc, "cholesterol panel")
+    assert view["text_source"] == documents.TEXT_SOURCE_ATTACHED == "attached"
+    assert _text_source(conn, doc) == "attached"
+
+
+def test_set_text_records_engine_provenance_when_asked(conn):
+    """The one engine caller (`reocr_documents`) overrides the default explicitly - the
+    whole point of the parameter, since both callers pass `force=True`."""
+    person = persons.add_person(conn, "jane-doe", "Jane Doe")
+    doc = _insert_document(conn, person.person_id, "ff00", ocr_text=None)
+    view = documents.set_document_text(
+        conn, doc, "extracted page", source=documents.TEXT_SOURCE_ENGINE
+    )
+    assert view["text_source"] == "engine"
+    assert _text_source(conn, doc) == "engine"
+
+
+def test_set_text_flips_provenance_on_a_forced_replace(conn):
+    """Provenance describes the text that is *there now*, so a replace overwrites it."""
+    person = persons.add_person(conn, "jane-doe", "Jane Doe")
+    doc = _insert_document(conn, person.person_id, "ff00", ocr_text=None)
+    documents.set_document_text(conn, doc, "typed by hand")
+    documents.set_document_text(
+        conn, doc, "re-extracted", force=True, source=documents.TEXT_SOURCE_ENGINE
+    )
+    assert documents.get_document_text(conn, doc) == "re-extracted"
+    assert _text_source(conn, doc) == "engine"
+
+
+def test_set_text_rejects_an_unknown_source_and_writes_nothing(seeded):
+    """The closed vocabulary is enforced in Python rather than by a DDL `CHECK` (013's
+    precedent), so the guard has to be here - and has to fire before any write."""
+    conn = seeded["conn"]
+    with pytest.raises(ValueError, match="unknown text source"):
+        documents.set_document_text(
+            conn, seeded["doc"], "replacement", force=True, source="guessed"
+        )
+    assert documents.get_document_text(conn, seeded["doc"]) == "scan text"
+    assert _text_source(conn, seeded["doc"]) is None
+
+
+def test_set_text_keeps_the_fts_row_single_despite_the_two_column_update(conn):
+    """`text_source` rides in the *same* UPDATE as `ocr_text`, so migration 003's
+    AFTER UPDATE trigger still fires exactly once - a second statement would double-fire
+    it for no benefit."""
+    person = persons.add_person(conn, "jane-doe", "Jane Doe")
+    doc = _insert_document(conn, person.person_id, "ff00", ocr_text=None)
+    documents.set_document_text(conn, doc, "cholesterol panel")
+    documents.set_document_text(conn, doc, "lipid panel", force=True)
+    rows = conn.execute(
+        "SELECT text FROM record_fts WHERE source_table = 'document' AND source_id = ?",
+        (doc,),
+    ).fetchall()
+    assert [r["text"] for r in rows] == ["lipid panel"]   # replaced, not accumulated
+
+
+def test_views_report_no_provenance_for_a_pre_015_row(seeded):
+    """A row written before 015 (here: the fixture's direct INSERT) reports `None` rather
+    than guessing - `has_ocr_text` is what tells "unknown" apart from "no text"."""
+    conn = seeded["conn"]
+    listed = documents.list_documents(conn)[0]
+    shown = documents.get_document_view(conn, seeded["doc"])
+    assert listed["has_ocr_text"] is True and listed["text_source"] is None
+    assert shown["text_source"] is None
+
+
+def test_views_tolerate_a_database_with_no_text_source_column(tmp_path):
+    """A snapshot restored from a pre-015 database still passes `db.is_migrated` (it only
+    checks 001's sentinel), so `SELECT *` hands back a row with no `text_source` key. The
+    read has to degrade to `None` rather than raise - the same reason
+    `curation.has_table` exists."""
+    import shutil
+
+    staged = tmp_path / "pre015"
+    staged.mkdir()
+    for path in sorted(db.DEFAULT_MIGRATIONS_DIR.glob("*.sql")):
+        if path.name < "015":
+            shutil.copy(path, staged / path.name)
+    old = db.connect(tmp_path / "old.db")
+    try:
+        db.migrate(old, staged)
+        person = persons.add_person(old, "jane-doe", "Jane Doe")
+        doc = _insert_document(old, person.person_id, "aa11bb22")
+        assert "text_source" not in {
+            r[1] for r in old.execute("PRAGMA table_info(document)").fetchall()
+        }
+        assert documents.list_documents(old)[0]["text_source"] is None
+        assert documents.get_document_view(old, doc)["text_source"] is None
+    finally:
+        old.close()
+
+
 # --- edit -------------------------------------------------------------------
 
 
@@ -827,6 +933,35 @@ def test_cli_document_show_json_keeps_the_stable_shape(cli_ready, capsys):
     assert payload["has_ocr_text"] is True
     assert payload["ocr_text_chars"] > 0
     assert "ocr_text" not in payload
+
+
+def test_cli_document_show_names_the_text_provenance(cli_ready, capsys):
+    """The fixture ingests with `--ocr-text-file`, i.e. the caller's own transcription -
+    so `attached`, even though `ingest` is the engine's own command (issue #175)."""
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "show", "1") == 0
+    assert "text_source    attached" in capsys.readouterr().out
+
+    assert _run(cli_ready, "document", "show", "1", "--json") == 0
+    assert json.loads(capsys.readouterr().out)["text_source"] == "attached"
+
+
+def test_cli_document_show_renders_unknown_provenance_rather_than_a_blank(
+    cli_ready, capsys
+):
+    """A document ingested with no text at all has no provenance to report. `_fmt` would
+    print an empty string there, which reads as a rendering bug rather than as "unknown"."""
+    blank = cli_ready / "untranscribed.txt"
+    blank.write_bytes(b"nothing extracted from this one")
+    assert _run(cli_ready, "ingest", str(blank), "--person", "jane-doe",
+                "--sources", str(cli_ready / "sources")) == 0
+    capsys.readouterr()
+    assert _run(cli_ready, "document", "show", "2") == 0
+    out = capsys.readouterr().out
+    assert "has_ocr_text   no" in out and "text_source    unknown" in out
+
+    assert _run(cli_ready, "document", "show", "2", "--json") == 0
+    assert json.loads(capsys.readouterr().out)["text_source"] is None
 
 
 def test_cli_document_show_reports_open_conflicts(cli_ready, capsys):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -964,6 +964,58 @@ def test_cli_document_show_renders_unknown_provenance_rather_than_a_blank(
     assert json.loads(capsys.readouterr().out)["text_source"] is None
 
 
+def test_cli_provenance_lifecycle_ingest_set_text_reocr(cli_ready, capsys):
+    """The whole provenance chain through the CLI, one document, in order (issue #175).
+
+    The per-step assertions exist elsewhere in this file at the API level; what this pins
+    is the *sequence* a real operator walks - extraction at ingest, a hand-attach over it,
+    then a re-OCR that takes it back - together with the FTS resync that rides on the
+    same two-column UPDATE. `record_fts` is asserted at each step because the trigger
+    firing once (not zero or twice) is what keeps `find` honest after a replace.
+    """
+    scan = cli_ready / "engine-scan.txt"
+    scan.write_bytes(b"jane engine token enginetoken alpha")
+    assert _run(cli_ready, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(cli_ready / "sources"), "--ocr", "auto") == 0
+
+    conn = db.connect(cli_ready / "cli.db")
+    try:
+        def fts_rows():
+            return conn.execute(
+                "SELECT COUNT(*) AS n FROM record_fts "
+                "WHERE source_table = 'document' AND document_id = 2"
+            ).fetchone()["n"]
+
+        # 1. pemr extracted it -> engine.
+        assert _text_source(conn, 2) == "engine"
+        assert fts_rows() == 1
+
+        # 2. a human replaces it -> attached, and `find` follows the new text.
+        hand = cli_ready / "hand.txt"
+        hand.write_text("jane corrected by hand handtoken bravo", encoding="utf-8")
+        assert _run(cli_ready, "document", "set-text", "2", "--force",
+                    "--ocr-text-file", str(hand)) == 0
+        assert _text_source(conn, 2) == "attached"
+        assert fts_rows() == 1
+        capsys.readouterr()
+        assert _run(cli_ready, "find", "handtoken") == 0
+        assert "document#2" in capsys.readouterr().out
+        assert _run(cli_ready, "find", "enginetoken") == 0
+        assert "no matches" in capsys.readouterr().out
+
+        # 3. re-OCR re-derives from the stored blob -> back to engine. Same
+        # `set_document_text` call as step 2, distinguished only by `source`.
+        assert _run(cli_ready, "document", "reocr", "2", "--force", "--allow-shrink",
+                    "--sources", str(cli_ready / "sources")) == 0
+        assert _text_source(conn, 2) == "engine"
+        assert fts_rows() == 1
+        capsys.readouterr()
+        assert _run(cli_ready, "find", "enginetoken") == 0
+        assert "document#2" in capsys.readouterr().out
+    finally:
+        conn.close()
+
+
 def test_cli_document_show_reports_open_conflicts(cli_ready, capsys):
     scan2 = cli_ready / "scan2.txt"
     scan2.write_bytes(b"hba1c 7.4 percent")

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1806,6 +1806,67 @@ def test_zero_width_only_ocr_text_is_no_text_at_all(conn, tmp_path, sources):
     assert not result.ocr_text_populated
 
 
+# --- text provenance (issue #175) -------------------------------------------
+
+
+def _text_source(conn, document_id):
+    return conn.execute(
+        "SELECT text_source FROM document WHERE document_id = ?", (document_id,)
+    ).fetchone()["text_source"]
+
+
+def test_extracted_text_records_engine_provenance(conn, tmp_path, sources):
+    """`--ocr auto` text came off the page through pemr, so it carries OCR-typical noise
+    a consumer may want to weigh differently."""
+    src = _make_file(tmp_path, "notes.txt", b"Sodium 140 mmol/L")
+    result = ingest.ingest_document(conn, src, "jane-doe", sources, ocr=True)
+    assert result.document.ocr_text == "Sodium 140 mmol/L"
+    assert _text_source(conn, result.document.document_id) == "engine"
+
+
+def test_supplied_text_records_attached_provenance(conn, tmp_path, sources):
+    """Provenance follows the text's *origin*, not the verb that wrote it:
+    `--ocr-text-file` is the agent's own transcription (the `AGENTS.md` default path),
+    so recording it as engine output would misclassify exactly the rows this column
+    exists to tell apart."""
+    src = _make_file(tmp_path, "scan.png", b"not really an image")
+    result = ingest.ingest_document(
+        conn, src, "jane-doe", sources, ocr_text="Sodium 140 mmol/L"
+    )
+    assert _text_source(conn, result.document.document_id) == "attached"
+
+
+def test_supplied_text_beats_extraction_for_provenance_too(conn, tmp_path, sources):
+    """When both are available the supplied text wins the column, so it must win the
+    provenance with it."""
+    src = _make_docx(tmp_path, paragraphs=("extracted body",))
+    result = ingest.ingest_document(
+        conn, src, "jane-doe", sources, ocr=True, ocr_text="agent transcription"
+    )
+    assert result.document.ocr_text == "agent transcription"
+    assert _text_source(conn, result.document.document_id) == "attached"
+
+
+def test_ingest_without_text_records_no_provenance(conn, tmp_path, sources):
+    """No text means nothing to attribute - both columns stay NULL, which is what makes
+    NULL's other reading ("written before 015") derivable from `ocr_text` alone."""
+    src = _make_file(tmp_path)
+    result = ingest.ingest_document(conn, src, "jane-doe", sources)
+    assert result.document.ocr_text is None
+    assert _text_source(conn, result.document.document_id) is None
+
+
+def test_zero_width_only_supplied_text_records_no_provenance(conn, tmp_path, sources):
+    """The emptiness predicate is shared, so a zero-width-only transcription is neither
+    stored nor attributed (#87 + #175)."""
+    src = _make_file(tmp_path, "scan.txt", b"a scan with no text")
+    result = ingest.ingest_document(
+        conn, src, "jane-doe", sources, ocr_text=chr(0x200B)
+    )
+    assert result.document.ocr_text is None
+    assert _text_source(conn, result.document.document_id) is None
+
+
 def test_supplied_ocr_text_is_stored_without_invisible_padding(conn, tmp_path, sources):
     """Normalise what is *stored*, not just what is rejected (#87)."""
     src = _make_file(tmp_path, "scan2.txt", b"another scan")
@@ -2107,6 +2168,38 @@ def test_reocr_force_replaces_existing_text(conn, tmp_path, sources):
     )
 
 
+def test_reocr_records_engine_provenance(conn, tmp_path, sources):
+    """Re-OCR text is `extract_text_routed` output. It reaches the column through the
+    same `set_document_text(force=True)` call a hand-attach uses, so `source` is the only
+    thing that tells the two apart (issue #175)."""
+    doc = _file_document(conn, tmp_path, sources, content=b"acute pericarditis noted")
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources)
+
+    assert result.status == "written"
+    assert _text_source(conn, doc.document_id) == "engine"
+
+
+def test_reocr_flips_attached_provenance_to_engine_on_a_forced_replace(
+    conn, tmp_path, sources
+):
+    """The replace path: a hand-attached transcription overwritten by re-derived text is
+    no longer hand-attached, and `force=True` must not be read as "leave provenance be"."""
+    doc = _file_document(
+        conn, tmp_path, sources, content=b"machine text, and then some more of it",
+        ocr_text="old transcription",
+    )
+    assert _text_source(conn, doc.document_id) == "attached"
+
+    (result,) = ingest.reocr_documents(conn, [doc.document_id], sources, force=True)
+
+    assert result.status == "written"
+    assert _stored_text(conn, doc.document_id) == (
+        "machine text, and then some more of it"
+    )
+    assert _text_source(conn, doc.document_id) == "engine"
+
+
 def test_reocr_dry_run_reports_chars_and_writes_nothing(conn, tmp_path, sources):
     doc = _file_document(conn, tmp_path, sources, content=b"twenty four characters!!")
 
@@ -2115,6 +2208,7 @@ def test_reocr_dry_run_reports_chars_and_writes_nothing(conn, tmp_path, sources)
     assert result.status == "would-write"
     assert result.chars == 24
     assert _stored_text(conn, doc.document_id) is None
+    assert _text_source(conn, doc.document_id) is None   # neither column written
 
 
 def test_reocr_dry_run_names_a_pdf_over_the_page_cap(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -381,6 +381,21 @@ def test_document_set_text_fills_an_empty_ocr_text(seeded):
     assert mcp_server.find(seeded, query_text="thyroid", person="jane-doe")
 
 
+def test_document_set_text_records_attached_provenance(seeded):
+    """The MCP front door is the human/agent write path, so its text is `attached`
+    (issue #175). Proven behaviourally rather than by a line of code in `mcp_server`:
+    the tool passes no `source`, and `set_document_text`'s default is what makes that
+    correct - so this test is what would fail if the default ever flipped."""
+    doc = _doc(seeded, "jane-doe", ocr=None)
+    out = mcp_server.document_set_text(
+        seeded, document_id=doc, text="thyroid panel within range"
+    )
+    assert out["text_source"] == "attached"
+    assert seeded.execute(
+        "SELECT text_source FROM document WHERE document_id = ?", (doc,)
+    ).fetchone()["text_source"] == "attached"
+
+
 def test_document_set_text_refuses_a_populated_document(seeded):
     doc = _doc(seeded, "jane-doe", ocr="the original transcription")
     with pytest.raises(mcp_server.ToolError, match="already has ocr_text"):

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -398,6 +398,33 @@ def test_ingest_study_dir_caller_values_win(conn, tmp_path, sources):
     assert doc.ocr_text == "IMPRESSION: no acute findings."
 
 
+def _text_source(conn, document_id):
+    return conn.execute(
+        "SELECT text_source FROM document WHERE document_id = ?", (document_id,)
+    ).fetchone()["text_source"]
+
+
+def test_ingest_study_dir_summary_records_engine_provenance(conn, tmp_path, sources):
+    """The derived modality/date/series summary is engine output like any extraction
+    (issue #175) - it is generated from the DICOM headers, not handed over by a human."""
+    root = make_study(tmp_path / "disc")
+    result = ingest.ingest_study_dir(conn, root, "jane-doe", sources)
+    assert "DICOM study: disc" in result.document.ocr_text
+    assert _text_source(conn, result.document.document_id) == "engine"
+
+
+def test_ingest_study_dir_supplied_text_records_attached_provenance(
+    conn, tmp_path, sources
+):
+    """A transcribed radiology report supplied by the caller beats the summary, and the
+    provenance goes with it."""
+    root = make_study(tmp_path / "disc")
+    result = ingest.ingest_study_dir(
+        conn, root, "jane-doe", sources, ocr_text="IMPRESSION: no acute findings.",
+    )
+    assert _text_source(conn, result.document.document_id) == "attached"
+
+
 def test_ingest_study_dir_zero_width_ocr_text_falls_back_to_the_summary(
     conn, tmp_path, sources
 ):


### PR DESCRIPTION
## Summary

`document.ocr_text` is written by two distinct paths — engine-extracted (ingest, re-OCR) and
hand-attached (`document set-text` / MCP `document_set_text`) — with no way to tell which one
produced the current text. This adds a `text_source` column (migration `015`) that records the
provenance of the text currently in `ocr_text`, threaded through every write path:

- **`migrations/015_document_text_source.sql`** — additive nullable `ALTER TABLE document ADD
  COLUMN text_source TEXT`. Values `'engine'` | `'attached'` | `NULL` (no `CHECK`, validated in
  Python per `013`'s precedent). No backfill: existing rows may be hand-attached, so a blanket
  `'engine'` default would misclassify them. `NULL` means *unknown provenance*, never "engine" —
  documented in the migration header and `docs/Architecture.md`.
- **`pemr/documents.py`** — `set_document_text(..., source=...)` validates and writes
  `text_source` in the same UPDATE as `ocr_text` (single trigger fire). `_document_view` exposes
  `text_source` for reads.
- **`pemr/ingest.py`** — `_insert_document` and `ingest_document`/`ingest_study_dir` derive
  `engine` vs `attached` from whether text was supplied vs extracted. `reocr_documents` always
  passes `engine` — the one thing distinguishing a re-OCR's `force=True` call from a genuine
  hand-attach `force=True` call.
- **`pemr/cli.py`** — `document show` renders `text_source` (`unknown` for `NULL`, not blank).
- **`pemr/mcp_server.py`** — no code change (by design): `document_set_text` passes no `source`,
  so the `'attached'` default applies. The MCP tool has no `source` parameter at all — an agent
  cannot stamp its own write as `engine`, nor launder engine text as `attached`. Pinned
  behaviourally by `tests/test_mcp_server.py`.
- **`docs/Architecture.md`** — schema entry + the origin-not-verb rule.

Full write-up of the design decisions, test coverage, and a real-run smoke walk (fresh 014-era
database migrated live, every AC exercised through the CLI/MCP against real blobs) are in the
verify and audit reports linked below.

Closes #175

## Test plan

- Full suite: 1539 passed (`pytest`), including new coverage in `test_db.py`, `test_documents.py`,
  `test_ingest.py`, `test_mcp_server.py`, `test_study.py` for both write paths, provenance
  round-tripping (`engine` → `attached` → `engine`), pre-015 tolerance, and FTS trigger discipline.
- Real-run smoke: built a genuine 014-era SQLite database from `origin/dev`, ran `pemr migrate`
  against it, then walked every acceptance criterion through the live CLI and MCP surfaces
  (ingest, set-text, reocr, show/list, find) against real files on disk.
- `npm run check:pii`, `npm run check:meta-drift`, `npm run sync:claude-config:check` — all clean.

## Reports

- Build: https://github.com/meridun/pemr/issues/175#issuecomment-5335980602
- Verify: https://github.com/meridun/pemr/issues/175#issuecomment-5336116530
- Audit: https://github.com/meridun/pemr/issues/175#issuecomment-5336155633

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>