### PR TITLE
docs(agents): lab collected_at prefers the collection date, result date as fallback (#189)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -519,7 +519,10 @@ for the dry run explicitly. An agent may run the enumeration in step 2 and hand 
 list, nothing further.
 
 1. Optionally `pemr document reocr <document_id> --dry-run` first, if `ocr_text` itself needs
-   re-deriving; drop `--dry-run` to store it.
+   re-deriving. Dropping `--dry-run` is not enough here: a document that **already** has
+   `ocr_text` — which every document in this remediation's scope does — is *skipped* unless you
+   also pass `--force`, and text that comes back shorter than what is stored is refused unless you
+   also pass `--allow-shrink` (`--force` does not imply it).
 2. Enumerate: `pemr query labs --person <slug> --json`, filtered to the CCDA's `document_id` (both
    `lab_result_id` and `document_id` are on the read payload).
 3. `pemr record edit lab_result <id> --set collected_at=<corrected> --identity --note "<why>"`,
@@ -530,8 +533,15 @@ list, nothing further.
      one identity is a merge, not a correction. The refusal names both repairs: drop the mis-dated
      duplicate with `pemr record rm lab_result <id>`, or record the merge with
      `pemr record annotate lab_result <id> --status merged-into --merged-into <base>`.
-   - **The two copies disagree on a value** — the move is *not* refused; the disagreement is then
-     an ordinary §5 conflict-review action, human sign-off and all.
+   - **The two copies disagree on a value** — the move is *not* refused, and **nothing adjudicates
+     the disagreement for you**. The row simply lands as the next *occurrence* of the target
+     identity, beside the copy already there: no conflict is staged, `pemr review-conflicts` reports
+     nothing, `pemr verify` is silent, and a later re-ingest of either payload dedups against its
+     own occurrence. Only `trends` hints at it, as `(1 of 2 at this timestamp)`. Reconciling the two
+     rows is therefore the operator's own next step — drop the redundant one with
+     `pemr record rm lab_result <id>`, or correct the payload in place with a plain
+     `pemr record edit lab_result <id> --set value_num=<corrected>` (payload columns are not
+     identity fields, so that edit needs no `--identity`).
 4. `record rm` plus a re-commit from `ocr_text` stays the **second** choice, for when the payload
    itself must be re-derived: it discards the row's edit ledger, which `--identity` exists to avoid.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,6 +396,11 @@ day or month the source didn't state, and never fall back to stashing an impreci
 - Date-only precision is also why two genuine same-day results collide: they derive one key, so the
   second stages a conflict. Emitting a time you invented is never the fix — the recovery path is
   `keep both` under human sign-off (§5).
+- This section governs a date's **precision**, never *which* of a document's dates a field takes.
+  For `lab_result.collected_at` that choice is §10: the specimen collection date, with the
+  result/verified date only as a fallback proxy. The rules above apply to that proxy exactly as
+  they apply to any other date — emit it at the precision the source states, and never stash it
+  elsewhere.
 
 ### 8. Medication discontinue reason
 
@@ -453,6 +458,82 @@ defense is `pemr verify`, which warns on any `medication.status` that is neither
 lifecycle value nor empty, naming the row id and the offending literal. Correct such a row with
 `pemr record edit medication <id> --set status= --note ...` (moving any dosing detail into
 `frequency`/`dose` in the same edit), not by re-committing the source document.
+
+### 10. Lab result dates — the collection date, with the result date only as a fallback
+
+A lab results table carries **two** dates per row, and they are not interchangeable. In an
+athenahealth CCDA export the results table renders as
+
+```
+<order/collection date> | <result date> | <panel> | <analyte> | <value> | <unit> | <reference range> | ...
+```
+
+and the same document's **orders** table carries a `collected` column holding the same
+specimen-collection timestamp as results column 1.
+
+**MUST — `lab_result.collected_at` is the specimen collection date whenever it is known**: results
+column 1, or the orders table's `collected` cell; cross-check them when both are present. A result
+reflects the person's condition as of the draw, not as of the lab's verification run.
+
+**MUST NOT take the result date while a collection date exists anywhere in the source.** The result
+date typically runs a day or more after the draw, so the row lands on the wrong day and derives a
+different date-only `dedup_key` (§5) from a portal-sourced copy of the same draw — `trends` then
+shows a phantom second draw that the dictionary cannot fold. For athena exports the collection date
+is the normal path, not the exception: column 1 was populated on every one of the 657 results lines
+of the export that surfaced this rule.
+
+**Fallback — the result date as a proxy for `collected_at` itself.** *Only* where the source
+genuinely carries no collection date anywhere — no results column 1, no orders-table
+cross-reference, or a non-CCDA source stating only a "result date" — the result/verified date may be
+committed **as `collected_at`**. Its cost is real: the row's `dedup_key` is then approximate, so a
+document that later carries the true collection date lands as a **separate row** rather than folding
+into this one. Two hard edges:
+
+- **Never as a second field.** No `lab_result` column holds a result date, and §7 forbids stashing
+  an unplaceable date elsewhere — not in `value_text`, not in a note. It is either `collected_at`
+  or omitted.
+- **Never while a collection date is reachable.** Check the orders table and any accompanying
+  documents first. "No collection date found" must be a conclusion, not a default.
+
+**Precision of the proxy** is §7's ordinary rule: emit it at the precision the source states. Do
+**not** degrade a full date to `YYYY-MM` to signal approximation — that invents a different claim
+about the draw and can be flatly wrong (a result dated the 1st, for a draw on the 28th, lands in the
+wrong month). What makes the proxy honest is **disclosure**: the agent MUST name, in its commit
+summary, which rows were committed on a proxy date, so the human can decide whether to chase a
+better source.
+
+**Read the header; don't index blindly.** The column layout above is athenahealth's shape, not a
+guarantee for every vendor. Map columns from the table's own header. If the header is absent or
+ambiguous *and* there is no orders-table `collected` to cross-check, ask the human — never guess
+which of two dates is the draw.
+
+**Remediation — rows already committed on the result date.** `collected_at` is an identity field
+(it feeds the `dedup_key`), so a plain `record edit --set collected_at=` is refused. Since issue
+#152 the first-choice repair is `record edit --identity`, a **one-row rekey**: the row keeps its
+`document_id`, provenance, row id, row-scoped curation verdicts and edit ledger, and only its
+`dedup_*` columns move. The repair itself is a **human-at-the-terminal** action: `record edit`,
+`record rm`, `record annotate` and `document reocr` are all CLI-only (see *Tool surface*). The
+three `record` verbs are dry-run by default — lead with the dry run and read what it says before
+adding `--apply`; `document reocr` is the inversion (it *writes* unless given `--dry-run`), so ask
+for the dry run explicitly. An agent may run the enumeration in step 2 and hand the human the
+list, nothing further.
+
+1. Optionally `pemr document reocr <document_id> --dry-run` first, if `ocr_text` itself needs
+   re-deriving; drop `--dry-run` to store it.
+2. Enumerate: `pemr query labs --person <slug> --json`, filtered to the CCDA's `document_id` (both
+   `lab_result_id` and `document_id` are on the read payload).
+3. `pemr record edit lab_result <id> --set collected_at=<corrected> --identity --note "<why>"`,
+   then re-run with `--apply`. Three branches:
+   - **Nothing at the true date yet** — the move is the whole repair.
+   - **A copy of the same draw already sits at the true date** (e.g. the same result already held
+     from a portal PDF) — the move is refused as an identity collision, because filing both under
+     one identity is a merge, not a correction. The refusal names both repairs: drop the mis-dated
+     duplicate with `pemr record rm lab_result <id>`, or record the merge with
+     `pemr record annotate lab_result <id> --status merged-into --merged-into <base>`.
+   - **The two copies disagree on a value** — the move is *not* refused; the disagreement is then
+     an ordinary §5 conflict-review action, human sign-off and all.
+4. `record rm` plus a re-commit from `ocr_text` stays the **second** choice, for when the payload
+   itself must be re-derived: it discards the row's edit ledger, which `--identity` exists to avoid.
 
 ## Privacy posture
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -962,6 +962,63 @@ def test_ccda_med_table_keeps_the_discontinue_reason_in_its_cell(
     assert row.endswith(cell)
 
 
+# The lab-table shape #189's convention (AGENTS.md §10) rests on: a results table whose
+# first two columns are the collection date and the result date - different days - and an
+# orders table repeating the collection date in its own `collected` cell. `_extract_ccda`
+# stays a vendor-neutral flattener (it never learns which column is which), so what this
+# pins is that both dates and the cross-reference survive #138's flattening in order -
+# i.e. the agent transcribing `ocr_text` can honor §10 with today's extraction.
+_CCDA_LABS = (
+    "<section><title>Results</title><text><table>"
+    "<thead><tr><th>Collected</th><th>Resulted</th><th>Panel</th><th>Test</th>"
+    "<th>Value</th><th>Unit</th><th>Reference Range</th></tr></thead>"
+    "<tbody>"
+    "<tr><td>03/01/2024</td><td>03/02/2024</td><td>Basic Panel</td>"
+    "<td>Zylotase</td><td>12</td><td>U/L</td><td>5-20</td></tr>"
+    "<tr><td>03/01/2024</td><td>03/02/2024</td><td>Basic Panel</td>"
+    "<td>Quorbin</td><td>4.1</td><td>g/dL</td><td>3.5-5.0</td></tr>"
+    "<tr><td>07/14/2024</td><td>07/16/2024</td><td>Renal Panel</td>"
+    "<td>Marrowlyte</td><td>138</td><td>mmol/L</td><td>135-145</td></tr>"
+    "</tbody></table></text></section>",
+    "<section><title>Orders</title><text><table>"
+    "<thead><tr><th>Order</th><th>Collected</th><th>Status</th></tr></thead>"
+    "<tbody>"
+    "<tr><td>Basic Panel</td><td>03/01/2024</td><td>Final</td></tr>"
+    "<tr><td>Renal Panel</td><td>07/14/2024</td><td>Final</td></tr>"
+    "</tbody></table></text></section>",
+)
+
+
+@pytest.mark.parametrize("analyte, collected, resulted, panel", [
+    ("Zylotase", "03/01/2024", "03/02/2024", "Basic Panel"),
+    ("Quorbin", "03/01/2024", "03/02/2024", "Basic Panel"),
+    ("Marrowlyte", "07/14/2024", "07/16/2024", "Renal Panel"),
+])
+def test_ccda_results_table_keeps_both_date_columns_in_order(
+    conn, tmp_path, sources, analyte, collected, resulted, panel
+):
+    """Both dates reach `ocr_text` on the analyte's own line, collection date first and
+    result date second, neither collapsed into the other - and the orders table's
+    `collected` cell survives as the cross-reference AGENTS.md §10 tells the agent to
+    check (issue #189's transcription dependency)."""
+    src = _make_ccda(tmp_path, name="DOC0189.XML", sections=_CCDA_LABS)
+    text = ingest.ingest_document(
+        conn, src, "jane-doe", sources, ocr=True
+    ).document.ocr_text
+    row = next(line for line in text.splitlines() if f"\t{analyte}\t" in line)
+    cells = row.split("\t")
+    assert cells[0] == collected
+    assert cells[1] == resulted
+    assert collected != resulted  # the bug this rule exists for: they are different days
+    assert cells[2] == panel
+    # the orders table repeats the collection date - not the result date - in its own row
+    order_row = next(line for line in text.splitlines() if line.startswith(f"{panel}\t"))
+    assert order_row.split("\t")[1] == collected
+    assert resulted not in order_row
+    # the header survives too, so the agent maps columns by name rather than by position
+    assert "Collected\tResulted\tPanel\tTest\tValue\tUnit\tReference Range" in text
+
+
 def test_ccda_never_shells_out(conn, tmp_path, sources, monkeypatch):
     def boom(path):  # pragma: no cover - the assertion is that this never runs
         raise AssertionError(f"run_ocr must not be called for {path}")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -768,6 +768,14 @@ def test_agents_md_documents_the_lab_collection_date_rule():
         "--identity",            # first-choice repair (issue #152)
         "record rm",             # second choice / the collision branch
         "document reocr",        # re-deriving ocr_text first
+        # The two corrections the engine forced on the remediation ladder: a disagreeing
+        # copy is *not* adjudicated (the row lands as another occurrence and nothing is
+        # staged, so `review-conflicts` shows nothing), and `document reocr` skips a
+        # document that already has `ocr_text` unless `--force`. Both were reassurances
+        # the prose originally got wrong; pinned so they cannot quietly come back.
+        "occurrence",
+        "review-conflicts",
+        "--force",
     ):
         assert token in section, f"AGENTS.md section 10 missing: {token}"
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -752,6 +752,26 @@ def test_agents_md_has_the_four_must_sections():
         assert heading in text, f"AGENTS.md missing MUST section: {heading}"
 
 
+def test_agents_md_documents_the_lab_collection_date_rule():
+    """Issue #189's rule has two halves and a repair path, and a later edit must not be
+    able to drop one of them silently: prefer the collection date, fall back to the
+    result date *as* `collected_at`, and name how an already-mis-dated row is fixed.
+    A lint on the load-bearing tokens, not a grader of the prose."""
+    text = AGENTS.read_text(encoding="utf-8")
+    assert "### 10. Lab result dates" in text
+    section = text.split("### 10. Lab result dates", 1)[1].split("\n## ", 1)[0]
+    for token in (
+        "collected_at",          # the field the rule is about
+        "collection date",       # the preferred source
+        "fallback",              # the proxy half, not an alternative
+        "proxy",
+        "--identity",            # first-choice repair (issue #152)
+        "record rm",             # second choice / the collision branch
+        "document reocr",        # re-deriving ocr_text first
+    ):
+        assert token in section, f"AGENTS.md section 10 missing: {token}"
+
+
 # --------------------------------------------------------------------------- #
 # Wire surface — the *registered* tool names must equal TOOL_NAMES (the contract
 # lint above only sees the documented strings; this asserts the real MCP surface,


### PR DESCRIPTION
## What shipped

Documentation/convention fix only — no engine code changed. `AGENTS.md` gets a new MUST section
**§10 (Lab result dates — the collection date, with the result date only as a fallback)**:

- For a `lab_result`, `collected_at` **prefers the specimen collection date** whenever known (the
  athenahealth CCDA results-table column 1, cross-checked against the orders table's `collected`
  cell).
- The result/verified date (results-table column 2) is an allowed **fallback proxy for
  `collected_at` itself** — never a second stored field — only when no collection date is
  reachable anywhere in the source, emitted at the source's stated precision and disclosed in the
  commit summary.
- A remediation ladder for rows already committed on the wrong date, built around `record edit
  --identity` (landed in #152) as the first-choice per-row repair, `record rm` as the
  fallback/second choice, and the corrected behavior of `document reocr` (`--force` required to
  replace existing `ocr_text`).

One added cross-reference bullet in §7 (date precision governs the §10 proxy the same as any
other date). Two new tests: `tests/test_ingest.py::test_ccda_results_table_keeps_both_date_columns_in_order`
(proves the generic CCDA flattener already preserves both date columns and the orders `collected`
cell — the evidence behind AC #4, no extractor change needed) and
`tests/test_mcp_server.py::test_agents_md_documents_the_lab_collection_date_rule` (contract lint
pinning both halves of the rule plus the repair-path tokens).

`pemr/ingest.py` and the rest of the engine are untouched by design — `_extract_ccda` stays a
vendor-neutral table flattener; identifying which column is which is an agent-transcription
convention, not an engine capability.

Went through one intake reversal mid-pipeline (human corrected the original "never column 2"
framing to prefer/fallback) and one verify bounce (the remediation ladder's disagreeing-copies
branch overstated that the engine forces §5 conflict-review — it doesn't; fixed to describe the
actual occurrence-allocation behavior, plus the `document reocr --force` requirement).

Closes #189

## Reports
- Verify (ADVANCE → audit): https://github.com/meridun/pemr/issues/189#issuecomment-5389356065
- Audit (ADVANCE → ship, no blocking findings): https://github.com/meridun/pemr/issues/189#issuecomment-5389383098

---
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
