### PR TITLE
feat(records): disclose an in-place correction on the row (#134)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,12 @@ payload, same as `--json` — an agent reading `query` sees which rows a human h
 `superseded`, `erroneous-in-source`, `merged-into`, or `disputed`, and why. That is unchanged
 from the rule above: an agent may read a verdict, never write or clear one.
 
+The same read/write split applies to a `record edit` correction (issue #134): `query`,
+`render_summary` and `render_journal` disclose a corrected row's `edited_at`/`edited_by` on the
+MCP payload exactly when the row carries them (never a NULL pair), same as `--json` — an agent
+sees that a value was corrected and by whom, but `record edit` itself stays off the tool surface,
+so only a human at the CLI can make or clear a correction.
+
 ## MUST rules
 
 ### 1. Extraction naming

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -160,7 +160,9 @@ CREATE UNIQUE INDEX idx_curation_row ON curation(record_type, record_id)
 -- retiring one would destroy the audit trail the table exists to create, while a stale
 -- entry mis-renders nothing. `record rm` discloses (never deletes) the entries naming the
 -- row it removes, and the dedup_base breadcrumb tells a reader whether a later occupant
--- of that id is even the same family.
+-- of that id is even the same family. The row-level DISCLOSURE that a correction happened
+-- is a separate thing, stamped on the row itself (edited_at/edited_by, migration 016) -
+-- see "A corrected row says so" below.
 CREATE TABLE record_edit (
   record_edit_id INTEGER PRIMARY KEY,
   record_type    TEXT NOT NULL,    -- one of dedup.KNOWN_TYPES; validated in Python
@@ -199,6 +201,37 @@ An edit keeps the row's provenance exactly as it was; what changes is that the r
 divergence. The visible consequence: since `unit` is one of the compared payload fields
 (§4), re-ingesting the original document after a unit correction stages a **conflict**
 rather than deduping. That is the honest outcome, not a bug.
+
+**A corrected row says so** (migration 016, issue #134). Keeping the provenance intact
+creates a second obligation: the row is still filed under a document that never stated the
+corrected value, so on the page it would read as a verbatim quotation of that document.
+`record edit` therefore stamps two columns on the row in the same transaction as the
+UPDATE and its ledger rows — `edited_at` (the newest correction's ISO8601 UTC stamp) and
+`edited_by` (its `--attributed-to`, nullable) — and every renderer discloses them:
+`(corrected by <who> <date>)`, or `(corrected <date>)` when unattributed, appended at every
+line builder that already carries `_attest_suffix`, and carried on a `query timeline`
+event. This is #110's failure mode in mirror image, so it gets #110's shape: columns on the
+row, one predicate, one suffix builder, `dedup.public_row` stripping the pair while it is
+NULL so an uncorrected row's `--json`/MCP payload is unchanged.
+
+Columns rather than a read-time join on `record_edit`, which would need no migration and is
+unsound: ledger entries deliberately outlive their row and a record id is a reusable rowid
+alias, so a stale entry would caveat an unrelated later occupant (the #114 hazard). The
+mark on the row closes that by construction. The duplication is deliberate and one-way —
+the ledger is the field-level audit trail (`old -> new`, every correction), the columns are
+only the row-level "corrected, by whom, when" marker; last correction wins on the row, and
+`record edit --list` is where a human reconciles the two. The one-time backfill applies the
+same breadcrumb guard: a ledger entry whose `dedup_base` no longer matches the row's is
+skipped, so the upgrade can leave a rekeyed family unmarked but can never mark the wrong
+fact.
+
+The mark is not a lever: `edited_at`/`edited_by` are outside `dedup.FIELD_SPECS`, so they
+are unnameable by `record edit`, invisible to `dedup_key`/`rekey`, and an edit cannot forge
+its own disclosure. **Identity-field refinement stays out of scope** — moving one row's
+identity in place (a `condition.name` rename) is a rekey, not a correction: it recomputes
+`dedup_key`/`dedup_base`, can collide with a live family and re-anchors staged conflicts.
+`pemr rekey` owns that operation with full collision resolution when the two names are
+synonyms; `record rm` + re-commit owns the case where the stored fact is simply wrong.
 
 The **display-unit overlay** (migration 013, issue #136) — one canonical *display* unit
 per person per measurement key:
@@ -1092,7 +1125,8 @@ pemr record edit <table> <id> --set NAME=VALUE [--set ...] --note <text>
                  [--attributed-to ...] [--apply]         # correct a row's NON-KEY fields in place (§2 record_edit);
                                                          # document_id/dedup_key/source blob untouched; NAME= clears;
                                                          # identity fields refused (that is a dictionary edit + rekey);
-                                                         # every change ledgered; dry run by default
+                                                         # every change ledgered; the row is stamped edited_at/edited_by
+                                                         #        so render/query disclose it (§2); dry run by default
 pemr record edit --list [<table>] [--json]               # recorded corrections, newest first (field: old -> new)
 pemr record annotate <table> <base-or-id> --status <s> --note <text> [--attributed-to ...]
                      [--merged-into <base-or-id>] [--allow-cross-person] [--row] [--apply]

--- a/migrations/016_record_correction_mark.sql
+++ b/migrations/016_record_correction_mark.sql
@@ -52,6 +52,13 @@
 -- holds the truth; a correction caveat on an unrelated fact is a provenance lie, which is
 -- the whole class of failure this migration exists to prevent.
 --
+-- The guard narrows but does not eliminate the hazard: a recycled row id whose new occupant
+-- shares the SAME dedup_base (record rm then re-commit of the same fact, or another
+-- occurrence of the same family landing on the freed id) still matches the breadcrumb and
+-- is stamped. That is a spurious caveat, not a provenance lie - over-disclosure, which this
+-- migration's own reasoning treats as the safe direction to fail - so it is accepted rather
+-- than guarded against further.
+--
 -- Purely additive: ADD COLUMN + UPDATE, no table rebuild, safe under foreign_keys=ON.
 -- record_edit exists since 012 and migrations apply in order, so no guard is needed.
 -- Every Python reader goes through .get()/_row_get on a mapping, so a restored pre-016

--- a/migrations/016_record_correction_mark.sql
+++ b/migrations/016_record_correction_mark.sql
@@ -1,0 +1,170 @@
+-- 016_record_correction_mark: disclose an in-place correction on the row itself (issue #134).
+--
+-- `record edit` (012, issue #129) corrects a row's non-key field and ledgers the change,
+-- but nothing reads that ledger at read time - by design (012's header: "nothing resolves
+-- through this table"). The consequence is the gap #134 names: after a correction, `render`
+-- and `query` present the corrected value **identically to a value the document actually
+-- stated**. That is the exact twin of #110's failure - a row whose stored value no longer
+-- matches its source must never read as verbatim source text.
+--
+-- **Columns, not an overlay** - the 009 shape, not 008/012's. A correction stamp is the
+-- row's *own* provenance caveat: it means nothing without the row, and it must die with the
+-- row. So it lives beside document_id and attested_by, on the row.
+--
+-- **Why not derive it from the ledger at read time.** A `curation.load_verdicts`-style map
+-- keyed by (record_type, record_id) would need no new columns, and is unsound. Ledger
+-- entries deliberately outlive their row (012 header) and a record id is a reusable rowid
+-- alias (001/006), so a stale entry would mark an unrelated later occupant as "corrected" -
+-- the #114 hazard, here in its worst form: a false provenance caveat on someone else's
+-- fact. Closing it would need a retirement stamp written by both delete paths
+-- (records.remove_record, documents.remove_document) plus a join in the render hot path.
+-- Storing the mark on the row closes the hazard BY CONSTRUCTION and needs no join.
+--
+-- The resulting duplication with the ledger is acceptable precisely because the derived
+-- form is unsound: the ledger stays the field-level audit trail (old -> new, per field,
+-- append-only), and these two columns are only the row-level "this row was corrected, by
+-- whom, when" marker that render and query disclose. Last correction wins on the row; the
+-- ledger keeps every one. They are reconciled for a human by `record edit --list`, and
+-- nothing resolves through either.
+--
+-- No CHECK and no FK: SQLite's ALTER TABLE ADD COLUMN can add neither, and the invariants
+-- stay Python-side (pemr/records.py), which is 007's and 009's stated choice. No index:
+-- every reader already has the row in hand.
+--
+-- The columns are absent from dedup.FIELD_SPECS, so dedup_key/dedup_base/rekey and
+-- `record edit`'s own editable set are bit-identical for corrected and uncorrected rows -
+-- by construction, not by a denylist. dedup.public_row strips them when NULL, so an
+-- uncorrected row's --json / MCP payload keeps the exact key set it had before this
+-- migration (the additive-only rule).
+--
+-- Semantics:
+--   edited_at  the newest correction's ISO8601 UTC stamp (as record_edit.edited_at)
+--   edited_by  that correction's `--attributed-to`, or NULL - the ledger allows an
+--              unattributed correction, so the render has a date-only form
+--
+-- BACKFILL. Rows corrected before this migration are reconstructed from the newest ledger
+-- entry naming them, guarded by the entry's dedup_base breadcrumb (the 010/012 reading of
+-- that column: a breadcrumb, never a lookup key). The guard is the one-shot answer to the
+-- same row-id-reuse hazard as above - without it the backfill could stamp a later occupant
+-- of a recycled id. It trades a false positive for a false negative: a family rekeyed since
+-- its correction no longer matches its breadcrumb and is left unmarked. That is the right
+-- direction to fail. An unmarked corrected row is today's behaviour and the ledger still
+-- holds the truth; a correction caveat on an unrelated fact is a provenance lie, which is
+-- the whole class of failure this migration exists to prevent.
+--
+-- Purely additive: ADD COLUMN + UPDATE, no table rebuild, safe under foreign_keys=ON.
+-- record_edit exists since 012 and migrations apply in order, so no guard is needed.
+-- Every Python reader goes through .get()/_row_get on a mapping, so a restored pre-016
+-- snapshot reads as "not corrected" rather than raising `no such column`.
+
+ALTER TABLE lab_result  ADD COLUMN edited_at TEXT;
+ALTER TABLE lab_result  ADD COLUMN edited_by TEXT;
+
+ALTER TABLE medication  ADD COLUMN edited_at TEXT;
+ALTER TABLE medication  ADD COLUMN edited_by TEXT;
+
+ALTER TABLE procedure   ADD COLUMN edited_at TEXT;
+ALTER TABLE procedure   ADD COLUMN edited_by TEXT;
+
+ALTER TABLE appointment ADD COLUMN edited_at TEXT;
+ALTER TABLE appointment ADD COLUMN edited_by TEXT;
+
+ALTER TABLE observation ADD COLUMN edited_at TEXT;
+ALTER TABLE observation ADD COLUMN edited_by TEXT;
+
+ALTER TABLE allergy     ADD COLUMN edited_at TEXT;
+ALTER TABLE allergy     ADD COLUMN edited_by TEXT;
+
+ALTER TABLE condition   ADD COLUMN edited_at TEXT;
+ALTER TABLE condition   ADD COLUMN edited_by TEXT;
+
+UPDATE lab_result SET
+  edited_at = (SELECT e.edited_at FROM record_edit e
+               WHERE e.record_type = 'lab_result' AND e.record_id = lab_result.lab_result_id
+                 AND e.dedup_base = lab_result.dedup_base
+               ORDER BY e.edited_at DESC, e.record_edit_id DESC LIMIT 1),
+  edited_by = (SELECT e.attributed_to FROM record_edit e
+               WHERE e.record_type = 'lab_result' AND e.record_id = lab_result.lab_result_id
+                 AND e.dedup_base = lab_result.dedup_base
+               ORDER BY e.edited_at DESC, e.record_edit_id DESC LIMIT 1)
+WHERE EXISTS (SELECT 1 FROM record_edit e
+              WHERE e.record_type = 'lab_result' AND e.record_id = lab_result.lab_result_id
+                AND e.dedup_base = lab_result.dedup_base);
+
+UPDATE medication SET
+  edited_at = (SELECT e.edited_at FROM record_edit e
+               WHERE e.record_type = 'medication' AND e.record_id = medication.medication_id
+                 AND e.dedup_base = medication.dedup_base
+               ORDER BY e.edited_at DESC, e.record_edit_id DESC LIMIT 1),
+  edited_by = (SELECT e.attributed_to FROM record_edit e
+               WHERE e.record_type = 'medication' AND e.record_id = medication.medication_id
+                 AND e.dedup_base = medication.dedup_base
+               ORDER BY e.edited_at DESC, e.record_edit_id DESC LIMIT 1)
+WHERE EXISTS (SELECT 1 FROM record_edit e
+              WHERE e.record_type = 'medication' AND e.record_id = medication.medication_id
+                AND e.dedup_base = medication.dedup_base);
+
+UPDATE procedure SET
+  edited_at = (SELECT e.edited_at FROM record_edit e
+               WHERE e.record_type = 'procedure' AND e.record_id = procedure.procedure_id
+                 AND e.dedup_base = procedure.dedup_base
+               ORDER BY e.edited_at DESC, e.record_edit_id DESC LIMIT 1),
+  edited_by = (SELECT e.attributed_to FROM record_edit e
+               WHERE e.record_type = 'procedure' AND e.record_id = procedure.procedure_id
+                 AND e.dedup_base = procedure.dedup_base
+               ORDER BY e.edited_at DESC, e.record_edit_id DESC LIMIT 1)
+WHERE EXISTS (SELECT 1 FROM record_edit e
+              WHERE e.record_type = 'procedure' AND e.record_id = procedure.procedure_id
+                AND e.dedup_base = procedure.dedup_base);
+
+UPDATE appointment SET
+  edited_at = (SELECT e.edited_at FROM record_edit e
+               WHERE e.record_type = 'appointment' AND e.record_id = appointment.appointment_id
+                 AND e.dedup_base = appointment.dedup_base
+               ORDER BY e.edited_at DESC, e.record_edit_id DESC LIMIT 1),
+  edited_by = (SELECT e.attributed_to FROM record_edit e
+               WHERE e.record_type = 'appointment' AND e.record_id = appointment.appointment_id
+                 AND e.dedup_base = appointment.dedup_base
+               ORDER BY e.edited_at DESC, e.record_edit_id DESC LIMIT 1)
+WHERE EXISTS (SELECT 1 FROM record_edit e
+              WHERE e.record_type = 'appointment' AND e.record_id = appointment.appointment_id
+                AND e.dedup_base = appointment.dedup_base);
+
+UPDATE observation SET
+  edited_at = (SELECT e.edited_at FROM record_edit e
+               WHERE e.record_type = 'observation' AND e.record_id = observation.observation_id
+                 AND e.dedup_base = observation.dedup_base
+               ORDER BY e.edited_at DESC, e.record_edit_id DESC LIMIT 1),
+  edited_by = (SELECT e.attributed_to FROM record_edit e
+               WHERE e.record_type = 'observation' AND e.record_id = observation.observation_id
+                 AND e.dedup_base = observation.dedup_base
+               ORDER BY e.edited_at DESC, e.record_edit_id DESC LIMIT 1)
+WHERE EXISTS (SELECT 1 FROM record_edit e
+              WHERE e.record_type = 'observation' AND e.record_id = observation.observation_id
+                AND e.dedup_base = observation.dedup_base);
+
+UPDATE allergy SET
+  edited_at = (SELECT e.edited_at FROM record_edit e
+               WHERE e.record_type = 'allergy' AND e.record_id = allergy.allergy_id
+                 AND e.dedup_base = allergy.dedup_base
+               ORDER BY e.edited_at DESC, e.record_edit_id DESC LIMIT 1),
+  edited_by = (SELECT e.attributed_to FROM record_edit e
+               WHERE e.record_type = 'allergy' AND e.record_id = allergy.allergy_id
+                 AND e.dedup_base = allergy.dedup_base
+               ORDER BY e.edited_at DESC, e.record_edit_id DESC LIMIT 1)
+WHERE EXISTS (SELECT 1 FROM record_edit e
+              WHERE e.record_type = 'allergy' AND e.record_id = allergy.allergy_id
+                AND e.dedup_base = allergy.dedup_base);
+
+UPDATE condition SET
+  edited_at = (SELECT e.edited_at FROM record_edit e
+               WHERE e.record_type = 'condition' AND e.record_id = condition.condition_id
+                 AND e.dedup_base = condition.dedup_base
+               ORDER BY e.edited_at DESC, e.record_edit_id DESC LIMIT 1),
+  edited_by = (SELECT e.attributed_to FROM record_edit e
+               WHERE e.record_type = 'condition' AND e.record_id = condition.condition_id
+                 AND e.dedup_base = condition.dedup_base
+               ORDER BY e.edited_at DESC, e.record_edit_id DESC LIMIT 1)
+WHERE EXISTS (SELECT 1 FROM record_edit e
+              WHERE e.record_type = 'condition' AND e.record_id = condition.condition_id
+                AND e.dedup_base = condition.dedup_base);

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -124,6 +124,16 @@ INTERNAL_COLUMNS = ("dedup_key", "dedup_base", "dedup_occurrence")
 # bit-identical for attested and document-sourced rows alike.
 ATTESTATION_COLUMNS = ("attested_by", "attested_on", "attested_at")
 
+# Correction-disclosure columns on every record table (migration 016, issue #134).
+# The :data:`ATTESTATION_COLUMNS` shape for the same reason: they are the row's own
+# provenance caveat - "this stored value no longer matches what its source said" - so they
+# stay visible in the `--json`/MCP payloads rather than being stripped as internal. Equally
+# deliberately NOT in :data:`FIELD_SPECS`: they are engine-set, never accepted from an
+# extraction, unnameable by `record edit`, and their absence is what keeps every dedup key
+# bit-identical for corrected and uncorrected rows alike. The field-level audit trail lives
+# in the `record_edit` ledger; this pair is only the row-level marker the renderers read.
+EDIT_MARK_COLUMNS = ("edited_at", "edited_by")
+
 # Date-typed fields per record type. These feed timeline sort / trends date math and
 # the dedup_key (via _date_only), all of which assume a lexically-sortable ISO date —
 # so validate_row enforces ISO on them, not just the base `str` type. A partial
@@ -611,9 +621,10 @@ def editable_fields(record_type: str) -> tuple[str, ...]:
 
     The safety property `record edit` (issue #129) rests on: identity is excluded by
     **derivation**, not by a hand-maintained denylist. Provenance is excluded for free —
-    ``document_id``, ``person_id``, the ``dedup_*`` columns and
-    :data:`ATTESTATION_COLUMNS` are not in :data:`FIELD_SPECS` at all, so no caller
-    reading this list can name one.
+    ``document_id``, ``person_id``, the ``dedup_*`` columns,
+    :data:`ATTESTATION_COLUMNS` and :data:`EDIT_MARK_COLUMNS` are not in
+    :data:`FIELD_SPECS` at all, so no caller reading this list can name one — an edit can
+    no more forge its own correction stamp than it can rewrite its provenance.
     """
     if record_type not in FIELD_SPECS:
         raise ValueError(
@@ -795,15 +806,19 @@ def public_row(row: sqlite3.Row | dict) -> dict:
     contract. The attestation columns go only when they are **NULL**: a document-sourced
     row keeps the exact key set it had before migration 009 (the additive-only
     guarantee), while an attested row carries its provenance, which is the whole point of
-    the feature and must never be quietly stripped.
+    the feature and must never be quietly stripped. :data:`EDIT_MARK_COLUMNS` follow the
+    same rule for the same reason (migration 016): an uncorrected row's payload is
+    byte-identical to what it was before, while a corrected row discloses that its stored
+    value diverges from its source.
 
     One function rather than one rule per front door: a payload that discloses provenance
     at the CLI but not over MCP is the drift this feature can least afford.
     """
+    nullable_provenance = ATTESTATION_COLUMNS + EDIT_MARK_COLUMNS
     return {
         name: value for name, value in dict(row).items()
         if name not in INTERNAL_COLUMNS
-        and not (name in ATTESTATION_COLUMNS and value is None)
+        and not (name in nullable_provenance and value is None)
     }
 
 

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -240,7 +240,10 @@ def query_timeline(
 
     An event off a **human-attested** row (issue #110) additionally carries
     ``attested_by``/``attested_on``; a document-sourced event carries neither key, so an
-    unattested record's event shape is unchanged.
+    unattested record's event shape is unchanged. An event off a row **corrected in
+    place** by `record edit` (issue #134) likewise carries ``edited_at``/``edited_by``, so
+    a corrected value is distinguishable from one the document literally stated; an
+    uncorrected row's event carries neither key.
 
     ``with_identity=True`` additionally stamps ``record_type``, ``dedup_base`` and
     ``record_id`` on every event — the family identity `render_journal` needs to apply
@@ -292,6 +295,15 @@ def query_timeline(
         if _row_get(row, "attested_by"):
             event["attested_by"] = row["attested_by"]
             event["attested_on"] = _row_get(row, "attested_on")
+        # The correction mark (issue #134) travels on the same terms, and for the
+        # same reason: an event off a row whose stored value was edited in place must not
+        # read as a verbatim quotation of the document it is still filed under. Keyed off
+        # `edited_at` because `edited_by` is nullable (an unattributed correction is still
+        # a correction); an uncorrected row - or a restored pre-016 snapshot, where the
+        # columns do not exist - carries neither key.
+        if _row_get(row, "edited_at"):
+            event["edited_at"] = row["edited_at"]
+            event["edited_by"] = _row_get(row, "edited_by")
         if with_identity:
             event["record_type"] = record_type
             event["dedup_base"] = row["dedup_base"]

--- a/pemr/records.py
+++ b/pemr/records.py
@@ -433,6 +433,13 @@ def edit_record(
     value is not an audit trail. Every changed field is written to the append-only
     ``record_edit`` ledger in the **same transaction** as the UPDATE.
 
+    That same transaction stamps :data:`dedup.EDIT_MARK_COLUMNS` on the row (migration
+    016, issue #134), which is what makes the correction visible in ``render`` and
+    ``query``: the mark is **disclosure**, the ledger is the **audit trail**. A corrected
+    row must never read as a verbatim quotation of its source, and only the row itself can
+    say so safely — the ledger outlives its row by design, so deriving the mark from it at
+    read time would caveat whichever row later inherits a recycled id.
+
     Validation is entirely front-loaded — nothing is written on any raise. In order:
     schema present; known type; row exists; at least one update; every name editable;
     a real note; the merged payload passes :func:`dedup.validate_row` (so type, ISO-date
@@ -548,8 +555,17 @@ def edit_record(
         # without its audit trail is exactly the failure the trail exists to prevent
         # (the `curation.retire_row_verdicts` precedent). record_fts follows via the
         # per-table AFTER UPDATE triggers (migrations 003/006).
-        assignments = ", ".join(f"{c['field']} = ?" for c in changes)
-        values = [updates[c["field"]] for c in changes]
+        # The row also gets the correction *mark* (migration 016, issue #134) in the same
+        # statement: the payload change and its disclosure must land together or not at
+        # all. These two columns are outside FIELD_SPECS, so they can never collide with a
+        # named change. Last correction wins on the row; the ledger below keeps every one.
+        assignments = ", ".join(
+            [f"{c['field']} = ?" for c in changes]
+            + [f"{name} = ?" for name in dedup.EDIT_MARK_COLUMNS]
+        )
+        values = [
+            *(updates[c["field"]] for c in changes), stamp, report.attributed_to,
+        ]
         with conn:
             cur = conn.execute(
                 f"UPDATE {record_type} SET {assignments} WHERE {pk} = ?",

--- a/pemr/render.py
+++ b/pemr/render.py
@@ -101,6 +101,15 @@ every line builder: ``(attested by <who> <date>; no source document)``. It must 
 as a document-sourced fact. Once a document backs it the row is promoted and renders
 unmarked, like any other sourced fact.
 
+**Corrected rows** (issue #134). The mirror image: a row whose non-key field was fixed in
+place by `pemr record edit` keeps its original provenance, so without a mark it would read
+as a verbatim quotation of a document that never said that. :func:`_correction_suffix` tags
+it at the same every-line-builder set: ``(corrected by <who> <date>)``, or
+``(corrected <date>)`` when the correction was unattributed. Suffix order on any line
+carrying several is verdict, provenance, correction, display conversion --
+:func:`_dispute_suffix`, :func:`_attest_suffix`, :func:`_correction_suffix`,
+:func:`_unit_suffix`.
+
 **Display units** (issue #136). A person may record one canonical display unit per
 measurement key (``person_unit_pref``, migration 013). ``render_summary`` reads that
 overlay the way it reads ``curation`` -- once, at the top -- and converts Latest Vitals
@@ -443,6 +452,36 @@ def _attest_suffix(row: dict) -> str:
     return f"  (attested by {row['attested_by']}{stamp}; no source document)"
 
 
+def _correction_suffix(row: dict) -> str:
+    """``  (corrected by <who> <date>)`` for a row edited in place, ``""`` otherwise
+    (issue #134).
+
+    The :func:`_attest_suffix` contract, for the mirror-image failure. There, an unsourced
+    fact must never read as a document-sourced one; here, a fact whose stored value has
+    since been *changed* must never read as a verbatim quotation of the document it is
+    still filed under. `record edit` (issue #129) keeps the row's provenance deliberately
+    intact, so without this mark nothing on the page distinguishes the two. Same
+    mitigation shape: one predicate, one suffix builder, appended at **every** line builder
+    that renders a typed-table row.
+
+    Read off :data:`dedup.EDIT_MARK_COLUMNS` on the row (migration 016), never off the
+    ``record_edit`` ledger: ledger entries outlive their row and record ids are reusable,
+    so a read-time join would caveat an unrelated later occupant. ``edited_by`` is NULL
+    when the correction was unattributed, which renders the date-only form; the mapping
+    lacking the key at all (a restored pre-016 snapshot) reads as "not corrected".
+
+    Placed after :func:`_attest_suffix` and before :func:`_unit_suffix`: verdict, then
+    provenance, then the display conversion.
+    """
+    if not isinstance(row, dict):
+        return ""
+    when = _date_part(row.get("edited_at")) or ""
+    if not when:
+        return ""
+    who = str(row.get("edited_by") or "").strip()
+    return f"  (corrected by {who} {when})" if who else f"  (corrected {when})"
+
+
 def _unit_suffix(d: units.Displayed) -> str:
     """``  [converted from 77.6 kg]`` for a display-converted number, ``""`` otherwise
     (issue #136).
@@ -558,7 +597,7 @@ def _condition_line(row: dict, *, past: bool = False) -> str:
     note = f" - {row['note']}" if row["note"] else ""
     return (
         f"- {row['name']}{since}{resolved}{note}"
-        f"{_dispute_suffix(row)}{_attest_suffix(row)}"
+        f"{_dispute_suffix(row)}{_attest_suffix(row)}{_correction_suffix(row)}"
     )
 
 
@@ -568,7 +607,7 @@ def _allergy_line(row: dict) -> str:
     noted = f"  (noted {row['noted_on']})" if row["noted_on"] else ""
     return (
         f"- {row['substance']}{crit}{reaction}{noted}"
-        f"{_dispute_suffix(row)}{_attest_suffix(row)}"
+        f"{_dispute_suffix(row)}{_attest_suffix(row)}{_correction_suffix(row)}"
     )
 
 
@@ -728,7 +767,7 @@ def _symptom_line(entry: dict) -> str:
     anchor = latest if latest is not None else resolved
     if anchor is None:
         return head
-    return f"{head}{_dispute_suffix(anchor)}{_attest_suffix(anchor)}"
+    return f"{head}{_dispute_suffix(anchor)}{_attest_suffix(anchor)}{_correction_suffix(anchor)}"
 
 
 def _symptom_section(entries: list[dict]) -> str | None:
@@ -1067,7 +1106,7 @@ def _order_line(row: dict) -> str:
     # displayed row - the same rule `_dispute_suffix` already follows here.
     return (
         f"- {_order_display(row)}{detail}{note}"
-        f"{_dispute_suffix(row)}{_attest_suffix(row)}"
+        f"{_dispute_suffix(row)}{_attest_suffix(row)}{_correction_suffix(row)}"
     )
 
 
@@ -1186,7 +1225,7 @@ def _procedure_line(row: dict) -> str:
     who = f"  ({row['provider']})" if row["provider"] else ""
     return (
         f"- {_date_part(row['performed_on']) or '(undated)'}  {row['name']}"
-        f"{outcome}{who}{_dispute_suffix(row)}{_attest_suffix(row)}"
+        f"{outcome}{who}{_dispute_suffix(row)}{_attest_suffix(row)}{_correction_suffix(row)}"
     )
 
 
@@ -1357,7 +1396,8 @@ def render_summary(
         freq = f" {m['frequency']}" if m["frequency"] else ""
         since = f" (since {m['started_on']})" if m["started_on"] else ""
         med_lines.append(
-            f"- {m['name']}{dose}{freq}{since}{_dispute_suffix(m)}{_attest_suffix(m)}"
+            f"- {m['name']}{dose}{freq}{since}"
+            f"{_dispute_suffix(m)}{_attest_suffix(m)}{_correction_suffix(m)}"
         )
 
     active_lines = [
@@ -1369,7 +1409,7 @@ def render_summary(
     ]
     family_lines = [
         f"- {c['relation'] or 'family'}: {c['name']}"
-        f"{_dispute_suffix(c)}{_attest_suffix(c)}"
+        f"{_dispute_suffix(c)}{_attest_suffix(c)}{_correction_suffix(c)}"
         for c in _conditions(conn, person_id, CONDITION_FAMILY, cur)
     ]
     allergy_lines = [_allergy_line(a) for a in _allergies(conn, person_id, cur)]
@@ -1389,7 +1429,7 @@ def render_summary(
         when = f"  ({_date_part(v['observed_at'])})" if v["observed_at"] else ""
         vital_lines.append(
             f"- {v['key']}: {_fmt(value)}{unit}{when}"
-            f"{_dispute_suffix(v)}{_attest_suffix(v)}{_unit_suffix(d)}"
+            f"{_dispute_suffix(v)}{_attest_suffix(v)}{_correction_suffix(v)}{_unit_suffix(d)}"
         )
 
     symptom_section = _symptom_section(
@@ -1406,7 +1446,7 @@ def render_summary(
         lab_lines.append(
             f"- {_date_part(r['collected_at'])}  {r['test_name']}  "
             f"{_lab_value(shown)}{flag}{_ref_range(shown)}"
-            f"{_dispute_suffix(r)}{_attest_suffix(r)}{_unit_suffix(d)}"
+            f"{_dispute_suffix(r)}{_attest_suffix(r)}{_correction_suffix(r)}{_unit_suffix(d)}"
         )
 
     # Curation first, routine filter second (issue #166): an appendix-bound row has to be
@@ -1426,7 +1466,7 @@ def render_summary(
         proc_lines.append(f"\n{note}" if proc_lines else note)
 
     appt_lines = [
-        f"- {_appt_line(a)}{_dispute_suffix(a)}{_attest_suffix(a)}"
+        f"- {_appt_line(a)}{_dispute_suffix(a)}{_attest_suffix(a)}{_correction_suffix(a)}"
         for a in _open_appointments(conn, person_id, today, cur)
     ]
 
@@ -1528,7 +1568,7 @@ def render_brief(
         dose = f" {m['dose']}" if m["dose"] else ""
         freq = f" {m['frequency']}" if m["frequency"] else ""
         med_lines.append(
-            f"- {m['name']}{dose}{freq}{_dispute_suffix(m)}{_attest_suffix(m)}"
+            f"- {m['name']}{dose}{freq}{_dispute_suffix(m)}{_attest_suffix(m)}{_correction_suffix(m)}"
         )
 
     # Recency stays the primary axis, but a single draw can carry a 50+ analyte panel —
@@ -1563,7 +1603,8 @@ def render_brief(
         abnormal = f"  [!]{_ref_range(r)}" if _is_abnormal(r) else ""
         lab_lines.append(
             f"- {_date_part(r['collected_at'])}  {r['test_name']}  "
-            f"{_lab_value(r)}{flag}{abnormal}{_dispute_suffix(r)}{_attest_suffix(r)}"
+            f"{_lab_value(r)}{flag}{abnormal}"
+            f"{_dispute_suffix(r)}{_attest_suffix(r)}{_correction_suffix(r)}"
         )
 
     proc_rows = _apply_curation(
@@ -1602,7 +1643,7 @@ def render_brief(
         outcome = f" - {p['outcome']}" if p["outcome"] else ""
         ctx_lines.append(
             f"- {_date_part(p['performed_on']) or '(undated)'}  procedure: "
-            f"{p['name']}{outcome}{_dispute_suffix(p)}{_attest_suffix(p)}"
+            f"{p['name']}{outcome}{_dispute_suffix(p)}{_attest_suffix(p)}{_correction_suffix(p)}"
         )
     for o in obs_rows:
         value = o["value_num"] if o["value_num"] is not None else o["value_text"]
@@ -1610,7 +1651,7 @@ def render_brief(
         detail = " ".join(p for p in (o["obs_type"], o["key"]) if p)
         ctx_lines.append(
             f"- {_date_part(o['observed_at']) or '(undated)'}  {detail}{val}"
-            f"{_dispute_suffix(o)}{_attest_suffix(o)}"
+            f"{_dispute_suffix(o)}{_attest_suffix(o)}{_correction_suffix(o)}"
         )
 
     brief_allergy_lines = [_allergy_line(a) for a in _allergies(conn, person_id, cur)]
@@ -1720,7 +1761,7 @@ def render_journal(
         # the suffix is the only thing that says where the fact came from (issue #110).
         lines.append(
             f"- **{e['type']}** -- {e['summary']}{ref}"
-            f"{_dispute_suffix(e)}{_attest_suffix(e)}"
+            f"{_dispute_suffix(e)}{_attest_suffix(e)}{_correction_suffix(e)}"
         )
 
     if footnote_order:

--- a/tests/test_attestations.py
+++ b/tests/test_attestations.py
@@ -689,6 +689,8 @@ def test_public_row_keeps_an_unattested_payload_byte_identical(conn, jane):
     payload = dedup.public_row(row)
     assert not set(payload) & set(dedup.ATTESTATION_COLUMNS)
     assert not set(payload) & set(dedup.INTERNAL_COLUMNS)
+    # The correction mark (migration 016, issue #134) obeys the same rule.
+    assert not set(payload) & set(dedup.EDIT_MARK_COLUMNS)
     assert payload["document_id"] == doc
 
 

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -200,6 +200,36 @@ def test_query_timeline_json(ready, capsys):
     assert {"date", "type", "summary", "document_id"} <= set(events[0])
 
 
+def test_query_json_discloses_a_correction_only_on_the_corrected_row(ready, capsys):
+    """Issue #134 at the CLI front door: `--json` must carry the correction caveat on a
+    row `record edit` changed, and must be byte-identical to before on every row it did
+    not — the additive-only half of the contract, at the door the agent layer reads."""
+    def _json(*argv):
+        assert _run(ready, *argv, "--json") == 0
+        return json.loads(capsys.readouterr().out)
+
+    before_labs = _json("query", "labs", "--person", "jane-doe")
+    before_meds = _json("query", "meds", "--person", "jane-doe")
+    before_events = _json("query", "timeline", "--person", "jane-doe")
+    assert all("edited_at" not in r for r in before_labs + before_meds + before_events)
+
+    assert _run(ready, "record", "edit", "medication", str(before_meds[0]["medication_id"]),
+                "--set", "route=oral", "--note", "route omitted by the extraction",
+                "--attributed-to", "Dr. Smith", "--apply") == 0
+    capsys.readouterr()
+
+    meds = _json("query", "meds", "--person", "jane-doe")
+    assert meds[0]["edited_by"] == "Dr. Smith" and meds[0]["edited_at"]
+    assert {k: v for k, v in meds[0].items() if not k.startswith("edited_")} \
+        == {**before_meds[0], "route": "oral"}
+    assert _json("query", "labs", "--person", "jane-doe") == before_labs
+
+    events = _json("query", "timeline", "--person", "jane-doe")
+    assert [e["type"] for e in events if "edited_at" in e] == ["med-start"]
+    assert [e for e in events if "edited_at" not in e] \
+        == [e for e in before_events if e["type"] != "med-start"]
+
+
 def test_find_human_and_json(ready, capsys):
     assert _run(ready, "find", "--person", "jane-doe", "cholesterol") == 0
     assert "cholesterol" in capsys.readouterr().out.lower()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -52,6 +52,7 @@ ALL_MIGRATIONS = [
     "013_person_unit_pref.sql",
     "014_medication_status_reason.sql",
     "015_document_text_source.sql",
+    "016_record_correction_mark.sql",
 ]
 
 # Every record table carries the occurrence-family columns (migration 005; 006's two
@@ -142,11 +143,112 @@ def test_migration_015_applies_on_a_014_era_database_without_backfilling(
     )
     conn.commit()
 
-    assert db.migrate(conn) == ["015_document_text_source.sql"]
+    assert db.migrate(conn) == [
+        "015_document_text_source.sql", "016_record_correction_mark.sql",
+    ]
 
     row = conn.execute("SELECT * FROM document").fetchone()
     assert row["ocr_text"] == "hand typed"
     assert row["text_source"] is None
+
+
+def _migrate_through_015(conn, tmp_path):
+    """Apply every migration up to 015, leaving 016 pending (a 015-era database)."""
+    import shutil
+
+    staged = tmp_path / "pre016"
+    staged.mkdir()
+    for path in sorted(db.DEFAULT_MIGRATIONS_DIR.glob("*.sql")):
+        if path.name < "016":
+            shutil.copy(path, staged / path.name)
+    db.migrate(conn, staged)
+    return staged
+
+
+def _seed_pre016_lab(conn, row_id, base, key):
+    conn.execute(
+        "INSERT INTO lab_result (lab_result_id, person_id, test_name, collected_at, "
+        "unit, dedup_key, dedup_base) VALUES (?, 1, 'HbA1c', '2024-01-01', ?, ?, ?)",
+        (row_id, "percent", key, base),
+    )
+
+
+def _seed_ledger(conn, row_id, base, field, edited_at, attributed_to):
+    conn.execute(
+        "INSERT INTO record_edit (record_type, record_id, dedup_base, field, "
+        "old_value, new_value, note, attributed_to, edited_at) VALUES "
+        "('lab_result', ?, ?, ?, '%', 'percent', 'normalise', ?, ?)",
+        (row_id, base, field, attributed_to, edited_at),
+    )
+
+
+def test_record_tables_have_correction_mark_columns(conn):
+    """Migration 016 (issue #134): a corrected row says so on the row, so `render` and
+    `query` can disclose it without joining the ledger."""
+    db.migrate(conn)
+    for table in RECORD_TABLES:
+        cols = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+        assert {"edited_at", "edited_by"} <= cols, table
+
+
+def test_migration_016_backfills_the_newest_ledger_entry_per_row(conn, tmp_path):
+    """The upgrade path: rows corrected before the columns existed are reconstructed from
+    the ledger, newest entry wins, and an unattributed correction backfills a NULL
+    `edited_by` rather than being skipped."""
+    _migrate_through_015(conn, tmp_path)
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane', 'Jane')")
+    _seed_pre016_lab(conn, 1, "base-a", "base-a")
+    _seed_pre016_lab(conn, 2, "base-b", "base-b")
+    _seed_pre016_lab(conn, 3, "base-c", "base-c")     # never corrected
+    _seed_ledger(conn, 1, "base-a", "unit", "2026-01-01T00:00:00+00:00", "Jane")
+    _seed_ledger(conn, 1, "base-a", "flag", "2026-02-01T00:00:00+00:00", "Sam")
+    _seed_ledger(conn, 2, "base-b", "unit", "2026-01-15T00:00:00+00:00", None)
+    conn.commit()
+
+    assert db.migrate(conn) == ["016_record_correction_mark.sql"]
+
+    marks = {
+        row["lab_result_id"]: (row["edited_at"], row["edited_by"])
+        for row in conn.execute("SELECT * FROM lab_result").fetchall()
+    }
+    assert marks[1] == ("2026-02-01T00:00:00+00:00", "Sam")   # newest wins
+    assert marks[2] == ("2026-01-15T00:00:00+00:00", None)    # unattributed, still marked
+    assert marks[3] == (None, None)
+
+
+def test_migration_016_leaves_a_recycled_row_id_unmarked(conn, tmp_path):
+    """The row-id-reuse hazard (issue #114), answered at backfill time by the ledger's
+    `dedup_base` breadcrumb: a stale entry naming a *different* family must not stamp a
+    correction caveat onto whichever row later inherited the id."""
+    _migrate_through_015(conn, tmp_path)
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane', 'Jane')")
+    _seed_pre016_lab(conn, 1, "base-new", "base-new")
+    _seed_ledger(conn, 1, "base-gone", "unit", "2026-01-01T00:00:00+00:00", "Jane")
+    conn.commit()
+
+    db.migrate(conn)
+
+    row = conn.execute("SELECT * FROM lab_result").fetchone()
+    assert (row["edited_at"], row["edited_by"]) == (None, None)
+    # The ledger entry is kept regardless: nothing resolves through it (migration 012).
+    assert conn.execute("SELECT COUNT(*) AS n FROM record_edit").fetchone()["n"] == 1
+
+
+def test_a_pre016_snapshot_renders_and_queries_without_the_columns(conn, tmp_path):
+    """`restore` can bring back a database predating 016. Every reader goes through
+    `.get()`/`_row_get` on a mapping, so a missing column reads as "not corrected"
+    rather than raising `no such column`."""
+    from pemr import query, render
+
+    _migrate_through_015(conn, tmp_path)
+    conn.execute("INSERT INTO person (slug, full_name) VALUES ('jane', 'Jane')")
+    _seed_pre016_lab(conn, 1, "base-a", "base-a")
+    conn.commit()
+
+    md = render.render_summary(conn, "jane")
+    assert "corrected" not in md
+    events = query.query_timeline(conn, "jane")
+    assert all("edited_at" not in e for e in events)
 
 
 def test_person_has_deactivated_at_column(conn):
@@ -209,6 +311,7 @@ def test_migration_006_moves_condition_and_allergy_observations(conn, tmp_path):
         "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
         "012_record_edit.sql", "013_person_unit_pref.sql",
         "014_medication_status_reason.sql", "015_document_text_source.sql",
+        "016_record_correction_mark.sql",
     ]
 
     a = conn.execute("SELECT * FROM allergy").fetchone()
@@ -344,6 +447,7 @@ def test_migration_008_applies_on_a_007_era_database(conn, tmp_path):
         "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
         "012_record_edit.sql", "013_person_unit_pref.sql",
         "014_medication_status_reason.sql", "015_document_text_source.sql",
+        "016_record_correction_mark.sql",
     ]
 
     assert curation.has_table(conn) is True
@@ -398,6 +502,7 @@ def test_migration_009_applies_on_an_008_era_database(conn, tmp_path):
         "011_curation_distinct_status.sql", "012_record_edit.sql",
         "013_person_unit_pref.sql", "014_medication_status_reason.sql",
         "015_document_text_source.sql",
+        "016_record_correction_mark.sql",
     ]
 
     assert attestations.has_columns(conn) is True
@@ -450,6 +555,7 @@ def test_migration_010_rebuilds_curation_and_preserves_every_verdict(conn, tmp_p
         "010_curation_row_scope.sql", "011_curation_distinct_status.sql",
         "012_record_edit.sql", "013_person_unit_pref.sql",
         "014_medication_status_reason.sql", "015_document_text_source.sql",
+        "016_record_correction_mark.sql",
     ]
 
     after = [dict(r) for r in conn.execute(
@@ -536,6 +642,7 @@ def test_migration_011_widens_the_status_check_and_preserves_every_verdict(
         "011_curation_distinct_status.sql", "012_record_edit.sql",
         "013_person_unit_pref.sql", "014_medication_status_reason.sql",
         "015_document_text_source.sql",
+        "016_record_correction_mark.sql",
     ]
 
     after = [dict(r) for r in conn.execute(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import pytest
 
 from pemr import (
-    __version__, curation, db, dedup, ingest, mcp_server, persons, tombstones,
+    __version__, curation, db, dedup, ingest, mcp_server, persons, records, tombstones,
 )
 
 REPO = Path(__file__).resolve().parent.parent
@@ -130,6 +130,39 @@ def test_query_with_no_verdicts_carries_no_curation_key(seeded):
     for kind in ("labs", "meds", "timeline"):
         rows = mcp_server.query(seeded, kind=kind, person="jane-doe")
         assert rows and all("_curation" not in r for r in rows)
+
+
+def test_query_discloses_a_correction_only_on_the_corrected_row(seeded):
+    """Issue #134 at the MCP front door: the agent's structured read must see the same
+    correction caveat the human view renders, and only there. `dedup.public_row` is what
+    carries it, so the half worth proving here is the additive one — an *uncorrected*
+    row's payload keeps the exact key set it had before migration 016."""
+    before = {
+        kind: mcp_server.query(seeded, kind=kind, person="jane-doe")
+        for kind in ("labs", "meds", "timeline")
+    }
+    assert all("edited_at" not in r for rows in before.values() for r in rows)
+
+    med_id = seeded.execute(
+        "SELECT medication_id FROM medication WHERE name = 'Metformin'"
+    ).fetchone()["medication_id"]
+    records.edit_record(
+        seeded, "medication", med_id, {"route": "oral"},
+        note="route omitted by the extraction", attributed_to="Dr. Smith", apply=True,
+    )
+
+    meds = mcp_server.query(seeded, kind="meds", person="jane-doe")
+    assert meds[0]["edited_by"] == "Dr. Smith" and meds[0]["edited_at"]
+    assert {k: v for k, v in meds[0].items() if k not in dedup.EDIT_MARK_COLUMNS} \
+        == {**before["meds"][0], "route": "oral"}
+
+    # Untouched record types keep their exact payload — no NULL mark leaks out.
+    assert mcp_server.query(seeded, kind="labs", person="jane-doe") == before["labs"]
+
+    events = mcp_server.query(seeded, kind="timeline", person="jane-doe")
+    assert [e["type"] for e in events if "edited_at" in e] == ["med-start"]
+    assert [e for e in events if "edited_at" not in e] \
+        == [e for e in before["timeline"] if e["type"] != "med-start"]
 
 
 def test_find_and_trends(seeded):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -347,6 +347,35 @@ def test_timeline_stamps_attestation_only_on_attested_events(seeded):
     assert [e for e in after if "attested_by" not in e] == before
 
 
+def test_timeline_stamps_the_correction_mark_only_on_corrected_events(seeded):
+    """Issue #134, on the same terms as the attestation stamp above: an uncorrected
+    database's timeline JSON keeps its exact key set."""
+    from pemr import records
+
+    before = query.query_timeline(seeded, "jane-doe")
+    assert all("edited_at" not in e and "edited_by" not in e for e in before)
+
+    row_id = int(seeded.execute(
+        "SELECT medication_id FROM medication WHERE name = 'Metformin'"
+    ).fetchone()["medication_id"])
+    records.edit_record(
+        seeded, "medication", row_id, {"frequency": "daily"},
+        note="transcription slip", attributed_to="Aunt Ada",
+        now="2026-03-02T09:00:00+00:00", apply=True,
+    )
+
+    after = query.query_timeline(seeded, "jane-doe")
+    corrected = [e for e in after if "edited_at" in e]
+    assert [(e["edited_at"], e["edited_by"]) for e in corrected] == [
+        ("2026-03-02T09:00:00+00:00", "Aunt Ada")
+    ]
+    # The mark is the only difference: strip it and the stream is byte-identical.
+    mark = ("edited_at", "edited_by")
+    assert [
+        {k: v for k, v in e.items() if k not in mark} for e in after
+    ] == before
+
+
 def test_timeline_with_identity_stamps_family_and_row_keys(seeded):
     """Issues #109/#114: `render_journal` needs each event's family identity to apply
     the curation overlay and its **row** id to apply a row-scoped verdict; an event

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -724,9 +724,12 @@ def test_editable_fields_excludes_identity_and_never_names_provenance():
             set(dedup.FIELD_SPECS[record_type]) - dedup.KEY_FIELDS[record_type]
         )
         # Provenance is out for free: it was never in FIELD_SPECS to begin with.
+        # The correction mark (issue #134) joins that set: an edit must not be able to
+        # forge, clear or backdate its own disclosure.
         for column in ("document_id", "person_id", *dedup.INTERNAL_COLUMNS,
-                       *dedup.ATTESTATION_COLUMNS):
+                       *dedup.ATTESTATION_COLUMNS, *dedup.EDIT_MARK_COLUMNS):
             assert column not in editable
+            assert column not in dedup.FIELD_SPECS[record_type]
 
 
 def test_editable_fields_rejects_an_unknown_type():
@@ -897,6 +900,121 @@ def test_clearing_a_field_nulls_it_and_ledgers_the_old_value(seeded):
     assert _row(conn, "lab_result", target)["unit"] is None
     entry = _ledger(conn)[0]
     assert (entry["old_value"], entry["new_value"]) == ("%", None)
+
+
+# --- the correction mark (issue #134) ----------------------------------------
+
+
+def _mark(conn, record_type, row_id):
+    row = _row(conn, record_type, row_id)
+    return (row["edited_at"], row["edited_by"])
+
+
+def test_apply_stamps_the_correction_mark_and_it_matches_the_ledger(seeded):
+    """The disclosure and the audit trail agree, because they are written in one
+    transaction off one stamp."""
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    before = _row(conn, "lab_result", target)
+    assert _mark(conn, "lab_result", target) == (None, None)
+
+    report = records.edit_record(
+        conn, "lab_result", target, {"unit": "percent"},
+        note="normalise the unit", attributed_to="Jane", apply=True,
+    )
+
+    after = _row(conn, "lab_result", target)
+    assert (after["edited_at"], after["edited_by"]) == (report.edited_at, "Jane")
+    entry = _ledger(conn)[0]
+    assert (entry["edited_at"], entry["attributed_to"]) == (report.edited_at, "Jane")
+    # The mark is disclosure, never identity: the key machinery is untouched.
+    for column in (*dedup.INTERNAL_COLUMNS, "document_id", "person_id"):
+        assert after[column] == before[column], column
+
+
+def test_an_unattributed_correction_marks_the_date_only(seeded):
+    """`--attributed-to` is optional in the ledger, so the row's mark is nullable too."""
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    report = records.edit_record(conn, "lab_result", target, {"unit": "percent"},
+                                 note="normalise", apply=True)
+    assert _mark(conn, "lab_result", target) == (report.edited_at, None)
+
+
+def test_a_dry_run_stamps_no_mark(seeded):
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    records.edit_record(conn, "lab_result", target, {"unit": "percent"},
+                        note="normalise", attributed_to="Jane")
+    assert _mark(conn, "lab_result", target) == (None, None)
+
+
+def test_an_all_unchanged_edit_stamps_no_mark(seeded):
+    """Nothing diverged from the source, so nothing is disclosed - the `if apply and
+    changes` guard covers the mark exactly as it covers the ledger."""
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "Glucose")
+    report = records.edit_record(conn, "lab_result", target, {"value_num": 95},
+                                 note="restate", apply=True)
+    assert report.changes == []
+    assert _mark(conn, "lab_result", target) == (None, None)
+    assert _ledger(conn) == []
+
+
+def test_a_second_correction_overwrites_the_mark_and_the_ledger_keeps_both(seeded):
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    first = records.edit_record(conn, "lab_result", target, {"unit": "percent"},
+                                note="normalise", attributed_to="Jane", apply=True)
+    second = records.edit_record(conn, "lab_result", target, {"unit": "%"},
+                                 note="revert", attributed_to="Sam", apply=True)
+
+    assert first.edited_at is not None
+    assert _mark(conn, "lab_result", target) == (second.edited_at, "Sam")
+    entries = _ledger(conn)
+    assert len(entries) == 2                       # last correction wins on the row only
+    assert [e["attributed_to"] for e in entries] == ["Jane", "Sam"]
+
+
+@pytest.mark.parametrize("column", dedup.EDIT_MARK_COLUMNS)
+def test_the_mark_columns_cannot_be_edited_by_name(seeded, column):
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    before = _row(conn, "lab_result", target)
+    with pytest.raises(records.FieldNotEditableError, match="unknown lab_result field"):
+        records.edit_record(conn, "lab_result", target, {column: "2026-01-01"},
+                            note="forge a mark", apply=True)
+    _assert_untouched(conn, "lab_result", target, before)
+    assert _ledger(conn) == []
+
+
+def test_a_corrected_rows_dedup_key_is_unchanged(seeded):
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    before = _row(conn, "lab_result", target)
+    records.edit_record(conn, "lab_result", target, {"unit": "percent"},
+                        note="normalise", apply=True)
+    after = _row(conn, "lab_result", target)
+    payload = {name: after[name] for name in dedup.FIELD_SPECS["lab_result"]}
+    assert after["dedup_key"] == before["dedup_key"]
+    assert dedup.dedup_key("lab_result", payload, after["person_id"]) == \
+        before["dedup_key"]
+
+
+def test_public_row_hides_the_mark_until_there_is_one(seeded):
+    """The additive-only read contract: an uncorrected row's payload key set is exactly
+    what it was before migration 016."""
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+    keys_before = set(dedup.public_row(_row(conn, "lab_result", target)))
+    assert keys_before.isdisjoint(dedup.EDIT_MARK_COLUMNS)
+
+    records.edit_record(conn, "lab_result", target, {"unit": "percent"},
+                        note="normalise", attributed_to="Jane", apply=True)
+
+    payload = dedup.public_row(_row(conn, "lab_result", target))
+    assert set(payload) == keys_before | set(dedup.EDIT_MARK_COLUMNS)
+    assert payload["edited_by"] == "Jane"
 
 
 def test_every_known_type_can_be_edited(conn):
@@ -1072,6 +1190,29 @@ def test_curation_verdicts_in_both_scopes_survive_an_edit(seeded):
     assert verdicts.rows[("lab_result", target)]["status"] == "disputed"
     # Neither is orphaned: both still resolve to a live target.
     assert all(entry["family_size"] for entry in curation.list_curation(conn))
+
+
+def test_a_correction_and_a_verdict_are_independent_overlays(seeded):
+    """AC 5, both directions. A verdict is a ruling on the *fact*; a correction is a note
+    on the value's fidelity to its source. Neither writes the other's storage."""
+    conn = seeded["conn"]
+    target = _row_id(conn, "lab_result", "test_name", "HbA1c")
+
+    records.edit_record(conn, "lab_result", target, {"unit": "percent"},
+                        note="normalise", attributed_to="Jane", apply=True)
+    mark = _mark(conn, "lab_result", target)
+    assert mark[0] is not None
+
+    # Annotating afterwards leaves the mark exactly as the correction left it...
+    curation.annotate_record(conn, "lab_result", str(target), status="disputed",
+                             note="pharmacy has no record", row=True, apply=True)
+    assert _mark(conn, "lab_result", target) == mark
+
+    # ...and correcting again leaves the verdict alone.
+    records.edit_record(conn, "lab_result", target, {"flag": "H"},
+                        note="the flag was dropped", apply=True)
+    verdict = curation.load_verdicts(conn).rows[("lab_result", target)]
+    assert (verdict["status"], verdict["note"]) == ("disputed", "pharmacy has no record")
 
 
 def test_record_rm_discloses_the_ledger_and_keeps_it(seeded):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1616,6 +1616,176 @@ def test_a_disputed_attested_row_carries_both_markers(seeded):
     assert line.index("[DISPUTED:") < line.index("(attested by")
 
 
+# --- corrected rows are never mistaken for verbatim source text (issue #134) --
+#
+# The mirror image of the attestation section above: `record edit` leaves the row's
+# provenance intact on purpose, so without a mark a corrected value would read as a
+# quotation of a document that never said it.
+
+_CORRECT_MARKER = "(corrected by Aunt Ada 2026-03-02)"
+_CORRECT_AT = "2026-03-02T09:00:00+00:00"
+
+
+def _rid(conn, record_type, where, params):
+    return int(conn.execute(
+        f"SELECT {record_type}_id FROM {record_type} WHERE {where}", params
+    ).fetchone()[f"{record_type}_id"])
+
+
+def _correct(conn, record_type, where, params, updates, who="Aunt Ada"):
+    from pemr import records as _records
+
+    return _records.edit_record(
+        conn, record_type, _rid(conn, record_type, where, params), updates,
+        dedup.load_dictionary(DICT_PATH), note="transcription slip",
+        attributed_to=who, now=_CORRECT_AT, apply=True,
+    )
+
+
+def _correct_all(conn):
+    """One in-place correction per typed table, all on jane."""
+    _correct(conn, "lab_result", "test_name = ?", ("Glucose, fasting",), {"flag": "H"})
+    _correct(conn, "medication", "name = ?", ("Metformin",), {"frequency": "daily"})
+    _correct(conn, "procedure", "name = ?", ("Colonoscopy",),
+             {"outcome": "normal, no polyps"})
+    _correct(conn, "appointment", "provider = ?", ("Dr. Smith",),
+             {"reason": "diabetes review"})
+    _correct(conn, "observation", "key = ? AND observed_at = ?",
+             ("weight", "2026-01-01"), {"value_num": 81})
+    _correct(conn, "allergy", "substance = ?", ("Penicillin",),
+             {"reaction": "rash and hives"})
+    _correct(conn, "condition", "name = ? AND status = 'active'",
+             ("Type 2 Diabetes",), {"note": "diet-controlled, reviewed"})
+
+
+def test_uncorrected_renders_are_byte_identical_to_today(seeded):
+    """The additive-only AC: a database with no corrected rows renders exactly as it did
+    before migration 016. Captured before/after correcting *jane*, since john's record is
+    the untouched control."""
+    d = dedup.load_dictionary(DICT_PATH)
+    before = (
+        render.render_summary(seeded, "john-doe", dictionary=d,
+                              now=datetime(2026, 6, 1)),
+        render.render_journal(seeded, "john-doe", now=datetime(2026, 6, 1)),
+    )
+    _correct_all(seeded)
+    after = (
+        render.render_summary(seeded, "john-doe", dictionary=d,
+                              now=datetime(2026, 6, 1)),
+        render.render_journal(seeded, "john-doe", now=datetime(2026, 6, 1)),
+    )
+    assert before == after
+    assert "corrected" not in before[0] and "corrected" not in before[1]
+
+
+def test_summary_marks_a_corrected_row_in_every_section(seeded):
+    _correct_all(seeded)
+    md = render.render_summary(
+        seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH),
+        now=datetime(2026, 6, 1),
+    )
+    for token in ("Metformin", "Type 2 Diabetes", "Penicillin", "weight",
+                  "Glucose, fasting", "Colonoscopy", "Dr. Smith"):
+        assert any(
+            token in line and _CORRECT_MARKER in line for line in md.splitlines()
+        ), token
+    assert md.isascii()
+
+
+def test_brief_marks_a_corrected_row(seeded):
+    _correct_all(seeded)
+    md = render.render_brief(
+        seeded, _upcoming_appt_id(seeded), dictionary=dedup.load_dictionary(DICT_PATH),
+        recent_labs=50, now=datetime(2026, 6, 1),
+    )
+    for token in ("Metformin", "Penicillin", "Type 2 Diabetes"):
+        assert any(
+            token in line and _CORRECT_MARKER in line for line in md.splitlines()
+        ), token
+
+
+def test_journal_marks_a_corrected_event(seeded):
+    _correct_all(seeded)
+    md = render.render_journal(seeded, "jane-doe", now=datetime(2026, 6, 1))
+    line = next(l for l in md.splitlines() if "Metformin" in l)
+    assert _CORRECT_MARKER in line
+    # The footnote stays: the row is still filed under its source document, which is
+    # exactly why the caveat is needed.
+    assert "[^" in line
+
+
+def test_an_unattributed_correction_renders_the_date_only_form(seeded):
+    _correct(seeded, "medication", "name = ?", ("Metformin",),
+             {"frequency": "daily"}, who="")
+    md = render.render_summary(
+        seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH),
+        now=datetime(2026, 6, 1),
+    )
+    line = next(l for l in md.splitlines() if "Metformin" in l)
+    assert line.endswith("(corrected 2026-03-02)")
+
+
+def test_adding_an_onset_to_a_document_sourced_condition_is_disclosed(seeded):
+    """The issue's headline example (#134): a row that came from a document gains a date
+    the document never stated, and says so."""
+    _correct(seeded, "condition", "name = ?", ("Chickenpox",), {"onset_on": "2001-05-01"})
+    md = render.render_summary(
+        seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH),
+        now=datetime(2026, 6, 1),
+    )
+    line = next(l for l in md.splitlines() if "Chickenpox" in l)
+    assert _CORRECT_MARKER in line
+
+
+def test_a_superseded_attestation_that_was_corrected_shows_only_the_correction(seeded):
+    """Two independent provenance facts, each with its own rule: a promoted attestation
+    is deliberately unmarked, a correction always is."""
+    _attest_all(seeded)
+    doc = _doc(seeded, "jane-doe")
+    dedup.commit_extraction(
+        seeded, doc, {"medication": [dict(_ATTESTED["medication"])]},
+        dedup.load_dictionary(DICT_PATH),
+    )
+    _correct(seeded, "medication", "name = ?", ("Amlodipine",), {"frequency": "daily"})
+    md = render.render_summary(
+        seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH),
+        now=datetime(2026, 6, 1),
+    )
+    line = next(l for l in md.splitlines() if "Amlodipine" in l)
+    assert _CORRECT_MARKER in line
+    assert _ATTEST_MARKER not in line
+
+
+def test_a_disputed_corrected_row_carries_both_markers_in_order(seeded):
+    """Verdict, then provenance, then correction: the verdict is about the fact, the
+    correction about the value's fidelity to its source, so the caveat reads last."""
+    from pemr import curation as _curation
+
+    row_id = _rid(seeded, "medication", "name = ?", ("Metformin",))
+    _correct(seeded, "medication", "name = ?", ("Metformin",), {"frequency": "daily"})
+    _curation.annotate_record(
+        seeded, "medication", str(row_id), status="disputed",
+        note="pharmacy has no record", row=True, apply=True,
+    )
+    md = render.render_summary(
+        seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH),
+        now=datetime(2026, 6, 1),
+    )
+    line = next(l for l in md.splitlines() if "Metformin" in l)
+    assert line.index("[DISPUTED:") < line.index("(corrected by")
+
+
+def test_a_mapping_without_the_mark_columns_reads_as_uncorrected(seeded):
+    """A row off a restored pre-016 database carries no mark columns at all; the suffix
+    goes through `.get()`, so it reads as "not corrected" rather than raising."""
+    assert render._correction_suffix({"name": "Metformin"}) == ""
+    md = render.render_summary(
+        seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH),
+        now=datetime(2026, 6, 1),
+    )
+    assert "corrected" not in md
+
+
 # --- display units: per-person canonical unit at render time (issue #136) -----
 #
 # The overlay is display-only: a preference converts what a summary *prints* and


### PR DESCRIPTION
## Summary

`record edit` (#129, migration 012) has always let a human correct one existing row by id and
ledger the change, but nothing read that ledger at read time — so a corrected value rendered and
queried identically to a value the source document actually stated. That is the exact twin of
#110's failure: a row whose stored value no longer matches its source must never read as
verbatim source text.

This closes the gap. Everything else the raw issue asked for (target-by-id, additive to
`assert_record`, dry-run default, `--json`, explicit `--apply`, human note +
`--attributed-to`, provenance untouched) was already delivered by #129 — the salvage sweep in
design's Implementation plan found that and scoped this PR to the residual read-side disclosure
only.

- **`migrations/016_record_correction_mark.sql`** — `edited_at`/`edited_by` on all seven record
  tables, nullable, plus a one-time backfill from the newest `record_edit` entry per row, guarded
  by the entry's `dedup_base` breadcrumb so a recycled row id belonging to a different family is
  never mis-marked. Shaped after migration 009 (attestation columns), not an overlay: ledger
  entries deliberately outlive their row, so a read-time join would risk caveating an unrelated
  later occupant of a reused id (the #114 hazard). Header now also documents the guard's residual
  edge — a same-family recycled id can still be marked (over-disclosure, not a provenance lie —
  the accepted-safe direction).
- **`pemr/dedup.py`** — `EDIT_MARK_COLUMNS`; `public_row` strips the pair while NULL, so an
  uncorrected row's `--json`/MCP payload is byte-identical to before.
- **`pemr/records.py`** — `edit_record` stamps the pair in the same `UPDATE`/transaction as the
  ledger insert.
- **`pemr/render.py`** — `_correction_suffix`, appended at all 15 sites that already interpolate
  `_attest_suffix`, ordered dispute → attest → correction → unit.
- **`pemr/query.py`** — `query_timeline` carries the pair only when the row has it.
- **`pemr/mcp_server.py`** — no change: `record edit` stays out of `WRITE_TOOLS`, matching
  `record assert`/`record annotate`/`record rm`; the read tools widen only through
  `dedup.public_row`, which they already call.
- **`docs/Architecture.md`** — new §2 "A corrected row says so" (columns-not-overlay rationale,
  rejected read-time join, identity-field decision), §5 `record edit` help block.
- **Docs fan-out (this PR):** `AGENTS.md`'s existing curation-verdict-disclosure paragraph
  (issue #131) didn't mention this issue's parallel read-side change, so an agent-facing reader
  would miss that `query`/`render_summary`/`render_journal` now also disclose a correction the
  same way — added.

**Decision** (recorded on the issue, not here): identity-field refinement (renaming
`condition.name` or any `dedup.KEY_FIELDS` member) is out of scope, resolved "no" — that's a
rekey, and `pemr rekey` / `record rm` + re-commit already own the two real cases.

Closes #134

## Reports

- Verify (full suite 1619 passed, real corpus walked at all four front doors — CLI render/query,
  `--json`, MCP — plus an A/B against `dev` for the additive-only read contract and a real
  pre-016 → 016 upgrade/backfill/restore path):
  https://github.com/meridun/pemr/issues/134#issuecomment-5355960047
- Audit (no blocking findings; three advisories, the migration-header one addressed in this PR):
  https://github.com/meridun/pemr/issues/134#issuecomment-5356033497

🤖 Generated with [Claude Code](https://claude.com/claude-code)