### PR TITLE
feat(dedup): adopt-source resolution links an attested row to its document (#190)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,8 +308,10 @@ Agents never resolve staged conflicts silently.
 
 - `review_conflicts` with no `resolve` id **lists** conflicts — call it freely.
 - **Resolution requires explicit human sign-off.** The human must have named the specific conflict
-  and the chosen resolution (`keep existing` / `keep incoming` / `keep both` / `keep merge`) in the
-  current session. "Clean this up", silence, or a standing general instruction is **not** sign-off.
+  and the chosen resolution (`keep existing` / `keep existing --adopt-source` / `keep incoming` /
+  `keep both` / `keep merge`) in the current session. "Clean this up", silence, or a standing
+  general instruction is **not** sign-off. `keep existing --adopt-source` is a **distinct** choice:
+  sign-off that said only "keep existing" does not authorize adding the flag.
 - Mechanically: `review_conflicts(resolve=…)` requires a non-empty `signoff` param quoting the
   human's instruction verbatim; the wrapper refuses the write otherwise and stores the sign-off
   text with the resolution.
@@ -343,6 +345,15 @@ Agents never resolve staged conflicts silently.
   takes no field, because the row is now filed under a different document.
   On a standing-fact type merge always refuses, because a conflict there is present-and-different by
   construction — use `keep incoming` for those.
+- `keep existing --adopt-source` (`adopt_source=True`) is the provenance-only resolution: the stored
+  row keeps every one of its own values, and the **only** thing written is the incoming document's
+  `document_id` onto it. Propose it for the case it exists for — a row entered by `record assert`
+  (`document_id` NULL) that a later document confirms while disagreeing on some field, where the
+  human wants to keep what was attested *and* link the source. It is refused with any other `keep`
+  (those already take the document's provenance with its payload), refused when the stored row
+  already has a `document_id` — it fills a missing source, it never re-points one — and refused when
+  the conflict carries no document. Report those refusals rather than reaching for a different keep
+  on your own: which payload wins is the human's call.
 - `commit_extraction` **rejects** two rows of one submission that derive the same key and disagree;
   that is an extraction error, not a conflict. For `observation`, re-read the source for times; if
   there genuinely are none, submit them separately and ask the human about `keep both`. For

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -516,7 +516,14 @@ comparison path:
   justification for auto-resolving a disagreement, only for recording an agreement.
   `keep incoming` then promotes the row (it already writes `document_id`), `keep existing`
   leaves the attestation live, and `keep both` admits the document row as the next
-  occurrence beside it.
+  occurrence beside it. Since issue #190, `keep existing --adopt-source` is the fourth
+  reading: the stored payload wins in full **and** the row adopts the incoming document's
+  `document_id`, which is how an attested row gains its source without taking the values
+  the human ruled against. It **fills** a missing source, never re-points an existing one
+  — an already-sourced row is refused, because keeping document A's payload under
+  document B's id would misattribute it (the same provenance guarantee `record edit`
+  enforces, one layer down); `keep incoming` / `keep merge` are the honest paths there,
+  since they take payload and provenance together.
 
 The mirror case — `record assert` onto a family the record already holds — is **refused,
 not staged**: an equal payload reports "already recorded" and writes nothing, a differing
@@ -1214,7 +1221,8 @@ pemr ingest <file> --person <slug> [--ocr auto] [--force]        # --force: skip
 pemr ingest <dir>  --person <slug> --study dicom [--allow-large] # a study folder as ONE document (§4)
 pemr commit-extraction --document <id> --json <file>
 pemr review-conflicts [--resolve <id> --keep existing|incoming|both|merge
-                       [--field NAME=existing|incoming ...] [--note ...]] [--dictionary <toml>]
+                       [--field NAME=existing|incoming ...] [--adopt-source] [--note ...]]
+                      [--dictionary <toml>]   # --adopt-source: only with --keep existing
 pemr document list [--person <slug>]                     # newest first; omit --person for everyone
 pemr document show <id> [--json | --text]                # one document's detail; --text dumps stored ocr_text
 pemr document edit <id> [--doc-date|--category|--provider ...]   # partial update; "" clears a field

--- a/pemr/cli.py
+++ b/pemr/cli.py
@@ -2594,6 +2594,7 @@ def _cmd_review_conflicts(args: argparse.Namespace) -> int:
                 result = dedup.resolve_conflict(
                     conn, args.resolve, keep=args.keep, note=args.note,
                     dictionary=dictionary, fields=_field_choices(args.fields),
+                    adopt_source=args.adopt_source,
                 )
                 print(f"resolved conflict #{args.resolve} ({_resolved_as(result)})")
                 return 0
@@ -2637,6 +2638,8 @@ def _cmd_review_conflicts(args: argparse.Namespace) -> int:
         "leaves unstated;"
         "\n         settle a field both rows state differently with "
         "`--field NAME=existing|incoming`"
+        "\n         existing = keep the stored payload; add `--adopt-source` to also "
+        "link an\n         unsourced (attested) row to the incoming document"
     )
     return 0
 
@@ -2667,10 +2670,13 @@ def _resolved_as(result: dedup.ResolveResult) -> str:
     those fields keeps the operator's line honest about the write, matching what
     `dedup._resolution_text` persists on the conflict. Field names only, never values --
     the resolution text is an audit trail, not a place to echo clinical data. keep-merge
-    reports through `dedup.merge_summary`, the same wording it persists.
+    and keep-existing + adopt-source report through `dedup.merge_summary` /
+    `dedup.adopt_summary`, the same wordings they persist.
     """
     if result.kept == "merge":
         return dedup.merge_summary(result)
+    if result.adopted_document_id is not None:
+        return dedup.adopt_summary(result)
     if result.kept != "both":
         return f"keep-{result.kept}"
     if result.no_op:
@@ -3827,6 +3833,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="only with --keep merge; repeatable. Settles one field both rows state "
              "differently: NAME=existing keeps the stored value, NAME=incoming takes "
              "the document's. Fields that do not collide are rejected",
+    )
+    p_review.add_argument(
+        "--adopt-source", action="store_true", dest="adopt_source",
+        help="only with --keep existing; keeps the stored row's payload untouched and "
+             "copies the incoming document's document_id onto it, so a previously "
+             "attested row gains its source. Refused if the row already has one",
     )
     p_review.add_argument("--note", help="optional resolution note")
     p_review.add_argument(

--- a/pemr/dedup.py
+++ b/pemr/dedup.py
@@ -1390,11 +1390,13 @@ class ResolveResult:
 
     ``row_id``/``occurrence`` describe the row the resolution landed on: the
     *admitted* row for ``keep='both'``, the *overwritten* one for
-    ``keep='incoming'``. ``keep='existing'`` writes nothing, so it leaves them
-    unset. ``dedup_key`` is that row's key (which for an occurrence >= 1 row is
-    *not* the conflict's key — see :func:`_anchor_row`); ``dedup_base`` is the
-    family it joined, re-derived under the current dictionary rather than taken
-    from the conflict (see :func:`_derive_base`).
+    ``keep='incoming'``, the row whose provenance was filled for
+    ``keep='existing'`` **with** ``adopt_source``. Plain ``keep='existing'``
+    writes nothing, so it leaves them unset. ``dedup_key`` is that row's key
+    (which for an occurrence >= 1 row is *not* the conflict's key — see
+    :func:`_anchor_row`); ``dedup_base`` is the family it joined, re-derived
+    under the current dictionary rather than taken from the conflict (see
+    :func:`_derive_base`).
     """
     kept: str
     record_type: str = ""
@@ -1414,6 +1416,10 @@ class ResolveResult:
     # keep-merge only: field -> 'existing'|'incoming', the collisions the operator ruled
     # on explicitly. Everything else on a merge was decided by the silence rule alone.
     settled: dict = field(default_factory=dict)
+    # keep-existing + adopt-source only (issue #190): the document_id copied from the
+    # conflict onto the stored row. `None` on every other path, which is what
+    # `_resolution_text` and the CLI switch on.
+    adopted_document_id: int | None = None
 
 
 @dataclass
@@ -1511,6 +1517,7 @@ def resolve_conflict(
     note: str | None = None,
     dictionary: dict[str, str] | None = None,
     fields: dict[str, str] | None = None,
+    adopt_source: bool = False,
 ) -> ResolveResult:
     """Resolve a staged conflict. ``keep`` is 'existing' (drop the incoming row),
     'incoming' (overwrite the stored record's payload fields with the incoming row),
@@ -1534,6 +1541,20 @@ def resolve_conflict(
     fields keep their stored display form (they are equal after norm() by
     construction, but may differ in casing/spacing); the dedup_key stays put.
 
+    ``adopt_source`` is a modifier of ``keep='existing'`` (issue #190), not a fifth
+    mode: the stored row's payload still wins in full, and the only thing written is
+    the incoming document's ``document_id`` onto that row — the supported way to link a
+    previously *attested* row to the document that later confirms the same fact, without
+    taking the document's differing values. It **refuses** on a row that already has a
+    ``document_id`` (filling a NULL is additive; re-pointing a sourced row at another
+    document while keeping the first document's payload would misattribute it — take
+    ``keep='incoming'`` or ``keep='merge'``, which adopt payload and provenance
+    together), and when the conflict itself carries no document to adopt. It is
+    deliberately *not* gated on ``attested_by``: the invariant is "provenance is filled,
+    never re-pointed", and ``document_id IS NULL`` is exactly that condition — an
+    attestation is the case that produces the interesting state
+    (:func:`attestation_state` -> ``"superseded"``), not the check.
+
     ``keep='both'`` re-validates the staged JSON before it becomes a row, and is
     idempotent by payload: if a sibling already carries that exact payload (two
     conflicts staged from one submission, both resolved 'both') nothing is inserted
@@ -1554,6 +1575,11 @@ def resolve_conflict(
     if fields and keep != "merge":
         raise ValueError(
             f"per-field choices only apply to keep 'merge', not {keep!r}"
+        )
+    if adopt_source and keep != "existing":
+        raise ValueError(
+            f"adopt-source only applies to keep 'existing', not {keep!r} - "
+            f"keep {keep!r} already takes the document's provenance with its payload"
         )
 
     row = conn.execute(
@@ -1579,6 +1605,10 @@ def resolve_conflict(
         )
     elif keep == "merge":
         result = _plan_keep_merge(conn, row, dictionary, fields)
+    elif adopt_source:
+        # Same discipline as the writing keeps: everything that can refuse happens
+        # before the transaction opens.
+        result = _plan_adopt_source(conn, row, dictionary)
     else:
         result = ResolveResult(
             kept=keep, record_type=record_type, dedup_key=row["dedup_key"]
@@ -1605,6 +1635,13 @@ def resolve_conflict(
                 conn, record_type, json.loads(row["incoming_json"]),
                 row["person_id"], row["document_id"],
                 result.dedup_base or row["dedup_key"], result.occurrence or 0,
+            )
+        elif adopt_source:
+            # Inside the transaction so the provenance write and the audit row commit
+            # together (and the rowcount guard rolls both back).
+            _adopt_source(
+                conn, record_type, int(result.row_id),
+                int(result.adopted_document_id),
             )
         resolution = _resolution_text(result) + (f": {note}" if note else "")
         conn.execute(
@@ -1636,12 +1673,29 @@ def merge_summary(result: ResolveResult) -> str:
     return "; ".join(parts)
 
 
+def adopt_summary(result: ResolveResult) -> str:
+    """How a keep-existing + adopt-source resolution describes itself, for the audit
+    trail *and* the CLI success line — one wording, so the stored resolution and what the
+    operator was told can't drift (same rule as :func:`merge_summary`).
+
+    Ids and column names only, never values: the payload was not touched, and the audit
+    trail is not a place to echo clinical data.
+    """
+    return (
+        f"keep-existing +adopt-source -> {result.record_type} #{result.row_id} "
+        f"(document_id={result.adopted_document_id})"
+    )
+
+
 def _resolution_text(result: ResolveResult) -> str:
     """The auditable resolution string stored on the conflict row. keep-both records
-    which row it admitted (or matched), keep-merge which fields came from which side, so
-    the decision stays reconstructable."""
+    which row it admitted (or matched), keep-merge which fields came from which side,
+    adopt-source which row gained which document, so the decision stays
+    reconstructable."""
     if result.kept == "merge":
         return merge_summary(result)
+    if result.adopted_document_id is not None:
+        return adopt_summary(result)
     if result.kept != "both":
         return f"keep-{result.kept}"
     if result.no_op:
@@ -1842,6 +1896,53 @@ def _plan_keep_merge(
         occurrence=int(anchor["dedup_occurrence"]),
         dedup_key=anchor["dedup_key"], dedup_base=anchor["dedup_base"],
         gains=plan.taken, preserved=plan.preserved, settled=plan.settled,
+    )
+
+
+def _plan_adopt_source(
+    conn: sqlite3.Connection,
+    conflict: sqlite3.Row,
+    dictionary: dict[str, str] | None,
+) -> ResolveResult:
+    """Validate the provenance-only write ``keep='existing' + adopt_source`` would make.
+
+    Everything that can refuse happens here, before the transaction opens (same
+    discipline as :func:`_plan_keep_both` / :func:`_plan_keep_merge`). Two refusals, and
+    both are the point of the feature:
+
+    * the conflict must carry a document to adopt (``conflict.document_id`` is nullable);
+    * the anchor row's ``document_id`` must be **NULL**. Filling a NULL is additive;
+      re-pointing an already-sourced row at a different document while keeping the first
+      document's payload would assert that document B says what document A said. That is
+      the provenance guarantee :func:`pemr.records.edit_record` protects, one layer down.
+
+    Reached only when the flag is set, so plain ``keep='existing'`` keeps resolving an
+    empty family (it writes nothing either way) rather than hitting
+    :func:`_anchor_row`'s refusal.
+    """
+    record_type = conflict["record_type"]
+    if conflict["document_id"] is None:
+        raise ValueError(
+            f"conflict {conflict['conflict_id']} carries no document to adopt - "
+            "the incoming row has no document_id, so there is no source to link. "
+            "Nothing was written"
+        )
+    # Same anchor (and same empty-family refusal) as the writing keeps.
+    anchor = _anchor_row(conn, conflict, dictionary)
+    row_id = int(anchor[f"{record_type}_id"])
+    if anchor["document_id"] is not None:
+        raise ValueError(
+            f"conflict {conflict['conflict_id']}: {record_type} #{row_id} already has "
+            f"document_id={anchor['document_id']} - adopt-source fills a missing source, "
+            "it never re-points an existing one at another document. Resolve with keep "
+            "'incoming' or 'merge' to take this document's payload and provenance "
+            "together. Nothing was written"
+        )
+    return ResolveResult(
+        kept="existing", record_type=record_type, row_id=row_id,
+        occurrence=int(anchor["dedup_occurrence"]),
+        dedup_key=anchor["dedup_key"], dedup_base=anchor["dedup_base"],
+        adopted_document_id=int(conflict["document_id"]),
     )
 
 
@@ -2521,4 +2622,34 @@ def _merge_record(
         raise ValueError(
             f"keep-merge matched no {record_type} row (id {row_id}) - refusing to "
             "resolve the conflict, the merged fields would have been discarded"
+        )
+
+
+def _adopt_source(
+    conn: sqlite3.Connection,
+    record_type: str,
+    row_id: int,
+    document_id: int,
+) -> None:
+    """Copy the incoming document's ``document_id`` onto one stored row, by primary key.
+
+    **No payload column is ever named in the assignment list** - that is the whole
+    difference from :func:`_overwrite_record` / :func:`_merge_record`, which take the
+    document's values *and* its provenance. Here the stored row keeps everything it
+    said and gains only the source that confirms it, so an attested row moves from
+    ``"attested"`` to ``"superseded"`` (:func:`attestation_state`) with its attestation
+    columns intact as history (issue #190).
+
+    Primary-key addressing and the ``rowcount`` guard mirror those two functions for the
+    same reasons (see :func:`_anchor_row`): a zero-row UPDATE would stamp the conflict
+    resolved having written nothing.
+    """
+    cur = conn.execute(
+        f"UPDATE {record_type} SET document_id = ? WHERE {record_type}_id = ?",
+        (document_id, row_id),
+    )
+    if cur.rowcount != 1:
+        raise ValueError(
+            f"adopt-source matched no {record_type} row (id {row_id}) - refusing to "
+            "resolve the conflict, the row would have been left unsourced"
         )

--- a/pemr/mcp_server.py
+++ b/pemr/mcp_server.py
@@ -335,6 +335,7 @@ def review_conflicts(
     signoff: str | None = None,
     note: str | None = None,
     fields: dict[str, str] | None = None,
+    adopt_source: bool = False,
     all: bool = False,
 ) -> Any:
     """[read to list / write to resolve] List or resolve staged dedup conflicts.
@@ -351,11 +352,21 @@ def review_conflicts(
     ``fields`` = ``{"<field>": "existing"|"incoming"}`` to settle one, and only for a
     field that actually collides.
 
+    ``adopt_source=True`` is a modifier of ``keep="existing"`` (refused with any other
+    keep): the stored row's payload is kept in full and only the incoming document's
+    ``document_id`` is copied onto it, which is how a previously *attested* row gains the
+    source that later confirms the same fact. It refuses when the stored row already has
+    a ``document_id`` (adopt-source fills a missing source, it never re-points an
+    existing one — use ``"incoming"``/``"merge"`` to take payload and provenance
+    together) and when the conflict carries no document to adopt.
+
     Listing is free. **Resolution requires explicit human sign-off** (``AGENTS.md``
-    conflict discipline) — ``"both"`` and ``"merge"`` included, and a ``fields`` choice is
-    itself a decision the human has to have made: ``signoff`` must quote the human's
-    instruction verbatim, or the write is refused. The sign-off text is threaded into the
-    stored resolution note so the record shows who authorized it.
+    conflict discipline) — ``"both"``, ``"merge"`` and ``adopt_source`` included, and a
+    ``fields`` choice is itself a decision the human has to have made: ``signoff`` must
+    quote the human's instruction verbatim, or the write is refused. Sign-off for "keep
+    existing" is **not** sign-off for ``adopt_source`` — it is a distinct choice the
+    human has to have named. The sign-off text is threaded into the stored resolution
+    note so the record shows who authorized it.
     """
     if resolve is not None:
         if not (signoff and signoff.strip()):
@@ -368,7 +379,7 @@ def review_conflicts(
         try:
             result = _dedup.resolve_conflict(
                 conn, resolve, keep=keep, note=merged_note, dictionary=_dictionary(),
-                fields=fields,
+                fields=fields, adopt_source=adopt_source,
             )
         # ValueError covers ValidationError, raised when a keep-both payload no longer
         # validates as a row.
@@ -391,6 +402,13 @@ def review_conflicts(
                 "taken": sorted(result.gains),
                 "preserved": sorted(result.preserved),
                 "settled": result.settled,
+            }
+        elif result.adopted_document_id is not None:
+            # Ids only, no payload was touched - same audit-trail rule as above.
+            payload |= {
+                "record_type": result.record_type,
+                "row_id": result.row_id,
+                "adopted_document_id": result.adopted_document_id,
             }
         return payload
 
@@ -708,9 +726,10 @@ def build_server():  # pragma: no cover - exercised only with the mcp SDK instal
     def review_conflicts_tool(resolve: int | None = None, keep: str = "existing",
                               signoff: str | None = None, note: str | None = None,
                               fields: dict[str, str] | None = None,
+                              adopt_source: bool = False,
                               all: bool = False) -> object:
         return _run(review_conflicts, resolve=resolve, keep=keep, signoff=signoff,
-                    note=note, fields=fields, all=all)
+                    note=note, fields=fields, adopt_source=adopt_source, all=all)
 
     return server
 

--- a/tests/test_attestations.py
+++ b/tests/test_attestations.py
@@ -670,6 +670,57 @@ def test_cli_walk_from_attestation_to_a_source_document(cli_ready, capsys):
     ]
 
 
+def test_cli_walk_from_attestation_to_a_source_via_adopt_source(cli_ready, capsys):
+    """The same walk when the document *disagrees* (issue #190): the promotion path
+    cannot fire, a conflict is staged instead, and `--keep existing --adopt-source` is
+    what links the attested row to its source without taking the document's values."""
+    assert _run(cli_ready, *_ASSERT_ARGV, "--field", "status=ordered", "--apply") == 0
+    capsys.readouterr()
+
+    scan = cli_ready / "note.txt"
+    scan.write_bytes(b"metformin 500 mg daily, completed")
+    assert _run(cli_ready, "ingest", str(scan), "--person", "jane-doe",
+                "--sources", str(cli_ready / "sources")) == 0
+    payload = cli_ready / "extract.json"
+    payload.write_text(
+        json.dumps({"medication": [MED | {"status": "completed"}]}), encoding="utf-8"
+    )
+    capsys.readouterr()
+    assert _run(cli_ready, "commit-extraction", "--document", "1",
+                "--json", str(payload)) == 0
+    assert "1 conflict" in capsys.readouterr().out
+
+    assert _run(cli_ready, "review-conflicts", "--resolve", "1",
+                "--keep", "existing", "--adopt-source") == 0
+    out = capsys.readouterr().out
+    assert "keep-existing +adopt-source -> medication #1 (document_id=1)" in out
+
+    # Off the needs-source queue, its attested payload intact.
+    assert _run(cli_ready, "record", "assert", "--list") == 0
+    assert "no attested records" in capsys.readouterr().out
+    assert _run(cli_ready, "record", "assert", "--list", "--all", "--json") == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert [(r["needs_source"], r["document_id"], r["attested_by"]) for r in rows] == [
+        (False, 1, "Mom")
+    ]
+    assert _run(cli_ready, "query", "meds", "--person", "jane-doe", "--json") == 0
+    assert json.loads(capsys.readouterr().out)[0]["status"] == "ordered"
+
+    # ...and it renders as an ordinary fact, not a live attestation.
+    assert _run(cli_ready, "render", "summary", "--person", "jane-doe") == 0
+    assert "no source document" not in capsys.readouterr().out
+
+
+def test_cli_adopt_source_with_another_keep_is_an_error(cli_ready, capsys):
+    """The refusals reach the operator as `error:` + exit 1, like every other
+    resolution refusal - no new exit code."""
+    assert _run(cli_ready, *_ASSERT_ARGV, "--apply") == 0
+    assert _run(cli_ready, "review-conflicts", "--resolve", "1",
+                "--keep", "incoming", "--adopt-source") == 1
+    err = capsys.readouterr().err
+    assert "adopt-source only applies to keep 'existing'" in err
+
+
 def test_cli_assert_on_an_unmigrated_db_is_friendly(tmp_path, capsys, unmigrated_db):
     unmigrated_db(tmp_path / "cli.db")
     assert _run(tmp_path, *_ASSERT_ARGV, "--apply") == 1

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from pemr import db, dedup, persons
+from pemr import attestations, db, dedup, persons
 
 
 @pytest.fixture()
@@ -772,3 +772,148 @@ def test_merge_on_a_sparse_type_always_refuses(conn):
     assert conn.execute(
         "SELECT criticality FROM allergy"
     ).fetchone()["criticality"] == "high"
+
+
+# --- keep existing + adopt-source (issue #190) --------------------------------
+#
+# A row entered by `record assert` has document_id NULL. When a document later carries
+# the same identity with a *differing* payload, a conflict is staged - and `keep
+# existing` used to leave the row permanently unlinked even though the document confirms
+# the same underlying fact. adopt-source keeps the attested payload and fills only the
+# missing provenance, so `attestation_state` moves attested -> superseded.
+
+@pytest.fixture()
+def attested_staged(conn):
+    """An attested medication row (document_id NULL) with one open conflict staged
+    against it from a document stating a *differing* payload."""
+    attestations.assert_record(
+        conn, "medication", "jane-doe", _med(prescriber="Dr Who", status="ordered"),
+        attributed_to="Mom", attested_on="2026-08-09", apply=True,
+    )
+    stored = _med_row(conn)
+    assert (stored["document_id"], dedup.attestation_state(stored)) == (None, "attested")
+    summary = dedup.commit_extraction(
+        conn, _doc(conn, "med-doc"), {"medication": [_med(status="completed")]}
+    )
+    assert summary.counts["conflict"] == 1
+    return dedup.list_conflicts(conn)[-1]["conflict_id"]
+
+
+def test_adopt_source_writes_only_the_document_id(conn, attested_staged):
+    """The core AC: provenance lands, and not one payload column moves toward the
+    incoming row's differing values."""
+    before = dict(_med_row(conn))
+    result = dedup.resolve_conflict(
+        conn, attested_staged, keep="existing", adopt_source=True
+    )
+    after = dict(_med_row(conn))
+
+    assert conn.execute("SELECT COUNT(*) AS n FROM medication").fetchone()["n"] == 1
+    assert after["document_id"] == result.adopted_document_id == 1
+    assert after["status"] == "ordered"          # not the incoming "completed"
+    assert {k: v for k, v in after.items() if k != "document_id"} == {
+        k: v for k, v in before.items() if k != "document_id"
+    }
+
+
+def test_adopt_source_supersedes_the_attestation(conn, attested_staged):
+    dedup.resolve_conflict(conn, attested_staged, keep="existing", adopt_source=True)
+    row = _med_row(conn)
+    assert dedup.attestation_state(row) == "superseded"
+    assert dedup.is_attested(row) is False
+    # The attestation survives as history on the row, not as a marker on the page.
+    assert (row["attested_by"], row["attested_on"]) == ("Mom", "2026-08-09")
+
+
+def test_adopt_source_result_names_the_row_it_landed_on(conn, attested_staged):
+    result = dedup.resolve_conflict(
+        conn, attested_staged, keep="existing", adopt_source=True
+    )
+    row = _med_row(conn)
+    assert (result.kept, result.record_type) == ("existing", "medication")
+    assert (result.row_id, result.occurrence) == (row["medication_id"], 0)
+    assert (result.dedup_key, result.dedup_base) == (row["dedup_key"], row["dedup_base"])
+    assert result.adopted_document_id == 1
+
+
+def test_adopt_source_records_a_distinct_auditable_resolution(conn, attested_staged):
+    dedup.resolve_conflict(
+        conn, attested_staged, keep="existing", adopt_source=True, note="Mom confirmed"
+    )
+    resolution = conn.execute(
+        "SELECT resolution FROM conflict WHERE conflict_id=?", (attested_staged,)
+    ).fetchone()["resolution"]
+
+    assert resolution.startswith(
+        "keep-existing +adopt-source -> medication #1 (document_id=1)"
+    )
+    assert "Mom confirmed" in resolution
+    for value in ("Dr Who", "ordered", "completed", "metformin"):
+        assert value not in resolution.split("Mom confirmed")[0]
+
+
+def test_plain_keep_existing_still_stores_the_bare_resolution(conn, attested_staged):
+    """The other half of "distinctly": without the flag nothing changed - same text,
+    same untouched provenance."""
+    result = dedup.resolve_conflict(conn, attested_staged, keep="existing")
+    assert result.adopted_document_id is None
+    assert conn.execute(
+        "SELECT resolution FROM conflict WHERE conflict_id=?", (attested_staged,)
+    ).fetchone()["resolution"] == "keep-existing"
+    assert _med_row(conn)["document_id"] is None
+
+
+def test_adopt_source_refuses_an_already_sourced_row(conn):
+    """Filling a NULL is additive; re-pointing a sourced row at another document while
+    keeping the first document's payload would misattribute it."""
+    cid = _stage_med(conn, {"status": "ordered"}, {"status": "completed"})
+    before = dict(_med_row(conn))
+    with pytest.raises(ValueError) as exc:
+        dedup.resolve_conflict(conn, cid, keep="existing", adopt_source=True)
+
+    assert "already has document_id=1" in str(exc.value)
+    assert "keep" in str(exc.value) and "'incoming'" in str(exc.value)
+    assert str(exc.value).isascii()          # printed by the CLI (issue #23)
+    assert dict(_med_row(conn)) == before
+    assert conn.execute(
+        "SELECT status FROM conflict WHERE conflict_id=?", (cid,)
+    ).fetchone()["status"] == "open"
+
+
+@pytest.mark.parametrize("keep", ["incoming", "both", "merge"])
+def test_adopt_source_refuses_the_other_keeps(conn, attested_staged, keep):
+    """Those keeps already take the document's provenance with its payload, so the flag
+    would be either redundant or a lie about which payload won."""
+    with pytest.raises(ValueError, match="adopt-source only applies to keep 'existing'"):
+        dedup.resolve_conflict(conn, attested_staged, keep=keep, adopt_source=True)
+    assert _med_row(conn)["document_id"] is None
+    assert conn.execute(
+        "SELECT status FROM conflict WHERE conflict_id=?", (attested_staged,)
+    ).fetchone()["status"] == "open"
+
+
+def test_adopt_source_refuses_a_conflict_with_no_document(conn, attested_staged):
+    """`conflict.document_id` is nullable: nothing to adopt is a refusal, not a
+    resolution that writes NULL over NULL."""
+    conn.execute(
+        "UPDATE conflict SET document_id = NULL WHERE conflict_id = ?",
+        (attested_staged,),
+    )
+    conn.commit()
+    with pytest.raises(ValueError, match="carries no document to adopt"):
+        dedup.resolve_conflict(conn, attested_staged, keep="existing", adopt_source=True)
+    assert conn.execute(
+        "SELECT status FROM conflict WHERE conflict_id=?", (attested_staged,)
+    ).fetchone()["status"] == "open"
+
+
+def test_adopt_source_refuses_when_the_family_is_empty(conn, orphaned_family):
+    """Same anchor rule as the writing keeps - and the pair with
+    `test_keep_existing_still_resolves_an_empty_family` is the guard that the anchor
+    lookup stays inside the flag's branch."""
+    _drop_occurrence(conn, 1)
+    with pytest.raises(ValueError, match="no stored lab_result row left"):
+        dedup.resolve_conflict(conn, orphaned_family, keep="existing", adopt_source=True)
+    assert conn.execute(
+        "SELECT status FROM conflict WHERE conflict_id=?", (orphaned_family,)
+    ).fetchone()["status"] == "open"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -18,7 +18,8 @@ from pathlib import Path
 import pytest
 
 from pemr import (
-    __version__, curation, db, dedup, ingest, mcp_server, persons, records, tombstones,
+    __version__, attestations, curation, db, dedup, ingest, mcp_server, persons,
+    records, tombstones,
 )
 
 REPO = Path(__file__).resolve().parent.parent
@@ -650,6 +651,65 @@ def test_review_conflicts_merge_collision_refuses_until_a_field_is_settled(
         "SELECT * FROM medication WHERE medication_id = ?", (res["row_id"],)
     ).fetchone()
     assert (row["status"], row["prescriber"]) == ("completed", "Dr Who")
+
+
+def _stage_attested_med_conflict(seeded, tmp_path, monkeypatch) -> int:
+    """An attested medication row (document_id NULL) plus one open conflict from a
+    document stating a differing payload (issue #190); returns its conflict id."""
+    monkeypatch.setenv("PEMR_SOURCES", str(tmp_path / "sources"))
+    identity = {"name": "metformin", "dose": "500 mg", "started_on": "2024-01-05"}
+    attestations.assert_record(
+        seeded, "medication", "jane-doe", identity | {"status": "ordered"},
+        attributed_to="Mom", attested_on="2026-08-09", apply=True,
+    )
+    scan = tmp_path / "portal.txt"
+    scan.write_bytes(b"portal")
+    doc = mcp_server.ingest_document(
+        seeded, file=str(scan), person="jane-doe", ocr_text="metformin",
+    )["document"]["document_id"]
+    mcp_server.commit_extraction(seeded, document_id=doc, records={
+        "medication": [identity | {"status": "completed"}],
+    })
+    return mcp_server.review_conflicts(seeded)[0]["conflict_id"]
+
+
+def test_review_conflicts_adopt_source_requires_signoff_and_reports_the_document(
+    seeded, tmp_path, monkeypatch
+):
+    """adopt-source writes, so it goes through the *same* sign-off gate - no new bypass -
+    and its payload names ids only, never the values it deliberately did not take."""
+    cid = _stage_attested_med_conflict(seeded, tmp_path, monkeypatch)
+    with pytest.raises(mcp_server.ToolError, match="sign-off"):
+        mcp_server.review_conflicts(seeded, resolve=cid, adopt_source=True)
+    assert seeded.execute(
+        "SELECT status FROM conflict WHERE conflict_id=?", (cid,)
+    ).fetchone()["status"] == "open"
+
+    res = mcp_server.review_conflicts(
+        seeded, resolve=cid, keep="existing", adopt_source=True,
+        signoff="Jane said link the row to this document but keep what Mom said",
+    )
+    assert res["keep"] == "existing" and res["record_type"] == "medication"
+    assert res["adopted_document_id"] is not None
+    row = seeded.execute(
+        "SELECT * FROM medication WHERE medication_id = ?", (res["row_id"],)
+    ).fetchone()
+    assert row["document_id"] == res["adopted_document_id"]
+    assert row["status"] == "ordered"          # payload untouched
+    assert dedup.attestation_state(row) == "superseded"
+    assert "ordered" not in str(res) and "completed" not in str(res)
+
+
+def test_review_conflicts_adopt_source_refuses_another_keep(
+    seeded, tmp_path, monkeypatch
+):
+    cid = _stage_attested_med_conflict(seeded, tmp_path, monkeypatch)
+    with pytest.raises(mcp_server.ToolError, match="adopt-source only applies"):
+        mcp_server.review_conflicts(seeded, resolve=cid, keep="merge",
+                                    adopt_source=True, signoff="Jane said adopt it")
+    assert seeded.execute(
+        "SELECT status FROM conflict WHERE conflict_id=?", (cid,)
+    ).fetchone()["status"] == "open"
 
 
 def test_review_conflicts_rejects_an_unknown_keep(seeded, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Adds an `--adopt-source` modifier to `review-conflicts --keep existing`: when a document's
extraction conflicts with a previously-attested row on a *differing* payload, this resolution
copies the incoming document's `document_id` onto the stored row — filling the row's
`document_id` (was `NULL`) without touching its attested payload — and leaves it reading
`superseded` per `dedup.attestation_state`. Previously, `--keep existing` (the default
resolution) dropped the incoming row entirely and left the attested row permanently unlinked
from its supporting document, with no verb available to fix that after the fact
(`record edit --set document_id=...` is refused by design — the provenance guarantee in
`pemr/records.py::edit_record`).

Ships as a modifier on the existing `keep='existing'` path (mirroring how `--field` modifies
`--keep merge`), not a new `KEEP_CHOICES` mode. Two refusals define the semantics: it only fills
a NULL `document_id` (an already-sourced row refuses — re-pointing is out of scope, by design,
one layer under the provenance guarantee), and it refuses when the conflicting row itself has no
`document_id` to adopt.

- `pemr/dedup.py`: `ResolveResult.adopted_document_id`; `resolve_conflict(..., adopt_source=False)`;
  `_plan_adopt_source` / `_adopt_source` (writes only `document_id`, inside the existing
  transaction, under the existing `rowcount != 1` guard); `adopt_summary`; `_resolution_text`
  branch.
- `pemr/cli.py`: `--adopt-source` flag on `review-conflicts`, threaded through, success-line and
  listing-hint updates.
- `pemr/mcp_server.py`: `adopt_source` threaded through `review_conflicts` (sign-off gate
  unchanged); payload gains `record_type`/`row_id`/`adopted_document_id` on the new path only
  (additive).
- `docs/Architecture.md` §3 and `AGENTS.md` §5 updated to document the new resolution and list
  `keep existing --adopt-source` as a sign-off choice distinct from plain `keep existing`.
- Tests: `tests/test_conflict.py`, `tests/test_attestations.py` (full CLI walk +
  refusal path), `tests/test_mcp_server.py` (sign-off + payload shape).

No migration, no change to `record edit`'s editable-field set, and the existing `promoted` /
`keep incoming` / `keep merge` provenance behavior (issue #110) is unchanged.

Closes #190

## Verify + audit

- Verify report: https://github.com/meridun/pemr/issues/190#issuecomment-5388609132 — full suite
  1662 passed, real out-of-process CLI walk covering every acceptance criterion (before/after
  column snapshot showing only `document_id` changed).
- Audit report: https://github.com/meridun/pemr/issues/190#issuecomment-5388639840 — no blocking
  findings; one non-blocking advisory (A1: `_adopt_source` could additionally enforce
  `document_id IS NULL` in its own `WHERE` clause as defense-in-depth, matching its sibling
  `_promote_to_document` — not required, the pre-transaction check already prevents any
  re-pointing in practice).

🤖 Generated with SDLC pipeline (ship worker, run dispatch-20260823-2108-5148-ship)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
