### PR TITLE
feat(condition): adopt the episode model - onset identifies the episode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,9 @@ the only path in the system that can put a fact into the record with no external
 human at the CLI may vouch for one. `record edit` sits on the same trust boundary from the other
 side: it mutates a *stored clinical value* with no new source backing the change, so the row stops
 matching what its document says on one person's say-so — which is exactly the kind of write that
-must carry a named human, not an agent.
+must carry a named human, not an agent. Its `--identity` flag (issue #152) is the same verb reaching
+further — it moves the row's `dedup_key` as well as its payload — so it is CLI-only for the same
+reason, and `record edit` in every form stays out of `WRITE_TOOLS`.
 
 The verbs above are CLI-only; verdict *content* is not. Since issue #131, `query`
 (`kind` = `labs`/`meds`/`timeline`) carries each row's `curation` verdict on the MCP read
@@ -207,16 +209,26 @@ carrying a diagnosis or an allergy MUST commit these rows:
   (`mother`, `father`, `sibling`, ... free text) — **never** an `active` condition row. The subject
   is part of the dedup key, so this is what keeps a mother's diabetes out of the patient's own
   problem list; miscommitting it there is a clinical-safety error, not a cosmetic one.
-- Both are **standing facts**: their dedup keys are date-free, so restating the same allergen or
-  problem across documents collapses to one row. A stated disagreement (`penicillin: rash` vs
-  `penicillin: anaphylaxis`, or `active` -> `resolved`) stages a **conflict** for human
-  adjudication (§5); a field the new document simply doesn't mention is silence, not a change, and
-  never conflicts. Do not "helpfully" restate a value the source omitted.
+- **`condition.onset_on` identifies the *episode*** (issue #152). State it whenever the source
+  gives one, at the source's true precision (§7) — never invent or pad a date. Some problems start
+  and stop repeatedly (kidney stones, UTIs, fractures, cellulitis), and the onset is what keeps two
+  episodes of one problem as two rows instead of folding them into one. `resolved_on` is not part
+  of the identity: an episode's end is payload.
+- Both are **standing facts** in the sense that a document restating one is not new news:
+  `allergy`'s key is date-free entirely, and a `condition` restated at the *same* onset collapses to
+  one row. A stated disagreement (`penicillin: rash` vs `penicillin: anaphylaxis`, or
+  `active` -> `resolved`) stages a **conflict** for human adjudication (§5); a field the new
+  document simply doesn't mention is silence, not a change, and never conflicts. Do not "helpfully"
+  restate a value the source omitted.
 - Silence only reads that way in one direction. A field the new document **does** state over a
   stored NULL is new information with nothing to adjudicate: it fills the stored row in place and
   the commit reports it as `enriched` rather than `duplicate`. So emit every field the source
   states even for an allergen or problem you know is already on file — a terse first document
   followed by a detailed one is the normal case, and this is what makes the detail land.
+  The one exception is `condition.onset_on`: it is identity, not payload, so a document that dates
+  a problem the record holds undated lands as a **new row** beside the undated one rather than
+  filling it in. Emit the date anyway — that is honest, and `pemr verify` warns about the pair so a
+  human can decide whether the two are one episode.
 
 ### 4. OCR text at ingest
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -151,6 +151,9 @@ CREATE UNIQUE INDEX idx_curation_row ON curation(record_type, record_id)
 -- leaves document_id, person_id, dedup_key and the source blob untouched. The editable
 -- set is DERIVED (dedup.FIELD_SPECS minus dedup.KEY_FIELDS, §3), so identity and
 -- provenance are unreachable from an edit by construction rather than by a denylist.
+-- `--identity` (issue #152, §3 Episodes) opens the identity half of that split and moves
+-- the row's key with the payload; provenance stays unreachable in both modes, and the
+-- ledger entry keeps the OLD dedup_base so the move stays reconstructable.
 -- One row per changed field, all sharing one edited_at, so a single command's correction
 -- reads as one act while each field stays individually legible.
 --
@@ -349,8 +352,11 @@ CREATE TABLE condition (                   -- migration 006 (promoted from obser
   document_id   INTEGER REFERENCES document(document_id),
   name          TEXT NOT NULL,
   status        TEXT NOT NULL,             -- active|resolved|history|family-history
-  onset_on      TEXT,
-  resolved_on   TEXT,
+  onset_on      TEXT,                      -- IDENTITY (§3 Episodes): which episode this
+                                           -- row is. Stored at the source's own precision
+                                           -- (YYYY | YYYY-MM | YYYY-MM-DD), never padded;
+                                           -- correct it with `record edit --identity`
+  resolved_on   TEXT,                      -- payload: an episode's end is not its identity
   relation      TEXT,                      -- family-history only: mother|father|...
   note          TEXT,
   dedup_key     TEXT NOT NULL,
@@ -442,19 +448,23 @@ procedure.dedup_key     = hash(person_id | norm(name) | performed_on)
 appointment.dedup_key   = hash(person_id | provider | scheduled_for)
 observation.dedup_key   = hash(person_id | obs_type | observed_at | key_token(key))
 allergy.dedup_key       = hash(person_id | norm(substance))
-condition.dedup_key     = hash(person_id | norm(name) | subject)
+condition.dedup_key     = hash(person_id | norm(name) | episode)
+    episode = subject + '@' + date_only(onset_on)  when an onset is stated
+            = subject                              otherwise
     subject = 'family:' + norm(relation)  when status = 'family-history'
             = 'self'                      otherwise
 ```
 
-The last two are deliberately **date-free**: allergies and problem lists are *standing
-facts* restated on every document with inconsistent or absent dates, so a date in the key
-would fork one allergy into one row per document. Their dates are payload, and a stated
-disagreement (in a date or anywhere else) stages a conflict. A field the incoming document
-simply omits is silence, not a change, and never conflicts — the one place the
-duplicate-vs-conflict comparison differs by record type (`dedup._SPARSE_TYPES`). The
-`subject` discriminator is a correctness fix, not a nicety: without it a patient's
-diabetes and her mother's derive one key and silently merge.
+`allergy` is deliberately **date-free**: an allergy is a *standing fact* restated on every
+document with inconsistent or absent dates, so a date in the key would fork one allergen
+into one row per document. Its dates are payload, and a stated disagreement (in a date or
+anywhere else) stages a conflict. A field the incoming document simply omits is silence,
+not a change, and never conflicts — the one place the duplicate-vs-conflict comparison
+differs by record type (`dedup._SPARSE_TYPES`). `condition` keeps that sparse reading but
+left the date-free class in issue #152 (**Episodes**, below): a problem that starts and
+stops repeatedly is not one standing fact, so its onset joins the key while its
+`resolved_on` stays payload. The `subject` discriminator is a correctness fix, not a
+nicety: without it a patient's diabetes and her mother's derive one key and silently merge.
 
 That reading is asymmetric by design. Treating a *stored* NULL as silence too would make the
 common terse-then-detailed document sequence lossy: the second document's `criticality` would
@@ -899,6 +909,98 @@ Because siblings legitimately share a date, every same-date ordering is tie-brok
 id (`query labs`, the summary/brief lab sections): the admitted row sorts as the later
 point, so `trends` deltas and "latest value" stay deterministic.
 
+### Episodes (issue #152)
+
+Some clinical states **start and stop repeatedly**: kidney stones, UTIs, fractures, DVTs,
+cellulitis, seizures; a course of antibiotics; an intermittent symptom. A row identified as
+a standing fact cannot hold two of them — the second episode collides with the first, there
+is nowhere for its date to live, and every recurrence folds into one row with the count and
+every date but one silently lost. This is the **episode primitive**, defined once here and
+adopted per record type, so each adopting type extends it rather than inventing a variant.
+`condition` adopts it first; `symptom` and medication courses-as-episodes are separate
+issues and take *this* shape when they land.
+
+**Identity is name + subject + onset.** The onset is folded into the existing subject key
+part (`self@2009-09-15`, `family:mother@2011`), not appended as a fourth part — the
+`key_token()` decision applied again, and the reason the migration is cheap: an **undated**
+row's `dedup_key` stays byte-identical, so only *dated* rows move and every family-scoped
+verdict on an undated family survives untouched. `dedup_occurrence` is **not** replaced by
+this; it is demoted to what it is now needed for — genuinely undated repeats and two
+episodes a source dates identically.
+
+**Onset stores true precision, FHIR-style.** `1998`, `1998-05`, `1998-05-20` are three
+different claims, stored exactly as the source stated them: no sentinel padding to
+`-01-01`, and no separate "approximate" flag. Precision is implicit in the value, and
+ordering is plain lexical comparison because each accepted form is a prefix of the next —
+the same three-precision rule `_is_iso_date` already enforces on every `DATE_FIELDS`
+column, so this needed no storage change (the columns are `TEXT`, and no consumer does date
+arithmetic on `onset_on`). Dates are *expected* for an episode; a genuinely undated one
+falls back to the occurrence tiebreaker.
+
+**Two temporalities, kept apart.** An episode's clinical validity window lives on the row
+(`onset_on` opens it, `resolved_on` closes it — the end is payload, not identity: a
+resolution date is news about an episode, not a different episode). *When we learned it,
+and from which source* stays owned by the provenance and curation layers —
+`document_id`/`attested_*`, `dedup_occurrence`, the verdict overlay. There is deliberately
+no SCD-2 effective-dating (`effective_from`/`effective_to`/`is_current`) on clinical rows:
+that would fuse the two temporalities into one column set and make every read ask which
+kind of time it meant.
+
+**One consequence to know about.** An undated umbrella claim and a dated episode are two
+identities, so a later document that dates a stored undated problem lands as a **new row**
+beside it rather than enriching it in place (`onset_on` left `_COMPARE_FIELDS`, so
+`_sparse_gains` cannot fill it). That is the intended semantics — auto-absorbing one into
+the other is exactly the silent fold this change ends — but unannounced it would trade
+silent folding for silent duplication, so `pemr verify` **warns** when a person has an
+undated condition row beside dated episodes of the same problem, naming both remedies.
+
+**Migration: rekey, then unfold.** The identity change is a key change, so it is a `pemr
+rekey`, not a SQL migration (SQL cannot compute the sha256 — the migration-006 precedent
+above). It is collision-free by construction: adding a discriminator to a key only ever
+*splits* families, never fuses two, and a split sibling keeps its stored
+`dedup_occurrence`, so no two rows can land on one key. A family split leaves a hole (the
+former occurrence 1 sits on `hash(base|1)` of its new base with no occurrence 0); that is
+deliberate, for the same reason deletion does not renumber — renumbering rewrites sibling
+keys out from under any staged conflict.
+
+```
+pemr rekey --apply --json > rekey.json      # dated conditions move; undated ones do not
+pemr record reaffirm --map-file rekey.json  # dry run, then --apply
+```
+
+**Unfolding an umbrella row is an operator sequence, not an inference.** Nothing in a
+stored row says it holds two episodes, and the free-text `note` must never be parsed for
+dates. The operator gives the umbrella row the episode it actually is, then files the other:
+
+```
+pemr record edit condition <id> --identity --set onset_on=2009-09-15 --note "..." --apply
+pemr record assert condition --person <slug> --field name=... --field onset_on=1998-05 ...
+```
+
+**Correcting an onset is itself a rekey, and carries its verdicts across.** With onset in
+the identity, fixing a wrong onset date moves the row's key — so it is `record edit
+--identity` (§5), a one-row rekey rather than an in-place correction, and its consequences
+are the ones `pemr rekey` already has, reported the same way rather than by a new mechanism:
+
+- **row-scoped** verdicts follow the row for free — `curation` resolves them by
+  `record_id`, and the `dedup_base` a row verdict also carries is a breadcrumb nothing
+  consults (that exclusion from the orphan kinds is load-bearing, above);
+- a **family-scoped** verdict on the base the row vacated is orphaned exactly when a
+  `rekey` base move would orphan it — only if the row was the family's last, which is
+  `no-live-family`'s own rule — and the report carries it in `rekey --apply --json`'s
+  `orphans` shape, so `record reaffirm --map-file` re-points it unmodified;
+- payload, provenance and row id are untouched (which is the whole reason this is not
+  `record rm` + re-commit: that re-attributes the row to whichever document is passed at
+  correction time), the correction mark and the edit ledger land as on any correction, and
+  the ledger entry keeps the **old** base as its breadcrumb so the move stays
+  reconstructable;
+- an open conflict anchored to the row is **refused** when the move would empty its family
+  and disclosed as re-anchoring when a sibling survives — `record rm`'s rule, for its
+  reason;
+- moving onto an identity a row already occupies with the same payload is **refused**: that
+  is a merge, and merging is a recorded human judgment (`record annotate --status
+  merged-into`, or `record rm`), not something a correction may do silently.
+
 ---
 
 ## 4. Ingestion pipeline
@@ -1123,11 +1225,19 @@ pemr document rm <id> [--apply] [--purge-blob] [--tombstone [--reason ...] [--no
 pemr record rm <table> <id> [--apply]                    # delete ONE record row; its document and every
                                                          # other record it produced survive; dry run by default
 pemr record edit <table> <id> --set NAME=VALUE [--set ...] --note <text>
-                 [--attributed-to ...] [--apply]         # correct a row's NON-KEY fields in place (§2 record_edit);
+                 [--attributed-to ...] [--identity] [--apply]
+                                                         # correct a row's NON-KEY fields in place (§2 record_edit);
                                                          # document_id/dedup_key/source blob untouched; NAME= clears;
-                                                         # identity fields refused (that is a dictionary edit + rekey);
+                                                         # identity fields refused (that is a dictionary edit + rekey,
+                                                         #        or --identity below);
                                                          # every change ledgered; the row is stamped edited_at/edited_by
                                                          #        so render/query disclose it (§2); dry run by default
+                                                         # --identity: name identity fields and MOVE the row onto the
+                                                         #        identity they derive - a one-row rekey (§3 Episodes).
+                                                         #        Payload/provenance/row id/ledger/row verdicts follow;
+                                                         #        a family verdict on an emptied base is reported in
+                                                         #        `record reaffirm --map-file` shape; an occupied
+                                                         #        target is refused (that is a merge, not a correction)
 pemr record edit --list [<table>] [--json]               # recorded corrections, newest first (field: old -> new)
 pemr record annotate <table> <base-or-id> --status <s> --note <text> [--attributed-to ...]
                      [--merged-into <base-or-id>] [--allow-cross-person] [--row] [--apply]

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -484,6 +484,7 @@ def _with_document_conn(args: argparse.Namespace, work):
             records.RecordNotFoundError,
             records.AnchoredConflictError,
             records.FieldNotEditableError,
+            records.IdentityCollisionError,
             curation.CurationNotFoundError,
             curation.FamilyNotFoundError,
             curation.RowNotFoundError,
@@ -1205,7 +1206,31 @@ def _print_record_edit_report(report: "records.RecordEditReport") -> None:
         print(f"  {name}: unchanged (already that value)")
     owner = f"#{report.document_id}" if report.document_id is not None else "none"
     print(f"  document: {owner} (unchanged - a correction is not a re-attribution)")
-    print(f"  identity: dedup_key {report.dedup_key[:12]}... (unchanged)")
+    if report.identity:
+        # The move, then its fallout. The occurrence is printed because a non-zero one
+        # is how a reader knows the row landed *beside* siblings rather than alone.
+        print(
+            f"  identity: dedup_key {report.dedup_key[:12]}... -> "
+            f"{report.new_dedup_key[:12]}... (occurrence {report.dedup_occurrence} -> "
+            f"{report.new_dedup_occurrence})"
+        )
+        for orphan in report.curation_orphaned:
+            print(
+                f"  warning: the family verdict '{orphan['status']}' on "
+                f"{str(orphan['dedup_base'])[:12]}... is orphaned by this move (no rows "
+                "are left on that base) - re-point it by feeding this command's --json "
+                "output to `pemr record reaffirm --map-file`",
+                file=sys.stderr,
+            )
+        if report.conflicts_reanchored:
+            ids = ", ".join(f"#{cid}" for cid in report.conflicts_reanchored)
+            print(
+                f"  note: open conflict(s) {ids} re-anchor to the lowest surviving "
+                "occurrence of the family this row leaves"
+            )
+        print("  row-scoped verdicts and ledger entries follow the row, by row id")
+    else:
+        print(f"  identity: dedup_key {report.dedup_key[:12]}... (unchanged)")
     print(f"  note: {report.note}")
     if report.attributed_to:
         print(f"  attributed to: {report.attributed_to}")
@@ -1257,6 +1282,7 @@ def _cmd_record_edit(args: argparse.Namespace) -> int:
             dictionary,
             note=args.note,
             attributed_to=args.attributed_to,
+            identity=args.identity,
             apply=args.apply,
         )
         if args.json:
@@ -1266,8 +1292,9 @@ def _cmd_record_edit(args: argparse.Namespace) -> int:
         if not report.changes:
             print("nothing to do: every named field already holds that value")
         elif report.applied:
+            moved = " and moved onto its corrected identity" if report.identity else ""
             print(
-                f"corrected {report.record_type} #{report.row_id} "
+                f"corrected {report.record_type} #{report.row_id}{moved} "
                 f"({len(report.changes)} field(s), recorded in the edit ledger)"
             )
         else:
@@ -3565,11 +3592,21 @@ def build_parser() -> argparse.ArgumentParser:
     r_edit.add_argument(
         "--set", action="append", metavar="NAME=VALUE",
         help="one field to correct; repeat for each (e.g. --set unit=lb). A bare "
-             "NAME= clears the column. Identity fields are refused - correcting one "
-             "is a dictionary edit + `pemr rekey`, not an edit. Note that correcting "
-             "a compared field (e.g. unit) makes a later re-ingest of the original "
-             "document stage a conflict rather than dedup, which is honest: the row "
-             "no longer says what its source says",
+             "NAME= clears the column. Identity fields are refused unless --identity "
+             "is given - correcting one otherwise is a dictionary edit + `pemr rekey`. "
+             "Note that correcting a compared field (e.g. unit) makes a later "
+             "re-ingest of the original document stage a conflict rather than dedup, "
+             "which is honest: the row no longer says what its source says",
+    )
+    r_edit.add_argument(
+        "--identity", action="store_true",
+        help="allow --set to name identity fields (e.g. a condition's onset_on) and "
+             "MOVE the row onto the identity they derive - a one-row rekey (issue "
+             "#152). Payload, provenance, row id, row-scoped verdicts and the edit "
+             "ledger all follow the row; a family-scoped verdict on a base the move "
+             "empties is reported as orphaned, in `pemr record reaffirm --map-file` "
+             "shape. Refused when the target identity already holds a row saying the "
+             "same thing - that is a merge, not a correction",
     )
     r_edit.add_argument(
         "--note", help="required: why the correction is being made"

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -571,14 +571,15 @@ def _key_parts(
         return [person_id, n("provider"), _date_only(row.get("scheduled_for"))]
     if record_type == "observation":
         return [person_id, n("obs_type"), norm_ts(row.get("observed_at")), kt("key")]
-    # allergy/condition are DATE-FREE by design: they are standing facts restated on
-    # every document with inconsistent or absent dates, so a date in the key would fork
-    # one allergy into one row per document. The dates are payload, and a disagreement
-    # in them stages a conflict (issue #63 design).
+    # `allergy` is DATE-FREE by design: an allergy is a standing fact restated on every
+    # document with inconsistent or absent dates, so a date in the key would fork one
+    # allergy into one row per document. Its dates are payload, and a disagreement in them
+    # stages a conflict (issue #63 design). `condition` left that class in issue #152 —
+    # see :func:`_condition_episode`.
     if record_type == "allergy":
         return [person_id, n("substance")]
     if record_type == "condition":
-        return [person_id, n("name"), _condition_subject(row, dictionary)]
+        return [person_id, n("name"), _condition_episode(row, dictionary)]
     raise ValidationError(f"unknown record type: {record_type}")  # guarded by validate()
 
 
@@ -595,6 +596,41 @@ def _condition_subject(row: dict, dictionary: dict[str, str] | None = None) -> s
     return "family:" + norm(row.get("relation"), dictionary)
 
 
+def _condition_episode(row: dict, dictionary: dict[str, str] | None = None) -> str:
+    """*Which episode* of a condition this row is — subject, plus onset when stated.
+
+    The **episode primitive** (issue #152; Architecture.md §3 "Episodes"). A condition
+    whose clinical state starts and stops repeatedly — kidney stones, UTIs, fractures,
+    cellulitis — is not one standing fact but a series of them. Keying on subject alone
+    folded every recurrence into the first row: the second episode collided with the
+    first, there was nowhere for its date to live, and the count and every date but one
+    were lost with no warning.
+
+    ``self`` / ``family:mother`` (:func:`_condition_subject`) when the row states no
+    onset; ``self@2009-09-15`` when it does, at the source's own precision
+    (``self@1998``, ``self@1998-05``). Onset is **folded into the existing subject part**
+    rather than appended as a fourth key part — the :func:`key_token` decision applied
+    again (issue #71). A fourth part would rewrite ``"a|b|c"`` into ``"a|b|c|"`` and so
+    move the key of *every* stored condition row, undated ones included, orphaning every
+    family-scoped verdict in the table. Folding leaves an undated row's ``dedup_key``
+    bit-identical, so `pemr rekey` moves only the dated rows the change actually affects.
+
+    :func:`_date_only` drops a stray time component and leaves each of the three accepted
+    precisions verbatim — no sentinel padding to ``-01-01``. That is what keeps ordering
+    lexical (each form is a prefix of the next) and keeps ``1998`` from claiming a day the
+    source never stated. A blank or whitespace-only ``onset_on`` is *absent*, not an empty
+    discriminator, so it keys identically to a NULL one.
+
+    Undated repeats still exist — a source that dates neither episode — and they still
+    collide. That is what :func:`occurrence_key` is for: `dedup_occurrence` is not replaced
+    by this change, only demoted from primary discriminator to the fallback tiebreaker for
+    same-date collisions and undated rows.
+    """
+    subject = _condition_subject(row, dictionary)
+    onset = _date_only(row.get("onset_on"))
+    return f"{subject}@{onset}" if onset else subject
+
+
 # Per record type: the :data:`FIELD_SPECS` names :func:`_key_parts` reads — the fields
 # whose value participates in the identity. Written down once, here, beside the function
 # it must stay true to, so `record edit` (issue #129) can derive its editable set as
@@ -604,7 +640,9 @@ def _condition_subject(row: dict, dictionary: dict[str, str] | None = None) -> s
 # from the document), so nothing reading this table could offer it for editing anyway.
 # `condition` lists `status` **and** `relation` because :func:`_condition_subject` reads
 # them together — moving status to/from `family-history` moves the key, and `relation` is
-# what it moves it to.
+# what it moves it to. It also lists `onset_on` since issue #152: onset identifies the
+# *episode* (:func:`_condition_episode`), so correcting one is a rekey
+# (`record edit --identity`), not an in-place correction.
 KEY_FIELDS: dict[str, frozenset[str]] = {
     "lab_result": frozenset({"test_name", "collected_at"}),
     "medication": frozenset({"name", "dose", "started_on"}),
@@ -612,7 +650,7 @@ KEY_FIELDS: dict[str, frozenset[str]] = {
     "appointment": frozenset({"provider", "scheduled_for"}),
     "observation": frozenset({"obs_type", "observed_at", "key"}),
     "allergy": frozenset({"substance"}),
-    "condition": frozenset({"name", "status", "relation"}),
+    "condition": frozenset({"name", "status", "relation", "onset_on"}),
 }
 
 
@@ -855,6 +893,11 @@ class CommitSummary:
 # but not the value, so a corrected or re-read value on an otherwise-matching key
 # collides and surfaces here as a CONFLICT instead of a silent duplicate — hence
 # value_num/value_text appear below.
+#
+# `condition.status`/`relation` are the exception that proves the rule: they reach the key
+# only through the `family-history` branch of :func:`_condition_subject`, so `active` vs
+# `resolved` on one episode is a genuine same-key disagreement and belongs here. A field
+# that *always* moves the key — `condition.onset_on` since issue #152 — does not.
 _COMPARE_FIELDS: dict[str, list[str]] = {
     "lab_result": ["value_num", "value_text", "unit", "ref_low", "ref_high", "flag", "loinc"],
     "medication": ["route", "frequency", "ended_on", "prescriber", "status",
@@ -863,7 +906,10 @@ _COMPARE_FIELDS: dict[str, list[str]] = {
     "appointment": ["specialty", "reason", "summary"],
     "observation": ["value_num", "value_text", "unit"],
     "allergy": ["reaction", "criticality", "noted_on"],
-    "condition": ["status", "onset_on", "resolved_on", "relation", "note"],
+    # `onset_on` left this list in issue #152: it identifies the episode now, so a
+    # difference in it yields a different key rather than a collision — and leaving it
+    # here would let `_sparse_gains` / `_merge_plan` offer to write an identity field.
+    "condition": ["status", "resolved_on", "relation", "note"],
 }
 
 # Types whose rows are standing facts restated across documents. For these, an absent

--- a/pemr/records.py
+++ b/pemr/records.py
@@ -12,7 +12,9 @@ Two operations, both shaped like `documents.remove_document`:
 
     * ``remove_record`` — delete a single typed record row, dry-run by default
     * ``edit_record`` — correct a single row's **non-key** fields in place,
-      dry-run by default, every change written to an append-only ledger
+      dry-run by default, every change written to an append-only ledger; with
+      ``identity=True`` (`record edit --identity`) it instead *moves* the row onto
+      the identity its corrected fields derive — a one-row rekey (issue #152)
 
 ``record_fts`` needs no explicit maintenance for either: migrations 003 and 006
 put AFTER DELETE **and** AFTER UPDATE triggers on every one of
@@ -63,6 +65,34 @@ verdict left behind would re-attach to whatever unrelated record lands on it. Th
 dry run names the verdict; ``apply`` lifts it in the same transaction as the delete
 (:func:`curation.retire_row_verdicts`). Family-scoped verdicts are untouched:
 ``dedup_base`` is content-derived, so re-attachment there is intentional.
+
+**An identity edit is a one-row rekey, not a fourth mechanism** (issue #152). Once
+``condition.onset_on`` identifies the *episode*, correcting a wrong onset date is by
+construction an identity change, and the old advice — "`record rm` and re-commit" —
+throws away the row's provenance and its ledger to fix a typo. ``--identity`` moves
+the row instead: same payload write, same ledger, same correction mark, plus the
+three ``dedup_*`` columns. Its consequences are deliberately the *same* consequences
+`pemr rekey` already has, reported the same way:
+
+    * **row-scoped** verdicts follow the row for free — :mod:`pemr.curation`
+      resolves them by ``record_id``, and a row verdict's stored ``dedup_base`` is a
+      breadcrumb that is never consulted (:data:`curation.ORPHAN_KINDS`);
+    * a **family-scoped** verdict on the base the row vacated orphans exactly as a
+      `rekey` base move orphans one — and *only* when the row was the last of its
+      family, :data:`curation.ORPHAN_NO_FAMILY`'s own rule. The report carries it in
+      the shape `pemr rekey --apply --json` emits, so `pemr record reaffirm
+      --map-file` re-points it with no new plumbing;
+    * ``dedup_occurrence`` is **not** renumbered on either side, for the reason
+      stated above for deletion;
+    * an open conflict anchored to the row is refused when the move would empty its
+      family, and disclosed as re-anchoring when a sibling survives — the
+      :func:`remove_record` rule, for the same reason: the document survives, so
+      `keep both` is still a live resolution.
+
+What it refuses outright is a *merge*: if the target family already holds a row that
+says the same thing, moving this one there would file one fact twice under one
+identity. That is `record rm` / `record annotate --status merged-into` work, and the
+error says so (:class:`IdentityCollisionError`).
 """
 
 from __future__ import annotations
@@ -89,8 +119,21 @@ class FieldNotEditableError(ValueError):
 
     Identity fields are not off-limits because editing them is unthinkable — it is
     because an identity change is a *different operation*, with its own answers
-    (a dictionary edit + `pemr rekey`, or `record rm` + re-commit). The message
-    points there rather than leaving the operator guessing.
+    (a dictionary edit + `pemr rekey`, or — since issue #152 — the same command with
+    ``--identity``). The message points there rather than leaving the operator
+    guessing.
+    """
+
+
+class IdentityCollisionError(ValueError):
+    """Refused: the identity the edit moves the row onto is already occupied by a row
+    saying the same thing (issue #152).
+
+    Not a correction but a **merge**, and merging is a recorded human judgment with its
+    own verbs (`record annotate --status merged-into`, or `record rm` once the operator
+    has decided which row is the survivor). Doing it silently here would file one
+    clinical fact twice under one identity and hide the duplicate behind an occurrence
+    number.
     """
 
 
@@ -148,6 +191,23 @@ class RecordEditReport:
     dedup_key: str = ""
     dedup_base: str = ""
     dedup_occurrence: int = 0
+    # --- identity edit (issue #152) --------------------------------------------
+    # Whether `--identity` was passed AND the corrected payload actually moves the key.
+    # False on an ordinary correction and on an inert `--identity` (nothing moved), so
+    # a reader never has to distinguish "asked for" from "happened".
+    identity: bool = False
+    # Where the row lands. Equal to the three columns above when `identity` is False.
+    new_dedup_key: str = ""
+    new_dedup_base: str = ""
+    new_dedup_occurrence: int = 0
+    # Family-scoped verdicts left pointing at the base this row vacated - only when it
+    # was the family's last row. Each entry is shaped like an entry of `pemr rekey
+    # --apply --json`'s `orphans` array, so the report feeds `pemr record reaffirm
+    # --map-file` unmodified. Empty on an ordinary correction.
+    curation_orphaned: list[dict] = field(default_factory=list)
+    # Open conflicts whose anchor row moves out from under them (siblings survive, so
+    # they re-anchor on their next resolution). The `remove_record` disclosure.
+    conflicts_reanchored: list[int] = field(default_factory=list)
     note: str = ""
     attributed_to: str | None = None
     edited_at: str = ""
@@ -166,6 +226,14 @@ class RecordEditReport:
             "dedup_key": self.dedup_key,
             "dedup_base": self.dedup_base,
             "dedup_occurrence": self.dedup_occurrence,
+            # Additive-only, per the `--json` contract rule: an existing consumer that
+            # never asked about identity edits reads exactly what it read before.
+            "identity": self.identity,
+            "new_dedup_key": self.new_dedup_key,
+            "new_dedup_base": self.new_dedup_base,
+            "new_dedup_occurrence": self.new_dedup_occurrence,
+            "curation_orphaned": self.curation_orphaned,
+            "conflicts_reanchored": self.conflicts_reanchored,
             "note": self.note,
             "attributed_to": self.attributed_to,
             "edited_at": self.edited_at,
@@ -399,6 +467,104 @@ def _same_value(stored: object, incoming: object) -> bool:
     return stored == incoming
 
 
+def _plan_identity_move(
+    conn: sqlite3.Connection,
+    record_type: str,
+    row: sqlite3.Row,
+    before: dict,
+    after: dict,
+    after_base: str,
+    dictionary: dict[str, str] | None,
+    report: RecordEditReport,
+) -> None:
+    """Gate a one-row rekey and fill in where the row lands (issue #152).
+
+    Everything that can refuse the move happens here, before the transaction opens —
+    :func:`dedup._plan_keep_both`'s shape, and for its reason. Writes nothing; it only
+    raises, or populates ``report``'s ``new_dedup_*`` / ``curation_orphaned`` /
+    ``conflicts_reanchored`` fields.
+
+    Called only when the corrected payload genuinely derives a different base, so the
+    "``--identity`` is inert" case never reaches here.
+    """
+    pk = f"{record_type}_id"
+    row_id = int(row[pk])
+    person_id = row["person_id"]
+
+    # 1. Drift. Both bases are checked, not just the one being left: moving *into* a
+    # family whose rows are stored under stale keys would file the row beside a sibling
+    # the engine can no longer see as one. Either way the remedy is the same run of
+    # `pemr rekey --apply`, and its message already says so.
+    dedup._assert_no_key_drift(conn, record_type, [before, after], person_id, dictionary)
+
+    # 2. Occupied target. `_rows_equal` is the engine's own duplicate-vs-conflict
+    # question, so "the same thing" here means exactly what it means at commit time -
+    # including the sparse-type reading, where a thinner stored sibling still counts as
+    # agreeing. The self-exclusion is belt-and-braces: gate 1 guarantees the row is
+    # stored under its pre-move base, so it cannot already be in the target family.
+    target = dedup.load_family(conn, record_type, after_base)
+    twin = next(
+        (m for m in target
+         if int(m[pk]) != row_id and dedup._rows_equal(record_type, m, after)),
+        None,
+    )
+    if twin is not None:
+        raise IdentityCollisionError(
+            f"refusing to move {record_type} {row_id} onto identity "
+            f"{after_base[:12]}...: {record_type} {int(twin[pk])} "
+            f"({dedup._rekey_label(record_type, twin)!r}) already says the same thing "
+            "there. Filing both under one identity is a merge, not a correction - "
+            f"record it with `pemr record annotate {record_type} {row_id} --status "
+            f"merged-into --merged-into {after_base}`, or drop the redundant row with "
+            f"`pemr record rm {record_type} {row_id}`; nothing was written"
+        )
+    # Monotonic over the target family and never reused, so a hole left by an earlier
+    # removal stays a hole rather than letting this row inherit a departed sibling's key.
+    occurrence = max((int(m["dedup_occurrence"] or 0) for m in target), default=-1) + 1
+    report.new_dedup_base = after_base
+    report.new_dedup_occurrence = occurrence
+    report.new_dedup_key = dedup.occurrence_key(after_base, occurrence)
+
+    # 3. Anchored conflicts, and what the vacated family loses. Both turn on the same
+    # question - does anything survive on the old base - so the survivors are computed
+    # once. Occurrence numbers on *that* side are not renumbered either.
+    survivors = [
+        m for m in dedup.load_family(conn, record_type, row["dedup_base"])
+        if int(m[pk]) != row_id
+    ]
+    anchored = dedup.conflicts_anchored_to_row(conn, record_type, row, dictionary)
+    if anchored and not survivors:
+        ids = ", ".join(f"#{cid}" for cid in anchored)
+        raise AnchoredConflictError(
+            f"{record_type} {row_id} ({report.label!r}) is the last row of the "
+            f"identity open conflict(s) {ids} are staged against - moving it to a new "
+            "identity would leave them with nothing to resolve against, and their "
+            "staged payload is not recoverable. Resolve them first with "
+            "`pemr review-conflicts --resolve <id> --keep both|existing`; "
+            "nothing was written"
+        )
+    report.conflicts_reanchored = anchored
+
+    # 4. Verdict carry-over. Row-scoped verdicts need nothing: `curation` resolves them
+    # by `record_id` and never consults the stored base. A family-scoped verdict is
+    # orphaned only when the base it names goes empty - `curation.ORPHAN_NO_FAMILY`'s own
+    # rule - so a family with survivors keeps its ruling and this stays quiet.
+    if not survivors:
+        verdict = curation.get_verdict(conn, record_type, row["dedup_base"])
+        if verdict is not None:
+            report.curation_orphaned = [{
+                **verdict,
+                "kinds": [curation.ORPHAN_NO_FAMILY],
+                "label": "",
+                "family_size": 0,
+                # The two keys `pemr record reaffirm --map-file` re-points on, named
+                # exactly as `pemr rekey --apply --json` names them, so this report is a
+                # valid map file with no reshaping.
+                "successor_base": after_base,
+                "successor_merge_base": None,
+            }]
+
+
 def edit_record(
     conn: sqlite3.Connection,
     record_type: str,
@@ -409,6 +575,7 @@ def edit_record(
     note: str,
     attributed_to: str | None = None,
     now: str | None = None,
+    identity: bool = False,
     apply: bool = False,
 ) -> RecordEditReport:
     """Correct one row's **non-key** fields in place, addressed by primary key.
@@ -449,13 +616,39 @@ def edit_record(
     because it compares like with like: a row whose stored key predates a dictionary edit
     is still editable, since both sides are recomputed under the same dictionary.
 
+    **``identity=True`` inverts that last guard into a move** (issue #152, the module
+    docstring). Identity fields become nameable, and instead of refusing the recomputed
+    key it *writes* it, carrying the row onto the corrected identity. The case it exists
+    for is the one the episode model creates: a ``condition`` whose ``onset_on`` — now
+    part of its key — was recorded wrong. Its own front-loaded gates, in order, nothing
+    written on any raise:
+
+        1. **drift** — :func:`dedup._assert_no_key_drift`. A row already stored under a
+           stale key has no meaningful base to move *from*; `pemr rekey --apply` first.
+        2. **no-move** — the corrected payload derives the same base, so ``--identity``
+           is inert and this is an ordinary correction. Not an error: passing the flag
+           defensively must not turn a no-op into a failure.
+        3. **occupied target** — a row in the destination family already says the same
+           thing (:func:`dedup._rows_equal`): :class:`IdentityCollisionError`, because
+           that is a merge (see the module docstring). Otherwise the row takes
+           ``max(dedup_occurrence) + 1`` of the target family, the monotonic rule
+           :func:`dedup._plan_keep_both` uses, so it can never land on an occupied key.
+        4. **anchored conflict** — :class:`AnchoredConflictError` when the row is the
+           last member of a family an open conflict is staged against; a survivable
+           re-anchoring is disclosed on the report instead.
+
+    A move can only ever *split* a family — adding a discriminator to an identity never
+    fuses two — so, gate 3 aside, it cannot manufacture a ``UNIQUE(dedup_key)`` violation.
+
     **Re-ingest divergence.** Once a unit is corrected, re-committing the *original*
     document stages a CONFLICT rather than deduping, because ``unit`` is one of
     ``dedup._COMPARE_FIELDS`` for ``lab_result`` and ``observation``. That is correct and
     loud: the stored row genuinely no longer says what its source says.
 
-    Raises :class:`FieldNotEditableError`, :class:`RecordNotFoundError`,
-    ``dedup.ValidationError`` or plain ``ValueError`` — all friendly rc=1 at the CLI.
+    Raises :class:`FieldNotEditableError`, :class:`IdentityCollisionError`,
+    :class:`AnchoredConflictError`, :class:`RecordNotFoundError`,
+    ``dedup.DictionaryDriftError``, ``dedup.ValidationError`` or plain ``ValueError`` —
+    all friendly rc=1 at the CLI.
     """
     db.require_migrated(conn)
     _require_type(record_type)
@@ -477,15 +670,19 @@ def edit_record(
         )
     editable = dedup.editable_fields(record_type)
     key_fields = dedup.KEY_FIELDS[record_type]
+    # With `--identity` the key fields join the nameable set; everything outside
+    # FIELD_SPECS stays unnameable in both modes, which is the provenance guarantee.
+    nameable = (*editable, *sorted(key_fields)) if identity else editable
     for name in updates:
-        if name in editable:
+        if name in nameable:
             continue
         if name in key_fields:
             raise FieldNotEditableError(
                 f"{record_type}.{name} is part of the row's identity (it feeds the "
                 "dedup_key), so it cannot be corrected in place - that is a different "
-                "operation: edit `data/dictionary.toml` and run `pemr rekey`, or "
-                f"`pemr record rm {record_type} {row_id}` and re-commit. Editable "
+                "operation: edit `data/dictionary.toml` and run `pemr rekey`, "
+                f"`pemr record rm {record_type} {row_id}` and re-commit, or pass "
+                "`--identity` to move the row onto the corrected identity. Editable "
                 f"{record_type} fields: {', '.join(editable)}; nothing was written"
             )
         raise FieldNotEditableError(
@@ -508,12 +705,13 @@ def edit_record(
     dedup.validate_row(record_type, {k: v for k, v in after.items() if v is not None})
 
     person_id = row["person_id"]
-    before_key = dedup.dedup_key(record_type, before, person_id, dictionary)
-    after_key = dedup.dedup_key(record_type, after, person_id, dictionary)
-    if before_key != after_key:
-        # Unreachable while KEY_FIELDS agrees with dedup._key_parts. Kept as the
-        # structural backstop: if a future key derivation reads a field this table does
-        # not list, the edit refuses instead of silently forking the fact.
+    before_base = dedup.dedup_key(record_type, before, person_id, dictionary)
+    after_base = dedup.dedup_key(record_type, after, person_id, dictionary)
+    moves = before_base != after_base
+    if moves and not identity:
+        # Reachable only when KEY_FIELDS has fallen out of step with dedup._key_parts:
+        # a named field the table does not list as identity nonetheless moved the key.
+        # (An intentional identity change comes through `identity=True` instead.)
         raise FieldNotEditableError(
             f"refusing to edit {record_type} {row_id}: the requested change would move "
             "its dedup_key, which is an identity change rather than a correction "
@@ -524,11 +722,11 @@ def edit_record(
     changes = [
         {"field": name, "old": _ledger_text(before[name]),
          "new": _ledger_text(updates[name])}
-        for name in editable
+        for name in nameable
         if name in updates and not _same_value(before[name], updates[name])
     ]
     unchanged = [
-        name for name in editable
+        name for name in nameable
         if name in updates and _same_value(before[name], updates[name])
     ]
 
@@ -545,10 +743,27 @@ def edit_record(
         dedup_key=row["dedup_key"],
         dedup_base=row["dedup_base"],
         dedup_occurrence=int(row["dedup_occurrence"] or 0),
+        identity=moves,
+        # Default to standing still: an ordinary correction reports the same three
+        # columns on both sides, so a reader never has to special-case the common path.
+        new_dedup_key=row["dedup_key"],
+        new_dedup_base=row["dedup_base"],
+        new_dedup_occurrence=int(row["dedup_occurrence"] or 0),
         note=cleaned_note,
         attributed_to=(attributed_to or "").strip() or None,
         edited_at=stamp,
     )
+
+    key_assignments: list[str] = []
+    key_values: list[object] = []
+    if moves:
+        _plan_identity_move(
+            conn, record_type, row, before, after, after_base, dictionary, report
+        )
+        key_assignments = [f"{name} = ?" for name in dedup.INTERNAL_COLUMNS]
+        key_values = [
+            report.new_dedup_key, report.new_dedup_base, report.new_dedup_occurrence,
+        ]
 
     if apply and changes:
         # One transaction for the UPDATE and its ledger rows: a correction that commits
@@ -559,12 +774,18 @@ def edit_record(
         # statement: the payload change and its disclosure must land together or not at
         # all. These two columns are outside FIELD_SPECS, so they can never collide with a
         # named change. Last correction wins on the row; the ledger below keeps every one.
+        # An identity move carries the three dedup_* columns in the *same* statement
+        # (issue #152): a payload that landed under its old key, or a key with no
+        # payload behind it, is precisely the drift `_assert_no_key_drift` exists to
+        # catch. They are outside FIELD_SPECS too, so they cannot collide with a change.
         assignments = ", ".join(
             [f"{c['field']} = ?" for c in changes]
             + [f"{name} = ?" for name in dedup.EDIT_MARK_COLUMNS]
+            + key_assignments
         )
         values = [
             *(updates[c["field"]] for c in changes), stamp, report.attributed_to,
+            *key_values,
         ]
         with conn:
             cur = conn.execute(

--- a/pemr/verify.py
+++ b/pemr/verify.py
@@ -10,10 +10,11 @@ One function, two callers: `pemr verify` prints this report, and `pemr restore` 
 the same report as its tail so the issue's acceptance drill is a single command
 afterwards.
 
-Beyond the blob pass the report also carries two per-row scans that need a human's eye
-but are not corruption: inert `curation` verdicts (issues #109, #114) and medication rows
-whose `status` is not a lifecycle value (issue #151). Both append to `warnings`, so
-neither moves the exit code.
+Beyond the blob pass the report also carries three per-row scans that need a human's eye
+but are not corruption: inert `curation` verdicts (issues #109, #114), medication rows
+whose `status` is not a lifecycle value (issue #151), and an undated `condition` row
+sitting beside dated episodes of the same problem (issue #152). All three append to
+`warnings`, so none of them moves the exit code.
 
 **Reports, never repairs.** No FTS rebuild, no blob refetch, no orphan sweep (blobs in
 `sources/` with no `document` row) — those are deliberate non-goals, see the issue's
@@ -316,6 +317,69 @@ def _check_med_status(conn: sqlite3.Connection, report: VerifyReport) -> None:
         )
 
 
+def _check_conditions(conn: sqlite3.Connection, report: VerifyReport) -> None:
+    """Warn about an **undated** condition row sitting beside dated episodes of the same
+    problem (issue #152).
+
+    The visible edge of the episode model. Once `onset_on` identifies the episode, an
+    undated umbrella claim ("kidney stones") and a dated episode ("kidney stones,
+    2009-09-15") are two identities, so a later document that dates the problem lands as
+    a **new row** beside the undated one rather than filling it in - `onset_on` left
+    `dedup._COMPARE_FIELDS`, so `_sparse_gains` can no longer enrich it in place.
+
+    That is the intended semantics: an undated umbrella claim and a dated episode are
+    different claims, and auto-absorbing one into the other is exactly the silent fold
+    this issue exists to end. But left unannounced it is silent *duplication* instead of
+    silent folding, which trades one invisible defect for another. So it is announced -
+    the operator decides whether the umbrella row is the same episode (give it the onset,
+    which is a rekey) or a genuinely separate undated claim (rule on it).
+
+    A warning, never a problem: two such rows are untidy, not corrupt, and which of the
+    two remedies applies is a clinical judgment `verify` has no way to make. The pairing
+    is derived dictionary-free (`dedup.norm` with no synonym table), so a synonym pair
+    spelled two ways across documents is a missed warning rather than a false one - the
+    conservative direction for a notice a human acts on.
+    """
+    # `condition` arrives in migration 006, so `is_migrated` is not enough on its own -
+    # the `_check_curation` / `curation.has_table` shim, for the same reason: a restored
+    # older snapshot must report nothing here rather than raise `no such table`.
+    if "condition" not in _existing_tables(conn):
+        return
+    rows = conn.execute(
+        "SELECT * FROM condition ORDER BY condition_id"
+    ).fetchall()
+    # (person, normalized name, subject-without-onset) -> undated ids, dated ids.
+    groups: dict[tuple, tuple[list[int], list[int]]] = {}
+    for row in rows:
+        payload = {name: row[name] for name in dedup.FIELD_SPECS["condition"]}
+        key = (
+            row["person_id"],
+            dedup.norm(row["name"], None),
+            # The episode discriminator with onset stripped: the family an episode
+            # belongs to, which is precisely what `_condition_subject` answers.
+            dedup._condition_episode({**payload, "onset_on": None}, None),
+        )
+        undated, dated = groups.setdefault(key, ([], []))
+        (dated if dedup._date_only(row["onset_on"]) else undated).append(
+            int(row["condition_id"])
+        )
+    for (_person, _name, _subject), (undated, dated) in groups.items():
+        if not undated or not dated:
+            continue
+        for row_id in undated:
+            # ASCII-only and PHI-free (issue #23; this repo is public): row ids only,
+            # never the condition name and never the person.
+            others = ", ".join(f"#{d}" for d in dated)
+            report.warnings.append(
+                f"condition row #{row_id} has no onset_on but the same problem is also "
+                f"stored as dated episode(s) {others} - since onset identifies the "
+                "episode these are separate rows, which may be a real undated claim or "
+                f"the same episode twice; date it with `pemr record edit condition "
+                f"{row_id} --identity --set onset_on=YYYY-MM-DD --note ...`, or rule on "
+                f"it with `pemr record annotate condition {row_id} --status ...`"
+            )
+
+
 def verify_report(
     conn: sqlite3.Connection, sources_dir: str | Path | None = None
 ) -> VerifyReport:
@@ -342,6 +406,7 @@ def verify_report(
         # `medication` ships in 001_init, so `is_migrated` is a sufficient guard - no
         # `has_table` shim like curation's (that table arrives in a later migration).
         _check_med_status(conn, report)
+        _check_conditions(conn, report)
 
     if sources_dir is None:
         report.blobs_skipped = "no sources dir configured"

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -708,7 +708,11 @@ def _seed_generic_condition_pair(ready, capsys, tmp_path, old):
     """The `meridun/pemr-data#12` item 6 shape at the CLI: two real, different conditions
     that the extractor labelled with numbered placeholders, one document each. A
     `"diagnosis 2" = "diagnosis"` dictionary entry folds them onto one key - the fuse a
-    dictionary edit cannot undo, because the labels are synonyms of nothing."""
+    dictionary edit cannot undo, because the labels are synonyms of nothing.
+
+    Both rows carry the **same** onset: since issue #152 onset is part of a condition's
+    identity, so two different dates would key the pair apart on their own and there
+    would be no fuse left for this test to exercise."""
     for i, (name, note) in enumerate(
         (("diagnosis", "hypertension, per cardiology"),
          ("diagnosis 2", "asthma, per pulmonology")), start=1
@@ -719,7 +723,7 @@ def _seed_generic_condition_pair(ready, capsys, tmp_path, old):
                     "--sources", str(tmp_path / "sources")) == 0
         doc = _document_id(tmp_path)[-1]["document_id"]
         payload = _write_json(tmp_path, f"generic{i}.json", {"condition": [
-            {"name": name, "status": "active", "onset_on": f"2024-0{i}-05", "note": note},
+            {"name": name, "status": "active", "onset_on": "2024-01-05", "note": note},
         ]})
         assert _run(tmp_path, "commit-extraction", "--document", str(doc),
                     "--json", str(payload), "--dictionary", str(old)) == 0
@@ -1567,6 +1571,11 @@ def test_post_006_stale_key_blocks_the_recommit_instead_of_forking_it(tmp_path, 
     (that was the pre-guard behaviour the doc used to describe). Enforcement is narrow:
     an unrelated condition still commits while the stale key sits there, which is why
     the doc has to tell operators to run the rekey rather than wait to be stopped.
+
+    The re-statement carries the migrated row's `onset_on`, because since issue #152 a
+    condition's onset is part of its identity: an *undated* restatement of a dated stored
+    episode is a different claim, not the same fact under a stale key, so it would
+    (correctly) commit as a new row rather than trip this guard.
     """
     staged = _stage_pre_006(tmp_path)
     assert _run(tmp_path, "migrate", "--create", "--migrations-dir", str(staged)) == 0
@@ -1587,8 +1596,11 @@ def test_post_006_stale_key_blocks_the_recommit_instead_of_forking_it(tmp_path, 
                 "--sources", str(tmp_path / "sources")) == 0
     capsys.readouterr()
 
-    same = _write_json(tmp_path, "same.json",
-                       {"condition": [{"name": "Hypertension", "status": "active"}]})
+    # 006 carries the observation's `observed_at` into `condition.onset_on`, so this is
+    # the same episode restated - what makes it collide with the stale key.
+    same = _write_json(tmp_path, "same.json", {"condition": [
+        {"name": "Hypertension", "status": "active", "onset_on": "2024-01-02"},
+    ]})
     assert _run(tmp_path, "commit-extraction", "--document", "1", "--json", str(same)) == 1
     err = capsys.readouterr().err
     assert "no longer matches the current dictionary" in err

--- a/tests/test_cli_phase4.py
+++ b/tests/test_cli_phase4.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from pemr import cli, db, dedup, persons, render
+from pemr import cli, curation, db, dedup, persons, render
 
 DICT_PATH = str(
     Path(__file__).resolve().parent.parent / "data" / "dictionary.example.toml"
@@ -687,3 +687,166 @@ def test_a_blank_key_assert_exits_non_zero(ready, capsys):
     err = capsys.readouterr().err
     assert "missing required field 'key'" in err
     assert err.isascii()
+
+
+# --- issue #152: the episode model, end to end at the CLI ---------------------
+#
+# The fixtures below are SYNTHETIC (AGENTS.md: this repo is public and carries no real
+# PII). The real umbrella row this issue was filed over is operator work in the private
+# data repo; what is pinned here is the *shape* of the unfold and of the migration.
+
+
+def _conditions(tmp_path):
+    """Every stored condition as ``{onset_on: (row_id, dedup_base)}``."""
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        return {
+            row["onset_on"]: (int(row["condition_id"]), row["dedup_base"])
+            for row in conn.execute("SELECT * FROM condition")
+        }
+    finally:
+        conn.close()
+
+
+def _commit_condition(tmp_path, sha, rows):
+    conn = db.connect(tmp_path / "cli.db")
+    pid = conn.execute(
+        "SELECT person_id FROM person WHERE slug='jane-doe'"
+    ).fetchone()["person_id"]
+    cur = conn.execute(
+        "INSERT INTO document (sha256, person_id, source_path, ingested_at) "
+        "VALUES (?, ?, 'aa/y.pdf', '2026-01-01T00:00:00')", (sha, pid),
+    )
+    conn.commit()
+    dedup.commit_extraction(conn, cur.lastrowid, {"condition": rows},
+                            dedup.load_dictionary(DICT_PATH))
+    conn.close()
+
+
+def test_unfolding_an_umbrella_condition_into_two_episodes(ready, capsys):
+    """The acceptance case (issue #152), as an operator sequence at the CLI.
+
+    A recurring problem was stored as ONE umbrella row because the old identity had
+    nowhere to put a second date. Unfolding it is deliberately *not* inferred - nothing
+    in the stored row says it holds two episodes, and the `note` text must never be
+    parsed for dates. The operator gives the umbrella row the episode it really is
+    (`record edit --identity`) and files the other one (`record assert`).
+    """
+    tmp_path, _ = ready
+    _commit_condition(tmp_path, "sha-umbrella", [
+        {"name": "Recurrent kidney stones", "status": "resolved",
+         "note": "two episodes; second ultrasound-confirmed"},
+    ])
+    umbrella = _conditions(tmp_path)[None][0]
+    capsys.readouterr()
+
+    # 1. The umbrella row *is* the documented recent episode - date it. That moves its
+    #    key, which is exactly why the flag has to be explicit.
+    assert _run(tmp_path, "record", "edit", "condition", str(umbrella), "--identity",
+                "--set", "onset_on=2009-09-15", "--note",
+                "ultrasound report dates this episode", "--apply") == 0
+    out = capsys.readouterr().out
+    assert "onset_on: (none) -> 2009-09-15" in out
+    assert "-> " in out.split("identity: dedup_key ")[1].splitlines()[0]
+    assert "moved onto its corrected identity" in out
+
+    # 2. The earlier, owner-reported episode is a separate claim with its own date.
+    assert _run(tmp_path, "record", "assert", "condition", "--person", "jane-doe",
+                "--attributed-to", "Jane Doe", "--date", "2026-08-18",
+                "--field", "name=Recurrent kidney stones",
+                "--field", "status=resolved", "--field", "onset_on=1998-05",
+                "--apply") == 0
+    capsys.readouterr()
+
+    rows = _conditions(tmp_path)
+    assert set(rows) == {"1998-05", "2009-09-15"}
+    # Two identities, not one family with two occurrences.
+    assert rows["1998-05"][1] != rows["2009-09-15"][1]
+    assert rows["2009-09-15"][0] == umbrella      # same row, same id, same provenance
+    # And the engine agrees both are stored under the keys it would compute today.
+    assert _run(tmp_path, "rekey") == 0
+    assert "0/2 key(s) change" in capsys.readouterr().out
+
+
+def test_the_rekey_migration_carries_a_family_verdict_across(ready, capsys):
+    """The migration sequence the doc records, composed end to end: `pemr rekey --apply
+    --json` > file, `pemr record reaffirm --map-file`, `pemr verify` clean.
+
+    The pre-#152 state is staged by writing the *old* (onset-free) key onto a dated row,
+    which is exactly what an existing database holds. The undated row beside it is the
+    control: its key must not move, which is the whole reason onset was folded into the
+    subject part instead of appended as a fourth one.
+    """
+    tmp_path, _ = ready
+    _commit_condition(tmp_path, "sha-migrate", [
+        {"name": "Gout", "status": "resolved", "onset_on": "2019-04-02"},
+        {"name": "Eczema", "status": "active"},
+    ])
+
+    conn = db.connect(tmp_path / "cli.db")
+    pid = conn.execute(
+        "SELECT person_id FROM person WHERE slug='jane-doe'"
+    ).fetchone()["person_id"]
+    gout = int(conn.execute(
+        "SELECT condition_id FROM condition WHERE name='Gout'"
+    ).fetchone()["condition_id"])
+    eczema_key = conn.execute(
+        "SELECT dedup_key FROM condition WHERE name='Eczema'"
+    ).fetchone()["dedup_key"]
+    # The key this row carried before onset joined the identity.
+    old_base = dedup.dedup_key(
+        "condition", {"name": "Gout", "status": "resolved"}, pid,
+        dedup.load_dictionary(DICT_PATH),
+    )
+    conn.execute(
+        "UPDATE condition SET dedup_key = ?, dedup_base = ? WHERE condition_id = ?",
+        (old_base, old_base, gout),
+    )
+    conn.commit()
+    conn.close()
+
+    assert _run(tmp_path, "record", "annotate", "condition", old_base,
+                "--status", "confirmed", "--note", "ruled before the episode model",
+                "--apply") == 0
+    capsys.readouterr()
+
+    assert _run(tmp_path, "rekey", "--apply", "--json") == 0
+    # The composed pipeline is one redirection in a shell (`... --json > f`); pytest
+    # captures stdout instead, so the redirection is spelled out here.
+    report = tmp_path / "rekey.json"
+    report.write_text(capsys.readouterr().out, encoding="utf-8")
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert payload["collisions"] == []
+    assert [c["row_id"] for c in payload["changed"]] == [gout]     # undated row unmoved
+    orphans = payload["orphans"]
+    assert [o["dedup_base"] for o in orphans] == [old_base]
+
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        assert conn.execute(
+            "SELECT dedup_key FROM condition WHERE name='Eczema'"
+        ).fetchone()["dedup_key"] == eczema_key
+        new_base = conn.execute(
+            "SELECT dedup_base FROM condition WHERE condition_id = ?", (gout,)
+        ).fetchone()["dedup_base"]
+    finally:
+        conn.close()
+    assert orphans[0]["successor_base"] == new_base
+
+    capsys.readouterr()
+    assert _run(tmp_path, "record", "reaffirm", "--map-file", str(report),
+                "--apply") == 0
+    capsys.readouterr()
+
+    conn = db.connect(tmp_path / "cli.db")
+    try:
+        moved = curation.get_verdict(conn, "condition", new_base)
+        assert moved is not None and moved["status"] == "confirmed"
+        assert curation.get_verdict(conn, "condition", old_base) is None
+        assert curation.list_orphans(conn) == []
+    finally:
+        conn.close()
+
+    assert _run(tmp_path, "verify") == 0
+    out = capsys.readouterr().out
+    assert "orphan" not in out and "no live family" not in out

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -1348,6 +1348,71 @@ def test_verify_is_silent_about_warnings_when_there_are_none(seeded):
     assert not any(line.startswith("warnings") for line in verify.format_report(report))
 
 
+# --- issue #152: an undated condition beside dated episodes of the same problem ---
+
+
+def _condition_warnings(conn):
+    return [w for w in verify.verify_report(conn).warnings if w.startswith("condition row")]
+
+
+def test_verify_warns_about_an_undated_condition_beside_a_dated_episode(seeded):
+    """The visible edge of the episode model. Once onset identifies the episode, a later
+    document that dates a problem lands as a *new* row beside the undated umbrella one
+    rather than filling it in - the intended semantics, but silent duplication if nobody
+    is told. The operator decides which of the two remedies applies."""
+    conn = seeded["conn"]
+    assert _condition_warnings(conn) == []
+    dedup.commit_extraction(conn, seeded["doc"], {"condition": [
+        {"name": "Kidney stones", "status": "resolved"},
+    ]})
+    assert _condition_warnings(conn) == []          # undated alone: nothing to say
+    dedup.commit_extraction(conn, seeded["doc"], {"condition": [
+        {"name": "Kidney stones", "status": "resolved", "onset_on": "2009-09-15"},
+    ]})
+
+    undated = _row_id(conn, "condition", "name", "Kidney stones")
+    report = verify.verify_report(conn)
+    warnings = _condition_warnings(conn)
+    assert len(warnings) == 1
+    assert f"condition row #{undated}" in warnings[0]
+    assert "record edit condition" in warnings[0] and "--identity" in warnings[0]
+    assert "Kidney stones" not in warnings[0]   # row ids only: no problem, no person
+    assert warnings[0].isascii()                # issue #23
+    # A warning is an observation; it must not flip the exit code.
+    assert report.ok is True and report.problems == []
+
+
+def test_verify_is_silent_when_every_episode_is_dated(seeded):
+    """Two dated episodes of one problem are exactly what the episode model is for -
+    warning on them would make the notice noise nobody reads."""
+    conn = seeded["conn"]
+    dedup.commit_extraction(conn, seeded["doc"], {"condition": [
+        {"name": "Kidney stones", "status": "resolved", "onset_on": "1998-05"},
+        {"name": "Kidney stones", "status": "resolved", "onset_on": "2009-09-15"},
+    ]})
+    assert _condition_warnings(conn) == []
+
+
+def test_verify_does_not_pair_a_relatives_episode_with_the_patients_own(seeded):
+    """The subject discriminator still separates them: an undated family-history entry
+    and the patient's own dated problem are different subjects, not two episodes of one.
+    """
+    conn = seeded["conn"]
+    dedup.commit_extraction(conn, seeded["doc"], {"condition": [
+        {"name": "Kidney stones", "status": "family-history", "relation": "mother"},
+        {"name": "Kidney stones", "status": "resolved", "onset_on": "2009-09-15"},
+    ]})
+    assert _condition_warnings(conn) == []
+
+
+def test_verify_condition_check_is_silent_on_an_empty_database(tmp_path):
+    """A freshly migrated archive has no `condition` rows: the check must add nothing and
+    must not move the exit code (`pemr verify` runs on empty DBs after `restore`)."""
+    conn = db.connect(tmp_path / "empty.db")
+    db.migrate(conn)
+    assert _condition_warnings(conn) == []
+
+
 def test_verify_warns_about_an_orphaned_row_scoped_verdict(seeded):
     """AC 7: the row-scope twin of the family orphan warning - the **backstop**.
 

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -2291,6 +2291,171 @@ def test_condition_lifecycle_change_stages_a_conflict(conn):
     assert (row["status"], row["resolved_on"]) == ("resolved", "2025-09-01")
 
 
+# --- issue #152: the episode model on `condition` -----------------------------
+
+def test_two_dated_episodes_of_one_condition_both_commit(conn):
+    """The defect this issue exists to fix. A recurring problem - kidney stones, UTIs,
+    fractures - used to fold every recurrence into the first row: the second episode
+    collided with the first, there was nowhere for its date to live, and the count and
+    every date but one vanished with no warning. Onset in the identity keys them apart."""
+    summary = _commit(conn, {"condition": [
+        {"name": "Kidney stones", "status": "resolved", "onset_on": "1998-05"},
+        {"name": "Kidney stones", "status": "resolved", "onset_on": "2009-09-15"},
+    ]})
+    assert summary.counts == {"new": 2, "duplicate": 0, "enriched": 0, "conflict": 0,
+                              "promoted": 0}
+    rows = conn.execute(
+        "SELECT * FROM condition ORDER BY onset_on"
+    ).fetchall()
+    assert [r["onset_on"] for r in rows] == ["1998-05", "2009-09-15"]
+    # Two identities, not one family with two occurrences: the occurrence tiebreaker is
+    # the fallback now, and a dated pair must never need it.
+    assert rows[0]["dedup_base"] != rows[1]["dedup_base"]
+    assert [int(r["dedup_occurrence"]) for r in rows] == [0, 0]
+    # ... and re-stating one of them is still an ordinary duplicate.
+    again = _commit(conn, {"condition": [
+        {"name": "kidney stones", "status": "resolved", "onset_on": "2009-09-15"}]})
+    assert again.counts["duplicate"] == 1
+
+
+def test_an_undated_condition_key_is_unchanged_by_the_episode_model(conn):
+    """The folding guarantee, pinned to a literal hash (issue #152).
+
+    Onset is folded into the existing subject part rather than appended as a fourth key
+    part, so an *undated* condition row hashes exactly what it hashed before the episode
+    model landed. That is what keeps the migration to `pemr rekey --apply` cheap and
+    keeps every family-scoped verdict on an undated family attached. A change here means
+    the whole condition table moved, undated rows included - re-read
+    `dedup._condition_episode` before touching this number."""
+    assert dedup.dedup_key(
+        "condition", {"name": "Chickenpox", "status": "history"}, 1
+    ) == "e5c118be803abf4ec14294ceef69f624c95c2f021a1466eeedcdc6ed0ff39a44"
+    # The family-history subject too - it is the same key part.
+    assert dedup.dedup_key(
+        "condition",
+        {"name": "Chickenpox", "status": "family-history", "relation": "Mother"}, 1,
+    ) == "48b2c929e52fbb0121f1f2805831a3d094a84eef88fd05f8a7312549c61185e8"
+    # A blank onset is *absent*, not an empty discriminator: `""` must key like NULL.
+    assert dedup.dedup_key(
+        "condition", {"name": "Chickenpox", "status": "history", "onset_on": "  "}, 1
+    ) == dedup.dedup_key(
+        "condition", {"name": "Chickenpox", "status": "history"}, 1
+    )
+
+
+def test_an_undated_repeat_still_falls_back_to_the_occurrence_tiebreaker(conn):
+    """`dedup_occurrence` is demoted, not replaced. Two undated statements of one problem
+    still collide - which is correct, since nothing distinguishes them - and `--keep both`
+    is still the recovery path that admits the second as a sibling."""
+    _commit(conn, {"condition": [
+        {"name": "Cellulitis", "status": "resolved", "note": "left calf"}]})
+    # A *stated* disagreement, not an omission: `condition` is a sparse type, so a note
+    # over a stored NULL would enrich the first row instead of colliding with it.
+    summary = _commit(conn, {"condition": [
+        {"name": "Cellulitis", "status": "resolved", "note": "right calf"}]})
+    assert summary.counts["conflict"] == 1
+
+    conflict_id = dedup.list_conflicts(conn)[0]["conflict_id"]
+    dedup.resolve_conflict(conn, conflict_id, keep="both")
+    rows = conn.execute(
+        "SELECT * FROM condition ORDER BY dedup_occurrence"
+    ).fetchall()
+    assert len(rows) == 2
+    assert rows[0]["dedup_base"] == rows[1]["dedup_base"]
+    assert [int(r["dedup_occurrence"]) for r in rows] == [0, 1]
+
+
+def test_onset_precision_gives_three_identities_stored_verbatim(conn):
+    """Partial dates, FHIR-style: `1998`, `1998-05` and `1998-05-20` are three different
+    claims, stored at the precision the source stated with no sentinel padding, and each
+    a lexical prefix of the next so they sort in that order."""
+    summary = _commit(conn, {"condition": [
+        {"name": "Migraine", "status": "history", "onset_on": "1998-05-20"},
+        {"name": "Migraine", "status": "history", "onset_on": "1998"},
+        {"name": "Migraine", "status": "history", "onset_on": "1998-05"},
+    ]})
+    assert summary.counts["new"] == 3
+    stored = [
+        r["onset_on"] for r in
+        conn.execute("SELECT onset_on FROM condition ORDER BY onset_on").fetchall()
+    ]
+    # Verbatim (no `1998-01-01` padding) and lexically ordered in one assertion.
+    assert stored == ["1998", "1998-05", "1998-05-20"]
+    assert len({
+        dedup.dedup_key("condition",
+                        {"name": "Migraine", "status": "history", "onset_on": v}, 1)
+        for v in stored
+    }) == 3
+    # A stray time component is still truncated to the date, as on every dated type.
+    assert dedup.dedup_key(
+        "condition",
+        {"name": "Migraine", "status": "history", "onset_on": "1998-05-20T09:00"}, 1,
+    ) == dedup.dedup_key(
+        "condition",
+        {"name": "Migraine", "status": "history", "onset_on": "1998-05-20"}, 1,
+    )
+
+
+def test_onset_is_identity_not_payload_in_both_tables():
+    """The two tables that have to agree once onset moved (issue #152): `record edit`
+    stops offering it, and the duplicate-vs-conflict comparison stops naming it - which
+    is what keeps `_sparse_gains` from offering to write an identity field."""
+    assert "onset_on" in dedup.KEY_FIELDS["condition"]
+    assert dedup.editable_fields("condition") == ("resolved_on", "note")
+    assert "onset_on" not in dedup._COMPARE_FIELDS["condition"]
+
+
+def test_rekey_splits_dated_episodes_and_leaves_undated_rows_alone(conn):
+    """The migration, end to end (issue #152). Over a table holding both kinds:
+
+    * every *dated* row's key moves - that is the rekey the identity change owes;
+    * every *undated* row's key does not, the folding guarantee;
+    * a `--keep both` pair with different onsets **splits** into two bases, and the
+      former occurrence-1 row keeps its stored occurrence rather than being renumbered
+      (renumbering would rewrite sibling keys out from under any staged conflict);
+    * nothing collides - adding a discriminator to a key only ever splits families.
+    """
+    doc = _make_document(conn)
+    # Two undated statements of one problem, admitted as a family via `--keep both`,
+    # then dated differently: the umbrella row that the episode model unfolds.
+    _commit(conn, {"condition": [
+        {"name": "UTI", "status": "resolved", "note": "first course"}]}, doc=doc)
+    _commit(conn, {"condition": [
+        {"name": "UTI", "status": "resolved", "note": "second course"}]}, doc=doc)
+    dedup.resolve_conflict(conn, dedup.list_conflicts(conn)[0]["conflict_id"],
+                           keep="both")
+    _commit(conn, {"condition": [{"name": "Eczema", "status": "active"}]}, doc=doc)
+
+    ids = [int(r["condition_id"]) for r in conn.execute(
+        "SELECT condition_id FROM condition ORDER BY condition_id")]
+    first, second, eczema = ids
+    before = {
+        int(r["condition_id"]): r["dedup_key"]
+        for r in conn.execute("SELECT condition_id, dedup_key FROM condition")
+    }
+    for row_id, onset in ((first, "2021-03-02"), (second, "2024-11-18")):
+        conn.execute("UPDATE condition SET onset_on = ? WHERE condition_id = ?",
+                     (onset, row_id))
+    conn.commit()
+
+    report = dedup.rekey(conn, None, apply=True)
+    assert report.collisions == [] and report.blocked == []
+    assert {c.row_id for c in report.changes} == {first, second}
+
+    rows = {int(r["condition_id"]): r
+            for r in conn.execute("SELECT * FROM condition")}
+    assert rows[eczema]["dedup_key"] == before[eczema]          # undated: untouched
+    assert rows[first]["dedup_base"] != rows[second]["dedup_base"]   # split
+    # The hole is deliberate: the second row stays occurrence 1 on its own new base.
+    assert int(rows[first]["dedup_occurrence"]) == 0
+    assert int(rows[second]["dedup_occurrence"]) == 1
+    assert rows[second]["dedup_key"] == dedup.occurrence_key(
+        rows[second]["dedup_base"], 1
+    )
+    # Idempotent: a second run has nothing left to move.
+    assert dedup.rekey(conn, None, apply=True).changes == []
+
+
 def test_sparse_types_do_not_conflict_on_an_omitted_field(conn):
     """A document that simply doesn't restate criticality means "didn't say", not
     "cleared" - otherwise re-ingesting next year's summary stages a conflict per allergy."""
@@ -2326,27 +2491,33 @@ def test_a_stated_field_over_a_stored_null_enriches_rather_than_dedups(conn):
 
 def test_enrichment_fills_only_nulls_and_never_launders_a_disagreement(conn):
     """A stated value must never overwrite a stored one on the quiet path - that is
-    still a conflict, even when the same row also has a NULL the document could fill."""
+    still a conflict, even when the same row also has a NULL the document could fill.
+
+    The fillable NULL is `resolved_on`, not `onset_on`: since issue #152 onset is part of
+    a condition's identity, so an incoming row stating one keys elsewhere entirely and
+    never reaches the duplicate-vs-conflict comparison this test is about."""
     _commit(conn, {"condition": [{"name": "Chickenpox", "status": "history"}]})
     summary = _commit(conn, {"condition": [
-        {"name": "Chickenpox", "status": "active", "onset_on": "1988-03-01"}]})
+        {"name": "Chickenpox", "status": "resolved", "resolved_on": "1988-03-01"}]})
     assert summary.counts == {"new": 0, "duplicate": 0, "enriched": 0, "conflict": 1, "promoted": 0}
     row = conn.execute("SELECT * FROM condition").fetchone()
-    assert (row["status"], row["onset_on"]) == ("history", None)
+    assert (row["status"], row["resolved_on"]) == ("history", None)
 
 
 def test_a_terser_row_later_in_one_submission_does_not_undo_an_enrichment(conn):
     """Both directions inside a single batch: the detailed row enriches the terse one,
-    and a third terse row after it is still just a duplicate."""
+    and a third terse row after it is still just a duplicate.
+
+    `resolved_on` rather than `onset_on`, for the reason the test above states."""
     summary = _commit(conn, {"condition": [
-        {"name": "Anemia", "status": "active"},
-        {"name": "Anemia", "status": "active", "note": "iron deficiency",
-         "onset_on": "2019-02-01"},
-        {"name": "Anemia", "status": "active"},
+        {"name": "Anemia", "status": "resolved"},
+        {"name": "Anemia", "status": "resolved", "note": "iron deficiency",
+         "resolved_on": "2019-02-01"},
+        {"name": "Anemia", "status": "resolved"},
     ]})
     assert summary.counts == {"new": 1, "duplicate": 1, "enriched": 1, "conflict": 0, "promoted": 0}
     row = conn.execute("SELECT * FROM condition").fetchone()
-    assert (row["note"], row["onset_on"]) == ("iron deficiency", "2019-02-01")
+    assert (row["note"], row["resolved_on"]) == ("iron deficiency", "2019-02-01")
 
 
 def test_keep_incoming_on_a_sparse_type_keeps_fields_the_document_did_not_state(conn):

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1330,6 +1330,243 @@ def test_the_reporters_unit_normalisation_scenario(conn):
     assert dedup.rekey(conn).changes == []
 
 
+# --- `--identity`: the one-row rekey (issue #152) ----------------------------
+
+
+def _condition(conn, name="Type 2 Diabetes"):
+    return _row_id(conn, "condition", "name", name)
+
+
+def test_an_identity_field_is_refused_without_the_flag_and_names_it(seeded):
+    """The door has to be visible from where the operator hits the wall: refusing
+    `onset_on` without pointing at `--identity` just recreates the old dead end
+    (`record rm` + re-commit, which throws the row's provenance away to fix a typo)."""
+    conn = seeded["conn"]
+    target = _condition(conn)
+    before = _row(conn, "condition", target)
+    with pytest.raises(records.FieldNotEditableError) as exc:
+        records.edit_record(conn, "condition", target, {"onset_on": "2024-02-01"},
+                            note="wrong date", apply=True)
+    assert "--identity" in str(exc.value)
+    _assert_untouched(conn, "condition", target, before)
+
+
+def test_identity_moves_the_row_and_leaves_provenance_alone(seeded):
+    """The correction the episode model makes necessary: a stored episode's onset was
+    recorded wrong. The row moves onto the corrected identity, keeping its id, its
+    document, its payload and its ledger - the whole reason this is not `rm` + re-commit.
+    """
+    conn = seeded["conn"]
+    target = _condition(conn)
+    before = _row(conn, "condition", target)
+
+    report = records.edit_record(
+        conn, "condition", target, {"onset_on": "2024-03-05"},
+        note="chart says March, not January", attributed_to="Jane", apply=True,
+        identity=True,
+    )
+
+    assert report.identity is True
+    assert report.new_dedup_key != report.dedup_key
+    assert report.new_dedup_base == dedup.dedup_key(
+        "condition", {**before, "onset_on": "2024-03-05"}, before["person_id"]
+    )
+    assert report.new_dedup_occurrence == 0        # the target family was empty
+    assert report.curation_orphaned == [] and report.conflicts_reanchored == []
+
+    after = _row(conn, "condition", target)
+    assert after["onset_on"] == "2024-03-05"
+    assert after["dedup_key"] == report.new_dedup_key
+    assert after["dedup_base"] == report.new_dedup_base
+    assert int(after["dedup_occurrence"]) == 0
+    # Provenance is not rewritten by a correction - the invariant `--identity` must not
+    # weaken, since the whole point is that the row still traces to its source.
+    for column in ("document_id", "person_id", "attested_by", "attested_on",
+                   "attested_at"):
+        assert after[column] == before[column]
+    # Disclosure and audit trail, exactly as an ordinary correction gets them.
+    assert after["edited_at"] and after["edited_by"] == "Jane"
+    ledger = _ledger(conn, "condition")
+    assert [(e["field"], e["old_value"], e["new_value"]) for e in ledger] == [
+        ("onset_on", "2024-01-01", "2024-03-05")
+    ]
+    # The ledger breadcrumb keeps the base the row moved *from*, which is what makes the
+    # move reconstructable afterwards.
+    assert ledger[0]["dedup_base"] == before["dedup_base"]
+    # ... and the engine agrees the row is now stored under the right key.
+    assert dedup.rekey(conn).changes == []
+
+
+def test_identity_is_inert_when_nothing_moves(seeded):
+    """Passing the flag defensively must not turn a no-op into a failure, and must not
+    report a move that did not happen."""
+    conn = seeded["conn"]
+    target = _condition(conn)
+    before = _row(conn, "condition", target)
+
+    report = records.edit_record(
+        conn, "condition", target, {"note": "diet-controlled"},
+        note="detail from the visit note", apply=True, identity=True,
+    )
+
+    assert report.identity is False
+    assert report.new_dedup_key == before["dedup_key"] == report.dedup_key
+    assert _row(conn, "condition", target)["dedup_key"] == before["dedup_key"]
+
+
+def test_identity_onto_an_occupied_family_is_refused_as_a_merge(seeded):
+    """Two rows saying the same thing under one identity is a duplicate hidden behind an
+    occurrence number. That call is a recorded human judgment, not something a
+    correction may make silently."""
+    conn = seeded["conn"]
+    dedup.commit_extraction(conn, seeded["doc"], {"condition": [
+        {"name": "Type 2 Diabetes", "status": "active", "onset_on": "2020-06-01"},
+    ]})
+    target = _row_id(conn, "condition", "onset_on", "2024-01-01")
+    before = _row(conn, "condition", target)
+    ledger_before = _ledger(conn)
+
+    with pytest.raises(records.IdentityCollisionError) as exc:
+        records.edit_record(conn, "condition", target, {"onset_on": "2020-06-01"},
+                            note="same episode", apply=True, identity=True)
+    assert "merge" in str(exc.value) and "nothing was written" in str(exc.value)
+    assert _row(conn, "condition", target) == before
+    assert _ledger(conn) == ledger_before
+
+
+def test_identity_on_a_drifted_row_is_refused_and_names_the_rekey(seeded):
+    """A row already stored under a stale key has no meaningful base to move *from*, so
+    the move would file it beside siblings the engine can no longer see as one."""
+    conn = seeded["conn"]
+    target = _condition(conn)
+    conn.execute(
+        "UPDATE condition SET dedup_key = 'stale', dedup_base = 'stale' "
+        "WHERE condition_id = ?", (target,)
+    )
+    conn.commit()
+    before = _row(conn, "condition", target)
+
+    with pytest.raises(dedup.DictionaryDriftError, match="rekey --apply"):
+        records.edit_record(conn, "condition", target, {"onset_on": "2024-03-05"},
+                            note="wrong date", apply=True, identity=True)
+    _assert_untouched(conn, "condition", target, before)
+
+
+def test_identity_is_refused_when_it_would_strand_an_anchored_conflict(seeded):
+    """The `record rm` rule, for the same reason: the document survives, so `keep both`
+    is still a live resolution and the staged payload is still worth something."""
+    conn = seeded["conn"]
+    target = _condition(conn)
+    # A stated lifecycle disagreement on the same episode: same key, different payload.
+    dedup.commit_extraction(conn, seeded["doc"], {"condition": [
+        {"name": "Type 2 Diabetes", "status": "resolved", "onset_on": "2024-01-01"},
+    ]})
+    assert dedup.list_conflicts(conn)
+    before = _row(conn, "condition", target)
+
+    with pytest.raises(records.AnchoredConflictError, match="review-conflicts"):
+        records.edit_record(conn, "condition", target, {"onset_on": "2024-03-05"},
+                            note="wrong date", apply=True, identity=True)
+    _assert_untouched(conn, "condition", target, before)
+
+
+def test_a_row_scoped_verdict_follows_the_moved_row(seeded):
+    """Carry-over, half one: nothing to do. `curation` resolves a row verdict by
+    `record_id`, and the stored base it also carries is a breadcrumb nothing consults -
+    the same property that makes a `rekey` safe for row-scoped rulings."""
+    conn = seeded["conn"]
+    target = _condition(conn)
+    curation.annotate_record(conn, "condition", str(target), status="confirmed",
+                             note="reviewed with the PCP", row=True, apply=True)
+
+    report = records.edit_record(
+        conn, "condition", target, {"onset_on": "2024-03-05"},
+        note="chart says March", apply=True, identity=True,
+    )
+
+    assert report.curation_orphaned == []
+    verdict = curation.load_verdicts(conn).rows[("condition", target)]
+    assert verdict["status"] == "confirmed"
+    # Not orphaned by the move, and not re-annotated by it either.
+    assert [o.record_id for o in curation.list_orphans(conn)] == []
+
+
+def test_a_family_verdict_on_the_vacated_base_is_reported_and_re_pointable(
+    seeded, tmp_path, capsys
+):
+    """Carry-over, half two: the orphan a base move makes, reported in the shape that
+    already has a remedy. No verdict vanishes and none attaches to a row it never
+    covered - the map entry re-points it onto exactly the family the row moved to."""
+    conn = seeded["conn"]
+    target = _condition(conn)
+    old_base = _row(conn, "condition", target)["dedup_base"]
+    curation.annotate_record(conn, "condition", old_base, status="confirmed",
+                             note="family verdict", apply=True)
+
+    report = records.edit_record(
+        conn, "condition", target, {"onset_on": "2024-03-05"},
+        note="chart says March", apply=True, identity=True,
+    )
+
+    assert len(report.curation_orphaned) == 1
+    entry = report.curation_orphaned[0]
+    assert entry["dedup_base"] == old_base
+    assert entry["record_id"] == 0
+    assert entry["successor_base"] == report.new_dedup_base
+    assert curation.ORPHAN_NO_FAMILY in entry["kinds"]
+    # The engine agrees it is orphaned - the report is not making its own claim.
+    live = curation.list_orphans(conn)
+    assert [o.dedup_base for o in live] == [old_base]
+
+    # And the report *is* a `record reaffirm --map-file` payload, unmodified.
+    map_file = tmp_path / "orphans.json"
+    map_file.write_text(json.dumps(report.curation_orphaned), encoding="utf-8")
+    plan = cli._plan_reaffirm(conn, live, cli._load_reaffirm_map(str(map_file)), False)
+    assert [action.action for action in plan] == ["reaffirm"]
+    assert plan[0].to_base == report.new_dedup_base
+
+
+def test_a_family_verdict_with_survivors_is_left_alone(seeded):
+    """`ORPHAN_NO_FAMILY`'s own rule: a base with rows left on it is not orphaned, so the
+    move stays quiet rather than crying wolf over a ruling that still applies."""
+    conn = seeded["conn"]
+    target = _condition(conn)
+    base = _row(conn, "condition", target)["dedup_base"]
+    dedup.commit_extraction(conn, seeded["doc"], {"condition": [
+        {"name": "Type 2 Diabetes", "status": "resolved", "onset_on": "2024-01-01"},
+    ]})
+    dedup.resolve_conflict(conn, dedup.list_conflicts(conn)[0]["conflict_id"],
+                           keep="both")
+    curation.annotate_record(conn, "condition", base, status="confirmed",
+                             note="family verdict", apply=True)
+
+    report = records.edit_record(
+        conn, "condition", target, {"onset_on": "2024-03-05"},
+        note="chart says March", apply=True, identity=True,
+    )
+
+    assert report.identity is True and report.curation_orphaned == []
+    assert curation.list_orphans(conn) == []
+    assert curation.get_verdict(conn, "condition", base)["status"] == "confirmed"
+
+
+def test_a_dry_run_identity_move_writes_nothing(seeded):
+    """The dry run is the safety mechanism here too - and it has to report the
+    destination, since where the row lands is the whole decision."""
+    conn = seeded["conn"]
+    target = _condition(conn)
+    before = _row(conn, "condition", target)
+
+    report = records.edit_record(
+        conn, "condition", target, {"onset_on": "2024-03-05"},
+        note="chart says March", identity=True,
+    )
+
+    assert report.applied is False and report.identity is True
+    assert report.new_dedup_key and report.new_dedup_key != report.dedup_key
+    _assert_untouched(conn, "condition", target, before)
+
+
 # --- CLI surface -------------------------------------------------------------
 
 
@@ -1385,10 +1622,18 @@ def test_cli_record_edit_json_shape_is_stable(cli_ready, capsys):
     assert set(payload) == {
         "record_type", "row_id", "person", "person_id", "document_id", "label",
         "changes", "unchanged", "dedup_key", "dedup_base", "dedup_occurrence",
+        # Appended by issue #152's identity edit, never inserted: the key set is a
+        # contract that may only widen.
+        "identity", "new_dedup_key", "new_dedup_base", "new_dedup_occurrence",
+        "curation_orphaned", "conflicts_reanchored",
         "note", "attributed_to", "edited_at", "applied",
     }
     assert payload["changes"] == [{"field": "unit", "old": "%", "new": "percent"}]
     assert payload["applied"] is False
+    # An ordinary correction reports standing still, not a null island.
+    assert payload["identity"] is False
+    assert payload["new_dedup_key"] == payload["dedup_key"]
+    assert payload["curation_orphaned"] == [] and payload["conflicts_reanchored"] == []
 
 
 def test_cli_record_rm_json_gained_the_edit_disclosure(cli_ready, capsys):
@@ -1436,6 +1681,29 @@ def test_cli_record_edit_refusals_are_friendly_rc1(cli_ready, capsys):
                 "--set", "value_num=abc", "--note", "n", "--apply") == 1
     assert "value_num" in capsys.readouterr().err
     assert _cli_field(cli_ready, "lab_result", target, "unit") == "%"
+
+
+def test_cli_record_edit_identity_collision_is_friendly_rc1(cli_ready, capsys):
+    """The merge refusal reaches the operator as a message, not a traceback (issue
+    #152): `IdentityCollisionError` is a ValueError, but it is named in the CLI's
+    friendly list so a future re-parenting cannot quietly demote it."""
+    conn = db.connect(cli_ready / "cli.db")
+    try:
+        dedup.commit_extraction(conn, 1, {"condition": [
+            {"name": "Type 2 Diabetes", "status": "active", "onset_on": "2020-06-01"},
+        ]})
+        target = _row_id(conn, "condition", "onset_on", "2024-01-01")
+    finally:
+        conn.close()
+    capsys.readouterr()
+
+    assert _run(cli_ready, "record", "edit", "condition", str(target), "--identity",
+                "--set", "onset_on=2020-06-01", "--note", "same episode",
+                "--apply") == 1
+    err = capsys.readouterr().err
+    assert "merge, not a correction" in err and "nothing was written" in err
+    assert err.isascii()                       # issue #23
+    assert _cli_field(cli_ready, "condition", target, "onset_on") == "2024-01-01"
 
 
 @pytest.mark.parametrize("argv", [

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1632,13 +1632,14 @@ def _rid(conn, record_type, where, params):
     ).fetchone()[f"{record_type}_id"])
 
 
-def _correct(conn, record_type, where, params, updates, who="Aunt Ada"):
+def _correct(conn, record_type, where, params, updates, who="Aunt Ada",
+             identity=False):
     from pemr import records as _records
 
     return _records.edit_record(
         conn, record_type, _rid(conn, record_type, where, params), updates,
         dedup.load_dictionary(DICT_PATH), note="transcription slip",
-        attributed_to=who, now=_CORRECT_AT, apply=True,
+        attributed_to=who, now=_CORRECT_AT, identity=identity, apply=True,
     )
 
 
@@ -1727,8 +1728,14 @@ def test_an_unattributed_correction_renders_the_date_only_form(seeded):
 
 def test_adding_an_onset_to_a_document_sourced_condition_is_disclosed(seeded):
     """The issue's headline example (#134): a row that came from a document gains a date
-    the document never stated, and says so."""
-    _correct(seeded, "condition", "name = ?", ("Chickenpox",), {"onset_on": "2001-05-01"})
+    the document never stated, and says so.
+
+    `--identity` since issue #152: giving a condition an onset now moves its key, so the
+    edit is a one-row rekey. The disclosure rule is unchanged by that - an identity move
+    stamps the correction mark exactly as an ordinary correction does, which is the point
+    of pinning it here."""
+    _correct(seeded, "condition", "name = ?", ("Chickenpox",), {"onset_on": "2001-05-01"},
+             identity=True)
     md = render.render_summary(
         seeded, "jane-doe", dictionary=dedup.load_dictionary(DICT_PATH),
         now=datetime(2026, 6, 1),


### PR DESCRIPTION
## Summary

Adopts the **episode model** for `condition` (umbrella design, #152): identity becomes
name + subject + onset (onset folded into the existing subject key part, per the #71
`key_token` precedent), so two dated episodes of the same problem no longer collide into
one row. `onset_on` stores true FHIR-style precision (`YYYY` / `YYYY-MM` / `YYYY-MM-DD`,
no sentinel padding, lexical ordering) and moves from an editable field to an identity
field. `dedup_occurrence` stays as the fallback tiebreaker for same-date or undated repeats.

- **New**: `record edit --identity` — the one door for moving a row onto a corrected
  identity (fixing a wrong onset), with front-loaded gates (drift, no-move short-circuit,
  occupied-target, anchored-conflict), one-transaction write, and a verdict carry-over
  story that reuses `rekey --apply --json`'s `orphans` shape / `record reaffirm
  --map-file` — no new mechanism. Stays **CLI-only**, not exposed to `WRITE_TOOLS`/MCP.
- **New**: `pemr verify` warns (never fails) when a person has an undated condition row
  beside dated episodes of the same problem — the visible signal for the one deliberate
  behavior change (a later-dated statement now lands as a new row instead of silently
  enriching the undated umbrella row in place).
- **Docs**: `docs/Architecture.md` gets a new "Episodes" subsection (identity, partial-date
  representation, the two-temporalities separation, the rekey-and-unfold migration
  sequence, onset-correction-carries-verdicts-across-rekey) plus updated §2 DDL comments
  and §5 CLI reference; `AGENTS.md` updated for the condition extraction rule and the
  `record edit` trust-boundary statement.
- **Migration**: no new SQL — a key change is a `rekey`, not a schema migration (the
  migration-006 precedent). Existing dated `condition` rows are **collision-free by
  construction** (adding a discriminator only ever splits families) but every archive
  needs the operator sequence documented in `docs/Architecture.md` §3 "Episodes" run once
  after this merges:

  ```
  pemr rekey --apply --json > rekey.json      # dated conditions move; undated ones do not
  pemr record reaffirm --map-file rekey.json  # re-point any orphaned family verdicts
  ```

  Until that runs, `_assert_no_key_drift` blocks re-ingest of an affected fact loudly
  (not silently) — no data is at risk either way.

## Reports

- Verify (full suite green, real-run smoke against a genuine pre-#152 database, all 8
  ACs covered): https://github.com/meridun/pemr/issues/152#issuecomment-5387708547
- Audit (no blocking findings; four advisory/informational notes, none requiring
  follow-up before ship): https://github.com/meridun/pemr/issues/152#issuecomment-5387739961

## Follow-ups for a human (not this PR)

- `symptom` episode adoption has no live tracker — #167 (named in the original issue body)
  is **closed** and shipped something unrelated (the observation lanes). A new child issue
  is needed.
- Medication courses-as-episodes child issue is now unblocked (#151 landed) but not yet
  filed.
- #186 (the narrow `distinct`-verdict collision stopgap) is still unbuilt at
  `stage:intake`; this change subsumes it for `condition` once #186 eventually lands —
  worth a note on that issue when it's picked up.

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)