### PR TITLE
feat(sdlc): adopt upstream sdlc-worker agent and vendored SDLC docs

### DIFF
--- a/.claude/agents/sdlc-worker.md
+++ b/.claude/agents/sdlc-worker.md
@@ -1,0 +1,40 @@
+---
+name: sdlc-worker
+description: "Isolated SDLC pipeline lane worker. Spawned by the sdlc-dispatch scheduled task to execute one prompts/sdlc/<lane>.md pass. Deliberately has NO agent-spawning tool: all owner work is done inline."
+tools: Read, Grep, Glob, Edit, Write, Bash
+---
+
+
+You are an **SDLC pipeline lane worker** for the `pemr` project. You execute exactly one pass of
+one worker prompt from `prompts/sdlc/` (the dispatcher's message tells you which lane), honoring every
+invariant in `prompts/sdlc/README.md`. Placeholder bindings (`<DEFAULT_BRANCH>`, `<TEST_CMD>`, …)
+live in `prompts/sdlc/PROFILE.md` — read it alongside the README.
+
+### No delegation — by construction
+
+You have **no Agent tool.** This is deliberate: in an async harness, subagents spawned by a worker run
+detached — the worker yields, nothing resumes it, and the item strands under `sdlc:wip`. So:
+
+- Where a lane prompt names an owner skill, checklist, or approach, that names the
+  **checklist/approach you apply yourself, inline** — not a subagent to spawn.
+- Never start background shell tasks and stop to wait on them; never poll a file in an unbounded wait
+  loop. Run commands in the foreground and act on their output in the same pass.
+
+### Working style
+
+- **Worktree isolation:** never work in the main checkout — use the issue-scoped worktree
+  `C:\Claude\pemr-wt-<issue#>` per the README universal loop. Claim with `sdlc:wip` + an
+  `sdlc:claim <run-id> <lane>` comment, then claim-verify (earliest claim wins).
+- Conventions, quality bars, and invariants: `.github/copilot-instructions.md` (loaded for every
+  agent) plus the `PROFILE.md` bindings — the quality-bar commands there are acceptance criteria on
+  every change.
+- Minimal change; follow existing patterns; defensive at boundaries; never assume single-actor state.
+- Decisions go to an in-issue `decision:` one-liner comment, never into doc prose.
+
+### Output
+
+Terse. Your final message is the dispatcher's record: the one-line outcome
+(`<LANE>: <#issue> → ADVANCE|BOUNCE|PARK|CONTINUE|idle — <reason>`) plus any PARK/BOUNCE specifics,
+ending with the fenced JSON result block per the README STOP contract
+(`{"issue": <n>, "outcome": "...", "next_stage": "...", "notes": "..."}` — always the last element
+of the reply). Nothing else.

--- a/.github/agents/sdlc-worker.agent.md
+++ b/.github/agents/sdlc-worker.agent.md
@@ -1,0 +1,40 @@
+---
+description: "Isolated SDLC pipeline lane worker. Spawned by the sdlc-dispatch scheduled task to execute one prompts/sdlc/<lane>.md pass. Deliberately has NO agent-spawning tool: all owner work is done inline."
+tools: [read, search, edit, execute]
+user-invocable: false
+---
+
+
+You are an **SDLC pipeline lane worker** for the `pemr` project. You execute exactly one pass of
+one worker prompt from `prompts/sdlc/` (the dispatcher's message tells you which lane), honoring every
+invariant in `prompts/sdlc/README.md`. Placeholder bindings (`<DEFAULT_BRANCH>`, `<TEST_CMD>`, …)
+live in `prompts/sdlc/PROFILE.md` — read it alongside the README.
+
+### No delegation — by construction
+
+You have **no Agent tool.** This is deliberate: in an async harness, subagents spawned by a worker run
+detached — the worker yields, nothing resumes it, and the item strands under `sdlc:wip`. So:
+
+- Where a lane prompt names an owner skill, checklist, or approach, that names the
+  **checklist/approach you apply yourself, inline** — not a subagent to spawn.
+- Never start background shell tasks and stop to wait on them; never poll a file in an unbounded wait
+  loop. Run commands in the foreground and act on their output in the same pass.
+
+### Working style
+
+- **Worktree isolation:** never work in the main checkout — use the issue-scoped worktree
+  `C:\Claude\pemr-wt-<issue#>` per the README universal loop. Claim with `sdlc:wip` + an
+  `sdlc:claim <run-id> <lane>` comment, then claim-verify (earliest claim wins).
+- Conventions, quality bars, and invariants: `.github/copilot-instructions.md` (loaded for every
+  agent) plus the `PROFILE.md` bindings — the quality-bar commands there are acceptance criteria on
+  every change.
+- Minimal change; follow existing patterns; defensive at boundaries; never assume single-actor state.
+- Decisions go to an in-issue `decision:` one-liner comment, never into doc prose.
+
+### Output
+
+Terse. Your final message is the dispatcher's record: the one-line outcome
+(`<LANE>: <#issue> → ADVANCE|BOUNCE|PARK|CONTINUE|idle — <reason>`) plus any PARK/BOUNCE specifics,
+ending with the fenced JSON result block per the README STOP contract
+(`{"issue": <n>, "outcome": "...", "next_stage": "...", "notes": "..."}` — always the last element
+of the reply). Nothing else.

--- a/docs/Development_SdlcAdoption.md
+++ b/docs/Development_SdlcAdoption.md
@@ -1,0 +1,150 @@
+# Adoption guide
+
+How to wire this template into a real repo. ~30 minutes for a first pass.
+
+## 1. Copy the trees
+
+- `prompts/sdlc/` → `prompts/sdlc/` in your repo (or anywhere your agent can read; the dispatcher just
+  needs the path).
+- `.github/agents/sdlc-worker.agent.md` → your harness's agent dir, with the matching frontmatter from that file:
+  - Claude Code: `.claude/agents/sdlc-worker.md`
+  - GitHub Copilot: `.github/agents/sdlc-worker.agent.md`
+
+Name the agent something project-scoped (e.g. `acme-sdlc-worker`) and use that everywhere `sdlc-worker`
+appears. Avoid names already claimed by session-orchestration layers installed at the user level —
+e.g. pilotfish registers `scout`, `Explore`, `plan-verifier`, `security-reviewer`, `mech-executor`,
+`executor`, `verifier`, `security-executor` — a collision would silently swap in the wrong agent
+body. A project-scoped name sidesteps the whole class.
+
+Two Claude Code notes:
+
+- **Version floor.** The worker's no-delegation guarantee rests on the harness *enforcing* the
+  agent file's tool list, not on prompt text. Enforced tool exclusion is reliable on Claude Code
+  ≥ 2.1.219 — treat that as the floor for scheduled operation.
+- **`CLAUDE_CODE_SUBAGENT_MODEL`** silently overrides per-spawn model arguments; if it's set on the
+  dispatch machine, the per-lane tier table in `dispatch.md` is a no-op. Unset it for the
+  dispatcher's environment.
+
+- *(optional)* `skills/proj-doc-tiers/` → your harness's skill dir (Claude Code:
+  `.claude/skills/proj-doc-tiers/`). Copy it if the ship stage's docs fan-out should follow the
+  hub-and-spoke tier discipline; skip it if your docs are a flat README.
+
+## 2. Create the labels
+
+Run the `gh` script in [Development_SdlcLabels.md](Development_SdlcLabels.md). It creates the `stage:*`, `sdlc:*`, and `priority:*`
+labels the prompts depend on.
+
+## 3. Fill the placeholders
+
+Grep for `<` across `prompts/` and `agents/` and replace every one. The full list:
+
+| Placeholder | Meaning | Example |
+|---|---|---|
+| `<PROJECT>` | Project name (appears in every worker's opening line) | `Acme API` |
+| `<REPO_PATH>` | Local working directory the scheduled agent runs in | `C:\work\acme` |
+| `sdlc-worker` | The isolated worker agent's `subagent_type` name | `acme-sdlc-worker` |
+| `<DEFAULT_BRANCH>` | Integration branch — PRs target it, branches cut from it | `dev` or `main` |
+| `<PROD_BRANCH>` | Release branch — **off-limits** to all workers | `main` or `release` |
+| `<WORKTREE_ROOT>` | Where issue-scoped worktrees live | `../acme-wt` |
+| `<BUILD_CMD>` | Build/compile/launch the software for a real run | `npm run build` |
+| `<TEST_CMD>` | Targeted test run (build stage) | `npm test -- <path>` |
+| `<FULL_SUITE_CMD>` | Full test suite (verify stage) | `npm test` |
+| `<LINT_CMD>` | Lint/format/type gate that must be clean before commit | `npm run lint` |
+| `<SMOKE_CMD>` | Repeatable real-run / e2e / smoke spec (verify stage) | `npm run e2e` |
+| `<LANG_CONVENTIONS>` | The lint/format/test bar in one line | `eslint clean, prettier applied, jest green` |
+| `<INVARIANTS>` | Project rules that are ACs on **every** change — list them | `no breaking API changes; all endpoints authz-checked; no PII in logs` |
+| `<DECISION_RECORD>` | Where decisions are logged (a doc section, a registry file) | `docs/Decisions.md` |
+| `<DESIGN_ARTIFACTS>` | *(optional, design UX track)* the fork's conventions for design artifacts — what storyboards/mockups are, where they live, how they're authored; leave unbound to run spec-track only | `docs/mockups/ per its README` |
+| `<KNOWN_ENV_LIMITS>` | *(optional, verify)* declared environment limitations: the gate that can't run, its accepted substitute, and the report wording — so verify honors them instead of rediscovering (or PARKing over) them each pass | `integration suite needs local MySQL — covered via Docker e2e` |
+| `<DOCS_SINKS>` | Documentation targets ship fans out to | `README.md, docs/API.md` |
+| `<DOCS_ROOT>` | *(optional, docs-tiers skill)* root of the L3 documentation tree | `docs/` |
+| `<DOC_DOMAINS>` | *(optional, docs-tiers skill)* thematic domain prefixes files route into | `Architecture_*, Testing_*, UserGuide_*` |
+| `<TOKEN_TOOL>` | *(optional)* shell-output compactor — either an explicit prefix on every command, or a transparent shell wrapper (see `.github/agents/sdlc-worker.agent.md` for the two binding modes); delete the mentions if none | `tok` |
+
+`<INVARIANTS>` is the one that most repays effort — it is the shared acceptance criterion build
+implements to, verify exercises, and audit reviews for. Be specific and concrete.
+
+## 4. Copy the reference CLI (recommended)
+
+Copy `scripts/sdlc.mjs` into your repo (plain Node, no dependencies) and adapt the constants at the
+top — `DEFAULT_BRANCH`, `PROD_BRANCH`, and the worktree naming function. Then wire the lane prompts
+to it: wherever a prompt describes the claim lock, outcome emit, stage swap, or dispatcher gate
+ritual, have
+workers run the CLI one-shot instead
+(`npm run sdlc -- claim|emit|advance|gate|cycle-prep|maint-lock|lanes|…`).
+
+Why bother: `advance` validates every transition against the stage graph, which kills the
+hand-typed label-typo class (`stage:verfy`) by construction, and it makes the gate, machine
+maintenance lock, and claim-verify race check deterministic — the agent supplies judgment (what to
+spawn, what to write in comments), the CLI supplies the state math. The pure helpers are exported and the
+gh/git executors injectable, so you can unit-test your adaptations without touching GitHub.
+
+## 5. Choose your variant
+
+- Small backlog / single tree → **serial** (see [Development_AgenticSDLC.md](Development_AgenticSDLC.md#concurrency-variants);
+  simplify `dispatch.md` per the note there, and you can ignore the worktree steps).
+- Throughput matters → keep the shipped **per-issue** model. Nothing to create up front: there is
+  no dispatcher singleton — overlapping dispatch runs deconflict via per-issue claims, idempotent
+  GitHub writes, and a per-machine maintenance lock the dispatcher creates automatically at
+  `.git/sdlc-maint.lock`. Just confirm your platform allows git worktrees.
+
+Design is a **standard stage** — every item gets a reviewed implementation plan there (spec-lite
+for small items), so the `stage:design` label and the shipped `prompts/sdlc/design.md` worker are
+part of the default pipeline. What you decide is whether to bind its **UX track**: bind
+`<DESIGN_ARTIFACTS>` in your profile if your work is user-facing and worth storyboarding; leave it
+unbound to run spec-track only.
+
+## 6. Write your conformance profile
+
+Create `prompts/sdlc/PROFILE.md` from the skeleton in
+[Development_SdlcComposability.md](Development_SdlcComposability.md#the-conformance-profile), declaring your bindings for the five
+variation points and any known deviations. This is what keeps ad-hoc drift audits against the spec
+cheap. Two worked examples: [profiles/github-single-repo.example.md](https://github.com/meridun/agentic-sdlc/blob/master/docs/profiles/github-single-repo.example.md)
+(the minimal single-repo GitHub case most forks start from) and
+[profiles/work-ado.example.md](https://github.com/meridun/agentic-sdlc/blob/master/docs/profiles/work-ado.example.md) (a multi-repo Azure DevOps
+read-only consumer).
+
+## 7. Dry-run manually before scheduling
+
+Paste `prompts/sdlc/README.md` + one stage file (start with `intake.md`) into an agent session pointed
+at your repo. Feed it a real issue labeled `stage:intake`. Watch it CLAIM, WORK, and EMIT. The prompt
+behaves identically whether a human or a scheduler fired it — so a clean manual pass means the
+scheduled one will work. Walk one issue all the way through intake → ship this way before automating.
+
+## 8. Schedule the dispatcher
+
+Register a recurring task whose body is a **thin pointer** to `dispatch.md`, e.g.:
+
+> Read `<REPO_PATH>/prompts/sdlc/dispatch.md` and execute one dispatch cycle for the `<PROJECT>`
+> project: spawn one `sdlc-worker` subagent per non-empty lane as the file directs. The file is
+> the canonical prompt; follow it exactly.
+
+Keep the delegation cue ("spawn one `sdlc-worker` subagent per …") in the pointer itself:
+harness versions have been observed declining to spawn subagents from prompts that carry no
+explicit delegation instruction, and the pointer is the first text the scheduled session sees.
+
+Cadence: hourly is typical (the 2h reap threshold assumes ≤ hourly). Options:
+- **Claude Code scheduled tasks** — the native path; the task calls the dispatcher subagent.
+- **cron + headless agent** — `cron` → a headless agent invocation with the pointer as its prompt.
+- **CI cron** (GitHub Actions `schedule:`) — a job that runs the agent CLI against the pointer.
+
+**Enable it only once your queue depth justifies the spend** — each cycle costs tokens per non-empty
+lane. Until then, run it manually on demand.
+
+**Dispatcher sizing:** keep the dispatcher itself mid-tier (sonnet-class) even once its steps are
+CLI-scripted — a dispatch failure is systemic (a whole cycle misroutes), not per-issue like a worker
+failure. Consider dropping it to a small model (haiku-class) only after the worktree sweep and
+conflict scan are scripted too and you've observed several clean cycles.
+
+## 9. Watch the first few cycles
+
+The dispatcher's digest (end of every run) is your dashboard: cycle duration, machine-lock result,
+git maintenance,
+one line per lane, queue depths, parked items, and **token cost per lane + cycle total**. That token line is the
+trend to watch for cost regressions. Parked (`sdlc:needs-human`) items are your action queue.
+
+**Track which pipeline paths the chain has actually exercised.** A full-chain ADVANCE run proves
+the happy path, but most BOUNCE/PARK/CONTINUE tails start out unproven — keep a short provenance
+list (which issues proved which paths) in your pipeline doc, and exercise an unproven tail
+manually before trusting it scheduled. Fold what those runs teach back into the worker prompts;
+the prompts, not the list, stay canonical for behavior.

--- a/docs/Development_SdlcComposability.md
+++ b/docs/Development_SdlcComposability.md
@@ -1,0 +1,243 @@
+# Composability: one spec, many forks
+
+How the agentic SDLC stays shared across projects that differ in tracker, topology, runtime, and
+quality bars — without a runtime dependency between them. Companion to
+[Development_AgenticSDLC.md](Development_AgenticSDLC.md) (the model) and [Development_SdlcAdoption.md](Development_SdlcAdoption.md) (the mechanics).
+
+## The problem this solves
+
+Four live adoptions, four different shapes:
+
+| Project | Tracker | Topology | Dispatcher runtime | Notable extras |
+|---|---|---|---|---|
+| IsekaiOnline | GitHub issues | single repo | Claude Code scheduled task → subagent lanes | design lane, playtest verify |
+| vtk | GitHub issues | single repo | Claude Code scheduled task | Go toolchain quality bar |
+| pemr | GitHub issues | single repo | Claude Code scheduled task | minimal — nearest to template |
+| work (ADO) | Azure DevOps work items | **multi-repo Features** (core-api / webapp / utility) | GitHub Copilot session dispatcher, scheduler TBD | PSI lifecycle, child PBIs, ADO parent/predecessor links |
+
+The work environment additionally has **read-only access to this repo and cannot install from
+it**. Whatever the framework ships must be consumable as *text an agent can read and transcribe*,
+not only as code.
+
+## Distribution model: hybrid, fork-per-project
+
+The framework is delivered in three layers of decreasing normativity. Every project **forks**
+(copies and diverges); nothing depends on this repo at runtime.
+
+1. **Normative spec** (`docs/` here) — the invariants, the lifecycle spine, and the variation-point
+   contracts below. This is the only layer every fork must conform to.
+2. **Reference prompts and contracts** (`prompts/sdlc/`, `.github/agents/sdlc-worker.agent.md`) — portable text.
+   A fork with write access copies the trees (per [Development_SdlcAdoption.md](Development_SdlcAdoption.md)); a **read-only
+   consumer transcribes**: an agent reads this repo, compares against the local implementation,
+   and ports the contract language by hand into whatever the local harness accepts (Copilot agent
+   files, ADO wiki, dispatch prompts).
+3. **Reference executable core** (`scripts/sdlc.mjs`, or a project's own `sdlc` CLI / `sdlc.ps1`) —
+   optional determinism. Deterministic state math (transition validation, claim/gate/lock rituals)
+   is strongly recommended where installable, and explicitly *not required* for conformance —
+   the work fork substitutes its own `sdlc.ps1` implementing the same operations.
+
+**Upstream sync is manual and ad hoc.** There is no version negotiation: when a fork learns
+something, port it here by hand; when this spec improves, port it outward when convenient. The
+conformance profile (below) is what makes an ad-hoc "diff my fork against the spec" pass cheap to
+run with an agent.
+
+## The canonical lifecycle spine
+
+The nine-stage Feature state machine is the universal spine. It supersedes the earlier six-stage
+form (`intake → queued → build → verify → audit → ship`): `ship` is decomposed into the explicit
+tail `ready → shipping → complete` so the second human gate is first-class, and `design` is a
+**standard stage** — its spec track (a reviewed implementation plan on the work item, spec-lite
+for small items) always runs, so every item reaches the `queued` gate carrying an approach the
+human can approve or veto. Only design's UX/artifact track is optional (VP3).
+
+```
+intake → design → queued → build → verify → audit → ready → shipping → complete
+         spec      HUMAN                            HUMAN
+         always    GATE 1                           GATE 2
+```
+
+Core semantics every fork keeps:
+
+- **Two human gates.** `queued` (a human reviews design's implementation plan and commits
+  engineering capacity) and `ready` (a human
+  approves release). Both are workerless; automation never advances through them.
+- **Evidence-based transitions.** Each stage records its artifact on the work item before the item
+  moves (intake's requirements + AC, design's implementation plan, build's branch, verify's
+  report, audit's findings). A downstream
+  stage reconstructs its full context from the work item alone.
+- **The five invariants** of [Development_AgenticSDLC.md](Development_AgenticSDLC.md) — one item/one outcome per pass,
+  idempotency, isolation (no delegation, no shared tree), stale-lock reaping never live-lock
+  stomping, bounce-to-owner / park-to-human — apply verbatim regardless of tracker or runtime.
+- **Worker contract.** CLAIM → WORK → EMIT (`ADVANCE`/`BOUNCE`/`PARK`/`CONTINUE`) → STOP, exactly
+  one item per pass.
+
+Stage *names* are canonical; stage *content* is parameterized (see quality-bar variation point).
+A fork may collapse `ready → shipping → complete` into a thin tail (a single-repo project's
+"shipping" is often just "human merges the PR") but the gates and orderings must survive.
+
+## Variation points
+
+These are the sanctioned axes of difference. Each has a small contract; a fork customizes by
+binding the contract, not by rewriting the spine.
+
+### VP1 — Tracker backend
+
+The spec's state machine needs, from any tracker, exactly these operations:
+
+| Abstract operation | GitHub binding (template) | ADO binding (work) |
+|---|---|---|
+| stage marker (exactly one) | `stage:*` label | `stage:*` tag on the Feature (native States stay coarse/derived) |
+| routing marker | repo labels / single repo | exactly one `repo:*` tag per child |
+| claim lock + timestamp | `sdlc:wip` + claim comment | stage-Task claim line written by rev-CAS + transient `sdlc:wip` visibility tag |
+| park to human | `sdlc:needs-human` | `sdlc:needs-human` **on the Feature**, HUMAN ACTION REQUIRED discussion comment |
+| human keep-off | `sdlc:hold` | `sdlc:hold` |
+| evidence record | issue **body sections** for durable artifacts (`## Requirements` / `## Acceptance criteria` / `## Design` / `## Implementation plan`, one owner per section) + comments for protocol traffic | split by level: Feature comments (team-facing traffic), PBI description (tech spec/plan), stage Tasks (agent working memory) |
+| hierarchy & ordering | n/a (flat issues) | ADO Parent link (membership), predecessor/successor links (provider→consumer order) |
+| tag mutation safety | `gh` label ops | **all tag ops via `sdlc.ps1`** — raw ADO CLI replaces rather than appends |
+| status dashboard *(optional cache)* | — (labels + thread suffice) | description status block, dispatcher-rewritten from evidence |
+
+Rule: a fork documents its binding table once, then every prompt in that fork speaks the local
+dialect. The abstract operation names are the shared vocabulary for cross-fork comparison.
+
+**Lock-substrate contract.** Whatever carries the claim lock must provide all three of:
+
+1. **Deterministic contention resolution** — either an *append-only, server-timestamped* record
+   (GitHub claim comments; requires the claim-verify + boundary ritual of
+   `prompts/sdlc/README.md`), or a *compare-and-swap* write (e.g. an ADO PATCH tested against
+   `System.Rev` — on a field or on a child Task's description), which serializes claims at the
+   tracker and collapses the claim-verify ritual entirely.
+2. **Provable age and owner from server-side data** — a comment timestamp, a field revision, or a
+   timeline event. A worker-authored string alone proves nothing, and a whole-item modified stamp
+   (`updatedAt` / `ChangedDate`) is refreshed by any edit. A lock whose age cannot be proven is
+   never reaped — leave it and record it.
+3. **A cheap "all locked items" query** for the dispatcher's Step 0 snapshot (a label filter, a
+   WIQL field/tag clause — not a full-text scan of a rich-text field).
+
+A fork may additionally cache a **derived status block** on the work item (see the ADO profile
+for the worked format). A cache is never authoritative: it is regenerated from the evidence
+record on any parse failure, never trusted or repaired by guesswork, and locks never live in it.
+
+### VP2 — Topology: single-repo item vs multi-repo Feature
+
+The multi-repo model is the general case; single-repo is its degenerate form.
+
+- **Feature** — the authoritative record: owns lifecycle, requirements, acceptance criteria,
+  dependencies, human gates, integration, release. Human attention consolidates here
+  (`sdlc:needs-human` lives at the Feature; children report `result:*` evidence but never own the
+  human-attention state).
+- **Child PBI** — a repository-scoped execution record, *not* an independent workflow: one routing
+  tag, technical plan, reserved branch/PR, phase evidence, short-lived worker locks.
+- **Cross-repo ordering** — providers and independent children build first; a consumer may start
+  once its predecessor publishes `contract-ready` evidence (it need not wait for the provider's PR
+  to ship). At `verify`, every child runs its own repo's full verification; `audit` reconciles
+  across children; `complete` requires all children shipped **and** Feature-level ACs pass.
+- **Single-repo forks** collapse this: the issue is simultaneously the Feature and its only child.
+  No hierarchy links, no routing tags, no contract-ready handshake. Nothing else changes.
+
+### VP3 — Lifecycle modules (optional, on top of the spine)
+
+- **Design UX track** — the design *stage* itself is spine, not a module: its spec track always
+  runs, and every item reaches `queued` carrying a reviewed implementation plan. What varies is
+  the **UX/artifact track**: a fork whose work is user-facing binds `<DESIGN_ARTIFACTS>` in its
+  profile (its conventions for storyboards/mockups — what "what it looks like / how it behaves"
+  is recorded in). Material UI changes then require version-controlled design artifacts + a human
+  A/B/C pick (a PARK inside the design phase, recorded as design evidence) before the spec is
+  written; design approval is distinct from and does not replace the `queued` gate. Forks without
+  UI work leave the binding empty — every item takes the spec track only (spec-lite for exempt
+  items), and product/scope questions still run as intake decision debates.
+- **PSI lane** (production-support investigation) — a customization, not core. Its own machine
+  (`reported → triage → diagnosed → decided → pending-fix → resolved`); the automated PSI worker is
+  **read-only** (documents severity/repro/evidence/root-cause, never writes code); at `decided` a
+  human chooses no-change / documentation / duplicate / needs-code; a needs-code PSI creates or
+  attaches to a normal Feature and rides the spine from there. No automation bypass for any
+  priority. Forks without production support omit the lane entirely.
+- Future modules follow the same shape: a named sub-machine that *enters* the spine at a defined
+  point (PSI enters at intake; the design UX track binds inside the design stage) and never adds a
+  third human gate to the spine itself. (The UX track's PARK is a worker parking for a missing
+  input, not a new gate.)
+
+### VP4 — Dispatcher runtime
+
+The dispatcher contract is runtime-agnostic: a concurrency model of per-issue claims + idempotent
+verify-before-write tracker writes + a per-machine maintenance lock (no dispatcher singleton),
+stale-lock reaping (2h heuristic, verify-before-write), git/PR maintenance, per-lane fan-out of
+isolated workers, end-of-cycle digest. The reference maintenance-lock binding is a lock
+**directory** at `.git/sdlc-maint.lock`: atomic-`mkdir` acquire (exactly one contender succeeds),
+an `owner.txt` stamp (`<run-id> <ISO timestamp>`), and a 30-minute stale reap by atomic
+**rename** (exactly one contender wins the reap). One gotcha rides the representation: because
+acquisition is a `mkdir` under `.git/`, the lock cannot be taken from inside a git worktree
+(there `.git` is a file, not a directory) — maintenance runs only from the main checkout.
+Bindings in the wild:
+
+- **Claude Code** — scheduled task → `dispatch.md` → one worker subagent per non-empty lane
+  (IsekaiOnline, vtk, pemr).
+- **GitHub Copilot** — interactive session runs the dispatcher prompt; scheduler mechanism TBD
+  (work). Same contract; the fork documents how machine-local maintenance is serialized.
+- **cron / CI** — headless agent invocation with the thin-pointer prompt.
+
+A fork must state its binding for: how the cycle is triggered, how machine-local maintenance is
+serialized (the per-machine lock's representation), and how workers are isolated (worktrees,
+separate clones, or serial-variant tree hygiene).
+
+**Coexistence with session-orchestration layers.** A machine running the dispatcher may also carry
+a user-level interactive-orchestration policy (e.g. [pilotfish](https://github.com/Nanako0129/pilotfish),
+which installs role agents and a delegation policy under `~/.claude/`). The two are orthogonal and
+compose by scope: the orchestration layer governs *interactive* sessions; the SDLC pipeline governs
+its own scheduled cycle, and `dispatch.md` declares that its fixed topology overrides any
+session-level delegation policy for the cycle (the specific-over-general precedence such layers
+themselves document). Two conventions deliberately differ and should not be "harmonized": role-agent
+layers pin the model in each agent's frontmatter and tell the orchestrator to *omit* the model
+argument when invoking a named role, while this pipeline uses **one** worker agent for every lane
+and therefore *always sets* the model per spawn (the lane tier table) — each is correct for its
+shape. Workers themselves are unaffected by construction: `sdlc-worker` has no delegation tool,
+so no session policy can make it spawn anything.
+
+### VP5 — Quality bars
+
+`<TEST_CMD>`, `<FULL_SUITE_CMD>`, `<SMOKE_CMD>`, `<LINT_CMD>`, `<INVARIANTS>`, `<DOCS_SINKS>` are
+per-fork by design and per-*repo* within a multi-repo fork (each child PBI verifies to its own
+repo's bar). The stage semantics ("verify proves it works", "audit reviews security + invariants +
+contracts + docs + merge order") are fixed; what proof consists of is the fork's declaration.
+
+## The conformance profile
+
+Each fork keeps one file — `prompts/sdlc/PROFILE.md` (suggested, co-located with the fork's
+prompts) — stating its bindings. This is the
+artifact that makes read-only consumption and ad-hoc drift audits work: an agent with read access
+to both repos can diff a profile against this spec mechanically.
+
+```markdown
+# SDLC conformance profile: <project>
+- Spine: intake → design → queued → build → verify → audit → ready → shipping → complete
+  (or the collapsed tail)
+- VP1 tracker: <GitHub labels | ADO tags+links> — binding table or link
+- VP2 topology: <single-repo | multi-repo Feature/child> — routing tags if multi
+- VP3 modules: design UX track <off | bound: `<DESIGN_ARTIFACTS>` conventions + trigger>,
+  PSI lane <on/off>, others
+- VP4 dispatcher: <trigger, maintenance-lock representation, worker isolation>
+- VP5 quality bars: per repo — test / full-suite / smoke / lint / invariants / known env limits /
+  docs sinks
+- Deterministic core: <none | scripts/sdlc.mjs | sdlc.ps1 | sdlc CLI> and which rituals it owns
+- Known deviations from spec: <list, with why>
+```
+
+Worked examples: [profiles/work-ado.example.md](https://github.com/meridun/agentic-sdlc/blob/master/docs/profiles/work-ado.example.md) (multi-repo Azure
+DevOps, read-only consumer) and
+[profiles/github-single-repo.example.md](https://github.com/meridun/agentic-sdlc/blob/master/docs/profiles/github-single-repo.example.md) (the minimal
+single-repo GitHub case with the reference CLI).
+
+The "known deviations" line is load-bearing: fork-per-project means divergence is legitimate, but
+*undeclared* divergence is drift. An audit pass = read profile, read spec, list deltas, file
+issues locally.
+
+## What is NOT a variation point
+
+- The five invariants.
+- The two human gates and their positions.
+- The worker contract (CLAIM → WORK → EMIT → STOP, one item, one outcome, never silent).
+- Human-set markers (`needs-human`, `hold`) being untouchable by automation.
+- Evidence-on-the-work-item as the only inter-stage state.
+- Read-only-ness of the audit stage and of any PSI investigation worker.
+
+A fork that needs to break one of these has found either a spec bug (port the fix here) or a
+different methodology (stop calling it this one).

--- a/docs/Development_SdlcLabels.md
+++ b/docs/Development_SdlcLabels.md
@@ -1,0 +1,81 @@
+# Label taxonomy
+
+The pipeline is driven entirely by GitHub labels. Create these once per repo.
+
+## The labels
+
+| Label | Colour | Meaning |
+|---|---|---|
+| `stage:intake` | `#0e8a16` | Awaiting triage/routing. |
+| `stage:design` | `#c5def5` | Awaiting design — the implementation plan (spec track, every item); plus UX artifacts when the profile binds them. |
+| `stage:queued` | `#fbca04` | Planned, awaiting admission — **the human throttle** (reviews the body's `## Implementation plan`). No worker. |
+| `stage:build` | `#1d76db` | Being implemented (or waiting to be). |
+| `stage:verify` | `#5319e7` | Awaiting full-suite + real-run validation. |
+| `stage:audit` | `#b60205` | Awaiting read-only security/invariant review. |
+| `stage:ship` | `#0052cc` | Awaiting docs fan-out + PR. |
+| `sdlc:wip` | `#d93f0b` | Per-issue lock. Machine-owned, volatile. Paired with an `sdlc:claim` comment. |
+| `sdlc:needs-human` | `#e99695` | Parked — a worker needs a human decision. Automation never advances it. |
+| `sdlc:hold` | `#000000` | Human keep-off. No worker touches it. |
+| `priority:critical` | `#b60205` | Claimed first within a lane. |
+| `priority:future` | `#c2e0c6` | Claimed last. |
+
+> **pemr divergence from upstream:** upstream also defines `priority:medium` as the default tier.
+> pemr retired it — **unlabeled is the default** and sorts between `critical` and `future`
+> (`scripts/sdlc.mjs` `PRIORITY_RANK`); only the two exceptional tiers carry a label.
+| `blocked` | `#d876e3` | *(optional)* Item bounced to queued as not-yet-buildable; readiness axis. |
+| `ready` | `#0e8a16` | *(optional)* Blocker cleared; complements `blocked`. |
+
+## Exactly one stage label per open issue
+
+Every open issue carries **exactly one** `stage:*` label — the pipeline invariant the dispatcher
+enforces (dispatch.md Step 0b). **Zero** stage labels makes an issue invisible to every lane
+forever (a triage escapee that will never be built or closed): the dispatcher auto-repairs it to
+`stage:intake` (verify-before-write) — intake is the safe re-entry, re-routing or reconciling from
+there. That covers the post-ship window too: ship's terminal ADVANCE removes `stage:ship` and the
+merge normally closes the issue promptly; an issue that outlives a dispatch cycle awaiting merge
+is routed back through intake, whose evidence-based reconciliation (open PR in flight / already
+merged) is a safe no-op or a PARK-with-evidence, never duplicate work. **Two or more** `stage:*`
+labels make an issue eligible in two lanes at once — two workers could claim it in one cycle — so
+the dispatcher parks it (`sdlc:needs-human`) for a human to pick: a snapshot can't adjudicate the
+right stage. `sdlc:wip` or `sdlc:needs-human` on a zero-stage issue means a worker died
+mid-transition; the same repair applies.
+
+The runtime check is a **hand-edit backstop**: the reference CLI's transition validation never
+creates a zero/dual-stage state, but labels edited by hand or by tooling outside the CLI still
+can. A fork whose tracker substrate cannot hold the invariant (e.g. a state field that must pass
+through a stageless value) declares the deviation in its `PROFILE.md` rather than silently
+diverging.
+
+## Create them (`gh`)
+
+Run from the repo, authenticated with `repo` scope. `--force` makes it idempotent (updates colour if
+the label already exists).
+
+```bash
+# stages
+gh label create "stage:intake"  --color 0e8a16 --description "Awaiting triage/routing" --force
+gh label create "stage:design"  --color c5def5 --description "Awaiting implementation plan (+ UX artifacts when bound)" --force
+gh label create "stage:queued"  --color fbca04 --description "Plan reviewed here — human throttle (no worker)" --force
+gh label create "stage:build"   --color 1d76db --description "Being implemented" --force
+gh label create "stage:verify"  --color 5319e7 --description "Awaiting validation" --force
+gh label create "stage:audit"   --color b60205 --description "Awaiting security/invariant review" --force
+gh label create "stage:ship"    --color 0052cc --description "Awaiting docs fan-out + PR" --force
+
+# sdlc control
+gh label create "sdlc:wip"          --color d93f0b --description "Per-issue lock (machine-owned)" --force
+gh label create "sdlc:needs-human"  --color e99695 --description "Parked — needs a human decision" --force
+gh label create "sdlc:hold"         --color 000000 --description "Human keep-off — no worker touches it" --force
+
+# priority
+gh label create "priority:critical" --color b60205 --description "Claimed first within a lane" --force
+gh label create "priority:future"   --color c2e0c6 --description "Claimed last" --force
+
+# optional readiness axis
+gh label create "blocked" --color d876e3 --description "Not yet buildable (bounced to queued)" --force
+gh label create "ready"   --color 0e8a16 --description "Blocker cleared" --force
+```
+
+No dispatcher-lock issue exists in this model: there is no dispatcher singleton. Overlapping
+dispatch runs deconflict via per-issue claims, idempotent GitHub writes, and a per-machine
+filesystem lock (`.git/sdlc-maint.lock`) the dispatcher manages itself — nothing to create on the
+tracker. See `prompts/sdlc/dispatch.md` Step -1.

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -23,6 +23,7 @@ process.
 - `Overview.md` — what the system is, for a newcomer
 - `Architecture.md` — hub linking to subsystem docs
 - `Development.md` — local setup, test commands, branch model
-- `Development_AgenticSDLC.md` — if you adopt the `prompts/sdlc/` pipeline, document the stage
-  graph and lane responsibilities here
+- `Development_AgenticSDLC.md` — the Agentic SDLC model and invariants (ported from upstream);
+  `Development_SdlcAdoption.md` (placeholders + setup), `Development_SdlcComposability.md`
+  (9-stage canonical spine), `Development_SdlcLabels.md` (gh-scriptable label list)
 - `Development_TokenTools.md` — vtk/graphify setup notes, if adopted

--- a/prompts/sdlc/PROFILE.md
+++ b/prompts/sdlc/PROFILE.md
@@ -34,7 +34,7 @@ upstream templates verbatim (resynced 2026-08-06 from agentic-sdlc `3e0db2d`, wi
 | `<DEFAULT_BRANCH>` | `dev` |
 | `<PROD_BRANCH>` | `main` |
 | `<WORKTREE_ROOT>` | `C:\Claude` (worktrees `pemr-wt-<issue#>`) |
-| `<WORKER_AGENT>` | `general-purpose` subagent with explicit `model` (no dedicated sdlc-worker agent yet) |
+| `<WORKER_AGENT>` | `sdlc-worker` subagent (`.github/agents/sdlc-worker.agent.md`, no Agent tool) with explicit `model` |
 | `<TEST_CMD>` | `pytest <targeted paths>` |
 | `<FULL_SUITE_CMD>` | `pytest` |
 | `<LINT_CMD>` | **unbound** — declare before enabling the scheduled dispatcher |

--- a/prompts/sdlc/README.md
+++ b/prompts/sdlc/README.md
@@ -6,7 +6,7 @@ specifics.
 
 Pipeline: `stage:intake` → `stage:design` → `stage:queued` → `stage:build` → `stage:verify` →
 `stage:audit` → `stage:ship` → *(PR merged, closed)* — the canonical spine's collapsed-tail form
-(see `docs/Composability.md` (agentic-sdlc repo): ship opens the PR, the human merge **is** the `ready` gate, and
+(see `docs/Development_SdlcComposability.md`: ship opens the PR, the human merge **is** the `ready` gate, and
 `shipping → complete` collapse into merge-and-close).
 
 `stage:design` is a **standard phase**: every triaged item passes through it for a reviewed
@@ -22,7 +22,7 @@ PARK, which is for *missing inputs* mid-phase: parked items beg for an answer; q
 comfortably.
 
 > **Placeholders.** Anything in `<ANGLE_BRACKETS>` is project-specific and must be filled in before
-> use. See `docs/Adoption.md` (agentic-sdlc repo) for the full list. The core ones: `<PROJECT>` (name), `<REPO_PATH>`
+> use. See `docs/Development_SdlcAdoption.md` for the full list. The core ones: `<PROJECT>` (name), `<REPO_PATH>`
 > (local working dir), `<DEFAULT_BRANCH>` (integration branch, e.g. `dev`), `<PROD_BRANCH>`
 > (release branch, off-limits to workers), `<WORKTREE_ROOT>` (e.g. `../<project>-wt`),
 > `<TEST_CMD>` / `<FULL_SUITE_CMD>` / `<LINT_CMD>` / `<BUILD_CMD>` / `<SMOKE_CMD>`, `<INVARIANTS>`
@@ -59,7 +59,7 @@ comfortably.
    creation date (FIFO). If none (or the snapshot is exhausted) → reply `<LANE>: idle` and stop.
 
    **CLI-first** (the primary path when the reference CLI is present — `scripts/sdlc.mjs`, see
-   `docs/Adoption.md` (agentic-sdlc repo)): do **not** re-derive the pick rule by eyeball (the eyeballed mis-claim is
+   `docs/Development_SdlcAdoption.md`): do **not** re-derive the pick rule by eyeball (the eyeballed mis-claim is
    a known failure class — lesson of #640). With a candidate snapshot (or an already-known issue,
    e.g. build's CONTINUE resumption), claim it directly:
    `node scripts/sdlc.mjs claim <issue> <run-id> <lane> --verify` — a non-zero exit means you lost

--- a/prompts/sdlc/dispatch.md
+++ b/prompts/sdlc/dispatch.md
@@ -21,7 +21,7 @@ executes one pass.
 
 > **Serial variant.** For a simpler single-worker pipeline, replace Step -1 + Step 0 with a global
 > gate — *any* `sdlc:wip` younger than 2h aborts the whole run; else reap and proceed — and run
-> lanes one at a time in pipeline order. See `docs/AgenticSDLC.md` (agentic-sdlc repo). The per-issue version below is
+> lanes one at a time in pipeline order. See `docs/Development_AgenticSDLC.md`. The per-issue version below is
 > the default.
 
 ---
@@ -82,7 +82,7 @@ safe under three rules:
 - **Never abort the cycle over this lock.** Whatever its outcome, proceed to Step 0 and per-lane
   dispatch; only Step 0a is conditional on holding it.
 
-If your repo carries the reference CLI (`scripts/sdlc.mjs`, see `docs/Adoption.md` (agentic-sdlc repo)), the protocol is
+If your repo carries the reference CLI (`scripts/sdlc.mjs`, see `docs/Development_SdlcAdoption.md`), the protocol is
 one command each way: `node scripts/sdlc.mjs maint-lock <run-id>` (exit 1 = held; skip Step 0a) and
 `node scripts/sdlc.mjs maint-release <run-id>`.
 
@@ -192,7 +192,7 @@ that refusal as "in use — leave it", never force.
 
 ### Step 0b — Stage-label integrity (you do this yourself)
 
-Every open issue must carry **exactly one** `stage:*` label (see `docs/Labels.md` (agentic-sdlc repo)). Zero makes it
+Every open issue must carry **exactly one** `stage:*` label (see `docs/Development_SdlcLabels.md`). Zero makes it
 invisible to every lane forever (a triage escapee that will never be built or closed); two makes
 it eligible in two lanes at once — two workers could claim it in one cycle. From the Step 0
 snapshot (no new query — the labels are already in hand), count each open issue's `stage:*` labels


### PR DESCRIPTION
Adopts the two upstream (model-repo `2b923ab` / agentic-sdlc `9161863`) changes pemr was missing:

- **Dedicated `sdlc-worker` agent** (`.github/agents/sdlc-worker.agent.md`, mirrored to `.claude/agents/`) with **no Agent tool by construction**, enforcing the dispatch.md "workers cannot delegate" invariant. `PROFILE.md` now binds `<WORKER_AGENT>` to it (was `general-purpose`, which has the Agent tool). Concretized for pemr: worktree root, PROFILE pointer, token-tool bullet dropped (none wired).
- **Vendored SDLC L3 docs** — `Development_SdlcAdoption.md`, `Development_SdlcComposability.md`, `Development_SdlcLabels.md` — so prompt references resolve inside this public repo instead of "(agentic-sdlc repo)" pointers to a local checkout. Prompt/doc references rewritten; `Documentation.md` index updated.
- Labels doc carries a pemr-divergence note: `priority:medium` retired here, unlabeled is the default tier.

Checks: `npm test` 168 pass; `npm run sync:claude-config:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)