### PR TITLE
fix(medication): status is lifecycle-only; prn/ordered are no longer legal values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,6 +360,29 @@ day or month the source didn't state, and never fall back to stashing an impreci
   second stages a conflict. Emitting a time you invented is never the fix — the recovery path is
   `keep both` under human sign-off (§5).
 
+### 8. Medication rows — `status` is lifecycle only
+
+`medication.status` answers exactly one question: **is this course still running?** Emit `active`,
+`completed` or `discontinued`, or leave it absent when the source doesn't say. Nothing else belongs
+in it (issue #151).
+
+- **PRN is a dosing pattern, not a lifecycle state.** "As needed" / "PRN" goes in `frequency` (or
+  `dose`) verbatim, exactly as the source words it — `frequency="PRN"`, `frequency="q6h PRN"`.
+  Never `status='prn'`: an as-needed med with no `ended_on` then reads as current forever, and it
+  hides from an audit for rows whose lifecycle is unrecorded (which is precisely what it is).
+- **An order/workflow state is not a lifecycle state either.** Never `status='ordered'`. If the
+  ordering fact itself is worth keeping, it is an `observation` with `obs_type='order'` (§2) — the
+  schema's existing home for order/workflow facts — never a `medication.status` value.
+- Leaving `status` absent is always better than inventing one. An unrecorded lifecycle is an
+  ordinary gap a human can see and close; a wrong label is one they cannot.
+
+This vocabulary is **not** enforced at the DB layer — there is no `CHECK` on the column, because a
+constraint would reject rows already stored and freeze the vocabulary inside a migration. The
+defense is `pemr verify`, which warns on any `medication.status` that is neither a recognized
+lifecycle value nor empty, naming the row id and the offending literal. Correct such a row with
+`pemr record edit medication <id> --set status= --note ...` (moving any dosing detail into
+`frequency`/`dose` in the same edit), not by re-committing the source document.
+
 ## Privacy posture
 
 This repository is **public**. It is framework + documentation only.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -216,7 +216,8 @@ CREATE TABLE medication (
   started_on    TEXT,
   ended_on      TEXT,                     -- NULL = current
   prescriber    TEXT,
-  status        TEXT,                     -- active|discontinued|prn
+  status        TEXT,                     -- lifecycle only: active|completed|discontinued|NULL
+                                          -- (AGENTS.md §MUST-8; prn/ordered are not lifecycle)
   dedup_key     TEXT NOT NULL,
   UNIQUE(dedup_key)
 );

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -52,7 +52,8 @@ CREATE TABLE medication (
   started_on    TEXT,
   ended_on      TEXT,                    -- NULL = current
   prescriber    TEXT,
-  status        TEXT,                    -- active|discontinued|prn
+  status        TEXT,                    -- lifecycle only: active|completed|discontinued|NULL
+                                         -- (AGENTS.md §MUST-8; prn/ordered are not lifecycle)
   dedup_key     TEXT NOT NULL,
   UNIQUE(dedup_key)
 );

--- a/pemr/query.py
+++ b/pemr/query.py
@@ -34,9 +34,19 @@ _WORD = re.compile(r"\w+", re.UNICODE)
 
 # Medication ``status`` values that end the course even when no explicit ``ended_on``
 # date was extracted (issue #21). ``status`` is unconstrained at the DB layer
-# (migrations/001_init.sql documents active|discontinued|prn, but extraction agents emit
-# terminal values like completed/stopped as well), so matching is lowercased and trimmed.
+# (migrations/001_init.sql documents the lifecycle-only vocabulary
+# active|completed|discontinued|NULL, but nothing rejects a row that says otherwise, and
+# extraction agents have emitted ``stopped`` as well), so matching is lowercased and trimmed.
 TERMINAL_MED_STATUSES = frozenset({"completed", "stopped", "discontinued"})
+
+# Every ``status`` value the read layer *recognizes* as a lifecycle state: the terminal
+# set plus the one non-terminal lifecycle value. Deliberately wider than the vocabulary
+# AGENTS.md §MUST-8 tells extraction agents to emit (which omits ``stopped``): the emit
+# side is a contract for new rows, this side is tolerance for what is already stored.
+# Anything outside it is not a lifecycle state at all - :func:`med_is_current` still
+# treats it as current (the safe default), and ``pemr verify`` reports it (issue #151)
+# instead of letting it hide, which is the whole fix for ``prn``/``ordered``.
+LIFECYCLE_MED_STATUSES = TERMINAL_MED_STATUSES | frozenset({"active"})
 
 
 def _row_get(row: sqlite3.Row | dict, key: str) -> object:

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -10,6 +10,11 @@ One function, two callers: `pemr verify` prints this report, and `pemr restore` 
 the same report as its tail so the issue's acceptance drill is a single command
 afterwards.
 
+Beyond the blob pass the report also carries two per-row scans that need a human's eye
+but are not corruption: inert `curation` verdicts (issues #109, #114) and medication rows
+whose `status` is not a lifecycle value (issue #151). Both append to `warnings`, so
+neither moves the exit code.
+
 **Reports, never repairs.** No FTS rebuild, no blob refetch, no orphan sweep (blobs in
 `sources/` with no `document` row) — those are deliberate non-goals, see the issue's
 design comment.
@@ -21,7 +26,7 @@ import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from . import curation, db, dedup, ingest
+from . import curation, db, dedup, ingest, query
 
 # Row counts reported, in a stable order. A table missing from the schema (a snapshot
 # predating its migration, checked before `restore` runs `migrate`) is simply omitted.
@@ -238,6 +243,45 @@ def _check_curation(conn: sqlite3.Connection, report: VerifyReport) -> None:
             )
 
 
+def _check_med_status(conn: sqlite3.Connection, report: VerifyReport) -> None:
+    """Warn about `medication.status` values that are not lifecycle states (issue #151).
+
+    `status` answers one question - is the course still running - but the column is
+    unconstrained at the DB layer, and extraction has written non-lifecycle values into
+    it (`prn`, a dosing pattern; `ordered`, an order-workflow state). Such a row with no
+    `ended_on` renders as current indefinitely, and - unlike an empty status - it does
+    not look like a gap to anyone auditing for one. That is the blind spot: permanently
+    current *and* invisible.
+
+    Deliberately not a `CHECK` constraint: one would reject rows already stored and
+    freeze the vocabulary inside a migration. This warning is the durable defense against
+    future extraction drift instead, which is why membership is tested against
+    :data:`query.LIFECYCLE_MED_STATUSES` in Python, through the same trim/lowercase
+    normalization :func:`query.med_is_current` uses - the check can never disagree with
+    the classifier it is warning about.
+
+    A warning, never a problem: the row is untidy, not corrupt, and correcting it is a
+    curation act with a source document in hand (`pemr record edit`), not something a
+    verify run should fail on.
+    """
+    rows = conn.execute(
+        "SELECT medication_id, status FROM medication "
+        "WHERE status IS NOT NULL AND trim(status) <> '' ORDER BY medication_id"
+    ).fetchall()
+    for row in rows:
+        value = str(row["status"])
+        if value.strip().lower() in query.LIFECYCLE_MED_STATUSES:
+            continue
+        # ASCII-only and PHI-free (issue #23; this repo is public): the row id and the
+        # offending literal, never the drug name and never the person.
+        report.warnings.append(
+            f"medication row #{row['medication_id']}: status '{value}' is not a "
+            "lifecycle value (active|completed|discontinued, or empty) - it renders as "
+            "current indefinitely; correct it with `pemr record edit medication "
+            f"{row['medication_id']} --set status= --note ...`"
+        )
+
+
 def verify_report(
     conn: sqlite3.Connection, sources_dir: str | Path | None = None
 ) -> VerifyReport:
@@ -261,6 +305,9 @@ def verify_report(
     report.row_counts = row_counts(conn)
     if db.is_migrated(conn):
         _check_curation(conn, report)
+        # `medication` ships in 001_init, so `is_migrated` is a sufficient guard - no
+        # `has_table` shim like curation's (that table arrives in a later migration).
+        _check_med_status(conn, report)
 
     if sources_dir is None:
         report.blobs_skipped = "no sources dir configured"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -333,6 +333,33 @@ def test_lifecycle_med_statuses_covers_the_terminal_set():
     assert "ordered" not in query.LIFECYCLE_MED_STATUSES
 
 
+def test_verify_is_silent_on_a_renewed_prescription(seeded):
+    """#151 and #159 share the ``status`` column and neither may shadow the other: a
+    renewal is ``status='discontinued'`` (a lifecycle value, so no warning) whose
+    ``status_reason`` keeps it current (so the warning's "renders as current
+    indefinitely" framing must not be read as a claim about *this* row)."""
+    doc = _doc(seeded, "jane-doe")
+    dedup.commit_extraction(seeded, doc, {
+        "medication": [
+            {"name": "Levothyroxine", "dose": "50mcg", "started_on": "2025-06-11",
+             "ended_on": "2026-06-11", "status": "discontinued",
+             "status_reason": "Reorder"},
+        ],
+    }, dedup.load_dictionary(DICT_PATH))
+    assert _med_warnings(seeded) == []
+    active = {m["name"] for m in query.query_meds(seeded, "jane-doe", active=True, now=NOW)}
+    assert "Levothyroxine" in active
+
+
+def test_verify_med_status_check_is_silent_on_an_empty_database(tmp_path):
+    """A freshly migrated archive has no `medication` rows: the check must add nothing
+    and must not move the exit code (`pemr verify` runs on empty DBs after `restore`)."""
+    conn = db.connect(tmp_path / "empty.db")
+    db.migrate(conn)
+    report = verify.verify_report(conn)
+    assert [w for w in report.warnings if w.startswith("medication row")] == []
+    assert report.ok is True
+
 
 # --- structured: timeline -----------------------------------------------------
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from pemr import db, dedup, persons, query
+from pemr import db, dedup, persons, query, verify
 
 DICT_PATH = Path(__file__).resolve().parent.parent / "data" / "dictionary.example.toml"
 
@@ -127,6 +127,10 @@ NOW = datetime(2026, 8, 2, 9, 30)  # fixed "today" so the currency tests never a
     ({"status": None, "ended_on": None}, True),          # nothing set -> current
     ({"status": "", "ended_on": None}, True),            # blank status -> current
     ({"status": "active", "ended_on": None}, True),      # explicitly active
+    # issue #151: `prn` is no longer a legal status (it is a dosing pattern, and belongs
+    # in `frequency`/`dose`). Classification is unchanged on purpose - a non-lifecycle
+    # value still reads as current, the safe default - but `verify` now reports it
+    # instead of letting it hide. See the vocabulary section below.
     ({"status": "prn", "ended_on": None}, True),         # prn is not terminal
     ({"status": "completed", "ended_on": None}, False),  # issue #21: terminal, no end date
     ({"status": "Stopped", "ended_on": None}, False),    # case-insensitive
@@ -196,6 +200,70 @@ def test_query_meds_active_excludes_expired_course_labelled_active(seeded):
     active = {m["name"] for m in query.query_meds(seeded, "jane-doe", active=True, now=NOW)}
     assert "Amoxicillin" not in active
     assert "Skyrizi" in active
+
+
+# --- verify: medication status vocabulary -------------------------------------
+# The `verify` check lives beside the classifier it guards (issue #151), the same way
+# test_curation.py houses the orphan-verdict warning beside curation's own behavior.
+
+def _seed_med(conn, name, status):
+    """Commit one medication row for jane, then force ``status`` to an exact literal.
+
+    The UPDATE is deliberate: these cases are *about* the bytes in the column (NULL vs
+    ``''`` vs ``' Discontinued '``), which an emit path is free to normalize away.
+    """
+    doc = _doc(conn, "jane-doe")
+    dedup.commit_extraction(conn, doc, {
+        "medication": [{"name": name, "dose": "1mg", "started_on": "2019-09-01"}],
+    }, dedup.load_dictionary(DICT_PATH))
+    med_id = conn.execute(
+        "SELECT medication_id FROM medication WHERE name = ?", (name,)
+    ).fetchone()["medication_id"]
+    conn.execute(
+        "UPDATE medication SET status = ? WHERE medication_id = ?", (status, med_id)
+    )
+    conn.commit()
+    return med_id
+
+
+def _med_warnings(conn):
+    return [w for w in verify.verify_report(conn).warnings
+            if w.startswith("medication row")]
+
+
+def test_verify_warns_on_a_non_lifecycle_med_status(seeded):
+    """`prn` is a dosing pattern, not a lifecycle state: the row renders as current
+    forever *and* hides from an audit for rows with no status. `verify` names it."""
+    assert _med_warnings(seeded) == []
+    med_id = _seed_med(seeded, "Ibuprofen", "prn")
+
+    report = verify.verify_report(seeded)
+    warnings = [w for w in report.warnings if w.startswith("medication row")]
+    assert len(warnings) == 1
+    assert f"medication row #{med_id}" in warnings[0]
+    assert "'prn'" in warnings[0]
+    assert "Ibuprofen" not in warnings[0]  # row id + literal only: no drug, no person
+    assert warnings[0].isascii()             # issue #23
+    # A warning is an observation; it must not flip the exit code.
+    assert report.ok is True and report.problems == []
+
+
+def test_verify_is_silent_on_lifecycle_statuses(seeded):
+    """Recognized values, in every stored form: trimmed, cased, empty and NULL."""
+    for i, status in enumerate(
+        ["active", "completed", "discontinued", " Discontinued ", "", None]
+    ):
+        _seed_med(seeded, f"Lifecycle{i}", status)
+    assert _med_warnings(seeded) == []
+
+
+def test_lifecycle_med_statuses_covers_the_terminal_set():
+    """Drift guard: the recognized set must never fall behind the terminal one, or a
+    terminal status would start warning as unrecognized."""
+    assert query.TERMINAL_MED_STATUSES <= query.LIFECYCLE_MED_STATUSES
+    assert "active" in query.LIFECYCLE_MED_STATUSES
+    assert "prn" not in query.LIFECYCLE_MED_STATUSES
+    assert "ordered" not in query.LIFECYCLE_MED_STATUSES
 
 
 # --- structured: timeline -----------------------------------------------------


### PR DESCRIPTION
## Summary

`medication.status` was carrying two non-lifecycle values — `prn` (a dosing pattern) and `ordered`
(an order/workflow state) — alongside the real lifecycle values (`active`/`completed`/
`discontinued`). Because `med_is_current()` treats any non-terminal status as current when
`ended_on` is absent, a `prn` or `ordered` row with no end date rendered as current indefinitely,
and unlike a `NULL`/`active` row it didn't look like a gap to anyone auditing for one — 26 `prn` +
5 `ordered` rows corpus-wide were silently invisible to that kind of audit while permanently
"current".

This closes the gap per the owner's decision (recorded on the issue): split the axes.
`medication.status` is lifecycle-only going forward; `prn` and `ordered` are no longer legal
values for it.

- **`migrations/001_init.sql` + `docs/Architecture.md`** — schema comment corrected to
  `active|completed|discontinued|NULL`, pointing at the new `AGENTS.md §MUST-9`.
- **`AGENTS.md` §MUST-9** — new rule: PRN dosing goes in `frequency`/`dose` verbatim, never
  `status='prn'`; an order/workflow fact belongs in `observation(obs_type='order')`, never
  `status='ordered'`. Not DB-enforced by design (a `CHECK` would reject already-stored rows and
  freeze the vocabulary in a migration) — the defense is the new `pemr verify` check below.
- **`pemr/query.py`** — `LIFECYCLE_MED_STATUSES` (`TERMINAL_MED_STATUSES | {"active"}`) beside the
  existing `TERMINAL_MED_STATUSES`; corrected the stale `active|discontinued|prn` comment.
  `med_is_current()` itself is unchanged — a non-lifecycle value still classifies as current (the
  safe default), it's now *reported* instead of silent.
- **`pemr/verify.py`** — `_check_med_status`, modelled on the existing `_check_curation` pattern:
  one `warnings` entry per row whose `status` is non-empty and not a recognized lifecycle value
  (row id + offending literal only — no drug name, no person). Doesn't move `report.ok`.
- **`tests/test_query.py`** — new verify-check tests plus a reworded `prn` case.
- **Corpus backfill** (data, not code — no fixture in this repo may hold corpus data): the 26
  `prn` + 5 `ordered` rows in the live DB were reclassified via `record edit` (dry-run then
  `--apply`, ledgered, no `--attributed-to` — a vocabulary correction, not a clinical assertion).
  `pemr verify` on the live corpus went from 31 medication-status warnings to zero.

**Decisions** (recorded on the issue, not here): `medication.status` becomes lifecycle-only
(intake); `ordered` is dropped rather than given its own column — all 5 rows already carry an
`ended_on`, and `observation(obs_type='order')` is the schema's existing home for order/workflow
facts (design).

**Behavior-neutral by construction**: clearing `status` doesn't change how any row classifies
today (before: `prn`+no-end-date → current, `ordered`+past-end-date → not current; after: same on
both). What changes is that the reclassified rows are now visible to a null-status audit and to
the new `verify` warning instead of hiding behind a value nobody enumerated.

**Not in scope** (per the issue): ending/dating the reclassified rows' actual lifecycle — that's
per-row clinical curation against source documents, left to a human; a new column or `CHECK`
constraint for `ordered`; a distinct third state in `med_is_current`/`query_meds` output.

Closes #151

## Reports

- Verify (full suite 1624 passed; live-corpus real run confirmed zero medication-status warnings
  post-backfill; cross-checked against #159's `status_reason` renewal case):
  https://github.com/meridun/pemr/issues/151#issuecomment-5361299190
- Audit (no blocking findings; two advisories — an untrusted-literal interpolation in the new
  warning's format string, repo-wide convention and out of scope here; a factual slip in the
  plan/verify narrative about `dedup.KEY_FIELDS["medication"]`'s composition, docs-only, code was
  always correct):
  https://github.com/meridun/pemr/issues/151#issuecomment-5361396104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
