### PR TITLE
fix(assert): honor a distinct verdict on the colliding row (#186)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -526,8 +526,9 @@ against oneself has no independent provenance to adjudicate.
 
 Since issue #133, that refusal first consults the `curation` overlay (§2): a colliding row
 already carrying a **releasing** verdict — `superseded` / `erroneous-in-source` /
-`merged-into` (row scope beats family scope, same precedence rule as §6) — no longer blocks.
-Only a `disputed` or unverdicted row still raises, and the error's remedy text only
+`merged-into`, or since issue #186 also `distinct` (row scope beats family scope, same
+precedence rule as §6) — no longer blocks. Only a `disputed`, `confirmed` or unverdicted row
+still raises, and the error's remedy text only
 recommends `record annotate` when annotating that row could actually change the outcome —
 a row already released is never named. Once every colliding row is released the attestation
 proceeds as an ordinary new occurrence of the identity (the next free `dedup_occurrence`),
@@ -535,6 +536,17 @@ not a replacement of what is stored. One consequence worth knowing: a **family**
 release covers that new occurrence too, so the freshly attested row itself leaves the
 clinical documents for the curation record (§6) until the verdict is re-scoped to the rows
 it meant or lifted — the CLI prints a note when this happens so it is not a silent surprise.
+
+The two releasing vocabularies release for opposite reasons, and the asymmetry is the point.
+An **appendix** status says *one fact filed twice*, so the released row (and, at family
+scope, the freshly attested one) leaves the live view for the curation record. `distinct`
+says *two real facts that happen to share a key* (#122) — it is deliberately **not** an
+appendix status, so **both** rows stay live in their clinical section, which is exactly the
+rendering a genuine second occurrence of a recurring fact needs. That makes
+`record annotate <type> <id> --row --status distinct`, then retry, the non-destructive
+remedy for a repeat: nothing sourced is deleted and no documented date is overwritten
+(issue #186 — the deliberate stopgap for the condition-episode model of #152, and the
+standing answer for the record types whose identity carries no occurrence date).
 
 `norm()` = lowercase, trim, collapse whitespace, drop parenthetical qualifiers, map
 synonyms via an **analyte/name dictionary** (`data/dictionary.toml`) — e.g. `A1c`,
@@ -1266,8 +1278,9 @@ pemr record assert <table> --person <slug> --attributed-to <who> --date <iso>
                                                          # commit a fact attested by a PERSON, with no
                                                          # source document (§2 attestation); dry run by default
                                                          # a colliding family fully released by curation
-                                                         # verdicts no longer blocks (§3, issue #133);
-                                                         # disputed/unverdicted rows still refuse it
+                                                         # verdicts no longer blocks (§3, issues #133/#186:
+                                                         # appendix statuses or `distinct`);
+                                                         # disputed/confirmed/unverdicted rows still refuse it
 pemr record assert --list [<table>] [--all] [--json]     # attested rows still needing a source document
 pemr document tombstone list [--json]                    # recorded intentional removals, newest first
 pemr document tombstone add (--file <path> | --sha256 <hex>) [--reason ...] [--note ...]

--- a/pemr/attestations.py
+++ b/pemr/attestations.py
@@ -28,9 +28,11 @@ disagreement, only for recording an agreement.
 **Refuse, don't stage.** The mirror case — asserting a fact the record already holds —
 never stages a conflict. An equal payload reports ``duplicate`` and writes nothing; a
 differing one raises :class:`AttestationCollisionError` naming the stored row — *unless*
-every colliding row already carries a verdict that released the identity
-(:data:`curation.APPENDIX_STATUSES`, issue #133), in which case the human has already ruled
-the identity free and the attestation is an ordinary new occurrence. Precedent:
+every colliding row already carries a verdict that released the identity: one of
+:data:`curation.APPENDIX_STATUSES` (issue #133, "one fact filed twice") or one of
+:data:`curation.DISTINCT_STATUSES` (issue #186, "two real facts sharing a key"). Either
+way the human has already ruled the identity free and the attestation is an ordinary new
+occurrence — the difference is only where the rows render. Precedent:
 ``commit_extraction``'s pass 1 already refuses two colliding rows of one submission,
 because the human is at the keyboard and a conflict staged against oneself has no
 independent provenance to adjudicate. A conflict would also have to carry
@@ -139,20 +141,48 @@ def _provenance(row: sqlite3.Row | dict) -> str:
     return "attestation"
 
 
+def _releases_identity(carrier: dict) -> bool:
+    """Whether an annotated row's verdict frees the identity for a new occurrence.
+
+    Two independent checks, deliberately not one tuple (issue #186):
+
+    * :func:`curation.is_appendix` — :data:`curation.APPENDIX_STATUSES` say **one fact
+      filed twice**, and the row leaves the live view for the curation record (#133).
+    * :data:`curation.DISTINCT_STATUSES` — ``distinct`` says **two real facts that
+      happen to share a key** (#122). It settles the identity question just as firmly,
+      which is why it releases here, but it must *not* join the appendix tuple: those
+      two vocabularies being disjoint is the guarantee that both rows of a distinct pair
+      keep rendering in their live clinical section, which is exactly the rendering a
+      genuine second occurrence needs.
+
+    Reads only what :func:`curation.annotate_rows` stamped under
+    :data:`curation.CURATION_FIELD` — never the record's own ``status`` column, which is
+    a *clinical* field (free-form text on ``medication``, an enum on ``condition``) and
+    has nothing to do with a curation verdict.
+    """
+    if curation.is_appendix(carrier):
+        return True
+    verdict = curation.verdict_of(carrier)
+    return verdict is not None and verdict.get("status") in curation.DISTINCT_STATUSES
+
+
 def _blocking_rows(
     conn: sqlite3.Connection, record_type: str, family: list[sqlite3.Row]
 ) -> tuple[list[dict], list[dict]]:
-    """Split a colliding family into ``(blocking, released)`` — issue #133.
+    """Split a colliding family into ``(blocking, released)`` — issues #133, #186.
 
-    A row *releases* the identity when a human already ruled on it with one of
-    :data:`curation.APPENDIX_STATUSES` (``superseded`` / ``erroneous-in-source`` /
-    ``merged-into``); ``disputed`` and unverdicted rows keep blocking, because a disputed
-    row still holds the identity, it is merely flagged.
+    A row *releases* the identity when a human already ruled on it with a verdict
+    :func:`_releases_identity` accepts — one of :data:`curation.APPENDIX_STATUSES`
+    (``superseded`` / ``erroneous-in-source`` / ``merged-into``) or ``distinct``;
+    ``disputed``, ``confirmed`` and unverdicted rows keep blocking, because such a row
+    still holds the identity — a disputed one is merely flagged, a confirmed one is
+    affirmed.
 
     Resolution runs through :func:`curation.annotate_rows`, never a hand-rolled lookup, so
     the row-beats-family precedence rule stays the single site :meth:`VerdictMap.for_row`
-    already is (issue #114) and "leaves the live view" stays :func:`curation.is_appendix`'s
-    vocabulary. Both lists keep the family's occurrence order.
+    already is (issue #114) — at both scopes, for ``distinct`` too, with no second rule —
+    and "leaves the live view" stays :func:`curation.is_appendix`'s vocabulary. Both lists
+    keep the family's occurrence order.
 
     The ``dict`` copy is required: ``annotate_rows`` stamps in place and ``sqlite3.Row`` is
     immutable. The stamped key is inert for every reader downstream of here —
@@ -162,40 +192,56 @@ def _blocking_rows(
     rows = curation.annotate_rows(
         [dict(row) for row in family], record_type, curation.load_verdicts(conn)
     )
-    blocking = [row for row in rows if not curation.is_appendix(row)]
-    released = [row for row in rows if curation.is_appendix(row)]
+    blocking = [row for row in rows if not _releases_identity(row)]
+    released = [row for row in rows if _releases_identity(row)]
     return blocking, released
 
 
 def _collision_remedy(record_type: str, stored: dict, released: int) -> str:
-    """The half of the collision message that must stay honest — issue #133.
+    """The half of the collision message that must stay honest — issues #133, #186.
 
     The defect this fixes was dead advice: the error recommended `record annotate` for a
     row whose verdict could not change the outcome. A row already carrying a releasing
     verdict is never in ``blocking``, so it can never be named here; what remains is a row
     with no verdict (annotating it *would* unblock) or one carrying a non-releasing verdict
     (say which, and name the ones that do release — interpolated from
-    :data:`curation.APPENDIX_STATUSES`, never hand-typed).
+    :data:`curation.APPENDIX_STATUSES` + :data:`curation.DISTINCT_STATUSES`, never
+    hand-typed, so the message can never drift from :func:`_releases_identity`).
+
+    Since #186 that vocabulary includes ``distinct``, and both branches name the
+    ``record annotate ... --row --status distinct`` -> retry flow: for a genuine second
+    occurrence of a recurring fact it is the *only* remedy that is not destructive of
+    what is stored, so a message that omitted it would be dead advice of a second kind.
 
     ``released`` discloses siblings already ruled on, rather than dropping them: an
     operator who annotated three rows of four must not be left guessing why the fourth
-    still refuses.
+    still refuses. Its count includes distinct-released siblings.
     """
     pk = f"{record_type}_id"
     row_id = stored[pk]
     verdict = curation.verdict_of(stored)
-    releasing = ", ".join(f"`{status}`" for status in curation.APPENDIX_STATUSES)
+    releasing = ", ".join(
+        f"`{status}`"
+        for status in curation.APPENDIX_STATUSES + curation.DISTINCT_STATUSES
+    )
+    distinct_cmd = (
+        f"`pemr record annotate {record_type} {row_id} --row --status distinct`"
+    )
     if verdict is None:
         remedy = (
             f"Correct the stored row (`pemr record rm {record_type} {row_id}`, or "
             f"`pemr record annotate {record_type} {row_id} --row --status superseded` "
-            "to rule on it) and retry"
+            "to rule on it) and retry; or, if both rows are real facts and this is a "
+            f"second occurrence of the same identity, rule the stored row `distinct` "
+            f"({distinct_cmd}) and retry"
         )
     else:
         remedy = (
             f"That row already carries the verdict '{verdict.get('status')}', which does "
-            f"not release the identity - only {releasing} do. Re-rule on it "
-            f"(`pemr record annotate {record_type} {row_id} --row --status superseded`) "
+            f"not release the identity - only {releasing} do. The appendix statuses say "
+            "one fact was filed twice; `distinct` says two real facts share a key. "
+            f"Re-rule on it (`pemr record annotate {record_type} {row_id} --row "
+            f"--status superseded`, or {distinct_cmd} for a genuine second occurrence) "
             f"or remove it (`pemr record rm {record_type} {row_id}`) and retry"
         )
     if released:
@@ -236,7 +282,8 @@ def assert_record(
     metadata, :class:`query.PersonNotFoundError` for an unknown slug,
     :class:`dedup.DictionaryDriftError` when a stored row of this identity is on a stale
     key, and :class:`AttestationCollisionError` when the identity is already stored with a
-    different payload.
+    different payload and at least one colliding row still holds it — i.e. no verdict
+    :func:`_releases_identity` accepts (an appendix status, #133, or ``distinct``, #186).
     """
     db.require_migrated(conn)
     _require_type(record_type)
@@ -303,9 +350,10 @@ def assert_record(
         )
         pk = f"{record_type}_id"
         if twin is None:
-            # The identity only still holds if some family row is unreleased (#133):
-            # a family the human already ruled superseded/corrected is theirs to
-            # re-file. Falls through to the ordinary write path when none blocks.
+            # The identity only still holds if some family row is unreleased (#133,
+            # #186): a family the human already ruled superseded/corrected — or ruled
+            # `distinct`, "these are two real facts" — is theirs to re-file. Falls
+            # through to the ordinary write path when none blocks.
             blocking, released = _blocking_rows(conn, record_type, family)
             if blocking:
                 stored = blocking[0]

--- a/tests/test_attestations.py
+++ b/tests/test_attestations.py
@@ -408,6 +408,136 @@ def test_an_unverdicted_database_is_byte_identical(conn, jane):
 
 
 # --------------------------------------------------------------------------- #
+# A `distinct` verdict also releases the identity (issue #186)
+#
+# The stopgap for #152's episode model: a genuine second occurrence of a recurring fact
+# collides with the stored one, and every remedy #133 left was wrong for it — `record rm`
+# deletes a sourced row, an appendix status pulls a live fact out of its clinical section,
+# and editing the date overwrites what a document said. `distinct` (#122) is the verdict
+# that means exactly "two real facts, one coincidental key collision", so it releases here
+# too — while staying out of APPENDIX_STATUSES, which is what keeps both rows rendering.
+# --------------------------------------------------------------------------- #
+
+def test_a_distinct_row_no_longer_blocks_a_differing_attestation(conn, jane):
+    """The motivating case: the second occurrence lands beside the first, not over it."""
+    _assert_med(conn, apply=True)
+    first = _stored_row_id(conn)
+    _rule(conn, first, status="distinct", row=True)
+    report = _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+    assert report.outcome == "new"
+    assert report.applied is True
+    assert report.dedup_occurrence == 1
+    assert conn.execute("SELECT COUNT(*) AS n FROM medication").fetchone()["n"] == 2
+    # The row ruled `distinct` is still there, untouched - nothing was replaced.
+    assert conn.execute(
+        "SELECT COUNT(*) AS n FROM medication WHERE medication_id = ?", (first,)
+    ).fetchone()["n"] == 1
+
+
+def test_a_distinct_release_dry_runs_without_writing(conn, jane):
+    """The dry-run-by-default invariant reaches the newly unblocked path too: it must
+    report the write it *would* make, and make none."""
+    _assert_med(conn, apply=True)
+    _rule(conn, _stored_row_id(conn), status="distinct", row=True)
+    report = _assert_med(conn, payload=MED | {"frequency": "daily"})
+    assert report.outcome == "new"
+    assert report.applied is False
+    assert report.dedup_occurrence == 1
+    assert report.dedup_key == dedup.occurrence_key(_base(conn, jane), 1)
+    assert conn.execute("SELECT COUNT(*) AS n FROM medication").fetchone()["n"] == 1
+
+
+def test_a_family_scoped_distinct_also_unblocks(conn, jane):
+    """Row-beats-family (#114) needed no second rule for `distinct`: both scopes work
+    because `_blocking_rows` reads what `annotate_rows` stamped."""
+    _assert_med(conn, apply=True)
+    _rule(conn, _base(conn, jane), status="distinct")
+    assert _assert_med(
+        conn, payload=MED | {"frequency": "daily"}, apply=True
+    ).outcome == "new"
+
+
+def test_distinct_composes_with_an_appendix_release(conn, jane):
+    """`distinct` is a second, independent check - it adds to the appendix release
+    rather than replacing it, so a mixed family unblocks."""
+    _assert_med(conn, apply=True)
+    _rule(conn, _stored_row_id(conn), status="distinct", row=True)
+    _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+    _rule(conn, _stored_row_id(conn, occurrence=1), status="superseded", row=True)
+
+    report = _assert_med(conn, payload=MED | {"frequency": "TID"}, apply=True)
+    assert report.outcome == "new"
+    assert report.dedup_occurrence == 2
+    assert len(dedup.load_family(conn, "medication", _base(conn, jane))) == 3
+
+
+@pytest.mark.parametrize("status", ["disputed", "confirmed"])
+@pytest.mark.parametrize("scope_row", [True, False])
+def test_a_non_releasing_verdict_still_blocks(conn, jane, status, scope_row):
+    """Widened, not removed. `confirmed` in particular sounds settling and is neither an
+    appendix status nor `distinct` - it affirms the row, so the row keeps the identity."""
+    _assert_med(conn, apply=True)
+    target = _stored_row_id(conn) if scope_row else _base(conn, jane)
+    _rule(conn, target, status=status, row=scope_row)
+    with pytest.raises(attestations.AttestationCollisionError):
+        _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+
+
+def test_one_unverdicted_sibling_still_blocks_a_distinct_released_family(conn, jane):
+    """The disclosure arithmetic counts distinct-released siblings, and the message
+    still names the row that actually blocks - never the released one."""
+    _assert_med(conn, apply=True)
+    first = _stored_row_id(conn)
+    _rule(conn, first, status="distinct", row=True)
+    _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+    second = _stored_row_id(conn, occurrence=1)
+
+    with pytest.raises(attestations.AttestationCollisionError) as exc:
+        _assert_med(conn, payload=MED | {"frequency": "TID"}, apply=True)
+    message = str(exc.value)
+    assert f"medication {second}" in message
+    assert f"medication {first}" not in message
+    assert "1 other row(s) in this family already carry a releasing verdict" in message
+
+
+def test_the_collision_message_offers_the_distinct_path(conn, jane):
+    """AC4: both branches must name `distinct` as a live remedy, and must keep naming
+    the appendix statuses - the vocabulary is interpolated, never hand-typed."""
+    _assert_med(conn, apply=True)
+    row_id = _stored_row_id(conn)
+
+    with pytest.raises(attestations.AttestationCollisionError) as bare:
+        _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+    unverdicted = str(bare.value)
+
+    _rule(conn, row_id, status="disputed", row=True)
+    with pytest.raises(attestations.AttestationCollisionError) as ruled:
+        _assert_med(conn, payload=MED | {"frequency": "daily"}, apply=True)
+    verdicted = str(ruled.value)
+
+    for message in (unverdicted, verdicted):
+        assert "`distinct`" in message
+        assert (
+            f"pemr record annotate medication {row_id} --row --status distinct" in message
+        )
+    # Still honest about the older remedies.
+    assert f"pemr record rm medication {row_id}" in unverdicted
+    assert "already carries the verdict 'disputed'" in verdicted
+    for status in curation.APPENDIX_STATUSES:
+        assert f"`{status}`" in verdicted
+
+
+def test_a_distinct_row_matching_the_payload_still_reports_duplicate(conn, jane):
+    """Twin semantics are untouched: a released row is still `dedup._rows_equal`'s call,
+    so an *equal* payload reports duplicate rather than filing a second copy."""
+    _assert_med(conn, apply=True)
+    _rule(conn, _stored_row_id(conn), status="distinct", row=True)
+    report = _assert_med(conn, apply=True)
+    assert report.outcome == "duplicate"
+    assert conn.execute("SELECT COUNT(*) AS n FROM medication").fetchone()["n"] == 1
+
+
+# --------------------------------------------------------------------------- #
 # list_attested — the "needs source" queue
 # --------------------------------------------------------------------------- #
 
@@ -598,6 +728,36 @@ def test_cli_annotating_every_colliding_row_unblocks_the_assert(cli_ready, capsy
 
     assert _run(cli_ready, *argv, "--apply") == 0
     assert "wrote medication #5" in capsys.readouterr().out
+
+
+def test_cli_annotating_distinct_unblocks_the_assert(cli_ready, capsys):
+    """The #186 operator flow end to end, through verbs that already existed: the assert
+    is refused, the error names the `distinct` path, the operator rules the stored row
+    `distinct`, and the retry lands a second occurrence beside a sourced row nothing
+    deleted or edited. No new verb or flag was needed (`--status distinct` is #122's)."""
+    ids = _seed_cli_family(cli_ready, 1)
+    argv = (*_ASSERT_ARGV, "--field", "status=discontinued")
+    assert _run(cli_ready, *argv, "--apply") == 1
+    err = capsys.readouterr().err
+    assert "already holds this identity" in err
+    assert "--row --status distinct" in err
+
+    assert _run(
+        cli_ready, "record", "annotate", "medication", str(ids[0]), "--row",
+        "--status", "distinct", "--note", "a second, unrelated occurrence", "--apply",
+    ) == 0
+    capsys.readouterr()
+
+    assert _run(cli_ready, *argv, "--apply") == 0
+    assert "wrote medication #2" in capsys.readouterr().out
+    conn = db.connect(cli_ready / "cli.db")
+    try:
+        rows = conn.execute(
+            "SELECT dedup_occurrence FROM medication ORDER BY dedup_occurrence"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert [int(row["dedup_occurrence"]) for row in rows] == [0, 1]
 
 
 def test_cli_assert_discloses_a_family_scoped_release(cli_ready, capsys):


### PR DESCRIPTION
## Summary

`record assert` widens its collision guard: a colliding row already carrying a `distinct`
verdict (issue #122) now releases the identity, alongside the existing appendix-status
release (`superseded` / `erroneous-in-source` / `merged-into`, issue #133). This is the
deliberate stopgap for the #152 episode model — it unblocks recording a genuine repeat
(e.g. a documented second occurrence of a recurring condition) today, non-destructively:
annotate the stored row `distinct`, retry the assert.

- `pemr/attestations.py`: new `_releases_identity()` predicate (appendix-or-distinct),
  used by `_blocking_rows`; `_collision_remedy` now names the `distinct` retry path instead
  of implying it can't help. No schema change, no migration, no new CLI verb/flag
  (`record annotate --row --status distinct` already existed).
- `docs/Architecture.md`: documents the widened release and the asymmetry between the two
  releasing vocabularies (appendix = one fact filed twice, leaves the live view; `distinct`
  = two real facts sharing a key, both stay live) — the reason `distinct` must never join
  `APPENDIX_STATUSES`.
- `tests/test_attestations.py`: 10 new/updated cases covering apply/dry-run release, mixed
  distinct+appendix release, still-blocking non-releasing verdicts, remedy-message wording,
  and the CLI annotate-then-assert flow.

Out of scope (deliberately): the #152 episode model itself, any change to
`curation.APPENDIX_STATUSES` / `is_appendix` / `DISTINCT_STATUSES` / the `distinct` status
definition, and a known-false note in `cli.py::_print_released_identity_note` for a
family released purely by `distinct` (flagged by audit as advisory, not blocking — a
follow-up issue is recommended, not yet filed).

Closes #186

## Reports

- Verify: https://github.com/meridun/pemr/issues/186#issuecomment-5388326108
- Audit: https://github.com/meridun/pemr/issues/186#issuecomment-5388347567

🤖 Generated with the pemr SDLC pipeline (ship worker)
