### PR TITLE
trends: chart vitals series alongside lab analytes (#176)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ Read-only tools (never mutate the DB; safe to call freely):
 - `person_show` — one person by slug.
 - `query` — structured reads; `kind` = `labs` | `meds` | `timeline`.
 - `find` — full-text search over `ocr_text` + record fields.
-- `trends` — min/max/latest/slope for one analyte.
+- `trends` — min/max/latest/slope for one lab analyte or vital sign; a key matching both is
+  refused, not merged.
 - `render_summary` — master summary Markdown for a person.
 - `render_brief` — walk-in brief Markdown for one appointment.
 - `render_journal` — narrative chronology Markdown for a person.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ layout, `migrations/001_init.sql`, `pemr migrate --create` (bootstrap a new arch
 (`pemr ingest`), semantic dedup keys with conflict staging (`migrations/002_conflict.sql`,
 `pemr review-conflicts`), starter analyte/name dictionary. **Phase 3 (query layer) is done**:
 structured reads (`pemr query labs|meds|timeline`), full-text search over OCR text + record
-fields (`migrations/003_fts.sql`, `pemr find`), and lab `pemr trends` — all with `--json`.
+fields (`migrations/003_fts.sql`, `pemr find`), and `pemr trends` over lab analytes and vital
+signs alike (a key present in both is refused, not merged) — all with `--json`.
 
 ## Data / privacy posture
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -513,6 +513,16 @@ albumin` matches on `norm()` and lists the whole analyte family, while `pemr tre
 matches on `key_token()` so a numeric series never interleaves two assays — and reports
 the rows it excluded on that basis (`other_assays`) instead of dropping them silently.
 
+`trends` charts a measurement **key**, not a table (issue #176): it reads `lab_result`
+rows *and* `obs_type='vital'` `observation` rows through one aliased row shape
+(`observed_at` standing in for `collected_at`, `key` for `test_name`), so weight,
+temperature and blood pressure reach the same statistics and the same per-person
+canonical-unit conversion an analyte does — the four vitals dimensions the units registry
+carries exist for exactly this population. A `--test` token matching numeric rows in
+*both* tables is **refused**, not merged: the same reasoning as the assay split, since a
+silently interleaved lab-and-vital series is a wrong chart even when the tokens coincide.
+`pemr labs` remains lab-only.
+
 **A dictionary edit is retroactive only if you make it so.** Stored keys are frozen at
 commit time, so a new synonym changes the key a *future* commit derives for a fact already
 in the DB: layer-2 dedup misses it and the same fact lands twice. `pemr rekey` re-derives
@@ -1135,6 +1145,9 @@ pemr trends --person jane --test hba1c                   # min/max/latest/slope
                                                          # numbers and the printed unit cannot disagree;
                                                          # a point that cannot be converted is kept and
                                                          # disclosed, never dropped
+pemr trends --person jane --test weight                  # a vital key charts too (labs + obs_type='vital');
+                                                         # a token present in BOTH tables is refused, not
+                                                         # merged - rc=1 naming both sources
 pemr due --person jane                                   # screening/vaccine gaps — NOT IMPLEMENTED (phase 7)
 pemr render summary --person jane        > exports/jane-summary.md
 pemr render brief --appointment <id>     > exports/brief.md

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -3830,10 +3830,15 @@ def build_parser() -> argparse.ArgumentParser:
     p_find.set_defaults(func=_cmd_find)
 
     p_trends = sub.add_parser(
-        "trends", help="min/max/latest/slope for one analyte over time"
+        "trends", help="min/max/latest/slope for one lab analyte or vital sign over time"
     )
     p_trends.add_argument("--person", required=True, help="owner slug")
-    p_trends.add_argument("--test", required=True, help="analyte name (dictionary-normalized)")
+    p_trends.add_argument(
+        "--test",
+        required=True,
+        help="analyte or vital key (dictionary-normalized); refused, not merged, if it "
+        "matches both a lab result and a vital observation",
+    )
     p_trends.add_argument("--dictionary", help="synonym dictionary TOML (overrides default)")
     p_trends.add_argument("--json", action="store_true", help="machine-readable output")
     p_trends.set_defaults(func=_cmd_trends)

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -2697,8 +2697,9 @@ def _fmt(value: object) -> str:
 
 
 def _with_conn_person(args: argparse.Namespace, work):
-    """Open the DB, run ``work(conn)``, translating the two friendly failure modes
-    (un-migrated DB, unknown person slug) into an rc=1 stderr message."""
+    """Open the DB, run ``work(conn)``, translating the friendly failure modes
+    (un-migrated DB, unknown person slug, a ``--test`` token that collides across two
+    record types) into an rc=1 stderr message."""
     conn = _connect_db(args)
     try:
         try:
@@ -2706,7 +2707,7 @@ def _with_conn_person(args: argparse.Namespace, work):
         except db.NotMigratedError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 1
-        except query.PersonNotFoundError as exc:
+        except (query.PersonNotFoundError, query.AmbiguousTestError) as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 1
     finally:

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -152,6 +152,13 @@ ENUM_FIELDS: dict[str, dict[str, frozenset[str]]] = {
     },
 }
 
+# The vitals lane: the `observation` rows render's `Latest Vitals` shows one at a time and
+# `query.trends` charts as a series (issue #176). It lives here rather than beside render's
+# `OBS_ORDER` because `query` became its second consumer and `render` imports `query` —
+# defining it in `render` would invert that edge, the same reasoning the self-attested
+# lanes below already follow.
+OBS_VITAL = "vital"
+
 # The self-attested lanes (issue #167): what the *patient* reports about themselves on a
 # given day, as opposed to what a clinician or a document asserted. Deliberately two
 # obs_types, not one — `activity` is the higher-volume, lower-signal of the pair, and
@@ -159,7 +166,7 @@ ENUM_FIELDS: dict[str, dict[str, frozenset[str]]] = {
 # `observation` catch-all and never reach `condition`/`Active Problems`, which is what
 # keeps unfiltered self-attested rows out of the verdict-curated problem list.
 #
-# They live here rather than beside render's `OBS_VITAL`/`OBS_ORDER` because `query` needs
+# They live here rather than beside render's `OBS_ORDER` because `query` needs
 # them too and it already imports from this module while `render` imports `query` —
 # defining them in `render` would invert that edge.
 OBS_SYMPTOM = "symptom"

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -468,10 +468,18 @@ def find(
 
 
 def trends(conn: sqlite3.Connection, *, person: str, test: str) -> dict[str, Any]:
-    """[read] min/max/latest/slope for one analyte over time. Mirrors ``pemr trends``."""
+    """[read] min/max/latest/slope for one lab analyte or vital sign over time. Mirrors
+    ``pemr trends``.
+
+    A ``test`` matching both a lab result and a vital is refused, not merged.
+    """
     try:
         return _query.trends(conn, person, test, dictionary=_dictionary())
-    except (db.NotMigratedError, _query.PersonNotFoundError) as exc:
+    except (
+        db.NotMigratedError,
+        _query.PersonNotFoundError,
+        _query.AmbiguousTestError,
+    ) as exc:
         raise _friendly(exc) from exc
 
 

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -1,4 +1,4 @@
-"""Phase 3 read layer: structured queries, full-text `find`, and lab `trends`.
+"""Phase 3 read layer: structured queries, full-text `find`, and `trends`.
 
 All functions are pure reads over the tables phases 1–2 populate (Architecture.md §5).
 They return plain Python data (dicts / lists of dicts) with stable field names; the CLI
@@ -16,6 +16,11 @@ The two readers match at deliberately **different granularities** (issue #71):
 ``key_token()`` so a numeric series never interleaves two different assays of one
 analyte (a CMP ``Albumin`` and an SPEP ``Albumin (SPEP)``) — and discloses the rows it
 excluded on that basis rather than dropping them silently.
+
+``trends`` charts a *measurement key*, not a table: it reads lab results and vitals
+``observation`` rows through one aliased row shape (issue #176), so weight, temperature
+and blood pressure reach the same statistics and the same per-person canonical-unit
+conversion an analyte does. ``query_labs`` remains lab-only.
 """
 
 from __future__ import annotations
@@ -26,7 +31,7 @@ import sqlite3
 from datetime import date, datetime
 
 from . import db, units
-from .dedup import enum_token, key_token, norm
+from .dedup import OBS_VITAL, enum_token, key_token, norm
 
 # Word tokens for a safe FTS5 query: strips punctuation/operators so raw user input
 # can never be mis-parsed as FTS syntax (each token is quoted as a phrase, AND-ed).
@@ -128,6 +133,14 @@ def med_is_current(row: sqlite3.Row | dict, *, now: datetime | None = None) -> b
 
 class PersonNotFoundError(ValueError):
     """Raised when a slug does not resolve to a person (friendly rc=1 at the CLI)."""
+
+
+class AmbiguousTestError(ValueError):
+    """Raised when a ``--test`` token matches numeric rows in **both** ``lab_result`` and
+    vitals ``observation`` (issue #176). :func:`trends` charts one series at a time — an
+    interleaved lab-and-vital series is the wrong chart #71 splits assays to avoid — so
+    the collision is refused rather than resolved by a silent preference. A friendly rc=1
+    at the CLI, like its sibling above."""
 
 
 def resolve_person_id(conn: sqlite3.Connection, slug: str) -> int:
@@ -426,6 +439,64 @@ def _ordinal(value: object) -> int | None:
         return None
 
 
+def _series_candidates(
+    conn: sqlite3.Connection, person_id: int
+) -> list[tuple[str, list[sqlite3.Row]]]:
+    """Every numeric measurement of one person, per source, in one row shape.
+
+    Returns ``[("lab_result", rows), ("observation", rows)]``. Both SELECTs alias their
+    table into ``(row_id, value_num, unit, at, label)`` — ``observed_at`` standing in for
+    ``collected_at`` and ``key`` for ``test_name`` — so the matching, the ``other_assays``
+    disclosure and every statistic below read a vital exactly like a lab result, with no
+    per-source branch (issue #176).
+
+    Ordering is load-bearing: ``matched[-1]`` is the latest point and ties break on the
+    greatest row id (most-recently-ingested wins), which holds for vitals only because
+    the vitals SELECT sorts the same way.
+    """
+    labs = conn.execute(
+        "SELECT lab_result_id AS row_id, value_num, unit, collected_at AS at, "
+        "test_name AS label FROM lab_result "
+        "WHERE person_id = ? AND value_num IS NOT NULL "
+        "ORDER BY collected_at, lab_result_id",
+        (person_id,),
+    ).fetchall()
+    vitals = conn.execute(
+        "SELECT observation_id AS row_id, value_num, unit, observed_at AS at, "
+        "key AS label FROM observation "
+        "WHERE person_id = ? AND obs_type = ? AND value_num IS NOT NULL "
+        "ORDER BY observed_at, observation_id",
+        (person_id, OBS_VITAL),
+    ).fetchall()
+    return [("lab_result", labs), ("observation", vitals)]
+
+
+def _match_series(
+    rows: list[sqlite3.Row],
+    target: str,
+    family: str,
+    dictionary: dict[str, str] | None,
+) -> tuple[list[sqlite3.Row], str, dict[str, int]]:
+    """Split one source's candidate rows into ``(matched, matched_token, others)``.
+
+    ``matched`` is the key-token series; ``others`` counts the same-family rows a
+    differing qualifier excluded, which are disclosed rather than dropped (issue #71).
+    """
+    matched: list[sqlite3.Row] = []
+    others: dict[str, int] = {}
+    matched_token = ""
+    for r in rows:
+        token = key_token(r["label"], dictionary)
+        if _loose(token) == target:
+            matched.append(r)
+            # Echo the stored spelling rather than whatever the caller typed, so a
+            # pasted `other_assays` token comes back labelled the way it was disclosed.
+            matched_token = matched_token or token
+        elif _loose(norm(r["label"], dictionary)) == family:
+            others[token] = others.get(token, 0) + 1
+    return matched, matched_token, others
+
+
 def _slope_per_day(points: list[tuple[int, float]]) -> float | None:
     """Least-squares slope (value units per day) of y vs x=ordinal-day. ``None`` when
     fewer than two points or all points share one date (zero x-variance)."""
@@ -447,16 +518,22 @@ def trends(
     test: str,
     dictionary: dict[str, str] | None = None,
 ) -> dict:
-    """Summary stats for one **assay** of one analyte over time.
+    """Summary stats for one **measurement key** over time — a lab analyte's assay or a
+    vital sign (issue #176), whichever the key matches.
 
     Returns ``{test, count, unit, min, max, latest, latest_at, latest_tie,
     slope_per_day, other_assays, other_assay_count, canonical_unit, converted_count,
-    unconverted_count}``. ``count`` is the number of
+    unconverted_count}`` — one contract, no source field and no vitals branch, so a
+    vitals series is shape-identical to a lab one. ``count`` is the number of
     numeric points; ``slope_per_day`` degrades to ``None`` with fewer than two distinct
-    collection dates. ``latest`` is the row with the greatest ``collected_at``, ties
-    broken by the greatest ``lab_result_id`` (most-recently-ingested wins);
-    ``latest_tie`` counts how many matched rows share that exact ``collected_at``
-    timestamp.
+    dates. ``latest`` is the row with the greatest timestamp (``collected_at`` for a lab,
+    ``observed_at`` for a vital, which is nullable by design and sorts first), ties broken
+    by the greatest row id (most-recently-ingested wins); ``latest_tie`` counts how many
+    matched rows share that exact timestamp.
+
+    A key token matching numeric rows in **both** tables raises
+    :class:`AmbiguousTestError` rather than merging them: same #71 reasoning as the assay
+    split — a silently interleaved series is a wrong chart even when the tokens coincide.
 
     Matching is on ``key_token()``, not ``norm()`` (issue #71): a series that silently
     interleaves a CMP albumin with an SPEP albumin is a wrong chart, the same class of
@@ -485,24 +562,30 @@ def trends(
     canonical = {_loose(k): v for k, v in units.load_prefs(conn, person_id).items()}.get(
         target
     )
-    rows = conn.execute(
-        "SELECT lab_result_id, value_num, unit, collected_at, test_name FROM lab_result "
-        "WHERE person_id = ? AND value_num IS NOT NULL "
-        "ORDER BY collected_at, lab_result_id",
-        (person_id,),
-    ).fetchall()
-    matched = []
+    matched: list[sqlite3.Row] = []
     others: dict[str, int] = {}
     matched_token = ""
-    for r in rows:
-        token = key_token(r["test_name"], dictionary)
-        if _loose(token) == target:
-            matched.append(r)
-            # Echo the stored spelling rather than whatever the caller typed, so a
-            # pasted `other_assays` token comes back labelled the way it was disclosed.
-            matched_token = matched_token or token
-        elif _loose(norm(r["test_name"], dictionary)) == family:
-            others[token] = others.get(token, 0) + 1
+    hits: dict[str, int] = {}
+    for source, rows in _series_candidates(conn, person_id):
+        source_matched, source_token, source_others = _match_series(
+            rows, target, family, dictionary
+        )
+        # One disclosure rule, not a per-source branch: a same-family sibling is reported
+        # wherever it lives, and its token pastes back as `--test` and finds it.
+        for token, count in source_others.items():
+            others[token] = others.get(token, 0) + count
+        if source_matched:
+            hits[source] = len(source_matched)
+            matched = source_matched
+            matched_token = matched_token or source_token
+    if len(hits) > 1:
+        # ASCII only: this reaches a cp1252/cp437 console (see `units` on the same rule).
+        raise AmbiguousTestError(
+            f"'{matched_token or target}' matches both lab results "
+            f"({hits['lab_result']} numeric rows) and vital observations "
+            f"({hits['observation']}) - trends charts one series at a time and will "
+            "not merge them"
+        )
 
     result: dict = {
         "test": matched_token or target,
@@ -546,17 +629,15 @@ def trends(
         result["unit"] = next(iter(seen)) if len(seen) == 1 else None
     result["min"] = min(values)
     result["max"] = max(values)
-    latest = matched[-1]  # rows came back ORDER BY collected_at, lab_result_id
+    latest = matched[-1]  # rows came back ORDER BY <timestamp>, <row id>
     result["latest"] = values[-1]
-    result["latest_at"] = latest["collected_at"]
-    result["latest_tie"] = sum(
-        1 for r in matched if r["collected_at"] == latest["collected_at"]
-    )
+    result["latest_at"] = latest["at"]
+    result["latest_tie"] = sum(1 for r in matched if r["at"] == latest["at"])
 
     points = [
         (o, value)
         for r, value in zip(matched, values)
-        if (o := _ordinal(r["collected_at"])) is not None
+        if (o := _ordinal(r["at"])) is not None
     ]
     result["slope_per_day"] = _slope_per_day(points)
     return result

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -131,6 +131,7 @@ from datetime import date, datetime, timedelta
 from . import curation, db, dedup, query, units
 from .dedup import (
     OBS_SYMPTOM,
+    OBS_VITAL,
     SELF_REPORTED_OBS_TYPES,
     enum_token,
     is_attested,
@@ -138,8 +139,9 @@ from .dedup import (
     norm,
 )
 
-# Observation obs_type conventions this layer reads (see module docstring).
-OBS_VITAL = "vital"
+# Observation obs_type conventions this layer reads (see module docstring). `OBS_VITAL`
+# lives in `dedup` now that `query.trends` reads it too (issue #176); `order` is still
+# render's alone.
 OBS_ORDER = "order"
 
 # How an order is matched to the `lab_result` that answered it (issue #128). No FK links

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -607,3 +607,63 @@ def test_trends_json_keys_are_inert_without_a_preference(ready, capsys):
     assert t["canonical_unit"] is None
     assert t["converted_count"] == 0 and t["unconverted_count"] == 0
     assert "converted to" not in json.dumps(t)
+
+
+# --- trends over vitals, through the real CLI (issue #176) --------------------
+
+def _seed_vitals(tmp_path, slug="jane-doe", rows=None):
+    """Commit `obs_type='vital'` observation rows for one person."""
+    conn = db.connect(tmp_path / "cli.db")
+    d = dedup.load_dictionary(DICT_ARG[1])
+    pid = conn.execute(
+        "SELECT person_id FROM person WHERE slug=?", (slug,)
+    ).fetchone()["person_id"]
+    doc = conn.execute(
+        "INSERT INTO document (sha256, person_id, doc_date, source_path, ocr_text, "
+        "ingested_at) VALUES (?, ?, ?, ?, ?, ?)",
+        (f"sha-{uuid.uuid4()}", pid, "2026-01-01", "aa/vitals.pdf", "clinic vitals",
+         "2026-01-01T00:00:00"),
+    ).lastrowid
+    conn.commit()
+    dedup.commit_extraction(conn, doc, {"observation": rows or []}, d)
+    conn.close()
+
+
+def test_trends_charts_a_vital_key(ready, capsys):
+    """A vitals series prints through the existing formatter and carries the same
+    `--json` key set a lab series does -- no new keys, no vitals branch."""
+    _seed_vitals(ready, rows=[
+        {"obs_type": "vital", "observed_at": "2026-01-01", "key": "Temperature",
+         "value_num": 37.0, "unit": "degC"},
+        {"obs_type": "vital", "observed_at": "2026-02-01", "key": "Temperature",
+         "value_num": 38.0, "unit": "degC"},
+    ])
+    assert _run(ready, "trends", "--person", "jane-doe", "--test", "temperature",
+                *DICT_ARG) == 0
+    out = capsys.readouterr().out
+    assert "temperature  (2 point(s))" in out
+    assert "latest 38.0 degC  @ 2026-02-01" in out
+
+    assert _run(ready, "trends", "--person", "jane-doe", "--test", "temperature",
+                *DICT_ARG, "--json") == 0
+    vital = json.loads(capsys.readouterr().out)
+    assert _run(ready, "trends", "--person", "jane-doe", "--test", "hba1c",
+                *DICT_ARG, "--json") == 0
+    lab = json.loads(capsys.readouterr().out)
+    assert set(vital) == set(lab)
+    assert vital["count"] == 2 and vital["latest_at"] == "2026-02-01"
+
+
+def test_trends_ambiguous_test_is_a_friendly_error(ready, capsys):
+    """The one non-additive behaviour change must reach the user as rc=1 with an
+    `error:` line, never a traceback."""
+    _seed_vitals(ready, rows=[
+        {"obs_type": "vital", "observed_at": "2026-01-01", "key": "HbA1c",
+         "value_num": 6.1, "unit": "%"},
+    ])
+    assert _run(ready, "trends", "--person", "jane-doe", "--test", "hba1c",
+                *DICT_ARG) == 1
+    err = capsys.readouterr().err
+    assert err.startswith("error: ")
+    assert "lab results" in err and "vital observations" in err
+    assert "Traceback" not in err

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -667,3 +667,46 @@ def test_trends_ambiguous_test_is_a_friendly_error(ready, capsys):
     assert err.startswith("error: ")
     assert "lab results" in err and "vital observations" in err
     assert "Traceback" not in err
+
+
+def test_trends_converts_a_vitals_series_through_the_cli(ready, capsys):
+    """The point of #176: #136's canonical-unit machinery, which lives inside
+    `trends`, now reaches the vitals dimensions the units registry carries for it --
+    end to end through the real CLI, not just the query layer."""
+    _seed_vitals(ready, rows=[
+        {"obs_type": "vital", "observed_at": "2026-01-01", "key": "Temperature",
+         "value_num": 98.6, "unit": "degF"},
+        {"obs_type": "vital", "observed_at": "2026-02-01", "key": "Temperature",
+         "value_num": 37.8, "unit": "degC"},
+        {"obs_type": "vital", "observed_at": "2026-03-01", "key": "Temperature",
+         "value_num": 100.4, "unit": "degF"},
+    ])
+    assert _run(ready, "person", "unit-pref", "set", "jane-doe", "--key",
+                "Temperature", "--unit", "degC", *DICT_ARG) == 0
+    capsys.readouterr()
+
+    assert _run(ready, "trends", "--person", "jane-doe", "--test", "temperature",
+                *DICT_ARG) == 0
+    out = capsys.readouterr().out
+    assert "38.0 degC" in out                      # max, converted from 100.4 degF
+    assert "converted to degC (canonical unit for this key)" in out
+    assert "left in their stored unit" not in out  # nothing was left behind
+    assert out.isascii()
+    out.encode("cp437")
+
+    assert _run(ready, "trends", "--person", "jane-doe", "--test", "temperature",
+                *DICT_ARG, "--json") == 0
+    t = json.loads(capsys.readouterr().out)
+    assert t["unit"] == "degC" and t["canonical_unit"] == "degC"
+    assert t["converted_count"] == 2 and t["unconverted_count"] == 0
+    assert t["count"] == 3 and t["min"] == 37.0 and t["max"] == 38.0
+
+    # A point in a spelling `units` cannot convert is kept and disclosed, never dropped.
+    _seed_vitals(ready, rows=[
+        {"obs_type": "vital", "observed_at": "2026-04-01", "key": "Temperature",
+         "value_num": 37.2, "unit": "quatloos"},
+    ])
+    assert _run(ready, "trends", "--person", "jane-doe", "--test", "temperature",
+                *DICT_ARG, "--json") == 0
+    t = json.loads(capsys.readouterr().out)
+    assert t["count"] == 4 and t["unconverted_count"] == 1

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -141,6 +141,37 @@ def test_find_and_trends(seeded):
     assert tr["latest"] == 6.5
 
 
+def test_trends_charts_a_vital_key(seeded):
+    """Issue #176: the tool signature and payload shape are unchanged -- a vitals series
+    is shape-identical to a lab one."""
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _doc(seeded, "jane-doe", ocr="clinic vitals", doc_date="2026-03-01")
+    dedup.commit_extraction(seeded, doc, {"observation": [
+        {"obs_type": "vital", "observed_at": "2026-01-01", "key": "Weight",
+         "value_num": 88.0, "unit": "kg"},
+        {"obs_type": "vital", "observed_at": "2026-02-01", "key": "Weight",
+         "value_num": 86.0, "unit": "kg"},
+    ]}, d)
+    vital = mcp_server.trends(seeded, person="jane-doe", test="weight")
+    lab = mcp_server.trends(seeded, person="jane-doe", test="a1c")
+    assert set(vital) == set(lab)
+    assert vital["count"] == 2 and vital["latest"] == 86.0
+    assert vital["latest_at"] == "2026-02-01" and vital["unit"] == "kg"
+
+
+def test_trends_collision_is_a_tool_error_not_a_raw_exception(seeded):
+    """A `test` matching both tables is refused, and the refusal reaches the agent as a
+    `ToolError` like every other friendly failure in this wrapper."""
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _doc(seeded, "jane-doe", ocr="a1c measured twice over", doc_date="2026-04-01")
+    dedup.commit_extraction(seeded, doc, {"observation": [
+        {"obs_type": "vital", "observed_at": "2026-01-01", "key": "HbA1c",
+         "value_num": 6.1, "unit": "%"},
+    ]}, d)
+    with pytest.raises(mcp_server.ToolError, match="vital observations"):
+        mcp_server.trends(seeded, person="jane-doe", test="a1c")
+
+
 def test_find_household_wide_omits_person(seeded):
     # person omitted -> whole-household search; each hit attributes its owner
     hits = mcp_server.find(seeded, query_text="glucose")

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -814,3 +814,192 @@ def test_an_empty_exclusion_set_filters_nothing(seeded):
     assert query.query_timeline(
         seeded, "jane-doe", exclude_obs_types=frozenset()
     ) == full
+
+
+# --- trends: vitals series (issue #176) ---------------------------------------
+#
+# `trends` charts a measurement *key*, not a table: an `obs_type='vital'` observation
+# reaches the same statistics and the same #136 conversion a lab analyte does. A key that
+# matches numeric rows in both tables is refused rather than merged -- the #71 rule.
+
+@pytest.fixture()
+def vital_temps(seeded):
+    """One person's temperature recorded in degF by one clinic and degC by another, with
+    no `lab_result` counterpart anywhere."""
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _doc(seeded, "jane-doe", ocr="clinic vitals flowsheets")
+    dedup.commit_extraction(seeded, doc, {"observation": [
+        {"obs_type": "vital", "observed_at": "2026-01-01", "key": "Temperature",
+         "value_num": 98.6, "unit": "degF"},
+        {"obs_type": "vital", "observed_at": "2026-01-15", "key": "Temperature",
+         "value_num": 37.5, "unit": "degC"},
+        {"obs_type": "vital", "observed_at": "2026-02-01", "key": "Temperature",
+         "value_num": 100.4, "unit": "degF"},
+    ]}, d)
+    return seeded
+
+
+def test_trends_charts_a_vitals_series(vital_temps):
+    """The whole point of the issue: a key with zero lab rows still gets a series, dated
+    off `observed_at`."""
+    d = dedup.load_dictionary(DICT_PATH)
+    assert vital_temps.execute(
+        "SELECT COUNT(*) c FROM lab_result WHERE test_name LIKE '%emperature%'"
+    ).fetchone()["c"] == 0
+
+    t = query.trends(vital_temps, "jane-doe", "Temperature", dictionary=d)
+    assert t["test"] == "temperature"
+    assert t["count"] == 3
+    assert t["latest"] == 100.4 and t["latest_at"] == "2026-02-01"
+    assert t["latest_tie"] == 1
+    assert t["slope_per_day"] is not None
+    # No preference set, so the mixed spellings are reported honestly (the pre-#136 rule).
+    assert t["unit"] is None and t["min"] == 37.5 and t["max"] == 100.4
+
+
+def test_trends_converts_a_vitals_series_to_the_canonical_unit(vital_temps):
+    """#136's guarantee, now reachable by the population the registry's temperature
+    dimension exists for: stats and reported unit cannot disagree."""
+    d = dedup.load_dictionary(DICT_PATH)
+    units.set_pref(vital_temps, "jane-doe", "Temperature", "degC", dictionary=d)
+
+    t = query.trends(vital_temps, "jane-doe", "Temperature", dictionary=d)
+    assert t["canonical_unit"] == "degC"
+    assert t["converted_count"] == 2        # the two degF rows
+    assert t["unconverted_count"] == 0
+    assert t["unit"] == "degC"
+    # 98.6 degF is 37.0 degC and 100.4 degF is 38.0 -- not the degF magnitudes.
+    assert t["min"] == 37.0 and t["max"] == 38.0
+    assert t["latest"] == 38.0 and t["latest_at"] == "2026-02-01"
+
+
+def test_trends_keeps_and_discloses_an_unconvertible_vital_point(vital_temps):
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _doc(vital_temps, "jane-doe", ocr="thermometer with no scale printed")
+    dedup.commit_extraction(vital_temps, doc, {"observation": [
+        {"obs_type": "vital", "observed_at": "2026-02-15", "key": "Temperature",
+         "value_num": 99.0, "unit": "balmy"},
+    ]}, d)
+    units.set_pref(vital_temps, "jane-doe", "Temperature", "degC", dictionary=d)
+
+    t = query.trends(vital_temps, "jane-doe", "Temperature", dictionary=d)
+    assert t["count"] == 4                   # kept in the series, never dropped
+    assert t["converted_count"] == 2 and t["unconverted_count"] == 1
+    assert t["unit"] is None                 # falls back rather than mislabelling
+
+
+def test_trends_vitals_stored_rows_are_untouched(vital_temps):
+    """The conversion is a read-time transform on `observation` exactly as it is on
+    `lab_result`."""
+    d = dedup.load_dictionary(DICT_PATH)
+    before = [dict(r) for r in vital_temps.execute(
+        "SELECT * FROM observation ORDER BY observation_id"
+    ).fetchall()]
+    units.set_pref(vital_temps, "jane-doe", "Temperature", "degC", dictionary=d)
+    query.trends(vital_temps, "jane-doe", "Temperature", dictionary=d)
+    assert [dict(r) for r in vital_temps.execute(
+        "SELECT * FROM observation ORDER BY observation_id"
+    ).fetchall()] == before
+
+
+def test_trends_lab_only_series_is_unchanged(albumin_assays):
+    """Regression-free for every existing caller: a key with no vitals rows behaves
+    exactly as it did before the second source existed."""
+    d = dedup.load_dictionary(DICT_PATH)
+    t = query.trends(albumin_assays, "jane-doe", "hba1c", dictionary=d)
+    assert t["count"] == 3 and t["unit"] == "%"
+    assert t["min"] == 5.5 and t["max"] == 6.5
+    assert t["latest"] == 6.5 and t["latest_at"] == "2026-01-01"
+    assert t["other_assays"] == [] and t["other_assay_count"] == 0
+
+    alb = query.trends(albumin_assays, "jane-doe", "albumin", dictionary=d)
+    assert alb["count"] == 2
+    assert alb["other_assays"] == ["albumin (spep)"] and alb["other_assay_count"] == 1
+
+
+def test_trends_refuses_a_key_present_in_both_tables(vital_temps):
+    """A lab `Temperature` and a vital `Temperature` are two different measurements that
+    happen to share a token; interleaving them is the wrong chart #71 splits assays to
+    avoid, so the collision is refused, not resolved."""
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _doc(vital_temps, "jane-doe", ocr="specimen temperature")
+    dedup.commit_extraction(vital_temps, doc, {"lab_result": [
+        {"test_name": "Temperature", "collected_at": "2026-03-01", "value_num": 4.0,
+         "unit": "degC"},
+    ]}, d)
+
+    with pytest.raises(query.AmbiguousTestError) as excinfo:
+        query.trends(vital_temps, "jane-doe", "Temperature", dictionary=d)
+    message = str(excinfo.value)
+    assert "lab results" in message and "vital observations" in message
+    assert "1 numeric rows" in message and "(3)" in message
+    assert message.isascii()                 # reaches a cp1252/cp437 console
+
+
+def test_trends_refusal_ignores_a_non_numeric_collision(seeded):
+    """A `120/80` blood pressure lives in `value_text` and can never join a numeric
+    series, so it must neither trigger the refusal nor block a legitimate lab series."""
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _doc(seeded, "jane-doe", ocr="vitals with a text-only reading")
+    dedup.commit_extraction(seeded, doc, {"observation": [
+        {"obs_type": "vital", "observed_at": "2026-04-01", "key": "HbA1c",
+         "value_text": "not run"},
+    ]}, d)
+    t = query.trends(seeded, "jane-doe", "hba1c", dictionary=d)
+    assert t["count"] == 3 and t["latest"] == 6.5
+
+
+def test_trends_discloses_a_vitals_family_sibling_as_another_assay(seeded):
+    """One disclosure rule across both sources: the excluded row is named wherever it
+    lives, and its token pastes back as `--test` and finds it."""
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _doc(seeded, "jane-doe", ocr="clinic scale + dialysis flowsheet")
+    dedup.commit_extraction(seeded, doc, {
+        "observation": [
+            {"obs_type": "vital", "observed_at": "2026-01-01", "key": "Weight",
+             "value_num": 88.0, "unit": "kg"},
+        ],
+        "lab_result": [
+            {"test_name": "Weight (Post-dialysis)", "collected_at": "2026-01-02",
+             "value_num": 86.0, "unit": "kg"},
+        ],
+    }, d)
+
+    t = query.trends(seeded, "jane-doe", "weight", dictionary=d)
+    assert t["count"] == 1 and t["latest"] == 88.0
+    assert t["other_assays"] == ["weight (post-dialysis)"]
+    assert t["other_assay_count"] == 1
+    # The disclosed token pastes back and reaches the lab row it named.
+    back = query.trends(seeded, "jane-doe", t["other_assays"][0], dictionary=d)
+    assert back["count"] == 1 and back["latest"] == 86.0
+    assert back["other_assays"] == ["weight"]
+
+
+def test_trends_undated_vital_counts_but_never_wins_latest(vital_temps):
+    """`observed_at` is nullable by design for vitals. The point is disclosed in the
+    stats, dropped only from the slope -- the same treatment an undated lab row gets."""
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _doc(vital_temps, "jane-doe", ocr="undated flowsheet")
+    dedup.commit_extraction(vital_temps, doc, {"observation": [
+        {"obs_type": "vital", "key": "Temperature", "value_num": 101.0, "unit": "degF"},
+    ]}, d)
+
+    t = query.trends(vital_temps, "jane-doe", "Temperature", dictionary=d)
+    assert t["count"] == 4 and t["max"] == 101.0     # counted
+    assert t["latest"] == 100.4 and t["latest_at"] == "2026-02-01"   # never latest
+    assert t["slope_per_day"] is not None            # dropped from the fit, not fatal
+
+
+def test_trends_vitals_are_person_scoped(vital_temps):
+    """Both SELECTs are person-scoped, so the isolation invariant still holds."""
+    d = dedup.load_dictionary(DICT_PATH)
+    doc = _doc(vital_temps, "john-doe", ocr="john vitals")
+    dedup.commit_extraction(vital_temps, doc, {"observation": [
+        {"obs_type": "vital", "observed_at": "2026-05-01", "key": "Temperature",
+         "value_num": 36.0, "unit": "degC"},
+    ]}, d)
+
+    jane = query.trends(vital_temps, "jane-doe", "Temperature", dictionary=d)
+    john = query.trends(vital_temps, "john-doe", "Temperature", dictionary=d)
+    assert jane["count"] == 3 and john["count"] == 1
+    assert john["latest"] == 36.0


### PR DESCRIPTION
## Summary

`trends()` previously selected only `lab_result` rows, so vital signs (weight, height,
temperature, blood pressure, pulse, SpO2, ...) had no over-time view and #136's per-person
canonical-unit conversion — implemented inside `trends` itself — could never reach the four
vitals dimensions (mass, length, temperature, pressure) the units registry carries for exactly
that population.

- `trends()` now also selects `obs_type='vital'` `observation` rows, matched on `key_token()`
  the same way `lab_result.test_name` is matched today, with `observed_at` standing in for
  `collected_at`. The #136 conversion path and the #71 `other_assays`/`unconverted_count`
  disclosure rules apply identically — same guarantee, same result shape, no vitals-specific
  branch.
- A `--test` token that matches numeric rows in **both** `lab_result` and vitals `observation`
  is refused (`query.AmbiguousTestError`, surfaced as a friendly rc=1 at the CLI and `ToolError`
  at the MCP boundary), never silently merged — consistent with #71's reasoning that an
  interleaved series is a wrong chart.
- `OBS_VITAL` moved from `render` to `dedup` (import-edge fix: `query` now needs it too, and
  `query` must never import `render`).
- Read-only change: no migration, no write path touched, no CLI/MCP signature change.
- Docs fan-out (this PR): corrected `pemr trends --help` / `--test`'s help string (previously
  "one analyte" / "analyte name") and README's "lab `pemr trends`" framing, both now false since
  trends covers vitals too. `AGENTS.md` and `docs/Architecture.md` were already corrected by
  build.

Closes #176

## Reports

- Verify (full suite 1532 passed, real-run walk of every AC, A/B against `dev` for the
  regression-free ACs): https://github.com/meridun/pemr/issues/176#issuecomment-5336443495
- Audit (no blocking findings, four advisory notes — the help-text one addressed in this PR):
  https://github.com/meridun/pemr/issues/176#issuecomment-5336498802

🤖 Generated with [Claude Code](https://claude.com/claude-code)