### PR TITLE
fix(observations): harden the self-reported symptom/activity lanes (#180)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1138,6 +1138,8 @@ pemr trends --person jane --test hba1c                   # min/max/latest/slope
 pemr due --person jane                                   # screening/vaccine gaps — NOT IMPLEMENTED (phase 7)
 pemr render summary --person jane        > exports/jane-summary.md
 pemr render brief --appointment <id>     > exports/brief.md
+                                                         # --include-self-reported: also show symptom/activity
+                                                         # rows in Procedures & Observations (default: hidden, #180)
 pemr render journal --person jane        > exports/jane-journal.md
 pemr render curation --person jane       > exports/jane-curation.md  # curation audit trail (empty = no verdicts)
 pemr backup                                              # VACUUM INTO snapshot
@@ -1257,7 +1259,17 @@ default to the same exclusion unless a human explicitly decides otherwise.
   `pemr rekey`.
 - **appointment brief** — for a given upcoming appointment: relevant history for that
   specialty, recent labs/imaging, current meds, med-interaction flags, suggested
-  questions. This is your "walk-in readiness" as a repeatable command.
+  questions. This is your "walk-in readiness" as a repeatable command. Since issue #180,
+  `## Procedures & Observations` hides self-attested `symptom`/`activity` rows by
+  default (`include_self_reported: bool = False`, `--include-self-reported` /
+  `include_self_reported` on the CLI and MCP surfaces, mirroring `render_journal`'s
+  identical #167 flag) — a record with none renders byte-identically to before the
+  flag existed. Unlike the routine-procedures list (above) and order grouping's `+N
+  earlier` (#93), this suppression is **not disclosed on the page**: no `+N hidden`
+  line and no collapsed summary section catch the hidden rows in the brief itself
+  (they remain fully visible via `pemr query timeline`). This is a deliberate,
+  human-approved exception to the disclosed-suppression convention this section
+  otherwise follows — flagged at audit for the merge reviewer, not a bug.
 - **journal** — chronological event stream (documents + appointments + procedures)
   rendered as a narrative timeline.
 - **curation record** (issue #168) — the audit trail: every recorded verdict that removed a

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -3008,7 +3008,12 @@ def _cmd_render_summary(args: argparse.Namespace) -> int:
 def _cmd_render_brief(args: argparse.Namespace) -> int:
     def work(conn):
         dictionary = dedup.load_dictionary(_resolve_dictionary_path(args))
-        markdown = render.render_brief(conn, args.appointment, dictionary=dictionary)
+        markdown = render.render_brief(
+            conn,
+            args.appointment,
+            dictionary=dictionary,
+            include_self_reported=args.include_self_reported,
+        )
         return _emit_markdown(markdown, args.out)
 
     return _render_with_conn(args, work)
@@ -3862,6 +3867,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--appointment", type=int, required=True, help="appointment id"
     )
     r_brief.add_argument("--dictionary", help="synonym dictionary TOML (overrides default)")
+    r_brief.add_argument(
+        "--include-self-reported", dest="include_self_reported", action="store_true",
+        help="include self-reported symptom and activity observations (excluded by default)",
+    )
     r_brief.add_argument("--out", help="write to file instead of stdout")
     r_brief.set_defaults(func=_cmd_render_brief)
 

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -186,13 +186,26 @@ OBS_TYPE_REQUIRED: dict[str, frozenset[str]] = {
 # :data:`OBS_TYPE_REQUIRED` so the presence rule and the precision rule stay separately
 # readable and separately testable.
 #
-# Why a precision rule rather than a new dedup discriminator: `_norm_ts` already keeps
+# Why a precision rule rather than a new dedup discriminator: `norm_ts` already keeps
 # `observation.observed_at` at full precision, so two same-day reports at *different times*
 # already get distinct keys (Architecture.md §3). The collision a same-day repeat hits is
 # therefore not a key defect — it is what a date-only `observed_at` means. Mandating the
 # time on these two lanes fixes it without forking observation identity, and it preserves
 # the property that a correction at the *same* timestamp still collides as a CONFLICT.
 OBS_TYPE_REQUIRES_TIME: frozenset[str] = SELF_REPORTED_OBS_TYPES
+
+# Obs_types whose `value_num` carries a bounded scale, checked at write time right after
+# the precision rule (issue #180). Inclusive bounds. Kept a separate name from its two
+# neighbours above for the same reason they are separate from each other: one rule, one
+# name, one test.
+#
+# `symptom` alone: its `value_num` is the 0-10 severity issue #167 defined and renders as
+# `severity N/10`, so `50` is a data-entry error the document would otherwise repeat back
+# as fact. `OBS_ACTIVITY` is deliberately absent -- it shares the column but stores
+# *minutes*, which has no defensible upper bound, so a column-wide rule would be wrong.
+# The lower bound is inclusive because `value_num == 0` is the "reported resolved"
+# sentinel (see `render._self_reported_symptoms`), not an out-of-range value.
+OBS_TYPE_VALUE_RANGE: dict[str, tuple[float, float]] = {OBS_SYMPTOM: (0.0, 10.0)}
 
 _WS = re.compile(r"\s+")
 # Capturing group so the same pattern both removes a parenthetical (`sub`, giving the
@@ -277,6 +290,18 @@ def _has_time_component(value: str) -> bool:
     ``len(value) > 10`` guard keeps a shorter value from ever indexing out of range.
     """
     return len(value) > 10 and value[10] in ("T", " ")
+
+
+def _is_blank(value: object) -> bool:
+    """True for a value that is *missing* in the sense a required-field rule means.
+
+    ``None`` and a whitespace-only string are the two spellings of the same absence
+    (issue #180): a presence-only ``is None`` test accepts ``key=""`` and renders a
+    blank-labelled symptom line -- precisely the untyped blob the self-attested lanes
+    exist to prevent. Non-strings (a REAL ``0.0``, say) are never blank: only text can
+    be present-but-empty.
+    """
+    return value is None or (isinstance(value, str) and not value.strip())
 
 
 # --------------------------------------------------------------------------- #
@@ -469,18 +494,24 @@ def _date_only(value: object) -> str:
     return text.replace("T", " ").split(" ")[0]
 
 
-def _norm_ts(value: object) -> str:
-    """Normalize an ISO date/datetime for use as a dedup-key identity part, keeping
-    *full precision* (unlike :func:`_date_only`, which truncates to the date).
+def norm_ts(value: object) -> str:
+    """Normalize an ISO date/datetime for use as a sortable/comparable identity part,
+    keeping *full precision* (unlike :func:`_date_only`, which truncates to the date).
 
-    Its one remaining consumer is ``observation.observed_at``: a timestamped
+    Its dedup consumer is ``observation.observed_at``: a timestamped
     observation (``2026-01-02T09:00``) and a bare-date one (``2026-01-02``) stay
     distinct, and two observations on the same day at different times keep distinct
     keys, so serial same-day repeats survive as separate rows. A re-read/correction of
     the *same* observation carries the same timestamp, collides, and surfaces as a
     CONFLICT via :data:`_COMPARE_FIELDS`. Only the ``T``/space separator and
     surrounding/collapsed whitespace are normalized, so trivial formatting differences
-    don't fork the key."""
+    don't fork the key.
+
+    Public (issue #180) because the render layer needs the same normalization for its
+    newest-wins ordering: the raw string sorts ``T`` (0x54) *after* a space (0x20), so a
+    space-separated 20:00 row loses "latest" to a ``T``-separated 09:00 one on the same
+    date. Ordering and comparing through this function is what makes the two spellings
+    of one timestamp sort as one."""
     if value is None:
         return ""
     return _WS.sub(" ", str(value).strip().replace("T", " "))
@@ -522,7 +553,7 @@ def _key_parts(
     if record_type == "appointment":
         return [person_id, n("provider"), _date_only(row.get("scheduled_for"))]
     if record_type == "observation":
-        return [person_id, n("obs_type"), _norm_ts(row.get("observed_at")), kt("key")]
+        return [person_id, n("obs_type"), norm_ts(row.get("observed_at")), kt("key")]
     # allergy/condition are DATE-FREE by design: they are standing facts restated on
     # every document with inconsistent or absent dates, so a date in the key would fork
     # one allergy into one row per document. The dates are payload, and a disagreement
@@ -676,8 +707,11 @@ def validate_row(record_type: str, row: object) -> None:
         # Matched verbatim (not via enum_token): `obs_type` is stored as written and every
         # reader selects on it with `=`, so a rule keyed to a normalized spelling would
         # bind a value that then renders nowhere.
+        # `_is_blank`, not `is None` (issue #180): `key=""` is missing in exactly the
+        # sense this rule means, and the message text is unchanged so the two spellings
+        # of keyless read identically to a human and to the CLI's error assertions.
         for field in sorted(OBS_TYPE_REQUIRED.get(row["obs_type"], frozenset())):
-            if row.get(field) is None:
+            if _is_blank(row.get(field)):
                 raise ValidationError(
                     f"observation: missing required field '{field}' "
                     f"for obs_type={row['obs_type']!r}"
@@ -694,6 +728,19 @@ def validate_row(record_type: str, row: object) -> None:
                 f"of day (YYYY-MM-DDTHH:MM), got {row['observed_at']!r} - two reports of "
                 "one key on the same day would otherwise dedup into a single row"
             )
+        # Last of the three, for the same ordering reason: the per-field loop has already
+        # proven `value_num` is a number (`_NUM`), so the comparison below is safe here
+        # and only here. Write-time only -- rows already stored out of range keep
+        # rendering as stored; clamping at render time would make the document disagree
+        # with the row it claims to display (issue #180).
+        bounds = OBS_TYPE_VALUE_RANGE.get(row["obs_type"])
+        if bounds is not None and row.get("value_num") is not None:
+            lo, hi = bounds
+            if not lo <= float(row["value_num"]) <= hi:
+                raise ValidationError(
+                    f"observation.value_num: obs_type={row['obs_type']!r} expects a "
+                    f"severity in {lo:g}-{hi:g}, got {row['value_num']!r}"
+                )
 
 
 def _type_names(types: object) -> str:

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -491,15 +491,29 @@ def render_summary(conn: sqlite3.Connection, *, person: str) -> dict[str, str]:
     return {"markdown": markdown}
 
 
-def render_brief(conn: sqlite3.Connection, *, appointment: int) -> dict[str, str]:
+def render_brief(
+    conn: sqlite3.Connection,
+    *,
+    appointment: int,
+    include_self_reported: bool = False,
+) -> dict[str, str]:
     """[read] Walk-in brief for one appointment -> Markdown. Mirrors ``pemr render brief``.
 
     The Markdown carries a placeholder "Medication Interaction Review" section; per
     ``AGENTS.md`` the agent fills it from general knowledge under the mandated
     verify-with-a-pharmacist framing, and must never claim safety or give dosing advice.
+
+    ``include_self_reported`` mirrors the CLI's ``--include-self-reported`` (issue #180),
+    a pass-through with no logic of its own: the two surfaces must not drift about what
+    the brief contains.
     """
     try:
-        markdown = _render.render_brief(conn, appointment, dictionary=_dictionary())
+        markdown = _render.render_brief(
+            conn,
+            appointment,
+            dictionary=_dictionary(),
+            include_self_reported=include_self_reported,
+        )
     except (db.NotMigratedError, _render.AppointmentNotFoundError) as exc:
         raise _friendly(exc) from exc
     return {"markdown": markdown}
@@ -624,8 +638,14 @@ def build_server():  # pragma: no cover - exercised only with the mcp SDK instal
         return _run(render_summary, person=person)
 
     @server.tool(name="render_brief", annotations=ro)
-    def render_brief_tool(appointment: int) -> dict:
-        return _run(render_brief, appointment=appointment)
+    def render_brief_tool(
+        appointment: int, include_self_reported: bool = False
+    ) -> dict:
+        return _run(
+            render_brief,
+            appointment=appointment,
+            include_self_reported=include_self_reported,
+        )
 
     @server.tool(name="render_journal", annotations=ro)
     def render_journal_tool(

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -136,6 +136,7 @@ from .dedup import (
     is_attested,
     key_token,
     norm,
+    norm_ts,
 )
 
 # Observation obs_type conventions this layer reads (see module docstring).
@@ -569,6 +570,23 @@ def _allergy_line(row: dict) -> str:
     )
 
 
+def _obs_sort_key(row: dict) -> tuple[str, int]:
+    """Chronological sort key for an ``observation`` row: newest-wins, in Python.
+
+    Why not a second SQL sort key: SQLite cannot call :func:`dedup.norm_ts`, and the raw
+    string is exactly the defect (issue #180). ``observed_at`` is stored verbatim and both
+    ``2026-08-18T09:00`` and ``2026-08-18 20:00`` validate, but ``T`` (0x54) sorts *after*
+    a space (0x20) -- so the 09:00 row lexicographically outranks the 20:00 one and wins
+    "latest" on a section that folds ascending-last-wins. Normalizing the separator makes
+    the two spellings of one timestamp order as one.
+
+    The SQL ``ORDER BY observed_at, observation_id`` stays as the deterministic base
+    fetch; this is the authority applied on top of it. ``observation_id`` keeps the
+    same tiebreak the SQL had, so equal timestamps still resolve by insertion order.
+    """
+    return (norm_ts(row["observed_at"]), row["observation_id"])
+
+
 def _latest_vitals(
     conn: sqlite3.Connection,
     person_id: int,
@@ -587,8 +605,10 @@ def _latest_vitals(
         (person_id, OBS_VITAL),
     ).fetchall()
     # Curation runs before the latest-wins fold, so a superseded reading cannot win
-    # "latest" and hide the good one behind it.
-    kept = _apply_curation([dict(r) for r in rows], "observation", cur)
+    # "latest" and hide the good one behind it. The re-sort runs first of all: the fold
+    # below is ascending-last-wins, so a mis-ordered row wins "latest" silently.
+    obs = sorted((dict(r) for r in rows), key=_obs_sort_key)
+    kept = _apply_curation(obs, "observation", cur)
     latest: dict[str, dict] = {}
     for r in kept:
         latest[key_token(r["key"], dictionary)] = r  # ascending -> last wins
@@ -630,7 +650,9 @@ def _self_reported_symptoms(
         "ORDER BY observed_at, observation_id",
         (person_id, OBS_SYMPTOM),
     ).fetchall()
-    kept = _apply_curation([dict(r) for r in rows], "observation", cur)
+    kept = _apply_curation(
+        sorted((dict(r) for r in rows), key=_obs_sort_key), "observation", cur
+    )
 
     anchor = _as_date(today)
     start = None if anchor is None else anchor - timedelta(days=_SYMPTOM_WINDOW_DAYS)
@@ -646,7 +668,7 @@ def _self_reported_symptoms(
         )
         entry["label"] = r["key"]
         entry["count"] += 1
-        entry["sort"] = r["observed_at"] or ""
+        entry["sort"] = norm_ts(r["observed_at"])
         if r["value_num"] == 0:
             entry["resolved"] = r
         else:
@@ -693,8 +715,11 @@ def _symptom_line(entry: dict) -> str:
             head += f" (severity {_severity(latest['value_num'])}/10)"
     # A resolution older than the newest present report is not news; only a resolution
     # that is the last word on the complaint earns the clause.
+    # Compared through `norm_ts`, not raw strings: the two rows can spell the same
+    # timestamp with a `T` or a space, and `T` sorts after the space (issue #180).
     if resolved is not None and (
-        latest is None or str(resolved["observed_at"]) > str(latest["observed_at"])
+        latest is None
+        or norm_ts(resolved["observed_at"]) > norm_ts(latest["observed_at"])
     ):
         head += f"; last reported resolved {_date_part(resolved['observed_at'])}"
 
@@ -977,8 +1002,11 @@ def _grouped_orders(
         (person_id, OBS_ORDER),
     ).fetchall()
     # Before the grouping fold: a superseded order must not become the group's
-    # "latest" row and speak for the ones behind it.
-    kept = _apply_curation([dict(r) for r in rows], "observation", cur)
+    # "latest" row and speak for the ones behind it. Sorted first, for the same reason
+    # -- `members[-1]` below is the group's latest only if the sequence is chronological.
+    kept = _apply_curation(
+        sorted((dict(r) for r in rows), key=_obs_sort_key), "observation", cur
+    )
     groups: dict[object, list[dict]] = {}
     for r in kept:
         token = key_token(r["key"], dictionary) or key_token(r["value_text"], dictionary)
@@ -1439,6 +1467,7 @@ def render_brief(
     *,
     dictionary: dict[str, str] | None = None,
     recent_labs: int = _BRIEF_RECENT_LABS,
+    include_self_reported: bool = False,
     now: datetime | None = None,
 ) -> str:
     """Markdown walk-in brief for one appointment: the appointment header, current meds,
@@ -1452,8 +1481,19 @@ def render_brief(
 
     Med-interaction flags and suggested questions require external drug knowledge and are
     NOT deterministic engine work (Architecture.md §Open questions); a placeholder section
-    is rendered here for the phase-5 agent layer to fill. Raises
-    :class:`AppointmentNotFoundError` for an unknown id (friendly rc=1)."""
+    is rendered here for the phase-5 agent layer to fill.
+
+    ``include_self_reported`` opts the ``symptom``/``activity`` lanes back into
+    ``## Procedures & Observations``, mirroring :func:`render_journal`'s identical flag
+    (issue #180). **Off by default** and for the same reason: that section is uncapped, so
+    a few hundred self-attestations a year push the clinician-sourced observations this
+    document exists to carry off the top of it. An opt-in rather than a row cap because a
+    cap would silently drop the clinician rows instead once the tail is long -- a worse
+    failure than the one being fixed. The rows stay reachable unfiltered through
+    ``pemr query timeline``, and the summary's collapsed ``## Self-Reported Symptoms``
+    section remains the useful reading of them.
+
+    Raises :class:`AppointmentNotFoundError` for an unknown id (friendly rc=1)."""
     db.require_migrated(conn)
     appt = conn.execute(
         "SELECT * FROM appointment WHERE appointment_id = ?", (appointment_id,)
@@ -1535,17 +1575,26 @@ def render_brief(
         "procedure",
         cur,
     )
-    obs_rows = _apply_curation(
-        [
-            dict(r) for r in conn.execute(
-                "SELECT * FROM observation WHERE person_id = ? "
-                "ORDER BY observed_at DESC, observation_id",
-                (person_id,),
-            ).fetchall()
-        ],
-        "observation",
-        cur,
+    # Placeholders generated from the frozenset rather than interpolated, so the lane
+    # names stay parameters and the query stays one statement whichever way the flag goes.
+    excluded = () if include_self_reported else tuple(sorted(SELF_REPORTED_OBS_TYPES))
+    obs_filter = (
+        f" AND obs_type NOT IN ({', '.join('?' * len(excluded))})" if excluded else ""
     )
+    obs_fetched = [
+        dict(r) for r in conn.execute(
+            "SELECT * FROM observation WHERE person_id = ?" + obs_filter
+            + " ORDER BY observed_at DESC, observation_id",
+            (person_id, *excluded),
+        ).fetchall()
+    ]
+    # Re-sorted through `norm_ts` for the same reason as `_obs_sort_key`'s docstring gives
+    # (issue #180). Two stable passes rather than one `reverse=True` composite: the two
+    # fields sort in *opposite* directions here (newest date first, lowest id first within
+    # a date), which is the order the SQL `observed_at DESC, observation_id` expressed.
+    obs_fetched.sort(key=lambda r: r["observation_id"])
+    obs_fetched.sort(key=lambda r: norm_ts(r["observed_at"]), reverse=True)
+    obs_rows = _apply_curation(obs_fetched, "observation", cur)
     ctx_lines = []
     for p in proc_rows:
         outcome = f" - {p['outcome']}" if p["outcome"] else ""

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -1839,7 +1839,7 @@ def test_same_day_distinct_draw_is_staged_and_keep_both_admits_it(ready, capsys)
 
 
 def test_observation_keeps_its_full_precision_key_at_the_cli(ready, capsys):
-    """The scope boundary: `observation` was deliberately left on `_norm_ts`, so the
+    """The scope boundary: `observation` was deliberately left on `norm_ts`, so the
     same mixed-precision pair still forks there -- two rows, no conflict."""
     tmp_path = ready
     for name, observed_at in (("obs1.txt", "2026-04-02"), ("obs2.txt", "2026-04-02T07:30")):

--- a/tests/test_cli_phase4.py
+++ b/tests/test_cli_phase4.py
@@ -632,3 +632,58 @@ def test_a_person_with_no_self_reports_gets_no_symptom_section(ready, capsys):
     tmp_path, _ = ready
     assert _run(tmp_path, "render", "summary", "--person", "jane-doe") == 0
     assert "Self-Reported Symptoms" not in capsys.readouterr().out
+
+
+# --- brief filtering + severity range, through argv (issue #180) ---------------
+
+def test_brief_hides_self_reports_until_asked(ready, capsys):
+    """The same flag the journal already had, on the brief -- one vocabulary across the
+    render verbs, and both spellings exit 0."""
+    tmp_path, aid = ready
+    day = date.today() - timedelta(days=1)
+    assert _assert_symptom(tmp_path, f"{day}T09:00") == 0
+    assert _assert_symptom(tmp_path, f"{day}T07:30", key="morning walk",
+                           obs_type="activity", severity="40") == 0
+    capsys.readouterr()
+
+    assert _run(tmp_path, "render", "brief", "--appointment", str(aid)) == 0
+    default = capsys.readouterr().out
+    assert "right foot ache" not in default and "morning walk" not in default
+    assert "# Appointment Brief: Jane Doe" in default   # control: the doc is otherwise whole
+
+    assert _run(tmp_path, "render", "brief", "--appointment", str(aid),
+                "--include-self-reported") == 0
+    opted_in = capsys.readouterr().out
+    assert "symptom right foot ache" in opted_in
+    assert "activity morning walk" in opted_in
+
+
+def test_an_out_of_range_severity_assert_exits_non_zero(ready, capsys):
+    """The range rule is a refusal with a message that names the bound, not a crash --
+    and the ValidationError -> rc=1 mapping is intact."""
+    tmp_path, _ = ready
+    day = date.today() - timedelta(days=1)
+    assert _assert_symptom(tmp_path, f"{day}T09:00", severity="50") == 1
+    err = capsys.readouterr().err
+    assert "expects a severity in 0-10" in err
+    assert err.isascii()
+
+
+def test_an_out_of_range_activity_value_is_still_accepted(ready, capsys):
+    """The rule is obs_type-conditional: `activity` stores minutes, and 240 of them is a
+    long hike, not a data-entry error."""
+    tmp_path, _ = ready
+    day = date.today() - timedelta(days=1)
+    assert _assert_symptom(tmp_path, f"{day}T07:30", key="morning walk",
+                          obs_type="activity", severity="240") == 0
+
+
+def test_a_blank_key_assert_exits_non_zero(ready, capsys):
+    """The other spelling of keyless: `key=` is the untyped blob the lane exists to
+    prevent, and now reads as missing rather than rendering a blank-labelled line."""
+    tmp_path, _ = ready
+    day = date.today() - timedelta(days=1)
+    assert _assert_symptom(tmp_path, f"{day}T09:00", key="") == 1
+    err = capsys.readouterr().err
+    assert "missing required field 'key'" in err
+    assert err.isascii()

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1002,6 +1002,91 @@ def test_observation_identity_is_not_forked_by_obs_type():
     assert dedup._key_parts("observation", _symptom(value_num=9), 1) == parts
 
 
+# --- self-report write-time hardening (issue #180) ----------------------------
+
+@pytest.mark.parametrize("value_num", [-1, -0.5, 10.5, 11, 50])
+def test_validate_rejects_a_symptom_severity_out_of_range(value_num):
+    # `value_num=50` used to validate and render as `(severity 50/10)` -- the document
+    # repeating a data-entry error back as fact.
+    with pytest.raises(dedup.ValidationError) as exc:
+        dedup.validate_row("observation", _symptom(value_num=value_num))
+    message = str(exc.value)
+    assert "expects a severity in 0-10" in message   # names the rule
+    assert repr(value_num) in message                # names what it saw
+    assert message.isascii()                         # cp1252 console (issue #23)
+
+
+@pytest.mark.parametrize("value_num", [0, 0.0, 10, 10.0, 3.5, None])
+def test_validate_accepts_a_symptom_severity_at_the_bounds(value_num):
+    # Both bounds are inclusive, and `0` is load-bearing: it is the "reported resolved"
+    # sentinel the summary's symptom line reads. A NULL severity is a present report of
+    # unknown intensity and stays legal too.
+    dedup.validate_row("observation", _symptom(value_num=value_num))
+
+
+def test_activity_value_num_is_not_range_checked():
+    # The rule is obs_type-conditional, not column-wide: `activity` shares `value_num`
+    # but stores minutes, which has no defensible upper bound.
+    dedup.validate_row(
+        "observation",
+        {"obs_type": "activity", "key": "walk", "observed_at": "2026-08-16T07:30",
+         "value_num": 240, "unit": "min"},
+    )
+
+
+@pytest.mark.parametrize("obs_type", ["symptom", "activity"])
+@pytest.mark.parametrize("key", ["", " ", "\t", "  \n "])
+def test_validate_rejects_a_blank_key_self_report(obs_type, key):
+    # The second spelling of keyless: presence-only validation stopped `None` and let
+    # `""` through, rendering a blank-labelled symptom line. Same message as the `None`
+    # case above -- both are "missing" in the sense the rule means.
+    with pytest.raises(dedup.ValidationError,
+                       match=rf"missing required field 'key'.*{obs_type}"):
+        dedup.validate_row(
+            "observation",
+            {"obs_type": obs_type, "key": key, "observed_at": "2026-08-16T09:00",
+             "value_text": "sore"},
+        )
+
+
+def test_a_blank_observed_at_is_rejected_by_the_iso_check_first():
+    # Scoping note for the widened check: `observed_at` is a DATE_FIELD, so the per-field
+    # ISO loop rejects a whitespace-only value before the presence rule ever sees it --
+    # with the more specific message, which is the right one to keep. The widening
+    # therefore closes exactly one real hole (`key`), and blank dates stay rejected.
+    for obs_type in ("functional", "symptom", "activity"):
+        with pytest.raises(dedup.ValidationError, match=r"observed_at.*ISO date"):
+            dedup.validate_row(
+                "observation",
+                {"obs_type": obs_type, "key": "meal_regularity", "observed_at": "   ",
+                 "value_text": "skipping meals"},
+            )
+
+
+def test_the_blank_key_rule_holds_through_the_commit_path(conn):
+    doc = _make_document(conn)
+    with pytest.raises(dedup.ValidationError, match="missing required field 'key'"):
+        dedup.commit_extraction(conn, doc, {"observation": [_symptom(key="")]})
+    assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 0
+
+
+def test_the_severity_range_rule_holds_through_the_commit_path(conn):
+    doc = _make_document(conn)
+    with pytest.raises(dedup.ValidationError, match="expects a severity in 0-10"):
+        dedup.commit_extraction(conn, doc, {"observation": [_symptom(value_num=50)]})
+    assert conn.execute("SELECT COUNT(*) AS n FROM observation").fetchone()["n"] == 0
+
+
+def test_norm_ts_collapses_the_separator_spellings():
+    # The rename to a public name is what lets `render` share this (issue #180); the
+    # normalization itself is unchanged, and is why the two spellings sort as one.
+    assert dedup.norm_ts("2026-08-18T20:00") == dedup.norm_ts("2026-08-18 20:00")
+    assert dedup.norm_ts(None) == ""
+    # And the hazard it exists to fix: raw, the 09:00 row outranks the 20:00 one.
+    assert "2026-08-18 20:00" < "2026-08-18T09:00"
+    assert dedup.norm_ts("2026-08-18 20:00") > dedup.norm_ts("2026-08-18T09:00")
+
+
 # --- intra-payload collisions (issue #58) -------------------------------------
 
 def test_intra_payload_collision_with_differing_values_is_rejected(conn):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -734,3 +734,31 @@ def test_the_query_tool_still_returns_self_reports(seeded):
     events = mcp_server.query(seeded, kind="timeline", person="jane-doe")
     assert any("morning walk" in e["summary"] for e in events)
     assert any("right foot ache" in e["summary"] for e in events)
+
+
+# --- brief opt-in parity (issue #180) -----------------------------------------
+
+def test_render_brief_tool_mirrors_the_cli_default(seeded):
+    """The brief gains the journal's flag on both surfaces in one pass, or the two
+    verbs drift about what a brief contains."""
+    _attest_self_reports(seeded)
+    md = mcp_server.render_brief(seeded, appointment=_appt_id(seeded))["markdown"]
+    assert "right foot ache" not in md and "morning walk" not in md
+    assert "# Appointment Brief" in md          # control: the doc is otherwise whole
+
+
+def test_render_brief_tool_forwards_the_opt_in(seeded):
+    _attest_self_reports(seeded)
+    md = mcp_server.render_brief(
+        seeded, appointment=_appt_id(seeded), include_self_reported=True
+    )["markdown"]
+    assert "symptom right foot ache" in md
+    assert "activity morning walk" in md
+
+
+def test_the_brief_opt_in_registers_no_new_tool(seeded):
+    """A parameter, never a name -- the wire surface is unchanged."""
+    assert "render_brief" in mcp_server.READ_ONLY_TOOLS
+    assert set(mcp_server.TOOL_NAMES) == set(
+        mcp_server.READ_ONLY_TOOLS + mcp_server.WRITE_TOOLS
+    )

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -2174,9 +2174,9 @@ def test_self_reports_never_reach_the_problem_list(seeded):
     )
     brief_active = brief.split("## Active Problems")[1].split("\n## ")[0]
     assert "right foot ache" not in brief_active and "morning walk" not in brief_active
-    # The brief is otherwise deliberately untouched: its generic recent-observations list
-    # still shows the raw rows, tagged as attested. Only the *problem list* is off-limits
-    # to these lanes, and only the summary gains a collapsed section.
+    # The brief gains no collapsed section either -- that one stays the summary's. Its
+    # generic recent-observations list is opt-in for these lanes as of issue #180; the
+    # pair of tests below covers both sides of that flag.
     assert _SYMPTOM_HEADER not in brief
 
 
@@ -2245,3 +2245,97 @@ def test_journal_includes_self_reports_on_request(seeded):
     )
     assert "symptom right foot ache" in md
     assert "activity morning walk" in md
+
+
+# --- brief filtering + mixed-separator ordering (issue #180) -------------------
+
+_BRIEF_OBS_HEADER = "## Procedures & Observations"
+
+
+def _brief(conn, **kwargs):
+    return render.render_brief(
+        conn, _upcoming_appt_id(conn), dictionary=dedup.load_dictionary(DICT_PATH),
+        now=_SYMPTOM_NOW, **kwargs
+    )
+
+
+def _brief_observations(md):
+    return md.split(_BRIEF_OBS_HEADER)[1].split("\n## ")[0]
+
+
+def test_brief_hides_self_reports_by_default(seeded):
+    """The drowning failure mode #167 fixed for the journal, left open on the brief: the
+    section is uncapped, so a few hundred attestations a year push the clinician-sourced
+    observations the document exists to carry off the top of it."""
+    _seed_symptoms(seeded, [
+        _symptom_row("2026-08-16T09:00"),
+        _symptom_row("2026-08-16T07:30", key="morning walk", obs_type="activity",
+                     value_num=40),
+    ])
+    section = _brief_observations(_brief(seeded))
+    assert "right foot ache" not in section and "morning walk" not in section
+
+
+def test_brief_includes_self_reports_on_request(seeded):
+    _seed_symptoms(seeded, [
+        _symptom_row("2026-08-16T09:00"),
+        _symptom_row("2026-08-16T07:30", key="morning walk", obs_type="activity",
+                     value_num=40),
+    ])
+    section = _brief_observations(_brief(seeded, include_self_reported=True))
+    assert "symptom right foot ache" in section
+    assert "activity morning walk" in section
+
+
+def test_brief_still_shows_clinician_sourced_observations(seeded):
+    """The exclusion is scoped to the two self-attested lanes -- it drops no `vital`,
+    `order` or other clinician-sourced row."""
+    _seed_symptoms(seeded, [_symptom_row("2026-08-16T09:00")])
+    default = _brief_observations(_brief(seeded))
+    opted_in = _brief_observations(_brief(seeded, include_self_reported=True))
+    for row in seeded.execute(
+        "SELECT DISTINCT key FROM observation WHERE obs_type NOT IN ('symptom','activity')"
+        " AND key IS NOT NULL"
+    ).fetchall():
+        assert row["key"] in default, row["key"]
+        assert row["key"] in opted_in, row["key"]
+
+
+def test_a_record_without_self_reports_renders_a_byte_identical_brief(seeded):
+    """AC bullet 1's backward-compatibility half: the default output moves for records
+    that use the lanes, and for nobody else."""
+    before = _brief(seeded)
+    _seed_symptoms(seeded, [_symptom_row("2026-08-16T09:00")])
+    # john-doe's brief is a different appointment; jane's own brief is the one that
+    # changes. Seeding jane cannot move a byte of the sections that carry neither.
+    assert _brief_observations(_brief(seeded)) == _brief_observations(before)
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_symptom_latest_survives_a_mixed_separator_timestamp(seeded, reverse):
+    """The AC's named regression test. `T` (0x54) sorts after a space (0x20), so raw
+    lexicographic ordering made the 09:00 report outrank the 20:00 resolution and the
+    `; last reported resolved` clause silently vanished."""
+    rows = [
+        _symptom_row("2026-08-18T09:00", value_num=3),
+        _symptom_row("2026-08-18 20:00", value_num=0, value_text="fine now"),
+    ]
+    _seed_symptoms(seeded, list(reversed(rows)) if reverse else rows)
+    line = _line(_symptom_summary(seeded), "right foot ache")
+    assert "; last reported resolved 2026-08-18" in line
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_latest_vitals_picks_the_newest_across_mixed_separators(seeded, reverse):
+    """The same hazard on the `_latest_vitals` fold, which the symptom test does not
+    exercise: it shares the `ORDER BY observed_at` idiom and the ascending-last-wins
+    fold, so a mis-ordered pair silently renders the older reading."""
+    rows = [
+        {"obs_type": "vital", "key": "heart_rate", "observed_at": "2026-08-18T09:00",
+         "value_num": 61, "unit": "bpm"},
+        {"obs_type": "vital", "key": "heart_rate", "observed_at": "2026-08-18 20:00",
+         "value_num": 88, "unit": "bpm"},
+    ]
+    _seed_symptoms(seeded, list(reversed(rows)) if reverse else rows)
+    line = _line(_symptom_summary(seeded), "heart_rate")
+    assert "88" in line and "61" not in line


### PR DESCRIPTION
## Summary

Four independent hardening fixes for the self-attested `symptom`/`activity` observation lanes (issue #167), all flagged as advisories by audit on #167's own ship pass and bundled into #180:

1. **`render_brief`'s `## Procedures & Observations` no longer unconditionally shows self-reports.** New keyword-only `include_self_reported: bool = False` on `render_brief`, mirrored as `--include-self-reported` (CLI) and `include_self_reported` (MCP, pure pass-through, no new tool) — the same opt-in `render_journal` already got for #167. A record with no self-reported rows renders byte-identically to before.
2. **`observed_at` "latest wins" comparisons now go through `dedup.norm_ts`** (promoted from `_norm_ts`), fixing a real ordering hazard: mixed `T`/space separators on the same date could invert newest-wins and silently drop a `; last reported resolved` clause. Fixed at all four `ORDER BY observed_at` fold sites plus `_symptom_line`'s comparison.
3. **`symptom.value_num` is now range-checked at write time** (`OBS_TYPE_VALUE_RANGE`, inclusive 0-10; `activity`'s minutes value is deliberately unaffected).
4. **Blank/whitespace-only `key` is now rejected** for `symptom`/`activity` at write time, closing the one spelling of "keyless" the presence-only `is None` check didn't catch.

No schema change, no migration, no retroactive rewrite of stored rows — fixes 3-4 are write-time only; existing rows with an out-of-range `value_num` or a blank `key` stay stored and keep rendering.

**Docs (this PR's addition over the audited diff):** `docs/Architecture.md` §5/§6 now document the new `--include-self-reported` flag on `render brief`, and explicitly call out that the suppression is **not disclosed on the page** (no `+N hidden` line) — a deliberate, human-approved exception to the disclosed-suppression convention the rest of that section follows. See "Worth your attention" below.

Full design rationale, implementation plan, and per-fix detail are in the issue body's `## Implementation plan`. Verify and audit reports:
- Verify: https://github.com/meridun/pemr/issues/180#issuecomment-5336846372
- Audit: https://github.com/meridun/pemr/issues/180#issuecomment-5336913325

Closes #180

## Worth your attention at merge

Audit's advisory 1 (non-blocking, but flagged for the human gate): making `render_brief` hide self-reported rows by default is a deliberate step away from this codebase's usual "suppression is always disclosed on the page" convention (`+N earlier` orders, the routine-procedures list). The opt-in was the issue's sanctioned design choice — a row cap was considered and rejected because it could silently drop *clinician-sourced* rows, which is worse — but nothing in the brief today discloses that self-reports were hidden. A one-line `+N self-reported hidden` note would be a natural, fully-compatible follow-up if you want the convention closed.

## Test plan
- [x] Full suite green (`pytest`, 1556 passed, per verify's report)
- [x] `npm run check:meta-drift` clean
- [x] `npm run check:pii` clean
- [x] `npm run sync:claude-config:check` clean
- [x] Targeted regression tests added for all four fixes, including both mixed-separator insertion orders (AC bullet 3) and the legacy dedup-hash stability check (rename blast radius)

🤖 Generated with [Claude Code](https://claude.com/claude-code)